### PR TITLE
Consume shared activation row in decoding step

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,8 +511,9 @@ matrix/rollup-style packaging layers described in the next-paper track.
 - Phase 10: `gemma_block_v4` binds shared-table normalization and activation
   rows inside the same top-level execution proof
 - Phase 11: fixed-shape proof-carrying decoding over `decoding_step_v1`
-- Phase 12: parameterized `decoding_step_v2` family with richer carried state
-  and proof-bound shared-lookup rows
+- Phase 12: parameterized `decoding_step_v2` family with richer carried state,
+  proof-bound shared-lookup rows, and an executed read of the shared activation
+  row inside the decoding transition itself
 - Phase 13: validated layout matrix for `decoding_step_v2`
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -203,7 +203,9 @@ Delivered:
 - a Phase 20 lookup-frontier layer over that same stack, preserving a recent non-arithmetic
   window alongside the cumulative lookup transcript so later accumulation work has a cleaner
   lookup boundary to consume, and binding that lookup state back to the embedded shared
-  normalization / activation claims already carried inside each `decoding_step_v2` proof payload.
+  normalization / activation claims already carried inside each `decoding_step_v2` proof payload,
+  with the current transition now reading the shared activation output row inside the executed
+  `decoding_step_v2` program instead of treating those lookup rows as write-only metadata.
 
 Current limitation:
 

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -449,15 +449,13 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
         instructions.push(Instruction::Store((output.start + 1) as u8));
     }
 
-    instructions.push(Instruction::LoadImmediate(layout.pair_width as i16));
-    instructions.push(Instruction::Store((output.start + 2) as u8));
-    instructions.push(Instruction::LoadImmediate(1));
-    instructions.push(Instruction::Store((output.start + 2) as u8));
-
     for (offset, value) in PHASE12_LOOKUP_ROW_VALUES.iter().enumerate() {
         instructions.push(Instruction::LoadImmediate(*value));
         instructions.push(Instruction::Store((lookup.start + offset) as u8));
     }
+
+    instructions.push(Instruction::Load((lookup.start + 3) as u8));
+    instructions.push(Instruction::Store((output.start + 2) as u8));
 
     let kv_cache = layout.kv_cache_range()?;
     for index in 0..(kv_cache.len().saturating_sub(layout.pair_width)) {
@@ -3953,6 +3951,29 @@ mod tests {
         assert!(matches_decoding_step_v2_family_with_layout(
             &program, &layout
         ));
+    }
+
+    #[test]
+    fn phase12_template_consumes_shared_activation_row() {
+        let layout = phase12_default_decoding_layout();
+        let program = decoding_step_v2_template_program(&layout).expect("program");
+        let lookup = layout.lookup_range().expect("lookup range");
+        let output = layout.output_range().expect("output range");
+        let instructions = program.instructions();
+        let store_last_lookup = Instruction::Store((lookup.start + PHASE12_SHARED_LOOKUP_ROWS - 1) as u8);
+        let store_output_flag = Instruction::Store((output.start + 2) as u8);
+        let lookup_store_index = instructions
+            .iter()
+            .rposition(|instruction| *instruction == store_last_lookup)
+            .expect("last lookup store");
+        assert_eq!(
+            instructions.get(lookup_store_index + 1),
+            Some(&Instruction::Load((lookup.start + 3) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 2),
+            Some(&store_output_flag)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- change `decoding_step_v2` so the executed transition reads the shared activation output row after writing the shared lookup table
- keep the bounded demo semantics unchanged while making the lookup-backed primitive part of the executed path instead of write-only metadata
- document the stronger boundary in the README and the stwo design note

## Validation
- cargo +nightly-2025-07-14 check --quiet --features stwo-backend
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli decoding_family_demo