### PR TITLE
Consume shared normalization row in decoding step

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ matrix/rollup-style packaging layers described in the next-paper track.
 - Phase 11: fixed-shape proof-carrying decoding over `decoding_step_v1`
 - Phase 12: parameterized `decoding_step_v2` family with richer carried state,
   proof-bound shared-lookup rows, and an executed read of the shared activation
-  row inside the decoding transition itself
+  row plus the shared normalization scale row inside the decoding transition itself
 - Phase 13: validated layout matrix for `decoding_step_v2`
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -204,8 +204,9 @@ Delivered:
   window alongside the cumulative lookup transcript so later accumulation work has a cleaner
   lookup boundary to consume, and binding that lookup state back to the embedded shared
   normalization / activation claims already carried inside each `decoding_step_v2` proof payload,
-  with the current transition now reading the shared activation output row inside the executed
-  `decoding_step_v2` program instead of treating those lookup rows as write-only metadata.
+  with the current transition now reading both the shared activation output row and the shared
+  normalization scale row inside the executed `decoding_step_v2` program instead of treating those
+  lookup rows as write-only metadata.
 
 Current limitation:
 

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -454,6 +454,9 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
         instructions.push(Instruction::Store((lookup.start + offset) as u8));
     }
 
+    instructions.push(Instruction::Load(output.start as u8));
+    instructions.push(Instruction::MulMemory((lookup.start + 1) as u8));
+    instructions.push(Instruction::Store(output.start as u8));
     instructions.push(Instruction::Load((lookup.start + 3) as u8));
     instructions.push(Instruction::Store((output.start + 2) as u8));
 
@@ -3954,13 +3957,14 @@ mod tests {
     }
 
     #[test]
-    fn phase12_template_consumes_shared_activation_row() {
+    fn phase12_template_consumes_shared_lookup_rows() {
         let layout = phase12_default_decoding_layout();
         let program = decoding_step_v2_template_program(&layout).expect("program");
         let lookup = layout.lookup_range().expect("lookup range");
         let output = layout.output_range().expect("output range");
         let instructions = program.instructions();
-        let store_last_lookup = Instruction::Store((lookup.start + PHASE12_SHARED_LOOKUP_ROWS - 1) as u8);
+        let store_last_lookup =
+            Instruction::Store((lookup.start + PHASE12_SHARED_LOOKUP_ROWS - 1) as u8);
         let store_output_flag = Instruction::Store((output.start + 2) as u8);
         let lookup_store_index = instructions
             .iter()
@@ -3968,10 +3972,22 @@ mod tests {
             .expect("last lookup store");
         assert_eq!(
             instructions.get(lookup_store_index + 1),
-            Some(&Instruction::Load((lookup.start + 3) as u8))
+            Some(&Instruction::Load(output.start as u8))
         );
         assert_eq!(
             instructions.get(lookup_store_index + 2),
+            Some(&Instruction::MulMemory((lookup.start + 1) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 3),
+            Some(&Instruction::Store(output.start as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 4),
+            Some(&Instruction::Load((lookup.start + 3) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 5),
             Some(&store_output_flag)
         );
     }

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -3993,6 +3993,32 @@ mod tests {
     }
 
     #[test]
+    fn phase12_runtime_uses_shared_lookup_rows_across_layouts() {
+        for layout in phase13_default_decoding_layout_matrix().expect("layout matrix") {
+            let latest_cached = layout.latest_cached_pair_range().expect("latest cached");
+            let query = layout.query_range().expect("query range");
+            let lookup = layout.lookup_range().expect("lookup range");
+            let output = layout.output_range().expect("output range");
+            for memory in phase12_demo_initial_memories(&layout).expect("memories") {
+                let expected_raw_dot: i16 = (0..layout.pair_width)
+                    .map(|offset| memory[query.start + offset] * memory[latest_cached.start + offset])
+                    .sum();
+                let program =
+                    decoding_step_v2_program_with_initial_memory(&layout, memory).expect("program");
+                let mut runtime =
+                    NativeInterpreter::new(program, Attention2DMode::AverageHard, 256);
+                let result = runtime.run().expect("run program");
+                assert!(result.halted);
+                let final_memory = result.final_state.memory;
+                let expected_scale = final_memory[lookup.start + 1];
+                let expected_activation = final_memory[lookup.start + 3];
+                assert_eq!(final_memory[output.start], expected_raw_dot * expected_scale);
+                assert_eq!(final_memory[output.start + 2], expected_activation);
+            }
+        }
+    }
+
+    #[test]
     fn phase12_decoding_layout_accepts_full_u8_address_space() {
         let layout = Phase12DecodingLayout::new(241, 1).expect("layout");
         assert_eq!(layout.memory_size().expect("memory size"), 256);


### PR DESCRIPTION
## Summary
- update `decoding_step_v2` so the executed transition multiplies the primary output by the shared normalization scale row after the lookup table is written
- keep the shared activation read from the previous stacked PR, so both lookup-backed components are now consumed by the executed path
- document the stronger executed lookup boundary in the README and the stwo design note

## Validation
- cargo +nightly-2025-07-14 check --quiet --features stwo-backend
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli decoding_family_demo