### PR TITLE
Add Phase 13 proving coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ matrix/rollup-style packaging layers described in the next-paper track.
   proof-bound shared-lookup rows, and an executed read of the shared activation
   row plus the shared normalization scale row inside the decoding transition itself,
   with exact semantic tests and real-backend proving coverage over all default demo steps
-- Phase 13: validated layout matrix for `decoding_step_v2`
+- Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend proving coverage across the default layout matrix
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries
 - Phase 16: rollups over verified Phase 15 segment bundles

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -227,7 +227,8 @@ Targets:
   into the main proved relation,
 - keep the same `statement-v1` claim boundary until a real semantic change forces `statement-v2`.
 
-The new Phase 13 layout-matrix demo, Phase 14 chunked-history chain, Phase 15 segmented-history
+The new Phase 13 layout-matrix demo, now covered by real-backend proving regressions across the
+default layout matrix, plus the Phase 14 chunked-history chain, Phase 15 segmented-history
 bundle, Phase 16 rollup layer, Phase 17 rollup-matrix layer, and Phase 18 frontier-boundary
 refinement, Phase 19 lookup-transcript layer, and Phase 20 lookup-frontier layer are the first
 steps on that path: they prove that the parameterized relation survives multiple public layouts

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -4061,6 +4061,42 @@ mod tests {
     }
 
     #[test]
+    fn phase13_real_stwo_prove_accepts_layout_matrix_demo_memories() {
+        let config = TransformerVmConfig {
+            num_layers: 1,
+            attention_mode: Attention2DMode::AverageHard,
+            ..TransformerVmConfig::default()
+        };
+        for layout in phase13_default_decoding_layout_matrix().expect("layout matrix") {
+            for (step_index, initial_memory) in phase12_demo_initial_memories(&layout)
+                .expect("memories")
+                .into_iter()
+                .enumerate()
+            {
+                let debug_layout = layout.clone();
+                let debug_memory = initial_memory.clone();
+                let program = decoding_step_v2_program_with_initial_memory(&layout, initial_memory)
+                    .expect("program");
+                let model = ProgramCompiler
+                    .compile_program(program, config.clone())
+                    .expect("compile");
+                prove_execution_stark_with_backend_and_options(
+                    &model,
+                    128,
+                    StarkProofBackend::Stwo,
+                    production_v1_stark_options(),
+                )
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "layout {:?} step {step_index} failed real stwo proof: {error}; initial_memory={debug_memory:?}",
+                        debug_layout
+                    )
+                });
+            }
+        }
+    }
+
+    #[test]
     fn phase12_decoding_layout_accepts_full_u8_address_space() {
         let layout = Phase12DecodingLayout::new(241, 1).expect("layout");
         assert_eq!(layout.memory_size().expect("memory size"), 256);


### PR DESCRIPTION
## Summary
- add real S-two proving coverage across the full default Phase 13 layout matrix
- extend the docs to describe Phase 13 only in terms of semantics and layouts that are actually covered by the real backend

## Why
The Phase 12 coverage PR closes the default-layout gap. This follow-up closes the next gap: the default Phase 13 layout matrix should also be exercised through the real S-two proving path before any deeper non-arithmetic AIR change lands.

## Validation
- cargo +nightly-2025-07-14 check --quiet --features stwo-backend
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase13_real_stwo_prove_accepts_layout_matrix_demo_memories