### PR TITLE
Bind Phase 12 fourth cache lane to primary output

### DIFF
--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -23,13 +23,13 @@ use crate::stwo_backend::{
 pub const STWO_DECODING_CHAIN_VERSION_PHASE11: &str = "stwo-phase11-decoding-chain-v1";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE11: &str = "stwo_execution_proof_carrying_decoding_chain";
 pub const STWO_DECODING_STATE_VERSION_PHASE11: &str = "stwo-decoding-state-v1";
-pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v2";
+pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v3";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE12: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_chain";
-pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v3";
+pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v4";
 pub const STWO_DECODING_LAYOUT_VERSION_PHASE12: &str = "stwo-decoding-layout-v1";
 pub const STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13: &str =
-    "stwo-phase13-decoding-layout-matrix-v2";
+    "stwo-phase13-decoding-layout-matrix-v3";
 pub const STWO_DECODING_LAYOUT_MATRIX_SCOPE_PHASE13: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_layout_matrix";
 pub const STWO_DECODING_CHAIN_VERSION_PHASE14: &str =
@@ -491,8 +491,7 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
                 instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
             }
             3 => {
-                instructions.push(Instruction::Load(lookup.start as u8));
-                instructions.push(Instruction::AddMemory((lookup.start + 4) as u8));
+                instructions.push(Instruction::Load(output.start as u8));
                 instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
             }
             _ => {
@@ -4078,15 +4077,14 @@ mod tests {
     }
 
     #[test]
-    fn phase12_template_writes_lookup_derived_fourth_cache_lane_when_available() {
+    fn phase12_template_writes_primary_output_into_fourth_cache_lane_when_available() {
         let layout = phase12_default_decoding_layout();
         let latest_cached = layout.latest_cached_pair_range().expect("latest cached");
-        let lookup = layout.lookup_range().expect("lookup range");
+        let output = layout.output_range().expect("output range");
         let program = decoding_step_v2_template_program(&layout).expect("program");
         let instructions = program.instructions();
         let expected = [
-            Instruction::Load(lookup.start as u8),
-            Instruction::AddMemory((lookup.start + 4) as u8),
+            Instruction::Load(output.start as u8),
             Instruction::Store((latest_cached.start + 3) as u8),
         ];
         assert!(
@@ -4125,7 +4123,6 @@ mod tests {
                 let expected_secondary_scale = final_memory[lookup.start + 5];
                 let expected_activation = final_memory[lookup.start + 3];
                 let expected_secondary_activation = final_memory[lookup.start + 7];
-                let expected_lookup_sum = final_memory[lookup.start] + final_memory[lookup.start + 4];
                 assert_eq!(
                     final_memory[output.start],
                     expected_raw_dot * expected_primary_scale + expected_activation
@@ -4144,7 +4141,7 @@ mod tests {
                         0 => expected_activation,
                         1 => expected_secondary_activation,
                         2 => final_memory[output.start + 2],
-                        3 => expected_lookup_sum,
+                        3 => final_memory[output.start],
                         _ => final_memory[incoming.start + offset],
                     };
                     assert_eq!(

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -138,7 +138,7 @@ pub const STWO_BACKEND_VERSION_PHASE5: &str = "stwo-phase10-gemma-block-v4";
 /// Backend version label used by the fixed-shape proof-carrying decoding demo family.
 pub const STWO_BACKEND_VERSION_PHASE11: &str = "stwo-phase11-decoding-step-v1";
 /// Backend version label used by the parameterized proof-carrying decoding family.
-pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v2";
+pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v3";
 /// Cargo feature that enables the experimental S-two backend seam.
 pub const STWO_BACKEND_FEATURE_NAME: &str = "stwo-backend";
 


### PR DESCRIPTION
## Summary
- replace the fourth latest-cached lane with the fully lookup-backed primary output
- bump the Phase 12 family/state/chain and Phase 13 matrix version surfaces again for the new instruction family
- keep the replay stack aligned so Phase 14-17 history now consumes the more output-bound carried pair

## Validation
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_template_writes_primary_output_into_fourth_cache_lane_when_available --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_runtime_uses_shared_lookup_rows_across_layouts --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase13_real_stwo_prove_accepts_layout_matrix_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase14_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase15_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase16_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase17_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli stwo_decoding