### PR TITLE
Bind decoding lookup state to embedded shared rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ matrix/rollup-style packaging layers described in the next-paper track.
   rows inside the same top-level execution proof
 - Phase 11: fixed-shape proof-carrying decoding over `decoding_step_v1`
 - Phase 12: parameterized `decoding_step_v2` family with richer carried state
+  and proof-bound shared-lookup rows
 - Phase 13: validated layout matrix for `decoding_step_v2`
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -202,7 +202,8 @@ Delivered:
   trace across chunked-history chains, segment bundles, rollups, and rollup matrices,
 - a Phase 20 lookup-frontier layer over that same stack, preserving a recent non-arithmetic
   window alongside the cumulative lookup transcript so later accumulation work has a cleaner
-  lookup boundary to consume.
+  lookup boundary to consume, and binding that lookup state back to the embedded shared
+  normalization / activation claims already carried inside each `decoding_step_v2` proof payload.
 
 Current limitation:
 

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -1001,6 +1001,145 @@ fn verify_phase10_embedded_shared_activation_lookup(
     Ok(())
 }
 
+pub(crate) fn phase12_shared_lookup_rows_from_proof_payload(
+    proof: &VanillaStarkExecutionProof,
+) -> Result<Option<Vec<i16>>> {
+    if !matches_decoding_step_v2(&proof.claim.program) {
+        return Ok(None);
+    }
+
+    let payload: serde_json::Value = serde_json::from_slice(&proof.proof)
+        .map_err(|error| VmError::Serialization(error.to_string()))?;
+    let normalization_value = payload
+        .get("embedded_shared_normalization")
+        .cloned()
+        .ok_or_else(|| {
+            VmError::InvalidConfig(
+                "decoding_step_v2 proof payload is missing embedded shared normalization rows"
+                    .to_string(),
+            )
+        })?;
+    let activation_value = payload
+        .get("embedded_shared_activation_lookup")
+        .cloned()
+        .ok_or_else(|| {
+            VmError::InvalidConfig(
+                "decoding_step_v2 proof payload is missing embedded shared activation rows"
+                    .to_string(),
+            )
+        })?;
+    let normalization: EmbeddedSharedNormalizationProof =
+        serde_json::from_value(normalization_value)
+            .map_err(|error| VmError::Serialization(error.to_string()))?;
+    let activation: EmbeddedSharedActivationLookupProof = serde_json::from_value(activation_value)
+        .map_err(|error| VmError::Serialization(error.to_string()))?;
+
+    let expected_norm_rows =
+        shared_normalization_claim_rows(&proof.claim.program, &proof.claim.final_state.memory)?;
+    if normalization.statement_version != STWO_SHARED_NORMALIZATION_STATEMENT_VERSION_PHASE10 {
+        return Err(VmError::InvalidConfig(format!(
+            "unsupported decoding_step_v2 shared normalization statement version `{}`",
+            normalization.statement_version
+        )));
+    }
+    if normalization.semantic_scope != DECODING_STEP_V2_SHARED_NORMALIZATION_SCOPE {
+        return Err(VmError::InvalidConfig(format!(
+            "unsupported decoding_step_v2 shared normalization scope `{}`",
+            normalization.semantic_scope
+        )));
+    }
+    if normalization.claimed_rows != expected_norm_rows {
+        return Err(VmError::InvalidConfig(
+            "decoding_step_v2 embedded shared normalization rows do not match the canonical final-state rows".to_string(),
+        ));
+    }
+    let normalization_envelope_rows = normalization
+        .proof_envelope
+        .get("claimed_rows")
+        .cloned()
+        .ok_or_else(|| {
+            VmError::InvalidConfig(
+                "decoding_step_v2 shared normalization proof envelope is missing claimed_rows"
+                    .to_string(),
+            )
+        })?;
+    let expected_norm_pairs: Vec<(u16, u16)> = expected_norm_rows
+        .iter()
+        .map(|row| (row.expected_norm_sq as u16, row.expected_inv_sqrt_q8 as u16))
+        .collect();
+    if normalization_envelope_rows
+        != serde_json::to_value(&expected_norm_pairs)
+            .map_err(|error| VmError::Serialization(error.to_string()))?
+    {
+        return Err(VmError::InvalidConfig(
+            "decoding_step_v2 shared normalization proof envelope rows do not match the canonical final-state rows".to_string(),
+        ));
+    }
+
+    let expected_activation_rows =
+        shared_activation_claim_rows(&proof.claim.program, &proof.claim.final_state.memory)?;
+    if activation.statement_version != STWO_SHARED_LOOKUP_STATEMENT_VERSION_PHASE10 {
+        return Err(VmError::InvalidConfig(format!(
+            "unsupported decoding_step_v2 shared activation statement version `{}`",
+            activation.statement_version
+        )));
+    }
+    if activation.semantic_scope != DECODING_STEP_V2_SHARED_ACTIVATION_SCOPE {
+        return Err(VmError::InvalidConfig(format!(
+            "unsupported decoding_step_v2 shared activation scope `{}`",
+            activation.semantic_scope
+        )));
+    }
+    if activation.claimed_rows != expected_activation_rows {
+        return Err(VmError::InvalidConfig(
+            "decoding_step_v2 embedded shared activation rows do not match the canonical final-state rows".to_string(),
+        ));
+    }
+    let activation_envelope_rows = activation
+        .proof_envelope
+        .get("claimed_rows")
+        .cloned()
+        .ok_or_else(|| {
+            VmError::InvalidConfig(
+                "decoding_step_v2 shared activation proof envelope is missing claimed_rows"
+                    .to_string(),
+            )
+        })?;
+    let expected_activation_pairs: Vec<Phase3LookupTableRow> = expected_activation_rows
+        .iter()
+        .map(|row| Phase3LookupTableRow {
+            input: row.expected_input,
+            output: row.expected_output as u8,
+        })
+        .collect();
+    if activation_envelope_rows
+        != serde_json::to_value(&expected_activation_pairs)
+            .map_err(|error| VmError::Serialization(error.to_string()))?
+    {
+        return Err(VmError::InvalidConfig(
+            "decoding_step_v2 shared activation proof envelope rows do not match the canonical final-state rows".to_string(),
+        ));
+    }
+    if expected_norm_rows.len() != expected_activation_rows.len() {
+        return Err(VmError::InvalidConfig(format!(
+            "decoding_step_v2 embedded shared lookup row counts disagree: normalization={}, activation={}",
+            expected_norm_rows.len(),
+            expected_activation_rows.len()
+        )));
+    }
+
+    let mut lookup_rows = Vec::with_capacity(expected_norm_rows.len() * 4);
+    for (normalization_row, activation_row) in
+        expected_norm_rows.iter().zip(expected_activation_rows.iter())
+    {
+        lookup_rows.push(normalization_row.expected_norm_sq);
+        lookup_rows.push(normalization_row.expected_inv_sqrt_q8);
+        lookup_rows.push(activation_row.expected_input);
+        lookup_rows.push(activation_row.expected_output);
+    }
+    Ok(Some(lookup_rows))
+}
+
 fn gemma_block_normalization_pair(final_memory: &[i16]) -> Result<(i16, i16)> {
     let norm_sq = *final_memory
         .get(GEMMA_BLOCK_NORM_SQ_MEMORY_INDEX)

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -14,7 +14,10 @@ use crate::proof::{
     production_v1_stark_options, prove_execution_stark_with_backend_and_options,
     verify_execution_stark, StarkProofBackend, VanillaStarkExecutionProof,
 };
-use crate::stwo_backend::STWO_BACKEND_VERSION_PHASE11;
+use crate::stwo_backend::{
+    arithmetic_subset_prover::phase12_shared_lookup_rows_from_proof_payload,
+    STWO_BACKEND_VERSION_PHASE11,
+};
 
 pub const STWO_DECODING_CHAIN_VERSION_PHASE11: &str = "stwo-phase11-decoding-chain-v1";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE11: &str = "stwo_execution_proof_carrying_decoding_chain";
@@ -807,7 +810,7 @@ pub fn phase12_prepare_decoding_chain(
             from_history_length,
         );
 
-        let to_view = derive_phase12_state_view(&proof.claim.final_state.memory, layout)?;
+        let to_view = derive_phase12_final_state_view_from_proof(&proof, layout)?;
         if to_view.layout_commitment != expected_layout_commitment {
             return Err(VmError::InvalidConfig(format!(
                 "decoding step {step_index} final state does not match the manifest layout commitment"
@@ -931,7 +934,7 @@ pub fn verify_phase12_decoding_chain(manifest: &Phase12DecodingChainManifest) ->
         let derived_from =
             derive_phase12_state_view(step.proof.claim.program.initial_memory(), &manifest.layout)?;
         let derived_to =
-            derive_phase12_state_view(&step.proof.claim.final_state.memory, &manifest.layout)?;
+            derive_phase12_final_state_view_from_proof(&step.proof, &manifest.layout)?;
         let (expected_history_commitment, expected_history_length) = if step_index == 0 {
             (
                 commit_phase12_history_seed(
@@ -1118,7 +1121,7 @@ pub fn phase14_prepare_decoding_chain(
         });
         let from_state = build_phase14_state(step_index, from_view, &current);
 
-        let to_view = derive_phase12_state_view(&step.proof.claim.final_state.memory, layout)?;
+        let to_view = derive_phase12_final_state_view_from_proof(&step.proof, layout)?;
         if to_view.layout_commitment != expected_layout_commitment {
             return Err(VmError::InvalidConfig(format!(
                 "Phase 14 decoding step {step_index} final state does not match the manifest layout commitment"
@@ -1254,7 +1257,8 @@ pub fn verify_phase14_decoding_chain(manifest: &Phase14DecodingChainManifest) ->
             )));
         }
 
-        let to_view = derive_phase12_state_view(&step.proof.claim.final_state.memory, &manifest.layout)?;
+        let to_view =
+            derive_phase12_final_state_view_from_proof(&step.proof, &manifest.layout)?;
         if to_view.layout_commitment != expected_layout_commitment {
             return Err(VmError::InvalidConfig(format!(
                 "chunked decoding step {step_index} final state does not match the manifest layout commitment"
@@ -2266,6 +2270,31 @@ fn derive_phase12_state_view(
     })
 }
 
+fn derive_phase12_final_state_view_from_proof(
+    proof: &VanillaStarkExecutionProof,
+    layout: &Phase12DecodingLayout,
+) -> Result<Phase12StateView> {
+    let mut view = derive_phase12_state_view(&proof.claim.final_state.memory, layout)?;
+    if let Some(proof_lookup_rows) = phase12_shared_lookup_rows_from_proof_payload(proof)? {
+        let lookup_range = layout.lookup_range()?;
+        if proof_lookup_rows.len() != lookup_range.len() {
+            return Err(VmError::InvalidConfig(format!(
+                "decoding_step_v2 proof payload exposes {} shared lookup values, but layout expects {}",
+                proof_lookup_rows.len(),
+                lookup_range.len()
+            )));
+        }
+        if &proof.claim.final_state.memory[lookup_range.clone()] != proof_lookup_rows.as_slice() {
+            return Err(VmError::InvalidConfig(
+                "decoding_step_v2 final-state lookup slice does not match the embedded shared lookup rows".to_string(),
+            ));
+        }
+        view.lookup_rows_commitment =
+            commit_phase12_named_slice("lookup-rows", &view.layout_commitment, &proof_lookup_rows);
+    }
+    Ok(view)
+}
+
 fn build_phase12_state(
     step_index: usize,
     view: Phase12StateView,
@@ -2961,7 +2990,7 @@ fn verify_phase15_segment_sequence(
 
         let mut expected_global_to = expected_global_from.clone();
         for (local_index, step) in segment.chain.steps.iter().enumerate() {
-            let to_view = derive_phase12_state_view(&step.proof.claim.final_state.memory, layout)?;
+            let to_view = derive_phase12_final_state_view_from_proof(&step.proof, layout)?;
             current = advance_phase14_history(
                 &expected_layout_commitment,
                 &current,
@@ -3649,6 +3678,7 @@ mod tests {
             NativeInterpreter::new(program.clone(), Attention2DMode::AverageHard, 256);
         let result = runtime.run().expect("run program");
         assert!(result.halted);
+        let final_memory = result.final_state.memory.clone();
         VanillaStarkExecutionProof {
             proof_backend: StarkProofBackend::Stwo,
             proof_backend_version: "stwo-phase12-decoding-family-v1".to_string(),
@@ -3666,8 +3696,69 @@ mod tests {
                 equivalence: None,
                 commitments: Some(sample_commitments()),
             },
-            proof: vec![4, 5, 6],
+            proof: sample_phase12_proof_payload(layout, &final_memory),
         }
+    }
+
+    fn sample_phase12_proof_payload(layout: &Phase12DecodingLayout, final_memory: &[i16]) -> Vec<u8> {
+        let lookup = layout.lookup_range().expect("lookup range");
+        serde_json::to_vec(&serde_json::json!({
+            "embedded_shared_normalization": {
+                "statement_version": "stwo-shared-normalization-lookup-v1",
+                "semantic_scope": "stwo_decoding_step_v2_execution_with_shared_normalization_lookup",
+                "claimed_rows": [
+                    {
+                        "norm_sq_memory_index": lookup.start,
+                        "inv_sqrt_q8_memory_index": lookup.start + 1,
+                        "expected_norm_sq": final_memory[lookup.start],
+                        "expected_inv_sqrt_q8": final_memory[lookup.start + 1]
+                    },
+                    {
+                        "norm_sq_memory_index": lookup.start + 4,
+                        "inv_sqrt_q8_memory_index": lookup.start + 5,
+                        "expected_norm_sq": final_memory[lookup.start + 4],
+                        "expected_inv_sqrt_q8": final_memory[lookup.start + 5]
+                    }
+                ],
+                "proof_envelope": {
+                    "claimed_rows": [
+                        [final_memory[lookup.start], final_memory[lookup.start + 1]],
+                        [final_memory[lookup.start + 4], final_memory[lookup.start + 5]]
+                    ]
+                }
+            },
+            "embedded_shared_activation_lookup": {
+                "statement_version": "stwo-shared-binary-step-lookup-v1",
+                "semantic_scope": "stwo_decoding_step_v2_execution_with_shared_binary_step_lookup",
+                "claimed_rows": [
+                    {
+                        "input_memory_index": lookup.start + 2,
+                        "output_memory_index": lookup.start + 3,
+                        "expected_input": final_memory[lookup.start + 2],
+                        "expected_output": final_memory[lookup.start + 3]
+                    },
+                    {
+                        "input_memory_index": lookup.start + 6,
+                        "output_memory_index": lookup.start + 7,
+                        "expected_input": final_memory[lookup.start + 6],
+                        "expected_output": final_memory[lookup.start + 7]
+                    }
+                ],
+                "proof_envelope": {
+                    "claimed_rows": [
+                        {
+                            "input": final_memory[lookup.start + 2],
+                            "output": final_memory[lookup.start + 3]
+                        },
+                        {
+                            "input": final_memory[lookup.start + 6],
+                            "output": final_memory[lookup.start + 7]
+                        }
+                    ]
+                }
+            }
+        }))
+        .expect("sample proof payload")
     }
 
     fn sample_phase17_rollup_matrix_manifest() -> Phase17DecodingHistoryRollupMatrixManifest {
@@ -3936,6 +4027,26 @@ mod tests {
         assert!(err
             .to_string()
             .contains("recorded from_state does not match the proof's initial state"));
+    }
+
+    #[test]
+    fn phase12_verify_decoding_chain_rejects_tampered_embedded_lookup_rows() {
+        let layout = phase12_default_decoding_layout();
+        let memories = phase12_demo_initial_memories(&layout).expect("memories");
+        let proofs = memories
+            .into_iter()
+            .map(|memory| sample_phase12_step_proof(&layout, memory))
+            .collect::<Vec<_>>();
+        let mut manifest = phase12_prepare_decoding_chain(&layout, &proofs).expect("manifest");
+        let mut payload: serde_json::Value =
+            serde_json::from_slice(&manifest.steps[1].proof.proof).expect("payload");
+        payload["embedded_shared_activation_lookup"]["claimed_rows"][1]["expected_output"] =
+            serde_json::json!(0);
+        manifest.steps[1].proof.proof = serde_json::to_vec(&payload).expect("payload bytes");
+        let err = verify_phase12_decoding_chain(&manifest).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("embedded shared activation rows do not match"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- derive `decoding_step_v2` final lookup state from the embedded shared normalization/activation claims carried inside the proof payload
- reject decoding manifests whose final lookup slice or lookup-row commitment diverges from those embedded shared rows
- document the proof-bound lookup boundary and add regressions for tampered embedded lookup rows

## Validation
- cargo +nightly-2025-07-14 check --quiet --features stwo-backend
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase14_
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli decoding_family_demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Phase 12 and Phase 20 descriptions to clarify proof state binding and shared lookup row semantics.

* **Tests**
  * Added validation tests for embedded proof components, including tamper-detection for proof payload integrity checks.

* **Bug Fixes**
  * Enhanced proof validation to detect inconsistencies in embedded normalization and activation claims within proof payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->