### PR TITLE
Add Phase 3 S-two framework components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ llm-provable-computer is an implemented Rust workspace for a deterministic trans
   - accepted subset: `NOP`, `LOADI`, `LOAD`, `STORE`, `ADD`, `ADDM`, `SUBM`, `MULM`, `JMP`, `JZ`, `HALT`
   - accepted fixture matrix: `addition`, `multiply`, `counter`, `dot_product`
   - official dependency seam: `stwo = 2.2.0`, `stwo-constraint-framework = 2.2.0`
-  - current behavior: subset-aware validation, dedicated adapter/layout modules, and explicit placeholder failure; no real S-two prover or verifier yet
+  - current behavior: subset-aware validation, dedicated adapter/layout modules, explicit placeholder failure in CLI proving/verification, plus real `stwo-constraint-framework` component builders for a narrow arithmetic pilot and a bounded lookup-backed binary-step activation pilot
 - Current proof is transparent, not zero-knowledge.
 - Current public claim fields include:
   - statement metadata: `statement_version`, `semantic_scope`

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Verifier checks enforce both fields exactly, so claim wording cannot drift from 
 Proof claims also include transformer config, equivalence metadata (`equivalence_checked_steps`, transformer fingerprint, native fingerprint), and artifact commitments (program hash, config hash, deterministic-model hash, STARK-options hash, prover-build info/hash) in CLI output.
 Verifier policy checks are available via `--min-conjectured-security`; `--strict` enforces an 80-bit floor and turns on re-execution checks.
 
-The `stwo` path is now an explicit experimental seam behind `--features stwo-backend`. In the current Phase 2 state it wires the official StarkWare crates (`stwo` and `stwo-constraint-framework` at `2.2.0`), performs backend-specific shape validation, and routes through a dedicated backend module layout before failing cleanly. That gives the repo a real S-two integration boundary without overstating that a prover exists yet.
+The `stwo` path is now an explicit experimental seam behind `--features stwo-backend`. In the current Phase 2/3 state it wires the official StarkWare crates (`stwo` and `stwo-constraint-framework` at `2.2.0`), performs backend-specific shape validation, routes through a dedicated backend module layout, and exposes real `FrameworkComponent` builders for a narrow arithmetic row pilot plus a bounded lookup-backed binary-step activation pilot before failing cleanly in the actual `prove-stark` / `verify-stark` path. That gives the repo a real S-two integration boundary without overstating that a prover exists yet.
 
 The canonical machine-readable statement contract is checked into `spec/statement-v1.json`.
 CI enforces sync between this file and verifier constants via:
@@ -548,7 +548,7 @@ Intentionally narrow. Intentionally correct.
 
 **Not implemented:** GPU acceleration. Learned/trained weights. Zero-knowledge proofs. WASM frontend. A real S-two/STWO prover or verifier backend. Full-ISA STARK AIR for bitwise and compare instructions.
 
-**Experimental seam only:** `--features stwo-backend` enables a Phase 2 backend boundary that wires the official `stwo` and `stwo-constraint-framework` crates, accepts only the minimum arithmetic subset (`NOP`, `LOADI`, `LOAD`, `STORE`, `ADD`, `ADDM`, `SUBM`, `MULM`, `JMP`, `JZ`, `HALT`) over the fixture matrix (`addition`, `multiply`, `counter`, `dot_product`), and preserves `statement-v1` claim semantics while keeping proof bytes opaque. It is a migration seam, not a working S-two prover.
+**Experimental seam only:** `--features stwo-backend` enables a Phase 2 backend boundary that wires the official `stwo` and `stwo-constraint-framework` crates, accepts only the minimum arithmetic subset (`NOP`, `LOADI`, `LOAD`, `STORE`, `ADD`, `ADDM`, `SUBM`, `MULM`, `JMP`, `JZ`, `HALT`) over the fixture matrix (`addition`, `multiply`, `counter`, `dot_product`), and preserves `statement-v1` claim semantics while keeping proof bytes opaque. Phase 3 extends that seam with real `stwo-constraint-framework` component construction for a `LOADI`/immediate-`ADD`/`HALT` arithmetic pilot and a bounded lookup-backed binary-step activation pilot. It is still a migration seam, not a working S-two prover.
 
 The narrowness is the point. The semantics are small enough to inspect, the test suite is strong enough to trust, and the structure is clean enough to prove over.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,5 +69,11 @@ pub use stwo_backend::{
     STWO_BACKEND_FEATURE_NAME, STWO_BACKEND_VERSION_PHASE2,
     STWO_CONSTRAINT_FRAMEWORK_VERSION_PHASE2, STWO_CRATE_VERSION_PHASE2,
 };
+#[cfg(feature = "stwo-backend")]
+pub use stwo_backend::{
+    phase3_arithmetic_component_metadata, phase3_arithmetic_preprocessed_columns,
+    phase3_binary_step_lookup_component_metadata, phase3_lookup_preprocessed_columns,
+    Phase3ArithmeticComponentMetadata, Phase3LookupComponentMetadata, Phase3TreeSubspan,
+};
 pub use tui::run_execution_tui;
 pub use verification::{verify_engines, verify_model_against_native, ExecutionComparison};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,8 @@ pub use stwo_backend::{
 pub use stwo_backend::{
     phase3_arithmetic_component_metadata, phase3_arithmetic_preprocessed_columns,
     phase3_binary_step_lookup_component_metadata, phase3_lookup_preprocessed_columns,
-    Phase3ArithmeticComponentMetadata, Phase3LookupComponentMetadata, Phase3TreeSubspan,
+    phase3_lookup_table_rows, Phase3ArithmeticComponentMetadata, Phase3LookupComponentMetadata,
+    Phase3LookupTableRow, Phase3TreeSubspan,
 };
 pub use tui::run_execution_tui;
 pub use verification::{verify_engines, verify_model_against_native, ExecutionComparison};

--- a/src/stwo_backend/arithmetic_component.rs
+++ b/src/stwo_backend/arithmetic_component.rs
@@ -33,6 +33,7 @@ const PHASE3_SELECTOR_LOADI: &str = "phase3/arith/selector_loadi";
 const PHASE3_SELECTOR_ADDI: &str = "phase3/arith/selector_addi";
 const PHASE3_SELECTOR_HALT: &str = "phase3/arith/selector_halt";
 const PHASE3_IMMEDIATE: &str = "phase3/arith/immediate";
+const PHASE3_PC_PLUS_ONE_WRAPPED: &str = "phase3/arith/pc_plus_one_wrapped";
 
 #[derive(Debug, Clone, Copy)]
 struct Phase3ArithmeticEval {
@@ -60,6 +61,8 @@ impl FrameworkEval for Phase3ArithmeticEval {
         let is_addi = eval.get_preprocessed_column(column_id(PHASE3_SELECTOR_ADDI));
         let is_halt = eval.get_preprocessed_column(column_id(PHASE3_SELECTOR_HALT));
         let immediate = eval.get_preprocessed_column(column_id(PHASE3_IMMEDIATE));
+        let pc_plus_one_wrapped =
+            eval.get_preprocessed_column(column_id(PHASE3_PC_PLUS_ONE_WRAPPED));
 
         let one = E::F::from(BaseField::from(1u32));
 
@@ -72,7 +75,7 @@ impl FrameworkEval for Phase3ArithmeticEval {
         eval.add_constraint(next_halted.clone() * (next_halted.clone() - one.clone()));
 
         let expected_next_pc = is_halt.clone() * pc.clone()
-            + (is_loadi.clone() + is_addi.clone()) * (pc.clone() + one.clone());
+            + (is_loadi.clone() + is_addi.clone()) * pc_plus_one_wrapped;
         let expected_next_acc = is_loadi.clone() * immediate.clone()
             + is_addi.clone() * (acc.clone() + immediate)
             + is_halt.clone() * acc;
@@ -117,6 +120,7 @@ pub fn phase3_arithmetic_preprocessed_columns() -> Vec<PreProcessedColumnId> {
         PHASE3_SELECTOR_ADDI,
         PHASE3_SELECTOR_HALT,
         PHASE3_IMMEDIATE,
+        PHASE3_PC_PLUS_ONE_WRAPPED,
     ]
     .into_iter()
     .map(column_id)
@@ -155,6 +159,7 @@ mod tests {
                 PHASE3_SELECTOR_ADDI.to_string(),
                 PHASE3_SELECTOR_HALT.to_string(),
                 PHASE3_IMMEDIATE.to_string(),
+                PHASE3_PC_PLUS_ONE_WRAPPED.to_string(),
             ]
         );
         assert!(metadata.statement_contract.contains("statement-v1"));
@@ -170,7 +175,7 @@ mod tests {
         assert_eq!(metadata.trace_locations.len(), 2);
         assert_eq!(metadata.trace_locations[0].tree_index, 0);
         assert_eq!(metadata.trace_locations[1].tree_index, 1);
-        assert_eq!(metadata.trace_log_degree_bounds[0].len(), 4);
+        assert_eq!(metadata.trace_log_degree_bounds[0].len(), 5);
         assert_eq!(metadata.trace_log_degree_bounds[1].len(), 6);
     }
 }

--- a/src/stwo_backend/arithmetic_component.rs
+++ b/src/stwo_backend/arithmetic_component.rs
@@ -1,0 +1,176 @@
+use ark_ff::Zero;
+use stwo::core::air::Component;
+use stwo::core::fields::m31::BaseField;
+use stwo::core::fields::qm31::SecureField;
+use stwo::core::pcs::TreeSubspan;
+use stwo_constraint_framework::preprocessed_columns::PreProcessedColumnId;
+use stwo_constraint_framework::{
+    EvalAtRow, FrameworkComponent, FrameworkEval, TraceLocationAllocator,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Phase3TreeSubspan {
+    pub tree_index: usize,
+    pub col_start: usize,
+    pub col_end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Phase3ArithmeticComponentMetadata {
+    pub log_size: u32,
+    pub max_constraint_log_degree_bound: u32,
+    pub n_constraints: usize,
+    pub trace_locations: Vec<Phase3TreeSubspan>,
+    pub trace_log_degree_bounds: Vec<Vec<u32>>,
+    pub preprocessed_columns: Vec<String>,
+    pub preprocessed_column_indices: Vec<usize>,
+    pub statement_contract: &'static str,
+    pub covered_instructions: &'static str,
+}
+
+const PHASE3_ARITHMETIC_COVERED_INSTRUCTIONS: &str = "LOADI, ADD-immediate, HALT";
+const PHASE3_SELECTOR_LOADI: &str = "phase3/arith/selector_loadi";
+const PHASE3_SELECTOR_ADDI: &str = "phase3/arith/selector_addi";
+const PHASE3_SELECTOR_HALT: &str = "phase3/arith/selector_halt";
+const PHASE3_IMMEDIATE: &str = "phase3/arith/immediate";
+
+#[derive(Debug, Clone, Copy)]
+struct Phase3ArithmeticEval {
+    log_size: u32,
+}
+
+impl FrameworkEval for Phase3ArithmeticEval {
+    fn log_size(&self) -> u32 {
+        self.log_size
+    }
+
+    fn max_constraint_log_degree_bound(&self) -> u32 {
+        self.log_size.saturating_add(1)
+    }
+
+    fn evaluate<E: EvalAtRow>(&self, mut eval: E) -> E {
+        let pc = eval.next_trace_mask();
+        let acc = eval.next_trace_mask();
+        let next_pc = eval.next_trace_mask();
+        let next_acc = eval.next_trace_mask();
+        let halted = eval.next_trace_mask();
+        let next_halted = eval.next_trace_mask();
+
+        let is_loadi = eval.get_preprocessed_column(column_id(PHASE3_SELECTOR_LOADI));
+        let is_addi = eval.get_preprocessed_column(column_id(PHASE3_SELECTOR_ADDI));
+        let is_halt = eval.get_preprocessed_column(column_id(PHASE3_SELECTOR_HALT));
+        let immediate = eval.get_preprocessed_column(column_id(PHASE3_IMMEDIATE));
+
+        let one = E::F::from(BaseField::from(1u32));
+
+        for selector in [is_loadi.clone(), is_addi.clone(), is_halt.clone()] {
+            eval.add_constraint(selector.clone() * (selector - one.clone()));
+        }
+
+        eval.add_constraint(is_loadi.clone() + is_addi.clone() + is_halt.clone() - one.clone());
+        eval.add_constraint(halted.clone() * (halted.clone() - one.clone()));
+        eval.add_constraint(next_halted.clone() * (next_halted.clone() - one.clone()));
+
+        let expected_next_pc = is_halt.clone() * pc.clone()
+            + (is_loadi.clone() + is_addi.clone()) * (pc.clone() + one.clone());
+        let expected_next_acc = is_loadi.clone() * immediate.clone()
+            + is_addi.clone() * (acc.clone() + immediate)
+            + is_halt.clone() * acc;
+
+        eval.add_constraint(next_pc - expected_next_pc);
+        eval.add_constraint(next_acc - expected_next_acc);
+        eval.add_constraint(next_halted - is_halt);
+        eval
+    }
+}
+
+pub fn phase3_arithmetic_component_metadata(log_size: u32) -> Phase3ArithmeticComponentMetadata {
+    let mut allocator = TraceLocationAllocator::new_with_preprocessed_columns(
+        &phase3_arithmetic_preprocessed_columns(),
+    );
+    let component = FrameworkComponent::new(
+        &mut allocator,
+        Phase3ArithmeticEval { log_size },
+        SecureField::zero(),
+    );
+
+    Phase3ArithmeticComponentMetadata {
+        log_size,
+        max_constraint_log_degree_bound: component.max_constraint_log_degree_bound(),
+        n_constraints: component.n_constraints(),
+        trace_locations: summarize_trace_locations(component.trace_locations()),
+        trace_log_degree_bounds: component.trace_log_degree_bounds().0,
+        preprocessed_columns: allocator
+            .preprocessed_columns()
+            .iter()
+            .map(|column| column.id.clone())
+            .collect(),
+        preprocessed_column_indices: component.preprocessed_column_indices().to_vec(),
+        statement_contract: "statement-v1 preserved; backend-specific internals only",
+        covered_instructions: PHASE3_ARITHMETIC_COVERED_INSTRUCTIONS,
+    }
+}
+
+pub fn phase3_arithmetic_preprocessed_columns() -> Vec<PreProcessedColumnId> {
+    [
+        PHASE3_SELECTOR_LOADI,
+        PHASE3_SELECTOR_ADDI,
+        PHASE3_SELECTOR_HALT,
+        PHASE3_IMMEDIATE,
+    ]
+    .into_iter()
+    .map(column_id)
+    .collect()
+}
+
+fn column_id(id: &str) -> PreProcessedColumnId {
+    PreProcessedColumnId { id: id.to_string() }
+}
+
+fn summarize_trace_locations(spans: &[TreeSubspan]) -> Vec<Phase3TreeSubspan> {
+    spans
+        .iter()
+        .map(|span| Phase3TreeSubspan {
+            tree_index: span.tree_index,
+            col_start: span.col_start,
+            col_end: span.col_end,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase3_arithmetic_component_builds_real_framework_component() {
+        let metadata = phase3_arithmetic_component_metadata(4);
+        assert_eq!(metadata.log_size, 4);
+        assert!(metadata.n_constraints >= 8);
+        assert!(!metadata.trace_locations.is_empty());
+        assert_eq!(
+            metadata.preprocessed_columns,
+            vec![
+                PHASE3_SELECTOR_LOADI.to_string(),
+                PHASE3_SELECTOR_ADDI.to_string(),
+                PHASE3_SELECTOR_HALT.to_string(),
+                PHASE3_IMMEDIATE.to_string(),
+            ]
+        );
+        assert!(metadata.statement_contract.contains("statement-v1"));
+        assert_eq!(
+            metadata.covered_instructions,
+            PHASE3_ARITHMETIC_COVERED_INSTRUCTIONS
+        );
+    }
+
+    #[test]
+    fn phase3_arithmetic_component_uses_preprocessed_and_original_trace_spans() {
+        let metadata = phase3_arithmetic_component_metadata(3);
+        assert_eq!(metadata.trace_locations.len(), 2);
+        assert_eq!(metadata.trace_locations[0].tree_index, 0);
+        assert_eq!(metadata.trace_locations[1].tree_index, 1);
+        assert_eq!(metadata.trace_log_degree_bounds[0].len(), 4);
+        assert_eq!(metadata.trace_log_degree_bounds[1].len(), 6);
+    }
+}

--- a/src/stwo_backend/arithmetic_component.rs
+++ b/src/stwo_backend/arithmetic_component.rs
@@ -80,9 +80,12 @@ impl FrameworkEval for Phase3ArithmeticEval {
             + is_addi.clone() * (acc.clone() + immediate)
             + is_halt.clone() * acc;
 
+        let expected_next_halted =
+            halted.clone() + (one.clone() - halted.clone()) * is_halt;
+
         eval.add_constraint(next_pc - expected_next_pc);
         eval.add_constraint(next_acc - expected_next_acc);
-        eval.add_constraint(next_halted - is_halt);
+        eval.add_constraint(next_halted - expected_next_halted);
         eval
     }
 }

--- a/src/stwo_backend/lookup_component.rs
+++ b/src/stwo_backend/lookup_component.rs
@@ -1,0 +1,140 @@
+use ark_ff::{One, Zero};
+use stwo::core::air::Component;
+use stwo::core::fields::m31::BaseField;
+use stwo::core::fields::qm31::SecureField;
+use stwo_constraint_framework::preprocessed_columns::PreProcessedColumnId;
+use stwo_constraint_framework::{
+    relation, EvalAtRow, FrameworkComponent, FrameworkEval, RelationEntry, TraceLocationAllocator,
+};
+
+relation!(Phase3BinaryStepLookupRelation, 2);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Phase3LookupComponentMetadata {
+    pub log_size: u32,
+    pub max_constraint_log_degree_bound: u32,
+    pub n_constraints: usize,
+    pub preprocessed_columns: Vec<String>,
+    pub preprocessed_column_indices: Vec<usize>,
+    pub logup_relations_per_row: Vec<(String, usize)>,
+    pub activation_semantics: &'static str,
+    pub statement_contract: &'static str,
+}
+
+const PHASE3_LOOKUP_TABLE_INPUT: &str = "phase3/lookup/table_input";
+const PHASE3_LOOKUP_TABLE_OUTPUT: &str = "phase3/lookup/table_output";
+const PHASE3_LOOKUP_SEMANTICS: &str = "bounded binary-step activation lookup pilot";
+
+#[derive(Debug, Clone, Copy)]
+struct Phase3BinaryStepLookupEval {
+    log_size: u32,
+}
+
+impl FrameworkEval for Phase3BinaryStepLookupEval {
+    fn log_size(&self) -> u32 {
+        self.log_size
+    }
+
+    fn max_constraint_log_degree_bound(&self) -> u32 {
+        self.log_size.saturating_add(1)
+    }
+
+    fn evaluate<E: EvalAtRow>(&self, mut eval: E) -> E {
+        let activation_input = eval.next_trace_mask();
+        let activation_output = eval.next_trace_mask();
+        let table_input = eval.get_preprocessed_column(column_id(PHASE3_LOOKUP_TABLE_INPUT));
+        let table_output = eval.get_preprocessed_column(column_id(PHASE3_LOOKUP_TABLE_OUTPUT));
+        let one = E::F::from(BaseField::from(1u32));
+
+        eval.add_constraint(activation_output.clone() * (activation_output.clone() - one));
+
+        let relation = Phase3BinaryStepLookupRelation::dummy();
+        eval.add_to_relation(RelationEntry::new(
+            &relation,
+            E::EF::one(),
+            &[activation_input, activation_output],
+        ));
+        eval.add_to_relation(RelationEntry::new(
+            &relation,
+            -E::EF::one(),
+            &[table_input, table_output],
+        ));
+        eval.finalize_logup();
+        eval
+    }
+}
+
+pub fn phase3_binary_step_lookup_component_metadata(
+    log_size: u32,
+) -> Phase3LookupComponentMetadata {
+    let mut allocator = TraceLocationAllocator::new_with_preprocessed_columns(
+        &phase3_lookup_preprocessed_columns(),
+    );
+    let component = FrameworkComponent::new(
+        &mut allocator,
+        Phase3BinaryStepLookupEval { log_size },
+        SecureField::zero(),
+    );
+    let mut logup_relations_per_row: Vec<_> = component
+        .logup_counts()
+        .iter()
+        .map(|(name, count)| (name.clone(), *count >> log_size))
+        .collect();
+    logup_relations_per_row.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+
+    Phase3LookupComponentMetadata {
+        log_size,
+        max_constraint_log_degree_bound: component.max_constraint_log_degree_bound(),
+        n_constraints: component.n_constraints(),
+        preprocessed_columns: allocator
+            .preprocessed_columns()
+            .iter()
+            .map(|column| column.id.clone())
+            .collect(),
+        preprocessed_column_indices: component.preprocessed_column_indices().to_vec(),
+        logup_relations_per_row,
+        activation_semantics: PHASE3_LOOKUP_SEMANTICS,
+        statement_contract: "statement-v1 preserved; lookup primitive remains internal",
+    }
+}
+
+pub fn phase3_lookup_preprocessed_columns() -> Vec<PreProcessedColumnId> {
+    [PHASE3_LOOKUP_TABLE_INPUT, PHASE3_LOOKUP_TABLE_OUTPUT]
+        .into_iter()
+        .map(column_id)
+        .collect()
+}
+
+fn column_id(id: &str) -> PreProcessedColumnId {
+    PreProcessedColumnId { id: id.to_string() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase3_lookup_component_exposes_logup_relation() {
+        let metadata = phase3_binary_step_lookup_component_metadata(4);
+        assert_eq!(metadata.n_constraints, 3);
+        assert_eq!(
+            metadata.preprocessed_columns,
+            vec![
+                PHASE3_LOOKUP_TABLE_INPUT.to_string(),
+                PHASE3_LOOKUP_TABLE_OUTPUT.to_string(),
+            ]
+        );
+        assert_eq!(
+            metadata.logup_relations_per_row,
+            vec![("Phase3BinaryStepLookupRelation".to_string(), 2)]
+        );
+        assert!(metadata.statement_contract.contains("statement-v1"));
+    }
+
+    #[test]
+    fn phase3_lookup_component_is_explicitly_bounded() {
+        let metadata = phase3_binary_step_lookup_component_metadata(3);
+        assert_eq!(metadata.activation_semantics, PHASE3_LOOKUP_SEMANTICS);
+        assert_eq!(metadata.preprocessed_column_indices, vec![0, 1]);
+    }
+}

--- a/src/stwo_backend/lookup_component.rs
+++ b/src/stwo_backend/lookup_component.rs
@@ -16,9 +16,16 @@ pub struct Phase3LookupComponentMetadata {
     pub n_constraints: usize,
     pub preprocessed_columns: Vec<String>,
     pub preprocessed_column_indices: Vec<usize>,
+    pub lookup_table_rows: Vec<Phase3LookupTableRow>,
     pub logup_relations_per_row: Vec<(String, usize)>,
     pub activation_semantics: &'static str,
     pub statement_contract: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Phase3LookupTableRow {
+    pub input: i16,
+    pub output: u8,
 }
 
 const PHASE3_LOOKUP_TABLE_INPUT: &str = "phase3/lookup/table_input";
@@ -92,6 +99,7 @@ pub fn phase3_binary_step_lookup_component_metadata(
             .map(|column| column.id.clone())
             .collect(),
         preprocessed_column_indices: component.preprocessed_column_indices().to_vec(),
+        lookup_table_rows: phase3_lookup_table_rows(),
         logup_relations_per_row,
         activation_semantics: PHASE3_LOOKUP_SEMANTICS,
         statement_contract: "statement-v1 preserved; lookup primitive remains internal",
@@ -103,6 +111,23 @@ pub fn phase3_lookup_preprocessed_columns() -> Vec<PreProcessedColumnId> {
         .into_iter()
         .map(column_id)
         .collect()
+}
+
+pub fn phase3_lookup_table_rows() -> Vec<Phase3LookupTableRow> {
+    vec![
+        Phase3LookupTableRow {
+            input: -1,
+            output: 0,
+        },
+        Phase3LookupTableRow {
+            input: 0,
+            output: 1,
+        },
+        Phase3LookupTableRow {
+            input: 1,
+            output: 1,
+        },
+    ]
 }
 
 fn column_id(id: &str) -> PreProcessedColumnId {
@@ -128,6 +153,7 @@ mod tests {
             metadata.logup_relations_per_row,
             vec![("Phase3BinaryStepLookupRelation".to_string(), 2)]
         );
+        assert_eq!(metadata.lookup_table_rows, phase3_lookup_table_rows());
         assert!(metadata.statement_contract.contains("statement-v1"));
     }
 
@@ -136,5 +162,6 @@ mod tests {
         let metadata = phase3_binary_step_lookup_component_metadata(3);
         assert_eq!(metadata.activation_semantics, PHASE3_LOOKUP_SEMANTICS);
         assert_eq!(metadata.preprocessed_column_indices, vec![0, 1]);
+        assert_eq!(metadata.lookup_table_rows, phase3_lookup_table_rows());
     }
 }

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -25,7 +25,7 @@ pub use layout::{
 #[cfg(feature = "stwo-backend")]
 pub use lookup_component::{
     phase3_binary_step_lookup_component_metadata, phase3_lookup_preprocessed_columns,
-    Phase3LookupComponentMetadata,
+    phase3_lookup_table_rows, Phase3LookupComponentMetadata, Phase3LookupTableRow,
 };
 
 /// Backend version label used by the experimental Phase 2 S-two seam.

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -1,5 +1,9 @@
 mod adapter;
+#[cfg(feature = "stwo-backend")]
+mod arithmetic_component;
 mod layout;
+#[cfg(feature = "stwo-backend")]
+mod lookup_component;
 
 use crate::config::Attention2DMode;
 use crate::error::{Result, VmError};
@@ -9,9 +13,19 @@ pub use adapter::{
     phase2_dependency_seam, StwoDependencySeam, STWO_CONSTRAINT_FRAMEWORK_VERSION_PHASE2,
     STWO_CRATE_VERSION_PHASE2,
 };
+#[cfg(feature = "stwo-backend")]
+pub use arithmetic_component::{
+    phase3_arithmetic_component_metadata, phase3_arithmetic_preprocessed_columns,
+    Phase3ArithmeticComponentMetadata, Phase3TreeSubspan,
+};
 pub use layout::{
     phase2_fixture_matrix, phase2_module_layout, phase2_supported_mnemonics,
     StwoBackendModuleLayout,
+};
+#[cfg(feature = "stwo-backend")]
+pub use lookup_component::{
+    phase3_binary_step_lookup_component_metadata, phase3_lookup_preprocessed_columns,
+    Phase3LookupComponentMetadata,
 };
 
 /// Backend version label used by the experimental Phase 2 S-two seam.
@@ -48,7 +62,7 @@ pub fn phase2_placeholder_prove_error() -> VmError {
 
     let seam = phase2_dependency_seam();
     VmError::UnsupportedProof(format!(
-        "S-two backend Phase 2 adapter seam is present (official crates: {} {}, {} {}; modules: {}, {}), but proving is not implemented yet",
+        "S-two backend Phase 2 adapter seam is present (official crates: {} {}, {} {}; modules: {}, {}), but proving is not implemented yet; Phase 3 component builders now cover an arithmetic LOADI/ADD/HALT pilot and a bounded lookup-backed binary-step activation pilot",
         seam.stwo_crate,
         seam.stwo_crate_version,
         seam.constraint_framework_crate,
@@ -66,7 +80,7 @@ pub fn phase2_placeholder_verify_error() -> VmError {
 
     let seam = phase2_dependency_seam();
     VmError::UnsupportedProof(format!(
-        "S-two backend Phase 2 adapter seam is present (official crates: {} {}, {} {}; modules: {}, {}), but verification is not implemented yet",
+        "S-two backend Phase 2 adapter seam is present (official crates: {} {}, {} {}; modules: {}, {}), but verification is not implemented yet; Phase 3 component builders now cover an arithmetic LOADI/ADD/HALT pilot and a bounded lookup-backed binary-step activation pilot",
         seam.stwo_crate,
         seam.stwo_crate_version,
         seam.constraint_framework_crate,


### PR DESCRIPTION
## Summary
- add real `stwo-constraint-framework` component construction for a narrow arithmetic VM-row pilot
- add a bounded lookup-backed binary-step activation pilot as the first nonlinearity primitive on the S-two side
- keep `statement-v1` and the CLI prove/verify path unchanged and explicitly nonfunctional for S-two

## Validation
- cargo fmt --all
- cargo test --quiet --features stwo-backend phase3_
- cargo test --quiet --features stwo-backend stwo_backend::arithmetic_component::tests::phase3_arithmetic_component_builds_real_framework_component
- cargo test --quiet --features stwo-backend stwo_backend::lookup_component::tests::phase3_lookup_component_exposes_logup_relation
- cargo test --quiet --test cli --features stwo-backend cli_prove_stark_reports_phase2_placeholder_on_supported_subset
- cargo test --quiet --test cli --features stwo-backend cli_prove_stark_rejects_program_outside_stwo_phase2_subset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental stwo-backend now exposes Phase 3 component builders for two pilots: an arithmetic (LOADI/ADD/HALT) pilot and a bounded binary-step lookup activation pilot; Phase 3 metadata and preprocessed-column builders are available in the prove/verify flow.

* **Documentation**
  * README and docs updated to reflect Phase 2→Phase 3 scope expansion and describe these real component-builder additions.

* **Bug Fixes**
  * CLI messages clarified to indicate explicit placeholder failure only occurs in CLI proving/verification workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->