### PR TITLE
Configure aggressive AI review bots

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,79 @@
+language: en-US
+
+early_access: false
+enable_free_tier: false
+reviews:
+  profile: assertive
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_placeholder: true
+  changed_files_summary: true
+  changed_files_summary_title: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  sequence_diagrams: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  suggested_reviewers: true
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    base_branches:
+      - main
+      - codex/.*
+    labels: []
+    ignore_title_keywords: []
+    auto_title_placeholder: false
+  path_filters:
+    - src/**
+    - tests/**
+    - programs/**
+    - scripts/**
+    - .github/**
+    - README.md
+    - docs/**/*.md
+    - '!scripts/node_modules/**'
+    - '!docs/paper/artifacts/**'
+    - '!docs/paper/evidence/**'
+    - '!docs/paper/figures/**'
+    - '!compiled/**'
+  path_instructions:
+    - path: 'src/stwo_backend/**'
+      instructions: |
+        Review aggressively for proof soundness, AIR/trace consistency, statement and backend version drift, replay invariants, layout/address arithmetic, carry/overflow assumptions, and any mismatch between embedded lookup claims and executed semantics. Treat correctness regressions as high priority. Ignore style-only remarks.
+    - path: 'src/bin/tvm.rs'
+      instructions: |
+        Focus on CLI behavior drift, proof-manifest IO safety, flag handling, and whether commands overclaim backend support. Prefer findings about broken workflows over formatting.
+    - path: 'tests/**'
+      instructions: |
+        Check that tests lock semantic behavior, tamper paths, and negative cases. Call out missing regressions when a PR changes proof semantics without adding failing-path coverage.
+    - path: 'scripts/**'
+      instructions: |
+        Treat these as reproducibility and artifact-generation code. Focus on determinism, path safety, environment assumptions, integrity metadata, and whether regenerated outputs can silently drift.
+    - path: '.github/workflows/**'
+      instructions: |
+        Review for CI coverage loss, missing feature combinations, silent matrix gaps, cache misuse, and workflows that no longer match the documented toolchain requirements.
+    - path: 'README.md'
+      instructions: |
+        Review aggressively for claim drift versus the actual repository behavior. Flag scope inflation, outdated commands, unsupported backend claims, and missing prerequisites.
+    - path: 'docs/**/*.md'
+      instructions: |
+        Review technical docs for alignment with code and proofs. Ignore pure prose taste, but flag any mismatch in supported phases, artifact semantics, backend capabilities, or reproducibility steps.
+chat:
+  auto_reply: true
+tools:
+  shellcheck:
+    enabled: true
+  markdownlint:
+    enabled: true
+  yamllint:
+    enabled: true
+  ast-grep:
+    essential_rules: true
+knowledge_base:
+  learnings:
+    scope: auto

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,9 +6,7 @@ reviews:
   profile: assertive
   request_changes_workflow: false
   high_level_summary: true
-  high_level_summary_placeholder: true
   changed_files_summary: true
-  changed_files_summary_title: true
   poem: false
   review_status: true
   collapse_walkthrough: false
@@ -27,7 +25,6 @@ reviews:
       - codex/.*
     labels: []
     ignore_title_keywords: []
-    auto_title_placeholder: false
   path_filters:
     - src/**
     - tests/**
@@ -37,6 +34,7 @@ reviews:
     - README.md
     - docs/**/*.md
     - '!scripts/node_modules/**'
+    - '!docs/artifacts/**'
     - '!docs/paper/artifacts/**'
     - '!docs/paper/evidence/**'
     - '!docs/paper/figures/**'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,6 +26,10 @@ reviews:
     labels: []
     ignore_title_keywords: []
   path_filters:
+    - .coderabbit.yaml
+    - .greptile/**
+    - .pr_agent.toml
+    - .gitignore
     - src/**
     - tests/**
     - programs/**
@@ -63,15 +67,6 @@ reviews:
         Review technical docs for alignment with code and proofs. Ignore pure prose taste, but flag any mismatch in supported phases, artifact semantics, backend capabilities, or reproducibility steps.
 chat:
   auto_reply: true
-tools:
-  shellcheck:
-    enabled: true
-  markdownlint:
-    enabled: true
-  yamllint:
-    enabled: true
-  ast-grep:
-    essential_rules: true
 knowledge_base:
   learnings:
     scope: auto

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@ scripts/node_modules/
 .agents/
 .claude/
 .codex/
-.greptile/
-.coderabbit.yaml
 CLAUDE.md
 AI_REVIEW_BOTS_BEST_PRACTICES_*.md
 **/.claude/tsc-cache/

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,16 @@
+{
+  "strictness": 1,
+  "commentTypes": ["syntax", "logic", "style", "info"],
+  "maxLines": 250,
+  "maxLineLength": 180,
+  "maxLinesToAnalyze": 20000,
+  "fileChangeLimit": 200,
+  "includeBranches": ["main", "codex/.*"],
+  "ignorePatterns": "scripts/node_modules/**\ndocs/paper/artifacts/**\ndocs/paper/evidence/**\ndocs/paper/figures/**\ncompiled/**",
+  "triggerOnUpdates": true,
+  "statusCheck": true,
+  "statusCommentsEnabled": true,
+  "updateExistingSummaryComment": false,
+  "showRepoMap": true,
+  "fixWithAI": true
+}

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -6,7 +6,14 @@
   "maxLinesToAnalyze": 20000,
   "fileChangeLimit": 200,
   "includeBranches": ["main", "codex/.*"],
-  "ignorePatterns": "scripts/node_modules/**\ndocs/paper/artifacts/**\ndocs/paper/evidence/**\ndocs/paper/figures/**\ncompiled/**",
+  "ignorePatterns": [
+    "scripts/node_modules/**",
+    "docs/artifacts/**",
+    "docs/paper/artifacts/**",
+    "docs/paper/evidence/**",
+    "docs/paper/figures/**",
+    "compiled/**"
+  ],
   "triggerOnUpdates": true,
   "statusCheck": true,
   "statusCommentsEnabled": true,

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,31 @@
+{
+  "files": [
+    {
+      "path": "README.md",
+      "description": "Top-level repository scope, supported proof surfaces, and user entrypoint."
+    },
+    {
+      "path": "docs/design/stwo-backend-design.md",
+      "description": "Canonical design note for the experimental stwo backend, decoding phases, carried-state packaging, and lookup semantics.",
+      "scope": ["src/stwo_backend/**", "tests/**", "src/bin/tvm.rs"]
+    },
+    {
+      "path": "docs/reproducibility.md",
+      "description": "Reproducibility requirements for bundles, figures, scripts, toolchains, and reviewable artifact generation.",
+      "scope": ["scripts/**", "docs/**", ".github/workflows/**"]
+    },
+    {
+      "path": ".github/workflows/ci.yml",
+      "description": "Required CI matrix for stable/full/onnx-export/burn-model coverage and ONNX validation workflow.",
+      "scope": ["src/**", "tests/**", "scripts/**", ".github/workflows/**"]
+    },
+    {
+      "path": "docs/paper/stark-transformer-alignment-2026.md",
+      "description": "Current released architecture/complexity paper. Relevant when reviewing README and scope claims."
+    },
+    {
+      "path": "docs/paper/proof-carrying-decoding-2026.md",
+      "description": "Next-paper draft describing proof-carrying decoding, carried-state layers, and lookup/KV boundaries. Relevant when reviewing decoding-related claims."
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,41 @@
+# Review Rules
+
+Review this repository aggressively.
+
+## Priorities
+
+1. Proof soundness and verification correctness.
+2. AIR/trace consistency and replay invariants.
+3. Statement-version / backend-version / manifest-version drift.
+4. Overflow, carry, index arithmetic, and layout-boundary bugs.
+5. CI coverage regressions and reproducibility drift.
+6. Documentation claims that no longer match the code.
+
+## High-signal targets
+
+- `src/stwo_backend/**`
+- `src/proof.rs`
+- `src/verification.rs`
+- `src/bin/tvm.rs`
+- `tests/**`
+- `.github/workflows/**`
+- `README.md`
+- `docs/design/**`
+- `docs/paper/*.md`
+
+## What to ignore
+
+Do not spend review budget on vendored or generated content:
+
+- `scripts/node_modules/**`
+- `docs/paper/artifacts/**`
+- `docs/paper/evidence/**`
+- `docs/paper/figures/**`
+- `compiled/**`
+
+## Review style
+
+- Prefer concrete bug reports over generic advice.
+- If a change affects proof semantics, ask whether there is a failing-path or tamper-path regression test.
+- Flag claim drift in docs and README whenever a command, backend claim, or paper statement no longer matches implementation.
+- Ignore formatting-only issues unless they hide a correctness or maintainability risk.

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -28,6 +28,7 @@ Review this repository aggressively.
 Do not spend review budget on vendored or generated content:
 
 - `scripts/node_modules/**`
+- `docs/artifacts/**`
 - `docs/paper/artifacts/**`
 - `docs/paper/evidence/**`
 - `docs/paper/figures/**`

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -27,6 +27,7 @@ extra_instructions = "Review aggressively for proof soundness, AIR and trace con
 [ignore]
 glob = [
   "scripts/node_modules/**",
+  "docs/artifacts/**",
   "docs/paper/artifacts/**",
   "docs/paper/evidence/**",
   "docs/paper/figures/**",

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,34 @@
+[github_app]
+pr_commands = ["/agentic_describe", "/agentic_review"]
+handle_push_trigger = true
+push_commands = ["/agentic_review"]
+
+[config]
+publish_output = true
+publish_output_progress = true
+verbosity_level = 2
+use_repo_settings_file = true
+ignore_pr_labels = ["skip-review", "artifact-only"]
+
+[review]
+require_score_review = false
+final_update_message = true
+persistent_comment = true
+comment_severity_threshold = 0
+wikipedia_reference = false
+
+[review_agent]
+comments_location_policy = "both"
+inline_comments_severity_threshold = 1
+enable_help_text = true
+num_code_suggestions = 6
+extra_instructions = "Review aggressively for proof soundness, AIR and trace consistency, statement/backend version drift, overflow and index arithmetic, missing negative tests, CI coverage loss, and documentation claim drift. Ignore vendored or generated artifacts unless they create a reproducibility or integrity risk."
+
+[ignore]
+glob = [
+  "scripts/node_modules/**",
+  "docs/paper/artifacts/**",
+  "docs/paper/evidence/**",
+  "docs/paper/figures/**",
+  "compiled/**"
+]


### PR DESCRIPTION
This PR adds repository-level configuration for CodeRabbit, Greptile, and Qodo with an aggressive review posture.

What it does:
- enables automatic review on `main` and stacked `codex/*` branches
- turns on incremental review / push-trigger reviews
- gives path-specific instructions for proof-critical Rust, tests, CI, scripts, and docs
- keeps generated and frozen artifact trees out of review noise
- unignores `.coderabbit.yaml` and `.greptile/` so these configs are tracked

Configured files:
- `.coderabbit.yaml`
- `.greptile/config.json`
- `.greptile/rules.md`
- `.greptile/files.json`
- `.pr_agent.toml`

Validation:
- parsed `.coderabbit.yaml` with Ruby YAML
- parsed `.greptile/*.json` with Python JSON
- parsed `.pr_agent.toml` with Python `tomllib`
- ran `git diff --check`

Intent:
- maximize review feedback on real code and real docs
- avoid wasting reviewer budget on vendored/generated artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository configuration for automated code review, PR agent behavior, and analysis tooling to enable incremental reviews, targeted path-scoped checks, status reporting, and optional automated fixes.
  * Introduced review guidance and file-index metadata to focus reviewers on correctness, reproducibility, and critical areas while excluding vendored/generated artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->