### PR TITLE
Enforce lockstep equivalence before STARK proving

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+
+reviews:
+  profile: chill
+  high_level_summary: true
+  review_status: true
+  review_details: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
+    labels:
+      - "!do-not-review"
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+      - "[skip review]"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+      - "github-actions[bot]"
+
+  # Keep review throughput high by excluding artifacts and generated outputs.
+  path_filters:
+    - "!target/**"
+    - "!compiled/**"
+    - "!**/*.svg"
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!**/*.jpeg"
+
+  # Keep instructions narrow and file-scoped (best signal-to-noise).
+  path_instructions:
+    - path: "src/proof.rs"
+      instructions: |
+        This file defines what statement is actually being proven and verified.
+        Focus on:
+        - proof/claim semantic correctness and wording-vs-implementation alignment,
+        - panic safety and malformed-input handling,
+        - verifier policy soundness (security thresholds, re-execution checks),
+        - commitment integrity checks and hash consistency.
+
+    - path: "src/vanillastark/**"
+      instructions: |
+        Focus on STARK soundness-critical behavior:
+        - reject malformed proof streams safely,
+        - deterministic transcript handling,
+        - no unchecked assumptions that could convert invalid proofs into accepted proofs,
+        - avoid panics on adversarial input.
+
+    - path: "src/verification.rs"
+      instructions: |
+        Prioritize lockstep semantic equivalence checks:
+        - transformer vs native state transitions,
+        - checked-steps accounting,
+        - mismatch localization correctness,
+        - no silent divergence paths.
+
+    - path: "src/bin/tvm.rs"
+      instructions: |
+        Ensure CLI claim wording and emitted metadata match implemented semantics exactly.
+        Flag any over-claiming language or defaults that weaken safety (prove/verify/research commands).
+
+    - path: "spec/**"
+      instructions: |
+        Treat these as statement contracts.
+        Verify schema/spec changes remain synchronized with runtime constants and validation logic in code.
+
+    - path: "tests/**"
+      instructions: |
+        Evaluate whether tests assert behavior, not just output shape.
+        Require negative tests for mismatch, malformed input, and policy enforcement where relevant.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        Focus on CI security and reproducibility:
+        - least privilege,
+        - deterministic commands,
+        - coverage of proof/verification and semantic artifact generation paths.

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,35 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax"],
+  "triggerOnUpdates": true,
+  "statusCheck": true,
+  "statusCommentsEnabled": true,
+  "ignorePatterns": "target/**\ncompiled/**\n**/*.svg\n**/*.png\n**/*.jpg\n**/*.jpeg",
+  "instructions": "Prioritize semantic correctness over stylistic feedback. Focus on proof statement soundness, verifier robustness, and transformer/native equivalence claims.",
+  "rules": [
+    {
+      "id": "statement-and-implementation-must-match",
+      "rule": "If claim wording or semantic scope changes, require corresponding code-level validation and tests. Reject over-claims where text promises stronger guarantees than implementation.",
+      "severity": "high",
+      "scope": ["src/proof.rs", "src/bin/tvm.rs", "spec/**", "README.md", "CLAUDE.md", "tests/**"]
+    },
+    {
+      "id": "panic-free-adversarial-verifier-path",
+      "rule": "Verifier and proof parsing code must fail closed (return errors/false) on malformed or truncated input instead of panicking.",
+      "severity": "high",
+      "scope": ["src/proof.rs", "src/vanillastark/**"]
+    },
+    {
+      "id": "equivalence-metadata-integrity",
+      "rule": "When equivalence metadata is emitted, require checked-steps, fingerprints, and final-state relationships to be internally consistent and test-covered.",
+      "severity": "high",
+      "scope": ["src/proof.rs", "src/verification.rs", "src/bin/tvm.rs", "tests/**"]
+    },
+    {
+      "id": "research-artifact-contracts",
+      "rule": "For research-v2 artifacts, require schema validation and commitment/hash validation tests. Spec changes must not drift silently from artifact generation code.",
+      "severity": "medium",
+      "scope": ["src/bin/tvm.rs", "spec/**", "tests/**", "README.md"]
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,32 @@
+{
+  "files": [
+    {
+      "path": "README.md",
+      "description": "Canonical user-facing behavior and claim wording."
+    },
+    {
+      "path": "CLAUDE.md",
+      "description": "Repository architecture, implemented boundaries, and workflow constraints."
+    },
+    {
+      "path": "spec/statement-v1.json",
+      "description": "Canonical v1 statement contract for STARK claim metadata.",
+      "scope": ["src/proof.rs", "src/bin/tvm.rs", "tests/**", "spec/**"]
+    },
+    {
+      "path": "spec/statement-v2-research.json",
+      "description": "Research v2 one-step semantic statement contract.",
+      "scope": ["src/bin/tvm.rs", "tests/**", "spec/**"]
+    },
+    {
+      "path": "spec/statement-v2-trace-research.json",
+      "description": "Research v2 prefix-trace semantic statement contract.",
+      "scope": ["src/bin/tvm.rs", "tests/**", "spec/**"]
+    },
+    {
+      "path": "spec/statement-v2-matrix-research.json",
+      "description": "Research v2 matrix semantic statement contract across programs.",
+      "scope": ["src/bin/tvm.rs", "tests/**", "spec/**"]
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,38 @@
+# Review Priorities For This Repository
+
+## 1) Proof Statement Integrity
+
+This repository is highly sensitive to claim wording drift. Any change to claim language, semantic scope, or statement version must be reflected in:
+
+- runtime validation logic,
+- proof/verification outputs,
+- test assertions,
+- statement spec files.
+
+If wording gets stronger while implementation stays the same, treat it as a blocking issue.
+
+## 2) Verifier Must Fail Closed
+
+For proof parsing and verification flows:
+
+- malformed input must return `Err`/`false`,
+- avoid panics on untrusted proof data,
+- reject unsupported modes/configurations explicitly,
+- preserve deterministic behavior.
+
+## 3) Equivalence Is First-Class
+
+Any transformer/native (or transformer/ONNX) equivalence claim should include verifiable metadata (checked steps, mismatch location, fingerprints, commitments), and tests should validate consistency.
+
+## 4) High-Signal Reviews
+
+Prefer logic/soundness/security findings over style nits.
+If a style comment does not affect correctness, maintainability, or reproducibility, skip it.
+
+## 5) Regression-Test Expectations
+
+For changes in `src/proof.rs`, `src/verification.rs`, `src/vanillastark/**`, and `src/bin/tvm.rs`:
+
+- request negative tests for mismatch/error paths,
+- request positive tests for expected happy paths,
+- ensure CLI output semantics remain aligned with proof semantics.

--- a/AI_REVIEW_BOTS_BEST_PRACTICES_2026-04.md
+++ b/AI_REVIEW_BOTS_BEST_PRACTICES_2026-04.md
@@ -1,0 +1,46 @@
+# AI Review Bots Playbook (April 2026)
+
+This repo uses **CodeRabbit** and **Greptile** with repo-scoped configuration to improve review quality and reduce noise.
+
+## Why these settings
+
+### CodeRabbit
+
+- Keep config in version control via `.coderabbit.yaml` at repo root.
+- Use **targeted path instructions** as a supplement, not a replacement for default review behavior.
+- Use **path filters** to exclude generated/artifact paths for faster, cleaner reviews.
+- Keep auto-review enabled on incremental pushes; skip drafts and bot-authored PRs.
+
+### Greptile
+
+- Prefer `.greptile/` over single-file `greptile.json` for scalable, directory-scoped config.
+- Start with balanced strictness (`strictness: 2`) and tune based on team feedback.
+- Limit comment types to logic/syntax for higher signal (style noise reduced).
+- Use `triggerOnUpdates: true` and status checks for consistent PR feedback.
+- Use `rules.md` + structured `rules` + `files.json` references for context-aware reviews.
+
+## Sources (official docs)
+
+### CodeRabbit
+
+- YAML config and precedence: https://docs.coderabbit.ai/getting-started/yaml-configuration
+- Repository settings & precedence: https://docs.coderabbit.ai/guides/repository-settings
+- Path instructions and filters: https://docs.coderabbit.ai/configuration/path-instructions
+- Automatic review controls: https://docs.coderabbit.ai/configuration/auto-review
+- AST-based instructions (optional advanced): https://docs.coderabbit.ai/configuration/ast-grep-instructions
+
+### Greptile
+
+- `.greptile/` configuration (recommended): https://www.greptile.com/docs/code-review/greptile-config
+- `.greptile/` file reference: https://www.greptile.com/docs/code-review/greptile-config-reference
+- `greptile.json` reference and parameters: https://www.greptile.com/docs/code-review-bot/greptile-json
+- Nitpick controls / strictness / triggers: https://www.greptile.com/docs/code-review/controlling-nitpickiness
+- Team learning and noise reduction behavior: https://www.greptile.com/docs/how-greptile-works/nitpicks
+- Best-practices guide: https://www.greptile.com/docs/code-review-bot/best-practices
+
+## Operational Notes
+
+- Keep rule changes small and review their effect over 1-2 weeks.
+- Prefer scoped rules over global blanket instructions.
+- If review noise rises, increase Greptile strictness and narrow bot instructions.
+- If critical issues are missed, add focused path/rule instructions + regression tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ llm-provable-computer is an implemented Rust workspace for a deterministic trans
 - Current vanilla STARK scope:
   - supported: `NOP`, `LOADI`, `LOAD`, `STORE`, `PUSH`, `POP`, `ADD`, `ADDM`, `SUB`, `SUBM`, `MUL`, `MULM`, `CALL`, `RET`, `JMP`, `JZ`, `JNZ`, `HALT`
   - rejected: softmax and hard-softmax proof paths, bitwise instructions, compare instructions, non-halted public claims, public claims with `carry_flag = true`
-- Current proof is transparent, not zero-knowledge: the public claim includes the program, attention mode, step count, and final state.
+- Current proof is transparent, not zero-knowledge: the public claim includes the program, attention mode, step count, final state, and lockstep equivalence metadata (checked steps plus transformer/native fingerprints).
 </status>
 
 <structure>

--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ cargo run --bin tvm -- prove-stark programs/factorial_recursive.tvm -o fact.proo
 cargo run --bin tvm -- verify-stark fact.proof.json
 ```
 
+`prove-stark` first runs transformer/native lockstep verification and aborts on any divergence before emitting a proof.
+Proof claims now also include equivalence metadata (`equivalence_checked_steps`, transformer fingerprint, native fingerprint) in the CLI output.
+
 The proof is transparent and public. The claim includes the program, attention mode, step count, and final state. Zero-knowledge hiding is out of scope.
 
 ---

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -358,6 +358,11 @@ fn prove_stark_command(
 ) -> llm_provable_computer::Result<()> {
     let model = compile_model(program, layers, attention_mode)?;
     let proof = prove_execution_stark(&model, max_steps)?;
+    let equivalence = proof.claim.equivalence.as_ref().ok_or_else(|| {
+        VmError::InvalidConfig(
+            "prove-stark produced a claim without equivalence metadata".to_string(),
+        )
+    })?;
     save_execution_stark_proof(&proof, output)?;
 
     println!("program: {}", program.display());
@@ -371,17 +376,15 @@ fn prove_stark_command(
     println!("carry_flag: {}", proof.claim.final_state.carry_flag);
     println!("memory: {:?}", proof.claim.final_state.memory);
     println!("attention_mode: {}", proof.claim.attention_mode);
-    if let Some(equivalence) = &proof.claim.equivalence {
-        println!("equivalence_checked_steps: {}", equivalence.checked_steps);
-        println!(
-            "equivalence_transformer_fingerprint: {}",
-            equivalence.transformer_fingerprint
-        );
-        println!(
-            "equivalence_native_fingerprint: {}",
-            equivalence.native_fingerprint
-        );
-    }
+    println!("equivalence_checked_steps: {}", equivalence.checked_steps);
+    println!(
+        "equivalence_transformer_fingerprint: {}",
+        equivalence.transformer_fingerprint
+    );
+    println!(
+        "equivalence_native_fingerprint: {}",
+        equivalence.native_fingerprint
+    );
     println!("proof_bytes: {}", proof.proof.len());
 
     Ok(())
@@ -407,17 +410,18 @@ fn verify_stark_command(proof_path: &Path) -> llm_provable_computer::Result<()> 
     println!("carry_flag: {}", proof.claim.final_state.carry_flag);
     println!("memory: {:?}", proof.claim.final_state.memory);
     println!("attention_mode: {}", proof.claim.attention_mode);
-    if let Some(equivalence) = &proof.claim.equivalence {
-        println!("equivalence_checked_steps: {}", equivalence.checked_steps);
-        println!(
-            "equivalence_transformer_fingerprint: {}",
-            equivalence.transformer_fingerprint
-        );
-        println!(
-            "equivalence_native_fingerprint: {}",
-            equivalence.native_fingerprint
-        );
-    }
+    let equivalence = proof.claim.equivalence.as_ref().ok_or_else(|| {
+        VmError::InvalidConfig("verified claim is missing equivalence metadata".to_string())
+    })?;
+    println!("equivalence_checked_steps: {}", equivalence.checked_steps);
+    println!(
+        "equivalence_transformer_fingerprint: {}",
+        equivalence.transformer_fingerprint
+    );
+    println!(
+        "equivalence_native_fingerprint: {}",
+        equivalence.native_fingerprint
+    );
     println!("instructions: {}", proof.claim.program.instructions().len());
     println!("proof_bytes: {}", proof.proof.len());
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -371,6 +371,17 @@ fn prove_stark_command(
     println!("carry_flag: {}", proof.claim.final_state.carry_flag);
     println!("memory: {:?}", proof.claim.final_state.memory);
     println!("attention_mode: {}", proof.claim.attention_mode);
+    if let Some(equivalence) = &proof.claim.equivalence {
+        println!("equivalence_checked_steps: {}", equivalence.checked_steps);
+        println!(
+            "equivalence_transformer_fingerprint: {}",
+            equivalence.transformer_fingerprint
+        );
+        println!(
+            "equivalence_native_fingerprint: {}",
+            equivalence.native_fingerprint
+        );
+    }
     println!("proof_bytes: {}", proof.proof.len());
 
     Ok(())
@@ -396,6 +407,17 @@ fn verify_stark_command(proof_path: &Path) -> llm_provable_computer::Result<()> 
     println!("carry_flag: {}", proof.claim.final_state.carry_flag);
     println!("memory: {:?}", proof.claim.final_state.memory);
     println!("attention_mode: {}", proof.claim.attention_mode);
+    if let Some(equivalence) = &proof.claim.equivalence {
+        println!("equivalence_checked_steps: {}", equivalence.checked_steps);
+        println!(
+            "equivalence_transformer_fingerprint: {}",
+            equivalence.transformer_fingerprint
+        );
+        println!(
+            "equivalence_native_fingerprint: {}",
+            equivalence.native_fingerprint
+        );
+    }
     println!("instructions: {}", proof.claim.program.instructions().len());
     println!("proof_bytes: {}", proof.proof.len());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,8 @@ pub use onnx_export::{
 pub use onnx_runtime::OnnxExecutionRuntime;
 pub use proof::{
     load_execution_stark_proof, prove_execution_stark, prove_execution_stark_with_options,
-    save_execution_stark_proof, verify_execution_stark, VanillaStarkExecutionClaim,
-    VanillaStarkExecutionProof, VanillaStarkProofOptions,
+    save_execution_stark_proof, verify_execution_stark, ExecutionEquivalenceMetadata,
+    VanillaStarkExecutionClaim, VanillaStarkExecutionProof, VanillaStarkProofOptions,
 };
 pub use runtime::ExecutionRuntime;
 pub use state::{decode_state, encode_state, MachineState, MIN_D_MODEL};

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,15 +1,18 @@
 use std::fs;
 use std::path::Path;
 
+use blake2::{Blake2b512, Digest};
 use serde::{Deserialize, Serialize};
 
 use crate::config::Attention2DMode;
+use crate::engine::ExecutionResult;
 use crate::error::{Result, VmError};
 use crate::instruction::{Instruction, Program};
 use crate::interpreter::NativeInterpreter;
 use crate::model::TransformerVm;
 use crate::state::MachineState;
 use crate::vanillastark::{FieldElement, MPolynomial, Stark};
+use crate::verification::verify_model_against_native;
 
 const PC: usize = 0;
 const ACC: usize = 1;
@@ -43,12 +46,21 @@ pub struct VanillaStarkExecutionClaim {
     pub steps: usize,
     pub final_state: MachineState,
     pub options: VanillaStarkProofOptions,
+    #[serde(default)]
+    pub equivalence: Option<ExecutionEquivalenceMetadata>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VanillaStarkExecutionProof {
     pub claim: VanillaStarkExecutionClaim,
     pub proof: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionEquivalenceMetadata {
+    pub checked_steps: usize,
+    pub transformer_fingerprint: String,
+    pub native_fingerprint: String,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -499,6 +511,20 @@ pub fn prove_execution_stark_with_options(
     options: VanillaStarkProofOptions,
 ) -> Result<VanillaStarkExecutionProof> {
     validate_proof_inputs(model.program(), &model.config().attention_mode)?;
+    let comparison = verify_model_against_native(model.clone(), max_steps)?;
+    let equivalence = ExecutionEquivalenceMetadata {
+        checked_steps: comparison.checked_steps,
+        transformer_fingerprint: execution_fingerprint_from_result(
+            "transformer",
+            comparison.checked_steps,
+            &comparison.transformer,
+        ),
+        native_fingerprint: execution_fingerprint_from_result(
+            "native",
+            comparison.checked_steps,
+            &comparison.native,
+        ),
+    };
 
     let mut interpreter = NativeInterpreter::new(
         model.program().clone(),
@@ -526,6 +552,7 @@ pub fn prove_execution_stark_with_options(
         steps: result.steps,
         final_state: result.final_state.clone(),
         options: options.clone(),
+        equivalence: Some(equivalence),
     };
     let stark = Stark::new(
         options.expansion_factor,
@@ -547,6 +574,7 @@ pub fn prove_execution_stark_with_options(
 pub fn verify_execution_stark(proof: &VanillaStarkExecutionProof) -> Result<bool> {
     validate_proof_inputs(&proof.claim.program, &proof.claim.attention_mode)?;
     validate_public_state(&proof.claim.program, &proof.claim.final_state)?;
+    validate_equivalence_metadata(&proof.claim)?;
 
     if !proof.claim.final_state.halted {
         return Err(VmError::UnsupportedProof(
@@ -640,6 +668,47 @@ fn validate_public_state(program: &Program, final_state: &MachineState) -> Resul
     Ok(())
 }
 
+fn validate_equivalence_metadata(claim: &VanillaStarkExecutionClaim) -> Result<()> {
+    let Some(metadata) = &claim.equivalence else {
+        return Ok(());
+    };
+
+    if metadata.checked_steps != claim.steps {
+        return Err(VmError::InvalidConfig(format!(
+            "equivalence checked_steps {} does not match claim steps {}",
+            metadata.checked_steps, claim.steps
+        )));
+    }
+
+    let expected_transformer = execution_fingerprint(
+        "transformer",
+        metadata.checked_steps,
+        claim.steps,
+        claim.final_state.halted,
+        &claim.final_state,
+    );
+    if metadata.transformer_fingerprint != expected_transformer {
+        return Err(VmError::InvalidConfig(
+            "invalid transformer equivalence fingerprint".to_string(),
+        ));
+    }
+
+    let expected_native = execution_fingerprint(
+        "native",
+        metadata.checked_steps,
+        claim.steps,
+        claim.final_state.halted,
+        &claim.final_state,
+    );
+    if metadata.native_fingerprint != expected_native {
+        return Err(VmError::InvalidConfig(
+            "invalid native equivalence fingerprint".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
 fn execution_trace_rows(layout: &ColumnLayout, trace: &[MachineState]) -> Vec<Vec<FieldElement>> {
     trace
         .iter()
@@ -722,6 +791,53 @@ fn inverse_or_zero(value: FieldElement) -> FieldElement {
     } else {
         value.inverse()
     }
+}
+
+fn execution_fingerprint_from_result(
+    engine: &str,
+    checked_steps: usize,
+    result: &ExecutionResult,
+) -> String {
+    execution_fingerprint(
+        engine,
+        checked_steps,
+        result.steps,
+        result.halted,
+        &result.final_state,
+    )
+}
+
+fn execution_fingerprint(
+    engine: &str,
+    checked_steps: usize,
+    steps: usize,
+    halted: bool,
+    final_state: &MachineState,
+) -> String {
+    #[derive(Serialize)]
+    struct FingerprintPayload<'a> {
+        engine: &'a str,
+        checked_steps: usize,
+        steps: usize,
+        halted: bool,
+        final_state: &'a MachineState,
+    }
+
+    let payload = FingerprintPayload {
+        engine,
+        checked_steps,
+        steps,
+        halted,
+        final_state,
+    };
+    let encoded = serde_json::to_vec(&payload).expect("fingerprint payload serialization");
+    let digest = Blake2b512::digest(encoded);
+    digest
+        .as_slice()
+        .iter()
+        .take(8)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
 }
 
 trait IsZeroExt {
@@ -833,5 +949,32 @@ HALT
 
         assert_eq!(loaded, proof);
         assert!(verify_execution_stark(&loaded).expect("verify"));
+    }
+
+    #[test]
+    fn proof_claim_includes_equivalence_metadata() {
+        let proof = prove_program("programs/addition.tvm", 32);
+        let metadata = proof.claim.equivalence.expect("equivalence metadata");
+        assert_eq!(metadata.checked_steps, proof.claim.steps);
+        assert_eq!(
+            metadata.transformer_fingerprint,
+            execution_fingerprint(
+                "transformer",
+                metadata.checked_steps,
+                proof.claim.steps,
+                proof.claim.final_state.halted,
+                &proof.claim.final_state,
+            )
+        );
+        assert_eq!(
+            metadata.native_fingerprint,
+            execution_fingerprint(
+                "native",
+                metadata.checked_steps,
+                proof.claim.steps,
+                proof.claim.final_state.halted,
+                &proof.claim.final_state,
+            )
+        );
     }
 }

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -670,7 +670,9 @@ fn validate_public_state(program: &Program, final_state: &MachineState) -> Resul
 
 fn validate_equivalence_metadata(claim: &VanillaStarkExecutionClaim) -> Result<()> {
     let Some(metadata) = &claim.equivalence else {
-        return Ok(());
+        return Err(VmError::InvalidConfig(
+            "missing equivalence metadata in STARK claim".to_string(),
+        ));
     };
 
     if metadata.checked_steps != claim.steps {
@@ -975,6 +977,19 @@ HALT
                 proof.claim.final_state.halted,
                 &proof.claim.final_state,
             )
+        );
+    }
+
+    #[test]
+    fn verify_rejects_claim_without_equivalence_metadata() {
+        let mut proof = prove_program("programs/addition.tvm", 32);
+        proof.claim.equivalence = None;
+        let err = verify_execution_stark(&proof).unwrap_err();
+        assert!(matches!(err, VmError::InvalidConfig(_)));
+        assert!(
+            err.to_string()
+                .contains("missing equivalence metadata in STARK claim"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -157,6 +157,7 @@ fn cli_can_prove_and_verify_stark_execution() {
         .arg(&proof_path)
         .assert()
         .success()
+        .stdout(predicate::str::contains("equivalence_checked_steps:"))
         .stdout(predicate::str::contains("proof_bytes:"))
         .stdout(predicate::str::contains("acc: 8"));
 
@@ -168,6 +169,7 @@ fn cli_can_prove_and_verify_stark_execution() {
         .arg(&proof_path)
         .assert()
         .success()
+        .stdout(predicate::str::contains("equivalence_checked_steps:"))
         .stdout(predicate::str::contains("verified_stark: true"))
         .stdout(predicate::str::contains("acc: 8"))
         .stdout(predicate::str::contains("instructions: 3"));


### PR DESCRIPTION
## Summary
- make `prove-stark` enforce transformer/native lockstep equivalence before proving
- fail early on mismatches instead of producing a proof with unstated assumptions
- align generated claims with the stricter precondition

## Why
This tightens the proven statement by ensuring the proof path only runs after runtime-equivalence checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proof claims now include execution equivalence metadata (checked steps and transformer/native fingerprints).
  * CLI outputs show equivalence fields during proving and verification.

* **Documentation**
  * README and playbook updated to document equivalence metadata and review/playbook guidance.
  * CLAUDE.md updated to describe lockstep equivalence metadata.

* **Tests**
  * CLI tests updated to assert presence of equivalence output.

* **Chores**
  * Added automated code-review configuration and repository review rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->