### PR TITLE
Extend lookup-backed Phase 12 cache semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,9 +515,10 @@ matrix/rollup-style packaging layers described in the next-paper track.
   proof-bound shared-lookup rows, and executed reads of both shared normalization
   scale rows plus both shared activation output rows inside the decoding
   transition itself, with the latest carried KV-cache pair now updated from
-  lookup-backed activation outputs rather than only forwarded incoming values,
-  plus exact semantic tests and real-backend proving coverage over all default
-  demo steps
+  lookup-backed values rather than only forwarded incoming values, including a
+  bounded shared-normalization-derived lane on the wider public layouts, plus
+  exact semantic tests and real-backend proving coverage over all default demo
+  steps
 - Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend proving coverage across the default layout matrix
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries
@@ -830,7 +831,8 @@ history segments, rollups, rollup matrices, and the newer KV / lookup frontier
 layers used by the next-paper track. The current Phase 12 transition now uses
 both shared normalization scale rows and both shared activation output rows in
 executed decoding semantics, not only as carried proof metadata, and feeds
-lookup-backed activation values into the latest carried KV-cache pair.
+lookup-backed values into the latest carried KV-cache pair on the public demo
+layouts.
 
 #### Phase Highlights
 

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -206,9 +206,9 @@ Delivered:
   normalization / activation claims already carried inside each `decoding_step_v2` proof payload,
   with the current transition now reading both shared normalization scale rows and both shared
   activation output rows inside the executed `decoding_step_v2` program instead of treating those
-  lookup rows as write-only metadata, feeding bounded lookup-backed activation values into the
-  latest carried KV-cache pair, and with exact tests plus real-backend proving coverage over all
-  default demo steps and the default layout matrix.
+  lookup rows as write-only metadata, feeding bounded lookup-backed values into the latest carried
+  KV-cache pair on the public demo layouts, and with exact tests plus real-backend proving
+  coverage over all default demo steps and the default layout matrix.
 
 Current limitation:
 

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -52,7 +52,6 @@ use crate::state::MachineState;
 
 pub const STWO_BACKEND_VERSION_PHASE5: &str = "stwo-phase10-gemma-block-v4";
 pub const STWO_BACKEND_VERSION_PHASE11: &str = "stwo-phase11-decoding-step-v1";
-pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v1";
 const M31_MODULUS: u32 = (1u32 << 31) - 1;
 const GEMMA_BLOCK_NORM_SQ_MEMORY_INDEX: usize = 13;
 const GEMMA_BLOCK_INV_SQRT_MEMORY_INDEX: usize = 14;
@@ -1992,7 +1991,7 @@ fn matches_gemma_block_v3(program: &Program) -> bool {
 
 fn stwo_backend_version_for_program(program: &Program) -> &str {
     if matches_decoding_step_v2(program) {
-        STWO_BACKEND_VERSION_PHASE12
+        super::STWO_BACKEND_VERSION_PHASE12
     } else if matches_decoding_step_v1(program) {
         STWO_BACKEND_VERSION_PHASE11
     } else {

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -23,13 +23,13 @@ use crate::stwo_backend::{
 pub const STWO_DECODING_CHAIN_VERSION_PHASE11: &str = "stwo-phase11-decoding-chain-v1";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE11: &str = "stwo_execution_proof_carrying_decoding_chain";
 pub const STWO_DECODING_STATE_VERSION_PHASE11: &str = "stwo-decoding-state-v1";
-pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v1";
+pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v2";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE12: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_chain";
-pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v2";
+pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v3";
 pub const STWO_DECODING_LAYOUT_VERSION_PHASE12: &str = "stwo-decoding-layout-v1";
 pub const STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13: &str =
-    "stwo-phase13-decoding-layout-matrix-v1";
+    "stwo-phase13-decoding-layout-matrix-v2";
 pub const STWO_DECODING_LAYOUT_MATRIX_SCOPE_PHASE13: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_layout_matrix";
 pub const STWO_DECODING_CHAIN_VERSION_PHASE14: &str =
@@ -3721,7 +3721,7 @@ mod tests {
         let final_memory = result.final_state.memory.clone();
         VanillaStarkExecutionProof {
             proof_backend: StarkProofBackend::Stwo,
-            proof_backend_version: "stwo-phase12-decoding-family-v1".to_string(),
+            proof_backend_version: crate::stwo_backend::STWO_BACKEND_VERSION_PHASE12.to_string(),
             stwo_auxiliary: None,
             claim: VanillaStarkExecutionClaim {
                 statement_version: "statement-v1".to_string(),

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -762,6 +762,7 @@ pub fn phase12_prepare_decoding_chain(
     proofs: &[VanillaStarkExecutionProof],
 ) -> Result<Phase12DecodingChainManifest> {
     layout.validate()?;
+    let latest_cached_range = layout.latest_cached_pair_range()?;
     let first = proofs.first().ok_or_else(|| {
         VmError::InvalidConfig("proof-carrying decoding requires at least one proof".to_string())
     })?;
@@ -851,7 +852,7 @@ pub fn phase12_prepare_decoding_chain(
         let to_history_commitment = advance_phase12_history_commitment(
             &expected_layout_commitment,
             &from_history_commitment,
-            &proof.claim.program.initial_memory()[layout.incoming_token_range()?],
+            &proof.claim.final_state.memory[latest_cached_range.clone()],
             to_history_length,
         );
         let to_state = build_phase12_state(
@@ -887,6 +888,7 @@ pub fn phase12_prepare_decoding_chain(
 pub fn verify_phase12_decoding_chain(manifest: &Phase12DecodingChainManifest) -> Result<()> {
     manifest.layout.validate()?;
     let expected_layout_commitment = commit_phase12_layout(&manifest.layout);
+    let latest_cached_range = manifest.layout.latest_cached_pair_range()?;
     if manifest.proof_backend != StarkProofBackend::Stwo {
         return Err(VmError::InvalidConfig(format!(
             "decoding chain backend `{}` is not `stwo`",
@@ -995,8 +997,7 @@ pub fn verify_phase12_decoding_chain(manifest: &Phase12DecodingChainManifest) ->
         let next_history_commitment = advance_phase12_history_commitment(
             &expected_layout_commitment,
             &expected_history_commitment,
-            &step.proof.claim.program.initial_memory()
-                [manifest.layout.incoming_token_range()?],
+            &step.proof.claim.final_state.memory[latest_cached_range.clone()],
             next_history_length,
         );
         let expected_to = build_phase12_state(
@@ -4237,6 +4238,33 @@ mod tests {
             manifest.steps[0].from_state.incoming_token_commitment,
             manifest.steps[1].from_state.incoming_token_commitment
         );
+    }
+
+    #[test]
+    fn phase12_history_commitment_tracks_executed_latest_cached_pair() {
+        let layout = phase12_default_decoding_layout();
+        let latest_cached_range = layout.latest_cached_pair_range().expect("latest cached range");
+        let memories = phase12_demo_initial_memories(&layout).expect("memories");
+        let proofs = memories
+            .into_iter()
+            .map(|memory| sample_phase12_step_proof(&layout, memory))
+            .collect::<Vec<_>>();
+
+        let manifest = phase12_prepare_decoding_chain(&layout, &proofs).expect("manifest");
+        let layout_commitment = commit_phase12_layout(&layout);
+        let seeded_history_commitment = commit_phase12_history_seed(
+            &layout_commitment,
+            &manifest.steps[0].proof.claim.program.initial_memory()[layout.kv_cache_range().expect("kv cache range")],
+            layout.pair_width,
+        );
+        let expected_commitment = advance_phase12_history_commitment(
+            &layout_commitment,
+            &seeded_history_commitment,
+            &manifest.steps[0].proof.claim.final_state.memory[latest_cached_range],
+            layout.rolling_kv_pairs + 1,
+        );
+
+        assert_eq!(manifest.steps[0].to_state.kv_history_commitment, expected_commitment);
     }
 
     #[test]

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -471,14 +471,29 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
         instructions.push(Instruction::Store(index as u8));
     }
     for offset in 0..layout.pair_width {
-        let source = match offset {
-            0 => lookup.start + 3,
-            1 => lookup.start + 7,
-            2 => output.start + 2,
-            _ => incoming.start + offset,
-        };
-        instructions.push(Instruction::Load(source as u8));
-        instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
+        match offset {
+            0 => {
+                instructions.push(Instruction::Load((lookup.start + 3) as u8));
+                instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
+            }
+            1 => {
+                instructions.push(Instruction::Load((lookup.start + 7) as u8));
+                instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
+            }
+            2 => {
+                instructions.push(Instruction::Load((output.start + 2) as u8));
+                instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
+            }
+            3 => {
+                instructions.push(Instruction::Load(lookup.start as u8));
+                instructions.push(Instruction::AddMemory((lookup.start + 4) as u8));
+                instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
+            }
+            _ => {
+                instructions.push(Instruction::Load((incoming.start + offset) as u8));
+                instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
+            }
+        }
     }
 
     instructions.push(Instruction::Load(layout.position_index()? as u8));
@@ -4032,6 +4047,25 @@ mod tests {
     }
 
     #[test]
+    fn phase12_template_writes_lookup_derived_fourth_cache_lane_when_available() {
+        let layout = phase12_default_decoding_layout();
+        let latest_cached = layout.latest_cached_pair_range().expect("latest cached");
+        let lookup = layout.lookup_range().expect("lookup range");
+        let program = decoding_step_v2_template_program(&layout).expect("program");
+        let instructions = program.instructions();
+        let expected = [
+            Instruction::Load(lookup.start as u8),
+            Instruction::AddMemory((lookup.start + 4) as u8),
+            Instruction::Store((latest_cached.start + 3) as u8),
+        ];
+        assert!(
+            instructions
+                .windows(expected.len())
+                .any(|window| window == expected.as_slice())
+        );
+    }
+
+    #[test]
     fn phase12_runtime_uses_shared_lookup_rows_across_layouts() {
         for layout in phase13_default_decoding_layout_matrix().expect("layout matrix") {
             let latest_cached = layout.latest_cached_pair_range().expect("latest cached");
@@ -4060,6 +4094,7 @@ mod tests {
                 let expected_secondary_scale = final_memory[lookup.start + 5];
                 let expected_activation = final_memory[lookup.start + 3];
                 let expected_secondary_activation = final_memory[lookup.start + 7];
+                let expected_lookup_sum = final_memory[lookup.start] + final_memory[lookup.start + 4];
                 assert_eq!(
                     final_memory[output.start],
                     expected_raw_dot * expected_primary_scale
@@ -4077,6 +4112,7 @@ mod tests {
                         0 => expected_activation,
                         1 => expected_secondary_activation,
                         2 => final_memory[output.start + 2],
+                        3 => expected_lookup_sum,
                         _ => final_memory[incoming.start + offset],
                     };
                     assert_eq!(

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -138,7 +138,7 @@ pub const STWO_BACKEND_VERSION_PHASE5: &str = "stwo-phase10-gemma-block-v4";
 /// Backend version label used by the fixed-shape proof-carrying decoding demo family.
 pub const STWO_BACKEND_VERSION_PHASE11: &str = "stwo-phase11-decoding-step-v1";
 /// Backend version label used by the parameterized proof-carrying decoding family.
-pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v1";
+pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v2";
 /// Cargo feature that enables the experimental S-two backend seam.
 pub const STWO_BACKEND_FEATURE_NAME: &str = "stwo-backend";
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,6 +10,13 @@ use blake2::Blake2bVar;
 use jsonschema::{Draft, JSONSchema};
 use predicates::prelude::*;
 
+#[cfg(feature = "stwo-backend")]
+use llm_provable_computer::stwo_backend::{
+    STWO_BACKEND_VERSION_PHASE12, STWO_DECODING_CHAIN_VERSION_PHASE12,
+    STWO_DECODING_CHAIN_VERSION_PHASE14,
+    STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13,
+};
+
 fn unique_temp_dir(name: &str) -> PathBuf {
     let suffix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1095,9 +1102,9 @@ fn cli_can_prove_and_verify_stwo_decoding_family_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("proof_backend: stwo"))
-        .stdout(predicate::str::contains(
-            "chain_version: stwo-phase12-decoding-chain-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "chain_version: {STWO_DECODING_CHAIN_VERSION_PHASE12}",
+        )))
         .stdout(predicate::str::contains(
             "semantic_scope: stwo_execution_parameterized_proof_carrying_decoding_chain",
         ))
@@ -1119,13 +1126,13 @@ fn cli_can_prove_and_verify_stwo_decoding_family_demo() {
         proof_json
             .get("chain_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase12-decoding-chain-v1")
+        Some(STWO_DECODING_CHAIN_VERSION_PHASE12)
     );
     assert_eq!(
         proof_json
             .get("proof_backend_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase12-decoding-family-v1")
+        Some(STWO_BACKEND_VERSION_PHASE12)
     );
 
     let mut verify = Command::cargo_bin("tvm").expect("binary");
@@ -1135,12 +1142,12 @@ fn cli_can_prove_and_verify_stwo_decoding_family_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("verified_stark: true"))
-        .stdout(predicate::str::contains(
-            "expected_chain_version: stwo-phase12-decoding-chain-v1",
-        ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_chain_version: {STWO_DECODING_CHAIN_VERSION_PHASE12}",
+        )))
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )))
         .stdout(predicate::str::contains("rolling_kv_pairs: 4"))
         .stdout(predicate::str::contains("pair_width: 4"))
         .stdout(predicate::str::contains("start_history_length: 4"))
@@ -1285,9 +1292,9 @@ fn cli_can_prove_and_verify_stwo_decoding_layout_matrix_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("proof_backend: stwo"))
-        .stdout(predicate::str::contains(
-            "matrix_version: stwo-phase13-decoding-layout-matrix-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "matrix_version: {STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13}",
+        )))
         .stdout(predicate::str::contains("total_layouts: 3"))
         .stdout(predicate::str::contains("total_steps: 9"));
 
@@ -1298,7 +1305,7 @@ fn cli_can_prove_and_verify_stwo_decoding_layout_matrix_demo() {
         proof_json
             .get("matrix_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase13-decoding-layout-matrix-v1")
+        Some(STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13)
     );
     assert_eq!(
         proof_json
@@ -1314,12 +1321,12 @@ fn cli_can_prove_and_verify_stwo_decoding_layout_matrix_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("verified_stark: true"))
-        .stdout(predicate::str::contains(
-            "expected_matrix_version: stwo-phase13-decoding-layout-matrix-v1",
-        ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ));
+        .stdout(predicate::str::contains(format!(
+            "expected_matrix_version: {STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13}",
+        )))
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )));
 
     let _ = std::fs::remove_file(proof_path);
 }
@@ -1378,9 +1385,9 @@ fn cli_can_prove_and_verify_stwo_decoding_chunked_history_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("proof_backend: stwo"))
-        .stdout(predicate::str::contains(
-            "chain_version: stwo-phase14-decoding-chunked-history-chain-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "chain_version: {STWO_DECODING_CHAIN_VERSION_PHASE14}",
+        )))
         .stdout(predicate::str::contains("history_chunk_pairs: 2"))
         .stdout(predicate::str::contains("start_sealed_chunks: 2"))
         .stdout(predicate::str::contains("final_history_length: 7"))
@@ -1393,7 +1400,7 @@ fn cli_can_prove_and_verify_stwo_decoding_chunked_history_demo() {
         proof_json
             .get("chain_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase14-decoding-chunked-history-chain-v1")
+        Some(STWO_DECODING_CHAIN_VERSION_PHASE14)
     );
     assert_eq!(
         proof_json
@@ -1409,12 +1416,12 @@ fn cli_can_prove_and_verify_stwo_decoding_chunked_history_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("verified_stark: true"))
-        .stdout(predicate::str::contains(
-            "expected_chain_version: stwo-phase14-decoding-chunked-history-chain-v1",
-        ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_chain_version: {STWO_DECODING_CHAIN_VERSION_PHASE14}",
+        )))
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )))
         .stdout(predicate::str::contains("history_chunk_pairs: 2"))
         .stdout(predicate::str::contains("final_sealed_chunks: 3"));
 
@@ -1509,9 +1516,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_segments_demo() {
         .stdout(predicate::str::contains(
             "expected_bundle_version: stwo-phase15-decoding-history-segment-bundle-v4",
         ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )))
         .stdout(predicate::str::contains("last_segment_start_step: 2"));
 
     let _ = std::fs::remove_file(proof_path);
@@ -1604,9 +1611,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_rollup_demo() {
         .stdout(predicate::str::contains(
             "expected_rollup_version: stwo-phase16-decoding-history-segment-rollup-v4",
         ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )))
         .stdout(predicate::str::contains("last_rollup_start_step: 2"));
 
     let _ = std::fs::remove_file(proof_path);
@@ -1701,9 +1708,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_rollup_matrix_demo() {
         .stdout(predicate::str::contains(
             "expected_matrix_version: stwo-phase17-decoding-history-rollup-matrix-v4",
         ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ));
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )));
 
     let _ = std::fs::remove_file(proof_path);
 }


### PR DESCRIPTION
## Summary
- extend the Phase 12 latest cached pair so wider layouts derive the fourth lane from bounded shared normalization rows instead of forwarded incoming data
- add template and runtime regressions for the new lookup-derived lane
- keep the carried-state docs aligned with the widened lookup-backed cache boundary

## Validation
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_template_writes_lookup_derived_fourth_cache_lane_when_available --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_runtime_uses_shared_lookup_rows_across_layouts --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_demo_initial_memories_follow_lookup_backed_cache_progression --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase13_real_stwo_prove_accepts_layout_matrix_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase14_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase15_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase16_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase17_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli decoding_family_demo
- git diff --check -- src/stwo_backend/decoding.rs README.md docs/design/stwo-backend-design.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Phase 12 transition wording to reference lookup-backed values and public demo layout behavior; refined Phase 4/backend design narrative and demo step descriptions.

* **Bug Fixes**
  * Fixed decoding instruction generation so a fourth cache lane is derived from lookup-backed values when available, improving correctness of Phase 12 decoding.

* **Tests**
  * Added/updated tests to assert the new instruction pattern and expected decoding outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->