### PR TITLE
Support multi-row lookup reads in Phase 12 AIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,9 +512,10 @@ matrix/rollup-style packaging layers described in the next-paper track.
   rows inside the same top-level execution proof
 - Phase 11: fixed-shape proof-carrying decoding over `decoding_step_v1`
 - Phase 12: parameterized `decoding_step_v2` family with richer carried state,
-  proof-bound shared-lookup rows, and an executed read of the shared activation
-  row plus the shared normalization scale row inside the decoding transition itself,
-  with exact semantic tests and real-backend proving coverage over all default demo steps
+  proof-bound shared-lookup rows, and executed reads of both shared normalization
+  scale rows plus both shared activation output rows inside the decoding
+  transition itself, with exact semantic tests and real-backend proving coverage
+  over all default demo steps
 - Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend proving coverage across the default layout matrix
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries
@@ -824,7 +825,9 @@ The public decoding artifacts currently cover:
 Those power the proof-carrying decoding demos, including layout-bound carried
 state, rolling KV-cache windows, cumulative KV-history commitments, mergeable
 history segments, rollups, rollup matrices, and the newer KV / lookup frontier
-layers used by the next-paper track.
+layers used by the next-paper track. The current Phase 12 transition now uses
+both shared normalization scale rows and both shared activation output rows in
+executed decoding semantics, not only as carried proof metadata.
 
 #### Phase Highlights
 

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -204,10 +204,10 @@ Delivered:
   window alongside the cumulative lookup transcript so later accumulation work has a cleaner
   lookup boundary to consume, and binding that lookup state back to the embedded shared
   normalization / activation claims already carried inside each `decoding_step_v2` proof payload,
-  with the current transition now reading both the shared activation output row and the shared
-  normalization scale row inside the executed `decoding_step_v2` program instead of treating those
+  with the current transition now reading both shared normalization scale rows and both shared
+  activation output rows inside the executed `decoding_step_v2` program instead of treating those
   lookup rows as write-only metadata, and with exact tests plus real-backend proving coverage over
-  all default demo steps.
+  all default demo steps and the default layout matrix.
 
 Current limitation:
 

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -318,7 +318,8 @@ impl FrameworkEval for Phase5ArithmeticSubsetEval {
             .fold(zero.clone(), |acc, (sel, value)| acc + sel * value);
         eval.add_constraint(loaded_memory_aux.clone() - loaded_memory.clone());
         eval.add_constraint(
-            mul_result_aux.clone() - current_acc.clone() * loaded_memory_aux.clone(),
+            opcode_flags[7].clone()
+                * (mul_result_aux.clone() - current_acc.clone() * loaded_memory_aux.clone()),
         );
         let jump_taken = current_zero.clone() * jump_target.clone()
             + (one.clone() - current_zero.clone()) * pc_plus_one.clone();
@@ -2451,7 +2452,10 @@ fn auxiliary_values(program: &Program, state: &MachineState) -> Result<Auxiliary
         Instruction::Halt => state.pc,
         _ => state.pc.saturating_add(1),
     };
-    let mul_result = state.acc.wrapping_mul(loaded_memory);
+    let mul_result = match instruction {
+        Instruction::MulMemory(_) => state.acc.wrapping_mul(loaded_memory),
+        _ => 0,
+    };
     let next_acc_active = match instruction {
         Instruction::LoadImmediate(value) => value,
         Instruction::Load(_) => loaded_memory,

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -3971,7 +3971,6 @@ mod tests {
         let instructions = program.instructions();
         let store_last_lookup =
             Instruction::Store((lookup.start + PHASE12_SHARED_LOOKUP_ROWS - 1) as u8);
-        let store_output_flag = Instruction::Store((output.start + 2) as u8);
         let lookup_store_index = instructions
             .iter()
             .rposition(|instruction| *instruction == store_last_lookup)
@@ -3990,11 +3989,27 @@ mod tests {
         );
         assert_eq!(
             instructions.get(lookup_store_index + 4),
-            Some(&Instruction::Load((lookup.start + 3) as u8))
+            Some(&Instruction::Load((output.start + 1) as u8))
         );
         assert_eq!(
             instructions.get(lookup_store_index + 5),
-            Some(&store_output_flag)
+            Some(&Instruction::MulMemory((lookup.start + 5) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 6),
+            Some(&Instruction::Store((output.start + 1) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 7),
+            Some(&Instruction::Load((lookup.start + 3) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 8),
+            Some(&Instruction::AddMemory((lookup.start + 7) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 9),
+            Some(&Instruction::Store((output.start + 2) as u8))
         );
     }
 

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -457,7 +457,11 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
     instructions.push(Instruction::Load(output.start as u8));
     instructions.push(Instruction::MulMemory((lookup.start + 1) as u8));
     instructions.push(Instruction::Store(output.start as u8));
+    instructions.push(Instruction::Load((output.start + 1) as u8));
+    instructions.push(Instruction::MulMemory((lookup.start + 5) as u8));
+    instructions.push(Instruction::Store((output.start + 1) as u8));
     instructions.push(Instruction::Load((lookup.start + 3) as u8));
+    instructions.push(Instruction::AddMemory((lookup.start + 7) as u8));
     instructions.push(Instruction::Store((output.start + 2) as u8));
 
     let kv_cache = layout.kv_cache_range()?;
@@ -4016,13 +4020,21 @@ mod tests {
                 assert!(result.halted);
                 let final_memory = result.final_state.memory;
                 let expected_primary_scale = final_memory[lookup.start + 1];
+                let expected_secondary_scale = final_memory[lookup.start + 5];
                 let expected_activation = final_memory[lookup.start + 3];
+                let expected_secondary_activation = final_memory[lookup.start + 7];
                 assert_eq!(
                     final_memory[output.start],
                     expected_raw_dot * expected_primary_scale
                 );
-                assert_eq!(final_memory[output.start + 1], expected_raw_accumulated);
-                assert_eq!(final_memory[output.start + 2], expected_activation);
+                assert_eq!(
+                    final_memory[output.start + 1],
+                    expected_raw_accumulated * expected_secondary_scale
+                );
+                assert_eq!(
+                    final_memory[output.start + 2],
+                    expected_activation + expected_secondary_activation
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary
- extend `decoding_step_v2` so the transition consumes both shared normalization scale rows and both shared activation output rows
- fix the Phase 5 arithmetic AIR helper so `mul_result_aux` is only constrained and populated on `MULM` rows
- keep README and S-two design docs aligned with the new executed semantics

## Why
The previous bounded multi-row lookup read failed on the real backend because the AIR was over-constraining `mul_result_aux` on non-`MULM` rows. That latent issue became visible once Phase 12 started reading more shared lookup rows during execution.

## Validation
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_runtime_uses_shared_lookup_rows_across_layouts --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_decoding_step_v2_trace_satisfies_constraints --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase13_real_stwo_prove_accepts_layout_matrix_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli decoding_family_demo
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified decoding transition and lookup-frontier semantics in design documentation.

* **Bug Fixes**
  * Fixed multiplication operation computation in arithmetic constraints to properly condition on instruction type.
  * Corrected decoding step instruction sequence and memory operation computations for accurate result calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->