### PR TITLE
Bind Phase 14 history to lookup-backed cache semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,8 +514,10 @@ matrix/rollup-style packaging layers described in the next-paper track.
 - Phase 12: parameterized `decoding_step_v2` family with richer carried state,
   proof-bound shared-lookup rows, and executed reads of both shared normalization
   scale rows plus both shared activation output rows inside the decoding
-  transition itself, with exact semantic tests and real-backend proving coverage
-  over all default demo steps
+  transition itself, with the latest carried KV-cache pair now updated from
+  lookup-backed activation outputs rather than only forwarded incoming values,
+  plus exact semantic tests and real-backend proving coverage over all default
+  demo steps
 - Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend proving coverage across the default layout matrix
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries
@@ -827,7 +829,8 @@ state, rolling KV-cache windows, cumulative KV-history commitments, mergeable
 history segments, rollups, rollup matrices, and the newer KV / lookup frontier
 layers used by the next-paper track. The current Phase 12 transition now uses
 both shared normalization scale rows and both shared activation output rows in
-executed decoding semantics, not only as carried proof metadata.
+executed decoding semantics, not only as carried proof metadata, and feeds
+lookup-backed activation values into the latest carried KV-cache pair.
 
 #### Phase Highlights
 

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -206,8 +206,9 @@ Delivered:
   normalization / activation claims already carried inside each `decoding_step_v2` proof payload,
   with the current transition now reading both shared normalization scale rows and both shared
   activation output rows inside the executed `decoding_step_v2` program instead of treating those
-  lookup rows as write-only metadata, and with exact tests plus real-backend proving coverage over
-  all default demo steps and the default layout matrix.
+  lookup rows as write-only metadata, feeding bounded lookup-backed activation values into the
+  latest carried KV-cache pair, and with exact tests plus real-backend proving coverage over all
+  default demo steps and the default layout matrix.
 
 Current limitation:
 

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -3104,6 +3104,10 @@ fn commit_phase12_persistent_state(
     lower_hex(&out)
 }
 
+fn decoding_program_step_limit(program: &Program) -> usize {
+    program.instructions().len().saturating_add(1)
+}
+
 fn commit_phase12_history_seed(
     layout_commitment: &str,
     kv_cache_values: &[i16],
@@ -3540,8 +3544,15 @@ pub(crate) fn phase12_demo_initial_memories(
         memory[position_index] = position as i16;
         memory[position_increment_index] = 1;
         let program = decoding_step_v2_program_with_initial_memory(layout, memory.clone())?;
-        let mut runtime = NativeInterpreter::new(program, Attention2DMode::AverageHard, 256);
+        let step_limit = decoding_program_step_limit(&program);
+        let mut runtime = NativeInterpreter::new(program, Attention2DMode::AverageHard, step_limit);
         let result = runtime.run()?;
+        if !result.halted {
+            return Err(VmError::InvalidConfig(format!(
+                "Phase 12 demo seed generation did not halt within {} steps",
+                step_limit
+            )));
+        }
         kv_cache.copy_from_slice(&result.final_state.memory[kv_cache_range.clone()]);
         memories.push(memory);
     }
@@ -4036,8 +4047,12 @@ mod tests {
                     expected_raw_dot + memory[incoming.clone()].iter().copied().sum::<i16>();
                 let program =
                     decoding_step_v2_program_with_initial_memory(&layout, memory).expect("program");
-                let mut runtime =
-                    NativeInterpreter::new(program, Attention2DMode::AverageHard, 256);
+                let step_limit = decoding_program_step_limit(&program);
+                let mut runtime = NativeInterpreter::new(
+                    program,
+                    Attention2DMode::AverageHard,
+                    step_limit,
+                );
                 let result = runtime.run().expect("run program");
                 assert!(result.halted);
                 let final_memory = result.final_state.memory;
@@ -4314,9 +4329,14 @@ mod tests {
                 let next = &pair[1];
                 let program =
                     decoding_step_v2_program_with_initial_memory(&layout, current).expect("program");
-                let mut runtime =
-                    NativeInterpreter::new(program, Attention2DMode::AverageHard, 256);
+                let step_limit = decoding_program_step_limit(&program);
+                let mut runtime = NativeInterpreter::new(
+                    program,
+                    Attention2DMode::AverageHard,
+                    step_limit,
+                );
                 let result = runtime.run().expect("run program");
+                assert!(result.halted);
                 assert_eq!(
                     &result.final_state.memory[kv_cache_range.clone()],
                     &next[kv_cache_range.clone()]

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -747,6 +747,7 @@ pub fn phase12_prepare_decoding_chain(
     proofs: &[VanillaStarkExecutionProof],
 ) -> Result<Phase12DecodingChainManifest> {
     layout.validate()?;
+    let latest_cached_range = layout.latest_cached_pair_range()?;
     let first = proofs.first().ok_or_else(|| {
         VmError::InvalidConfig("proof-carrying decoding requires at least one proof".to_string())
     })?;
@@ -836,7 +837,7 @@ pub fn phase12_prepare_decoding_chain(
         let to_history_commitment = advance_phase12_history_commitment(
             &expected_layout_commitment,
             &from_history_commitment,
-            &proof.claim.program.initial_memory()[layout.incoming_token_range()?],
+            &proof.claim.final_state.memory[latest_cached_range.clone()],
             to_history_length,
         );
         let to_state = build_phase12_state(
@@ -872,6 +873,7 @@ pub fn phase12_prepare_decoding_chain(
 pub fn verify_phase12_decoding_chain(manifest: &Phase12DecodingChainManifest) -> Result<()> {
     manifest.layout.validate()?;
     let expected_layout_commitment = commit_phase12_layout(&manifest.layout);
+    let latest_cached_range = manifest.layout.latest_cached_pair_range()?;
     if manifest.proof_backend != StarkProofBackend::Stwo {
         return Err(VmError::InvalidConfig(format!(
             "decoding chain backend `{}` is not `stwo`",
@@ -980,8 +982,7 @@ pub fn verify_phase12_decoding_chain(manifest: &Phase12DecodingChainManifest) ->
         let next_history_commitment = advance_phase12_history_commitment(
             &expected_layout_commitment,
             &expected_history_commitment,
-            &step.proof.claim.program.initial_memory()
-                [manifest.layout.incoming_token_range()?],
+            &step.proof.claim.final_state.memory[latest_cached_range.clone()],
             next_history_length,
         );
         let expected_to = build_phase12_state(
@@ -4217,6 +4218,33 @@ mod tests {
             manifest.steps[0].from_state.incoming_token_commitment,
             manifest.steps[1].from_state.incoming_token_commitment
         );
+    }
+
+    #[test]
+    fn phase12_history_commitment_tracks_executed_latest_cached_pair() {
+        let layout = phase12_default_decoding_layout();
+        let latest_cached_range = layout.latest_cached_pair_range().expect("latest cached range");
+        let memories = phase12_demo_initial_memories(&layout).expect("memories");
+        let proofs = memories
+            .into_iter()
+            .map(|memory| sample_phase12_step_proof(&layout, memory))
+            .collect::<Vec<_>>();
+
+        let manifest = phase12_prepare_decoding_chain(&layout, &proofs).expect("manifest");
+        let layout_commitment = commit_phase12_layout(&layout);
+        let seeded_history_commitment = commit_phase12_history_seed(
+            &layout_commitment,
+            &manifest.steps[0].proof.claim.program.initial_memory()[layout.kv_cache_range().expect("kv cache range")],
+            layout.pair_width,
+        );
+        let expected_commitment = advance_phase12_history_commitment(
+            &layout_commitment,
+            &seeded_history_commitment,
+            &manifest.steps[0].proof.claim.final_state.memory[latest_cached_range],
+            layout.rolling_kv_pairs + 1,
+        );
+
+        assert_eq!(manifest.steps[0].to_state.kv_history_commitment, expected_commitment);
     }
 
     #[test]

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -3104,8 +3104,15 @@ fn commit_phase12_persistent_state(
     lower_hex(&out)
 }
 
-fn decoding_program_step_limit(program: &Program) -> usize {
-    program.instructions().len().saturating_add(1)
+fn decoding_program_step_limit(program: &Program) -> Result<usize> {
+    let instruction_count = program.instructions().len();
+    let max_reachable_instructions = usize::from(u8::MAX) + 1;
+    if instruction_count > max_reachable_instructions {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 12 demo seed program has {instruction_count} instructions, exceeding the u8 program counter limit {max_reachable_instructions}"
+        )));
+    }
+    Ok(instruction_count.saturating_add(1))
 }
 
 fn commit_phase12_history_seed(
@@ -3544,7 +3551,7 @@ pub(crate) fn phase12_demo_initial_memories(
         memory[position_index] = position as i16;
         memory[position_increment_index] = 1;
         let program = decoding_step_v2_program_with_initial_memory(layout, memory.clone())?;
-        let step_limit = decoding_program_step_limit(&program);
+        let step_limit = decoding_program_step_limit(&program)?;
         let mut runtime = NativeInterpreter::new(program, Attention2DMode::AverageHard, step_limit);
         let result = runtime.run()?;
         if !result.halted {
@@ -4047,7 +4054,7 @@ mod tests {
                     expected_raw_dot + memory[incoming.clone()].iter().copied().sum::<i16>();
                 let program =
                     decoding_step_v2_program_with_initial_memory(&layout, memory).expect("program");
-                let step_limit = decoding_program_step_limit(&program);
+                let step_limit = decoding_program_step_limit(&program).expect("step limit");
                 let mut runtime = NativeInterpreter::new(
                     program,
                     Attention2DMode::AverageHard,
@@ -4169,6 +4176,15 @@ mod tests {
         assert!(error
             .to_string()
             .contains("exceeds the encoded address limit 256"));
+    }
+
+    #[test]
+    fn phase12_decoding_program_step_limit_rejects_programs_beyond_u8_pc_horizon() {
+        let program = Program::new(vec![Instruction::Nop; usize::from(u8::MAX) + 2], 1);
+        let error = decoding_program_step_limit(&program).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("exceeding the u8 program counter limit"));
     }
 
     #[test]
@@ -4329,7 +4345,7 @@ mod tests {
                 let next = &pair[1];
                 let program =
                     decoding_step_v2_program_with_initial_memory(&layout, current).expect("program");
-                let step_limit = decoding_program_step_limit(&program);
+                let step_limit = decoding_program_step_limit(&program).expect("step limit");
                 let mut runtime = NativeInterpreter::new(
                     program,
                     Attention2DMode::AverageHard,

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -9,6 +9,7 @@ use crate::assembly::parse_program;
 use crate::compiler::ProgramCompiler;
 use crate::config::{Attention2DMode, TransformerVmConfig};
 use crate::error::{Result, VmError};
+use crate::interpreter::NativeInterpreter;
 use crate::instruction::{Instruction, Program};
 use crate::proof::{
     production_v1_stark_options, prove_execution_stark_with_backend_and_options,
@@ -470,7 +471,13 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
         instructions.push(Instruction::Store(index as u8));
     }
     for offset in 0..layout.pair_width {
-        instructions.push(Instruction::Load((incoming.start + offset) as u8));
+        let source = match offset {
+            0 => lookup.start + 3,
+            1 => lookup.start + 7,
+            2 => output.start + 2,
+            _ => incoming.start + offset,
+        };
+        instructions.push(Instruction::Load(source as u8));
         instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
     }
 
@@ -1105,7 +1112,7 @@ pub fn phase14_prepare_decoding_chain(
     let layout = &chain.layout;
     let expected_layout_commitment = commit_phase12_layout(layout);
     let kv_cache_range = layout.kv_cache_range()?;
-    let incoming_token_range = layout.incoming_token_range()?;
+    let latest_cached_range = layout.latest_cached_pair_range()?;
     let mut steps = Vec::with_capacity(chain.steps.len());
     let mut accumulator: Option<Phase14HistoryAccumulator> = None;
 
@@ -1135,7 +1142,7 @@ pub fn phase14_prepare_decoding_chain(
         let next = advance_phase14_history(
             &expected_layout_commitment,
             &current,
-            &step.proof.claim.program.initial_memory()[incoming_token_range.clone()],
+            &step.proof.claim.final_state.memory[latest_cached_range.clone()],
             &to_view.lookup_rows_commitment,
             layout.pair_width,
         )?;
@@ -1167,7 +1174,7 @@ pub fn verify_phase14_decoding_chain(manifest: &Phase14DecodingChainManifest) ->
     manifest.layout.validate()?;
     let expected_layout_commitment = commit_phase12_layout(&manifest.layout);
     let kv_cache_range = manifest.layout.kv_cache_range()?;
-    let incoming_token_range = manifest.layout.incoming_token_range()?;
+    let latest_cached_range = manifest.layout.latest_cached_pair_range()?;
     if manifest.proof_backend != StarkProofBackend::Stwo {
         return Err(VmError::InvalidConfig(format!(
             "chunked decoding chain backend `{}` is not `stwo`",
@@ -1272,7 +1279,7 @@ pub fn verify_phase14_decoding_chain(manifest: &Phase14DecodingChainManifest) ->
         let next = advance_phase14_history(
             &expected_layout_commitment,
             &current,
-            &step.proof.claim.program.initial_memory()[incoming_token_range.clone()],
+            &step.proof.claim.final_state.memory[latest_cached_range.clone()],
             &to_view.lookup_rows_commitment,
             manifest.layout.pair_width,
         )?;
@@ -2925,7 +2932,7 @@ fn verify_phase15_segment_sequence(
 ) -> Result<usize> {
     let expected_layout_commitment = commit_phase12_layout(layout);
     let kv_cache_range = layout.kv_cache_range()?;
-    let incoming_token_range = layout.incoming_token_range()?;
+    let latest_cached_range = layout.latest_cached_pair_range()?;
     let mut expected_global_start_step_index = initial_global_start_step_index;
 
     for (local_segment_index, segment) in segments.iter().enumerate() {
@@ -2999,7 +3006,7 @@ fn verify_phase15_segment_sequence(
             current = advance_phase14_history(
                 &expected_layout_commitment,
                 &current,
-                &step.proof.claim.program.initial_memory()[incoming_token_range.clone()],
+                &step.proof.claim.final_state.memory[latest_cached_range.clone()],
                 &to_view.lookup_rows_commitment,
                 layout.pair_width,
             )?;
@@ -3532,11 +3539,11 @@ pub(crate) fn phase12_demo_initial_memories(
         memory[lookup_range.clone()].copy_from_slice(&PHASE12_LOOKUP_ROW_VALUES);
         memory[position_index] = position as i16;
         memory[position_increment_index] = 1;
+        let program = decoding_step_v2_program_with_initial_memory(layout, memory.clone())?;
+        let mut runtime = NativeInterpreter::new(program, Attention2DMode::AverageHard, 256);
+        let result = runtime.run()?;
+        kv_cache.copy_from_slice(&result.final_state.memory[kv_cache_range.clone()]);
         memories.push(memory);
-
-        kv_cache.rotate_left(layout.pair_width);
-        let tail_start = kv_cache.len() - layout.pair_width;
-        kv_cache[tail_start..].copy_from_slice(&incoming_values);
     }
     Ok(memories)
 }
@@ -4050,6 +4057,18 @@ mod tests {
                     final_memory[output.start + 2],
                     expected_activation + expected_secondary_activation
                 );
+                for offset in 0..layout.pair_width {
+                    let expected_latest_value = match offset {
+                        0 => expected_activation,
+                        1 => expected_secondary_activation,
+                        2 => final_memory[output.start + 2],
+                        _ => final_memory[incoming.start + offset],
+                    };
+                    assert_eq!(
+                        final_memory[latest_cached.start + offset],
+                        expected_latest_value
+                    );
+                }
             }
         }
     }
@@ -4152,6 +4171,10 @@ mod tests {
         assert_eq!(
             manifest.steps[0].to_state.persistent_state_commitment,
             manifest.steps[1].from_state.persistent_state_commitment
+        );
+        assert_eq!(
+            manifest.steps[0].to_state.kv_cache_commitment,
+            manifest.steps[1].from_state.kv_cache_commitment
         );
         assert_eq!(
             manifest.steps[0].to_state.kv_history_commitment,
@@ -4277,6 +4300,27 @@ mod tests {
             assert_eq!(memories.len(), 3);
             for memory in memories {
                 assert_eq!(memory.len(), layout.memory_size().expect("memory size"));
+            }
+        }
+    }
+
+    #[test]
+    fn phase12_demo_initial_memories_follow_lookup_backed_cache_progression() {
+        for layout in phase13_default_decoding_layout_matrix().expect("layout matrix") {
+            let kv_cache_range = layout.kv_cache_range().expect("kv cache range");
+            let memories = phase12_demo_initial_memories(&layout).expect("memories");
+            for pair in memories.windows(2) {
+                let current = pair[0].clone();
+                let next = &pair[1];
+                let program =
+                    decoding_step_v2_program_with_initial_memory(&layout, current).expect("program");
+                let mut runtime =
+                    NativeInterpreter::new(program, Attention2DMode::AverageHard, 256);
+                let result = runtime.run().expect("run program");
+                assert_eq!(
+                    &result.final_state.memory[kv_cache_range.clone()],
+                    &next[kv_cache_range.clone()]
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary
- make the Phase 12 seeded demo memories follow executed lookup-backed cache semantics
- advance Phase 14 carried history from the final latest cached pair instead of the initial incoming token slice
- add semantic regressions for lookup-backed cache progression and document the new carried-cache boundary

## Validation
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase13_real_stwo_prove_accepts_layout_matrix_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase14_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase15_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase16_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase17_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli decoding_family_demo
- git diff --check -- src/stwo_backend/decoding.rs README.md docs/design/stwo-backend-design.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified phase descriptions to explain updated decoding semantics and how lookup-backed activation values feed into KV-cache progression.

* **Improvements**
  * Demo seed generation and KV-cache advancement now derive states from executed runs and enforce a runtime step limit to ensure halting.

* **Tests**
  * Added and strengthened tests to verify successive KV-cache states, decoding-step behavior, history/commitment advancement, and step-limit enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->