### PR TITLE
Bind Phase 12 second cache lane to combined output

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,10 +515,10 @@ matrix/rollup-style packaging layers described in the next-paper track.
   proof-bound shared-lookup rows, and executed reads of both shared normalization
   scale rows plus both shared activation output rows inside the decoding
   transition itself, with the latest carried KV-cache pair now updated from
-  lookup-backed values rather than only forwarded incoming values, including a
-  bounded shared-normalization-derived lane on the wider public layouts, plus
-  exact semantic tests and real-backend proving coverage over all default demo
-  steps
+  lookup-backed values rather than only forwarded incoming values, with three
+  carried lanes now driven by the bounded combined-output cell and one by the
+  lookup-backed primary output on the wider public layouts, plus exact semantic
+  tests and real-backend proving coverage over all default demo steps
 - Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend proving coverage across the default layout matrix
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries
@@ -832,7 +832,8 @@ layers used by the next-paper track. The current Phase 12 transition now uses
 both shared normalization scale rows and both shared activation output rows in
 executed decoding semantics, not only as carried proof metadata, and feeds
 lookup-backed values into the latest carried KV-cache pair on the public demo
-layouts.
+layouts, with the current wider layout frontier now mostly output-derived
+rather than forwarded-input-derived.
 
 #### Phase Highlights
 

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -207,8 +207,10 @@ Delivered:
   with the current transition now reading both shared normalization scale rows and both shared
   activation output rows inside the executed `decoding_step_v2` program instead of treating those
   lookup rows as write-only metadata, feeding bounded lookup-backed values into the latest carried
-  KV-cache pair on the public demo layouts, and with exact tests plus real-backend proving
-  coverage over all default demo steps and the default layout matrix.
+  KV-cache pair on the public demo layouts, with three carried lanes now bound to the combined
+  output cell and one to the lookup-backed primary output on the wider layouts, and with exact
+  tests plus real-backend proving coverage over all default demo steps and the default layout
+  matrix.
 
 Current limitation:
 

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -26,7 +26,7 @@ pub const STWO_DECODING_STATE_VERSION_PHASE11: &str = "stwo-decoding-state-v1";
 pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v5";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE12: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_chain";
-pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v6";
+pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v7";
 pub const STWO_DECODING_LAYOUT_VERSION_PHASE12: &str = "stwo-decoding-layout-v1";
 pub const STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13: &str =
     "stwo-phase13-decoding-layout-matrix-v5";

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -23,13 +23,13 @@ use crate::stwo_backend::{
 pub const STWO_DECODING_CHAIN_VERSION_PHASE11: &str = "stwo-phase11-decoding-chain-v1";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE11: &str = "stwo_execution_proof_carrying_decoding_chain";
 pub const STWO_DECODING_STATE_VERSION_PHASE11: &str = "stwo-decoding-state-v1";
-pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v4";
+pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v5";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE12: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_chain";
-pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v5";
+pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v6";
 pub const STWO_DECODING_LAYOUT_VERSION_PHASE12: &str = "stwo-decoding-layout-v1";
 pub const STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13: &str =
-    "stwo-phase13-decoding-layout-matrix-v4";
+    "stwo-phase13-decoding-layout-matrix-v5";
 pub const STWO_DECODING_LAYOUT_MATRIX_SCOPE_PHASE13: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_layout_matrix";
 pub const STWO_DECODING_CHAIN_VERSION_PHASE14: &str =
@@ -483,7 +483,7 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
                 instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
             }
             1 => {
-                instructions.push(Instruction::Load((lookup.start + 7) as u8));
+                instructions.push(Instruction::Load((output.start + 2) as u8));
                 instructions.push(Instruction::Store((latest_cached.start + offset) as u8));
             }
             2 => {
@@ -4113,6 +4113,24 @@ mod tests {
     }
 
     #[test]
+    fn phase12_template_writes_combined_output_into_second_cache_lane_when_available() {
+        let layout = phase12_default_decoding_layout();
+        let latest_cached = layout.latest_cached_pair_range().expect("latest cached");
+        let output = layout.output_range().expect("output range");
+        let program = decoding_step_v2_template_program(&layout).expect("program");
+        let instructions = program.instructions();
+        let expected = [
+            Instruction::Load((output.start + 2) as u8),
+            Instruction::Store((latest_cached.start + 1) as u8),
+        ];
+        assert!(
+            instructions
+                .windows(expected.len())
+                .any(|window| window == expected.as_slice())
+        );
+    }
+
+    #[test]
     fn phase12_runtime_uses_shared_lookup_rows_across_layouts() {
         for layout in phase13_default_decoding_layout_matrix().expect("layout matrix") {
             let latest_cached = layout.latest_cached_pair_range().expect("latest cached");
@@ -4157,7 +4175,7 @@ mod tests {
                 for offset in 0..layout.pair_width {
                     let expected_latest_value = match offset {
                         0 => final_memory[output.start + 2],
-                        1 => expected_secondary_activation,
+                        1 => final_memory[output.start + 2],
                         2 => final_memory[output.start + 2],
                         3 => final_memory[output.start],
                         _ => final_memory[incoming.start + offset],

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -33,20 +33,20 @@ pub const STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13: &str =
 pub const STWO_DECODING_LAYOUT_MATRIX_SCOPE_PHASE13: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_layout_matrix";
 pub const STWO_DECODING_CHAIN_VERSION_PHASE14: &str =
-    "stwo-phase14-decoding-chunked-history-chain-v4";
+    "stwo-phase14-decoding-chunked-history-chain-v5";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE14: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_chunked_history_chain";
 pub const STWO_DECODING_STATE_VERSION_PHASE14: &str = "stwo-decoding-state-v6";
 pub const STWO_DECODING_SEGMENT_BUNDLE_VERSION_PHASE15: &str =
-    "stwo-phase15-decoding-history-segment-bundle-v4";
+    "stwo-phase15-decoding-history-segment-bundle-v5";
 pub const STWO_DECODING_SEGMENT_BUNDLE_SCOPE_PHASE15: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_history_segment_bundle";
 pub const STWO_DECODING_SEGMENT_ROLLUP_VERSION_PHASE16: &str =
-    "stwo-phase16-decoding-history-segment-rollup-v4";
+    "stwo-phase16-decoding-history-segment-rollup-v5";
 pub const STWO_DECODING_SEGMENT_ROLLUP_SCOPE_PHASE16: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_history_segment_rollup";
 pub const STWO_DECODING_ROLLUP_MATRIX_VERSION_PHASE17: &str =
-    "stwo-phase17-decoding-history-rollup-matrix-v4";
+    "stwo-phase17-decoding-history-rollup-matrix-v5";
 pub const STWO_DECODING_ROLLUP_MATRIX_SCOPE_PHASE17: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_history_rollup_matrix";
 const DECODING_KV_CACHE_RANGE: std::ops::Range<usize> = 0..6;

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -138,7 +138,7 @@ pub const STWO_BACKEND_VERSION_PHASE5: &str = "stwo-phase10-gemma-block-v4";
 /// Backend version label used by the fixed-shape proof-carrying decoding demo family.
 pub const STWO_BACKEND_VERSION_PHASE11: &str = "stwo-phase11-decoding-step-v1";
 /// Backend version label used by the parameterized proof-carrying decoding family.
-pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v4";
+pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v5";
 /// Cargo feature that enables the experimental S-two backend seam.
 pub const STWO_BACKEND_FEATURE_NAME: &str = "stwo-backend";
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -15,6 +15,9 @@ use llm_provable_computer::stwo_backend::{
     STWO_BACKEND_VERSION_PHASE12, STWO_DECODING_CHAIN_VERSION_PHASE12,
     STWO_DECODING_CHAIN_VERSION_PHASE14,
     STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13,
+    STWO_DECODING_ROLLUP_MATRIX_VERSION_PHASE17,
+    STWO_DECODING_SEGMENT_BUNDLE_VERSION_PHASE15,
+    STWO_DECODING_SEGMENT_ROLLUP_VERSION_PHASE16,
 };
 
 fn unique_temp_dir(name: &str) -> PathBuf {
@@ -1483,9 +1486,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_segments_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("proof_backend: stwo"))
-        .stdout(predicate::str::contains(
-            "bundle_version: stwo-phase15-decoding-history-segment-bundle-v4",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "bundle_version: {STWO_DECODING_SEGMENT_BUNDLE_VERSION_PHASE15}",
+        )))
         .stdout(predicate::str::contains("total_segments: 2"))
         .stdout(predicate::str::contains("max_segment_steps: 2"))
         .stdout(predicate::str::contains("final_history_length: 7"));
@@ -1497,7 +1500,7 @@ fn cli_can_prove_and_verify_stwo_decoding_history_segments_demo() {
         proof_json
             .get("bundle_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase15-decoding-history-segment-bundle-v4")
+        Some(STWO_DECODING_SEGMENT_BUNDLE_VERSION_PHASE15)
     );
     assert_eq!(
         proof_json
@@ -1513,9 +1516,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_segments_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("verified_stark: true"))
-        .stdout(predicate::str::contains(
-            "expected_bundle_version: stwo-phase15-decoding-history-segment-bundle-v4",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_bundle_version: {STWO_DECODING_SEGMENT_BUNDLE_VERSION_PHASE15}",
+        )))
         .stdout(predicate::str::contains(format!(
             "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
         )))
@@ -1578,9 +1581,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_rollup_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("proof_backend: stwo"))
-        .stdout(predicate::str::contains(
-            "rollup_version: stwo-phase16-decoding-history-segment-rollup-v4",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "rollup_version: {STWO_DECODING_SEGMENT_ROLLUP_VERSION_PHASE16}",
+        )))
         .stdout(predicate::str::contains("total_rollups: 2"))
         .stdout(predicate::str::contains("total_segments: 3"))
         .stdout(predicate::str::contains("final_history_length: 7"));
@@ -1592,7 +1595,7 @@ fn cli_can_prove_and_verify_stwo_decoding_history_rollup_demo() {
         proof_json
             .get("rollup_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase16-decoding-history-segment-rollup-v4")
+        Some(STWO_DECODING_SEGMENT_ROLLUP_VERSION_PHASE16)
     );
     assert_eq!(
         proof_json
@@ -1608,9 +1611,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_rollup_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("verified_stark: true"))
-        .stdout(predicate::str::contains(
-            "expected_rollup_version: stwo-phase16-decoding-history-segment-rollup-v4",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_rollup_version: {STWO_DECODING_SEGMENT_ROLLUP_VERSION_PHASE16}",
+        )))
         .stdout(predicate::str::contains(format!(
             "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
         )))
@@ -1683,9 +1686,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_rollup_matrix_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("proof_backend: stwo"))
-        .stdout(predicate::str::contains(
-            "matrix_version: stwo-phase17-decoding-history-rollup-matrix-v4",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "matrix_version: {STWO_DECODING_ROLLUP_MATRIX_VERSION_PHASE17}",
+        )))
         .stdout(predicate::str::contains("total_layouts: 3"));
 
     let proof_json: serde_json::Value =
@@ -1695,7 +1698,7 @@ fn cli_can_prove_and_verify_stwo_decoding_history_rollup_matrix_demo() {
         proof_json
             .get("matrix_version")
             .and_then(serde_json::Value::as_str),
-        Some("stwo-phase17-decoding-history-rollup-matrix-v4")
+        Some(STWO_DECODING_ROLLUP_MATRIX_VERSION_PHASE17)
     );
 
     let mut verify = Command::cargo_bin("tvm").expect("binary");
@@ -1705,9 +1708,9 @@ fn cli_can_prove_and_verify_stwo_decoding_history_rollup_matrix_demo() {
         .assert()
         .success()
         .stdout(predicate::str::contains("verified_stark: true"))
-        .stdout(predicate::str::contains(
-            "expected_matrix_version: stwo-phase17-decoding-history-rollup-matrix-v4",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "expected_matrix_version: {STWO_DECODING_ROLLUP_MATRIX_VERSION_PHASE17}",
+        )))
         .stdout(predicate::str::contains(format!(
             "expected_proof_backend_version: {STWO_BACKEND_VERSION_PHASE12}",
         )));


### PR DESCRIPTION
## Summary
- replace the second latest-cached lane with the bounded combined-output cell instead of the raw secondary activation row
- bump the Phase 12 family/state/chain and Phase 13 matrix version surfaces again for the new instruction family
- keep the carried replay stack aligned while staying inside the current vanilla AIR arithmetic limits

## Validation
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_template_writes_combined_output_into_second_cache_lane_when_available --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_runtime_uses_shared_lookup_rows_across_layouts --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase13_real_stwo_prove_accepts_layout_matrix_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase14_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase15_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase16_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase17_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli stwo_decoding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Phase 12 decoding-family and Phase 4 backend design descriptions to specify how carried KV-cache lanes bind and to emphasize the output-derived frontier semantics.

* **Chores**
  * Bumped Phase 12 decoding and Phase 13 layout version identifiers.

* **Tests**
  * Added a unit test for the Phase 12 template and updated a Phase 12 runtime test expectation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->