### PR TITLE
Expand Phase 12 proving coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,8 @@ matrix/rollup-style packaging layers described in the next-paper track.
 - Phase 11: fixed-shape proof-carrying decoding over `decoding_step_v1`
 - Phase 12: parameterized `decoding_step_v2` family with richer carried state,
   proof-bound shared-lookup rows, and an executed read of the shared activation
-  row plus the shared normalization scale row inside the decoding transition itself
+  row plus the shared normalization scale row inside the decoding transition itself,
+  with exact semantic tests and real-backend proving coverage over all default demo steps
 - Phase 13: validated layout matrix for `decoding_step_v2`
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -206,7 +206,8 @@ Delivered:
   normalization / activation claims already carried inside each `decoding_step_v2` proof payload,
   with the current transition now reading both the shared activation output row and the shared
   normalization scale row inside the executed `decoding_step_v2` program instead of treating those
-  lookup rows as write-only metadata.
+  lookup rows as write-only metadata, and with exact tests plus real-backend proving coverage over
+  all default demo steps.
 
 Current limitation:
 

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -2757,12 +2757,19 @@ mod tests {
     #[test]
     fn phase12_decoding_step_v2_trace_satisfies_constraints() {
         let layout = phase12_default_decoding_layout();
-        let memory = phase12_demo_initial_memories(&layout)
+        for (step_index, memory) in phase12_demo_initial_memories(&layout)
             .expect("memories")
-            .remove(0);
-        let program =
-            decoding_step_v2_program_with_initial_memory(&layout, memory).expect("program");
-        assert_trace_satisfies_constraints_for_program(program);
+            .into_iter()
+            .enumerate()
+        {
+            let program =
+                decoding_step_v2_program_with_initial_memory(&layout, memory).expect("program");
+            assert_trace_satisfies_constraints_for_program(program.clone());
+            assert!(
+                matches_decoding_step_v2_family(&program),
+                "step {step_index} is not recognized as decoding_step_v2-family"
+            );
+        }
     }
 
     #[test]
@@ -2832,12 +2839,19 @@ mod tests {
     #[test]
     fn phase12_decoding_step_v2_trace_polys_satisfy_constraints() {
         let layout = phase12_default_decoding_layout();
-        let memory = phase12_demo_initial_memories(&layout)
+        for (step_index, memory) in phase12_demo_initial_memories(&layout)
             .expect("memories")
-            .remove(0);
-        let program =
-            decoding_step_v2_program_with_initial_memory(&layout, memory).expect("program");
-        assert_trace_polys_satisfy_constraints_for_program(program);
+            .into_iter()
+            .enumerate()
+        {
+            let program =
+                decoding_step_v2_program_with_initial_memory(&layout, memory).expect("program");
+            assert_trace_polys_satisfy_constraints_for_program(program.clone());
+            assert!(
+                matches_decoding_step_v2_family(&program),
+                "step {step_index} is not recognized as decoding_step_v2-family"
+            );
+        }
     }
 
     #[test]

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -3617,9 +3617,11 @@ mod tests {
     use crate::config::Attention2DMode;
     use crate::interpreter::NativeInterpreter;
     use crate::proof::{
-        production_v1_stark_options, ExecutionClaimCommitments, VanillaStarkExecutionClaim,
+        production_v1_stark_options, prove_execution_stark_with_backend_and_options,
+        ExecutionClaimCommitments, VanillaStarkExecutionClaim,
     };
     use crate::state::MachineState;
+    use crate::{ProgramCompiler, TransformerVmConfig};
 
     fn sample_commitments() -> ExecutionClaimCommitments {
         ExecutionClaimCommitments {
@@ -3996,6 +3998,7 @@ mod tests {
     fn phase12_runtime_uses_shared_lookup_rows_across_layouts() {
         for layout in phase13_default_decoding_layout_matrix().expect("layout matrix") {
             let latest_cached = layout.latest_cached_pair_range().expect("latest cached");
+            let incoming = layout.incoming_token_range().expect("incoming range");
             let query = layout.query_range().expect("query range");
             let lookup = layout.lookup_range().expect("lookup range");
             let output = layout.output_range().expect("output range");
@@ -4003,6 +4006,8 @@ mod tests {
                 let expected_raw_dot: i16 = (0..layout.pair_width)
                     .map(|offset| memory[query.start + offset] * memory[latest_cached.start + offset])
                     .sum();
+                let expected_raw_accumulated: i16 =
+                    expected_raw_dot + memory[incoming.clone()].iter().copied().sum::<i16>();
                 let program =
                     decoding_step_v2_program_with_initial_memory(&layout, memory).expect("program");
                 let mut runtime =
@@ -4010,11 +4015,48 @@ mod tests {
                 let result = runtime.run().expect("run program");
                 assert!(result.halted);
                 let final_memory = result.final_state.memory;
-                let expected_scale = final_memory[lookup.start + 1];
+                let expected_primary_scale = final_memory[lookup.start + 1];
                 let expected_activation = final_memory[lookup.start + 3];
-                assert_eq!(final_memory[output.start], expected_raw_dot * expected_scale);
+                assert_eq!(
+                    final_memory[output.start],
+                    expected_raw_dot * expected_primary_scale
+                );
+                assert_eq!(final_memory[output.start + 1], expected_raw_accumulated);
                 assert_eq!(final_memory[output.start + 2], expected_activation);
             }
+        }
+    }
+
+    #[test]
+    fn phase12_real_stwo_prove_accepts_default_layout_demo_memories() {
+        let layout = phase12_default_decoding_layout();
+        let config = TransformerVmConfig {
+            num_layers: 1,
+            attention_mode: Attention2DMode::AverageHard,
+            ..TransformerVmConfig::default()
+        };
+        for (step_index, initial_memory) in phase12_demo_initial_memories(&layout)
+            .expect("memories")
+            .into_iter()
+            .enumerate()
+        {
+            let debug_memory = initial_memory.clone();
+            let program =
+                decoding_step_v2_program_with_initial_memory(&layout, initial_memory).expect("program");
+            let model = ProgramCompiler
+                .compile_program(program, config.clone())
+                .expect("compile");
+            prove_execution_stark_with_backend_and_options(
+                &model,
+                128,
+                StarkProofBackend::Stwo,
+                production_v1_stark_options(),
+            )
+            .unwrap_or_else(|error| {
+                panic!(
+                    "default layout step {step_index} failed real stwo proof: {error}; initial_memory={debug_memory:?}"
+                )
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- widen Phase 12 arithmetic-subset trace and polynomial tests across all seeded demo steps
- add a real S-two proving regression for the default Phase 12 demo chain
- align README and design-note wording with the exact proved semantics

## Why
A proposed multi-output lookup extension exposed that our low-level Phase 12 tests only covered the first seeded demo memory. This PR hardens correctness by requiring all default Phase 12 demo steps to satisfy both the AIR and the real S-two proving path before any deeper semantic extension lands.

## Validation
- cargo +nightly-2025-07-14 check --quiet --features stwo-backend
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_decoding_step_v2_trace_satisfies_constraints
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_decoding_step_v2_trace_polys_satisfy_constraints
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_runtime_uses_shared_lookup_rows_across_layouts
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli decoding_family_demo