### PR TITLE
Bind Phase 12 secondary output to shared activation

### DIFF
--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -52,7 +52,6 @@ use crate::state::MachineState;
 
 pub const STWO_BACKEND_VERSION_PHASE5: &str = "stwo-phase10-gemma-block-v4";
 pub const STWO_BACKEND_VERSION_PHASE11: &str = "stwo-phase11-decoding-step-v1";
-pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v1";
 const M31_MODULUS: u32 = (1u32 << 31) - 1;
 const GEMMA_BLOCK_NORM_SQ_MEMORY_INDEX: usize = 13;
 const GEMMA_BLOCK_INV_SQRT_MEMORY_INDEX: usize = 14;
@@ -1992,7 +1991,7 @@ fn matches_gemma_block_v3(program: &Program) -> bool {
 
 fn stwo_backend_version_for_program(program: &Program) -> &str {
     if matches_decoding_step_v2(program) {
-        STWO_BACKEND_VERSION_PHASE12
+        super::STWO_BACKEND_VERSION_PHASE12
     } else if matches_decoding_step_v1(program) {
         STWO_BACKEND_VERSION_PHASE11
     } else {

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -765,6 +765,7 @@ pub fn phase12_prepare_decoding_chain(
     proofs: &[VanillaStarkExecutionProof],
 ) -> Result<Phase12DecodingChainManifest> {
     layout.validate()?;
+    let latest_cached_range = layout.latest_cached_pair_range()?;
     let first = proofs.first().ok_or_else(|| {
         VmError::InvalidConfig("proof-carrying decoding requires at least one proof".to_string())
     })?;
@@ -854,7 +855,7 @@ pub fn phase12_prepare_decoding_chain(
         let to_history_commitment = advance_phase12_history_commitment(
             &expected_layout_commitment,
             &from_history_commitment,
-            &proof.claim.program.initial_memory()[layout.incoming_token_range()?],
+            &proof.claim.final_state.memory[latest_cached_range.clone()],
             to_history_length,
         );
         let to_state = build_phase12_state(
@@ -890,6 +891,7 @@ pub fn phase12_prepare_decoding_chain(
 pub fn verify_phase12_decoding_chain(manifest: &Phase12DecodingChainManifest) -> Result<()> {
     manifest.layout.validate()?;
     let expected_layout_commitment = commit_phase12_layout(&manifest.layout);
+    let latest_cached_range = manifest.layout.latest_cached_pair_range()?;
     if manifest.proof_backend != StarkProofBackend::Stwo {
         return Err(VmError::InvalidConfig(format!(
             "decoding chain backend `{}` is not `stwo`",
@@ -998,8 +1000,7 @@ pub fn verify_phase12_decoding_chain(manifest: &Phase12DecodingChainManifest) ->
         let next_history_commitment = advance_phase12_history_commitment(
             &expected_layout_commitment,
             &expected_history_commitment,
-            &step.proof.claim.program.initial_memory()
-                [manifest.layout.incoming_token_range()?],
+            &step.proof.claim.final_state.memory[latest_cached_range.clone()],
             next_history_length,
         );
         let expected_to = build_phase12_state(
@@ -4253,6 +4254,33 @@ mod tests {
             manifest.steps[0].from_state.incoming_token_commitment,
             manifest.steps[1].from_state.incoming_token_commitment
         );
+    }
+
+    #[test]
+    fn phase12_history_commitment_tracks_executed_latest_cached_pair() {
+        let layout = phase12_default_decoding_layout();
+        let latest_cached_range = layout.latest_cached_pair_range().expect("latest cached range");
+        let memories = phase12_demo_initial_memories(&layout).expect("memories");
+        let proofs = memories
+            .into_iter()
+            .map(|memory| sample_phase12_step_proof(&layout, memory))
+            .collect::<Vec<_>>();
+
+        let manifest = phase12_prepare_decoding_chain(&layout, &proofs).expect("manifest");
+        let layout_commitment = commit_phase12_layout(&layout);
+        let seeded_history_commitment = commit_phase12_history_seed(
+            &layout_commitment,
+            &manifest.steps[0].proof.claim.program.initial_memory()[layout.kv_cache_range().expect("kv cache range")],
+            layout.pair_width,
+        );
+        let expected_commitment = advance_phase12_history_commitment(
+            &layout_commitment,
+            &seeded_history_commitment,
+            &manifest.steps[0].proof.claim.final_state.memory[latest_cached_range],
+            layout.rolling_kv_pairs + 1,
+        );
+
+        assert_eq!(manifest.steps[0].to_state.kv_history_commitment, expected_commitment);
     }
 
     #[test]

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -461,6 +461,9 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
     instructions.push(Instruction::Load((output.start + 1) as u8));
     instructions.push(Instruction::MulMemory((lookup.start + 5) as u8));
     instructions.push(Instruction::Store((output.start + 1) as u8));
+    instructions.push(Instruction::Load((output.start + 1) as u8));
+    instructions.push(Instruction::AddMemory((lookup.start + 7) as u8));
+    instructions.push(Instruction::Store((output.start + 1) as u8));
     instructions.push(Instruction::Load((lookup.start + 3) as u8));
     instructions.push(Instruction::AddMemory((lookup.start + 7) as u8));
     instructions.push(Instruction::Store((output.start + 2) as u8));
@@ -4034,7 +4037,7 @@ mod tests {
         );
         assert_eq!(
             instructions.get(lookup_store_index + 7),
-            Some(&Instruction::Load((lookup.start + 3) as u8))
+            Some(&Instruction::Load((output.start + 1) as u8))
         );
         assert_eq!(
             instructions.get(lookup_store_index + 8),
@@ -4042,6 +4045,18 @@ mod tests {
         );
         assert_eq!(
             instructions.get(lookup_store_index + 9),
+            Some(&Instruction::Store((output.start + 1) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 10),
+            Some(&Instruction::Load((lookup.start + 3) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 11),
+            Some(&Instruction::AddMemory((lookup.start + 7) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 12),
             Some(&Instruction::Store((output.start + 2) as u8))
         );
     }
@@ -4102,6 +4117,7 @@ mod tests {
                 assert_eq!(
                     final_memory[output.start + 1],
                     expected_raw_accumulated * expected_secondary_scale
+                        + expected_secondary_activation
                 );
                 assert_eq!(
                     final_memory[output.start + 2],

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -23,13 +23,13 @@ use crate::stwo_backend::{
 pub const STWO_DECODING_CHAIN_VERSION_PHASE11: &str = "stwo-phase11-decoding-chain-v1";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE11: &str = "stwo_execution_proof_carrying_decoding_chain";
 pub const STWO_DECODING_STATE_VERSION_PHASE11: &str = "stwo-decoding-state-v1";
-pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v1";
+pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v2";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE12: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_chain";
-pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v2";
+pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v3";
 pub const STWO_DECODING_LAYOUT_VERSION_PHASE12: &str = "stwo-decoding-layout-v1";
 pub const STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13: &str =
-    "stwo-phase13-decoding-layout-matrix-v1";
+    "stwo-phase13-decoding-layout-matrix-v2";
 pub const STWO_DECODING_LAYOUT_MATRIX_SCOPE_PHASE13: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_layout_matrix";
 pub const STWO_DECODING_CHAIN_VERSION_PHASE14: &str =
@@ -3724,7 +3724,7 @@ mod tests {
         let final_memory = result.final_state.memory.clone();
         VanillaStarkExecutionProof {
             proof_backend: StarkProofBackend::Stwo,
-            proof_backend_version: "stwo-phase12-decoding-family-v1".to_string(),
+            proof_backend_version: crate::stwo_backend::STWO_BACKEND_VERSION_PHASE12.to_string(),
             stwo_auxiliary: None,
             claim: VanillaStarkExecutionClaim {
                 statement_version: "statement-v1".to_string(),

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -138,7 +138,7 @@ pub const STWO_BACKEND_VERSION_PHASE5: &str = "stwo-phase10-gemma-block-v4";
 /// Backend version label used by the fixed-shape proof-carrying decoding demo family.
 pub const STWO_BACKEND_VERSION_PHASE11: &str = "stwo-phase11-decoding-step-v1";
 /// Backend version label used by the parameterized proof-carrying decoding family.
-pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v1";
+pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v2";
 /// Cargo feature that enables the experimental S-two backend seam.
 pub const STWO_BACKEND_FEATURE_NAME: &str = "stwo-backend";
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,6 +10,13 @@ use blake2::Blake2bVar;
 use jsonschema::{Draft, JSONSchema};
 use predicates::prelude::*;
 
+#[cfg(feature = "stwo-backend")]
+use llm_provable_computer::stwo_backend::{
+    STWO_BACKEND_VERSION_PHASE12, STWO_DECODING_CHAIN_VERSION_PHASE12,
+    STWO_DECODING_CHAIN_VERSION_PHASE14,
+    STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13,
+};
+
 fn unique_temp_dir(name: &str) -> PathBuf {
     let suffix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1095,9 +1102,9 @@ fn cli_can_prove_and_verify_stwo_decoding_family_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("proof_backend: stwo"))
-        .stdout(predicate::str::contains(
-            "chain_version: stwo-phase12-decoding-chain-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "chain_version: {STWO_DECODING_CHAIN_VERSION_PHASE12}",
+        )))
         .stdout(predicate::str::contains(
             "semantic_scope: stwo_execution_parameterized_proof_carrying_decoding_chain",
         ))
@@ -1119,13 +1126,13 @@ fn cli_can_prove_and_verify_stwo_decoding_family_demo() {
         proof_json
             .get("chain_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase12-decoding-chain-v1")
+        Some(STWO_DECODING_CHAIN_VERSION_PHASE12)
     );
     assert_eq!(
         proof_json
             .get("proof_backend_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase12-decoding-family-v1")
+        Some(STWO_BACKEND_VERSION_PHASE12)
     );
 
     let mut verify = Command::cargo_bin("tvm").expect("binary");
@@ -1135,12 +1142,12 @@ fn cli_can_prove_and_verify_stwo_decoding_family_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("verified_stark: true"))
-        .stdout(predicate::str::contains(
-            "expected_chain_version: stwo-phase12-decoding-chain-v1",
-        ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_chain_version: {STWO_DECODING_CHAIN_VERSION_PHASE12}",
+        )))
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )))
         .stdout(predicate::str::contains("rolling_kv_pairs: 4"))
         .stdout(predicate::str::contains("pair_width: 4"))
         .stdout(predicate::str::contains("start_history_length: 4"))
@@ -1285,9 +1292,9 @@ fn cli_can_prove_and_verify_stwo_decoding_layout_matrix_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("proof_backend: stwo"))
-        .stdout(predicate::str::contains(
-            "matrix_version: stwo-phase13-decoding-layout-matrix-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "matrix_version: {STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13}",
+        )))
         .stdout(predicate::str::contains("total_layouts: 3"))
         .stdout(predicate::str::contains("total_steps: 9"));
 
@@ -1298,7 +1305,7 @@ fn cli_can_prove_and_verify_stwo_decoding_layout_matrix_demo() {
         proof_json
             .get("matrix_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase13-decoding-layout-matrix-v1")
+        Some(STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13)
     );
     assert_eq!(
         proof_json
@@ -1314,12 +1321,12 @@ fn cli_can_prove_and_verify_stwo_decoding_layout_matrix_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("verified_stark: true"))
-        .stdout(predicate::str::contains(
-            "expected_matrix_version: stwo-phase13-decoding-layout-matrix-v1",
-        ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ));
+        .stdout(predicate::str::contains(format!(
+            "expected_matrix_version: {STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13}",
+        )))
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )));
 
     let _ = std::fs::remove_file(proof_path);
 }
@@ -1378,9 +1385,9 @@ fn cli_can_prove_and_verify_stwo_decoding_chunked_history_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("proof_backend: stwo"))
-        .stdout(predicate::str::contains(
-            "chain_version: stwo-phase14-decoding-chunked-history-chain-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "chain_version: {STWO_DECODING_CHAIN_VERSION_PHASE14}",
+        )))
         .stdout(predicate::str::contains("history_chunk_pairs: 2"))
         .stdout(predicate::str::contains("start_sealed_chunks: 2"))
         .stdout(predicate::str::contains("final_history_length: 7"))
@@ -1393,7 +1400,7 @@ fn cli_can_prove_and_verify_stwo_decoding_chunked_history_demo() {
         proof_json
             .get("chain_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase14-decoding-chunked-history-chain-v1")
+        Some(STWO_DECODING_CHAIN_VERSION_PHASE14)
     );
     assert_eq!(
         proof_json
@@ -1409,12 +1416,12 @@ fn cli_can_prove_and_verify_stwo_decoding_chunked_history_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("verified_stark: true"))
-        .stdout(predicate::str::contains(
-            "expected_chain_version: stwo-phase14-decoding-chunked-history-chain-v1",
-        ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_chain_version: {STWO_DECODING_CHAIN_VERSION_PHASE14}",
+        )))
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )))
         .stdout(predicate::str::contains("history_chunk_pairs: 2"))
         .stdout(predicate::str::contains("final_sealed_chunks: 3"));
 
@@ -1509,9 +1516,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_segments_demo() {
         .stdout(predicate::str::contains(
             "expected_bundle_version: stwo-phase15-decoding-history-segment-bundle-v4",
         ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )))
         .stdout(predicate::str::contains("last_segment_start_step: 2"));
 
     let _ = std::fs::remove_file(proof_path);
@@ -1604,9 +1611,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_rollup_demo() {
         .stdout(predicate::str::contains(
             "expected_rollup_version: stwo-phase16-decoding-history-segment-rollup-v4",
         ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )))
         .stdout(predicate::str::contains("last_rollup_start_step: 2"));
 
     let _ = std::fs::remove_file(proof_path);
@@ -1701,9 +1708,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_rollup_matrix_demo() {
         .stdout(predicate::str::contains(
             "expected_matrix_version: stwo-phase17-decoding-history-rollup-matrix-v4",
         ))
-        .stdout(predicate::str::contains(
-            "expected_proof_backend_version: stwo-phase12-decoding-family-v1",
-        ));
+        .stdout(predicate::str::contains(format!(
+            "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
+        )));
 
     let _ = std::fs::remove_file(proof_path);
 }


### PR DESCRIPTION
## Summary
- make the secondary Phase 12 output lane depend on a bounded shared activation row after shared normalization scaling
- keep the widened output commitment compatible with the existing Phase 13 layout matrix and Phase 14-17 carried-state stack
- add the change without widening the memory footprint or breaking the current AIR arithmetic limits

## Validation
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_template_consumes_shared_lookup_rows --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_runtime_uses_shared_lookup_rows_across_layouts --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase13_real_stwo_prove_accepts_layout_matrix_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase14_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase15_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase16_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase17_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli decoding_family_demo
- git diff --check -- src/stwo_backend/decoding.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decoding accumulation for shared activations so intermediate values are computed and stored correctly across steps.

* **Chores**
  * Bumped decoding protocol/version identifiers (chain, state, layout matrix) and backend label values to new v2/v3 releases.

* **Tests**
  * Updated tests, proofs, and CLI demo expectations to reflect the new decoding behavior and version identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->