### PR TITLE
Bind Phase 12 primary output to shared activation

### DIFF
--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -458,6 +458,9 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
     instructions.push(Instruction::Load(output.start as u8));
     instructions.push(Instruction::MulMemory((lookup.start + 1) as u8));
     instructions.push(Instruction::Store(output.start as u8));
+    instructions.push(Instruction::Load(output.start as u8));
+    instructions.push(Instruction::AddMemory((lookup.start + 3) as u8));
+    instructions.push(Instruction::Store(output.start as u8));
     instructions.push(Instruction::Load((output.start + 1) as u8));
     instructions.push(Instruction::MulMemory((lookup.start + 5) as u8));
     instructions.push(Instruction::Store((output.start + 1) as u8));
@@ -4025,15 +4028,15 @@ mod tests {
         );
         assert_eq!(
             instructions.get(lookup_store_index + 4),
-            Some(&Instruction::Load((output.start + 1) as u8))
+            Some(&Instruction::Load(output.start as u8))
         );
         assert_eq!(
             instructions.get(lookup_store_index + 5),
-            Some(&Instruction::MulMemory((lookup.start + 5) as u8))
+            Some(&Instruction::AddMemory((lookup.start + 3) as u8))
         );
         assert_eq!(
             instructions.get(lookup_store_index + 6),
-            Some(&Instruction::Store((output.start + 1) as u8))
+            Some(&Instruction::Store(output.start as u8))
         );
         assert_eq!(
             instructions.get(lookup_store_index + 7),
@@ -4041,7 +4044,7 @@ mod tests {
         );
         assert_eq!(
             instructions.get(lookup_store_index + 8),
-            Some(&Instruction::AddMemory((lookup.start + 7) as u8))
+            Some(&Instruction::MulMemory((lookup.start + 5) as u8))
         );
         assert_eq!(
             instructions.get(lookup_store_index + 9),
@@ -4049,7 +4052,7 @@ mod tests {
         );
         assert_eq!(
             instructions.get(lookup_store_index + 10),
-            Some(&Instruction::Load((lookup.start + 3) as u8))
+            Some(&Instruction::Load((output.start + 1) as u8))
         );
         assert_eq!(
             instructions.get(lookup_store_index + 11),
@@ -4057,6 +4060,18 @@ mod tests {
         );
         assert_eq!(
             instructions.get(lookup_store_index + 12),
+            Some(&Instruction::Store((output.start + 1) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 13),
+            Some(&Instruction::Load((lookup.start + 3) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 14),
+            Some(&Instruction::AddMemory((lookup.start + 7) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 15),
             Some(&Instruction::Store((output.start + 2) as u8))
         );
     }
@@ -4112,7 +4127,7 @@ mod tests {
                 let expected_lookup_sum = final_memory[lookup.start] + final_memory[lookup.start + 4];
                 assert_eq!(
                     final_memory[output.start],
-                    expected_raw_dot * expected_primary_scale
+                    expected_raw_dot * expected_primary_scale + expected_activation
                 );
                 assert_eq!(
                     final_memory[output.start + 1],

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -768,6 +768,7 @@ pub fn phase12_prepare_decoding_chain(
     proofs: &[VanillaStarkExecutionProof],
 ) -> Result<Phase12DecodingChainManifest> {
     layout.validate()?;
+    let latest_cached_range = layout.latest_cached_pair_range()?;
     let first = proofs.first().ok_or_else(|| {
         VmError::InvalidConfig("proof-carrying decoding requires at least one proof".to_string())
     })?;
@@ -857,7 +858,7 @@ pub fn phase12_prepare_decoding_chain(
         let to_history_commitment = advance_phase12_history_commitment(
             &expected_layout_commitment,
             &from_history_commitment,
-            &proof.claim.program.initial_memory()[layout.incoming_token_range()?],
+            &proof.claim.final_state.memory[latest_cached_range.clone()],
             to_history_length,
         );
         let to_state = build_phase12_state(
@@ -893,6 +894,7 @@ pub fn phase12_prepare_decoding_chain(
 pub fn verify_phase12_decoding_chain(manifest: &Phase12DecodingChainManifest) -> Result<()> {
     manifest.layout.validate()?;
     let expected_layout_commitment = commit_phase12_layout(&manifest.layout);
+    let latest_cached_range = manifest.layout.latest_cached_pair_range()?;
     if manifest.proof_backend != StarkProofBackend::Stwo {
         return Err(VmError::InvalidConfig(format!(
             "decoding chain backend `{}` is not `stwo`",
@@ -1001,8 +1003,7 @@ pub fn verify_phase12_decoding_chain(manifest: &Phase12DecodingChainManifest) ->
         let next_history_commitment = advance_phase12_history_commitment(
             &expected_layout_commitment,
             &expected_history_commitment,
-            &step.proof.claim.program.initial_memory()
-                [manifest.layout.incoming_token_range()?],
+            &step.proof.claim.final_state.memory[latest_cached_range.clone()],
             next_history_length,
         );
         let expected_to = build_phase12_state(
@@ -4268,6 +4269,33 @@ mod tests {
             manifest.steps[0].from_state.incoming_token_commitment,
             manifest.steps[1].from_state.incoming_token_commitment
         );
+    }
+
+    #[test]
+    fn phase12_history_commitment_tracks_executed_latest_cached_pair() {
+        let layout = phase12_default_decoding_layout();
+        let latest_cached_range = layout.latest_cached_pair_range().expect("latest cached range");
+        let memories = phase12_demo_initial_memories(&layout).expect("memories");
+        let proofs = memories
+            .into_iter()
+            .map(|memory| sample_phase12_step_proof(&layout, memory))
+            .collect::<Vec<_>>();
+
+        let manifest = phase12_prepare_decoding_chain(&layout, &proofs).expect("manifest");
+        let layout_commitment = commit_phase12_layout(&layout);
+        let seeded_history_commitment = commit_phase12_history_seed(
+            &layout_commitment,
+            &manifest.steps[0].proof.claim.program.initial_memory()[layout.kv_cache_range().expect("kv cache range")],
+            layout.pair_width,
+        );
+        let expected_commitment = advance_phase12_history_commitment(
+            &layout_commitment,
+            &seeded_history_commitment,
+            &manifest.steps[0].proof.claim.final_state.memory[latest_cached_range],
+            layout.rolling_kv_pairs + 1,
+        );
+
+        assert_eq!(manifest.steps[0].to_state.kv_history_commitment, expected_commitment);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- bind the primary Phase 12 output cell to the shared activation row after normalization scaling
- keep the widened lookup-backed cache semantics and versioned Phase 12 surfaces from the lower stack
- extend runtime/template coverage so replayed state and CLI surfaces stay aligned

## Validation
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_template_consumes_shared_lookup_rows --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_runtime_uses_shared_lookup_rows_across_layouts --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase13_real_stwo_prove_accepts_layout_matrix_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase14_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase15_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase16_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase17_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli stwo_decoding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal decoding backend test expectations and runtime assertions to reflect revised instruction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->