### PR TITLE
Bind Phase 12 primary output to combined activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,8 +517,11 @@ matrix/rollup-style packaging layers described in the next-paper track.
   transition itself, with the latest carried KV-cache pair now updated from
   lookup-backed values rather than only forwarded incoming values, with three
   carried lanes now driven by the bounded combined-output cell and one by the
-  lookup-backed primary output on the wider public layouts, plus exact semantic
-  tests and real-backend proving coverage over all default demo steps
+  lookup-backed primary output on the wider public layouts, and with the primary
+  output itself now absorbing that bounded combined-output cell so both shared
+  activation rows influence the carried primary lane and output commitment, plus
+  exact semantic tests and real-backend proving coverage over all default demo
+  steps
 - Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend proving coverage across the default layout matrix
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries
@@ -833,7 +836,8 @@ both shared normalization scale rows and both shared activation output rows in
 executed decoding semantics, not only as carried proof metadata, and feeds
 lookup-backed values into the latest carried KV-cache pair on the public demo
 layouts, with the current wider layout frontier now mostly output-derived
-rather than forwarded-input-derived.
+rather than forwarded-input-derived, while the primary output now also absorbs
+the bounded combined-output cell before being carried forward.
 
 #### Phase Highlights
 

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -208,9 +208,10 @@ Delivered:
   activation output rows inside the executed `decoding_step_v2` program instead of treating those
   lookup rows as write-only metadata, feeding bounded lookup-backed values into the latest carried
   KV-cache pair on the public demo layouts, with three carried lanes now bound to the combined
-  output cell and one to the lookup-backed primary output on the wider layouts, and with exact
-  tests plus real-backend proving coverage over all default demo steps and the default layout
-  matrix.
+  output cell and one to the lookup-backed primary output on the wider layouts, with that primary
+  output now also absorbing the bounded combined-output cell before it is carried forward, and
+  with exact tests plus real-backend proving coverage over all default demo steps and the default
+  layout matrix.
 
 Current limitation:
 

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -3133,14 +3133,16 @@ fn commit_phase12_persistent_state(
     lower_hex(&out)
 }
 
-fn decoding_program_step_limit(program: &Program) -> usize {
-    debug_assert!(
-        program.instructions().len() <= usize::from(u8::MAX) + 1,
-        "Phase 12 decoding program instruction count {} exceeds the u8 pc horizon {}",
-        program.instructions().len(),
-        usize::from(u8::MAX) + 1
-    );
-    program.instructions().len().saturating_add(1)
+fn decoding_program_step_limit(program: &Program) -> Result<usize> {
+    let instruction_count = program.instructions().len();
+    let max_reachable_instructions = usize::from(u8::MAX) + 1;
+    if instruction_count > max_reachable_instructions {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 12 decoding program instruction count {} exceeds the u8 pc horizon {}",
+            instruction_count, max_reachable_instructions
+        )));
+    }
+    Ok(instruction_count + 1)
 }
 
 fn commit_phase12_history_seed(
@@ -3555,6 +3557,12 @@ fn phase11_demo_initial_memories() -> Vec<Vec<i16>> {
     ]
 }
 
+fn write_phase12_noncanonical_lookup_seed(memory: &mut [i16], lookup: std::ops::Range<usize>) {
+    for (offset, cell) in memory[lookup].iter_mut().enumerate() {
+        *cell = PHASE12_LOOKUP_ROW_VALUES[offset] + 1;
+    }
+}
+
 pub(crate) fn phase12_demo_initial_memories(
     layout: &Phase12DecodingLayout,
 ) -> Result<Vec<Vec<i16>>> {
@@ -3575,11 +3583,11 @@ pub(crate) fn phase12_demo_initial_memories(
         memory[kv_cache_range.clone()].copy_from_slice(&kv_cache);
         memory[incoming_token_range.clone()].copy_from_slice(&incoming_values);
         memory[query_range.clone()].copy_from_slice(&query_values);
-        memory[lookup_range.clone()].copy_from_slice(&PHASE12_LOOKUP_ROW_VALUES);
+        write_phase12_noncanonical_lookup_seed(&mut memory, lookup_range.clone());
         memory[position_index] = position as i16;
         memory[position_increment_index] = 1;
         let program = decoding_step_v2_program_with_initial_memory(layout, memory.clone())?;
-        let step_limit = decoding_program_step_limit(&program);
+        let step_limit = decoding_program_step_limit(&program)?;
         let mut runtime = NativeInterpreter::new(program, Attention2DMode::AverageHard, step_limit);
         let result = runtime.run()?;
         if !result.halted {
@@ -3739,7 +3747,7 @@ mod tests {
         let mut runtime = NativeInterpreter::new(
             program.clone(),
             Attention2DMode::AverageHard,
-            decoding_program_step_limit(&program),
+            decoding_program_step_limit(&program).expect("step limit"),
         );
         let result = runtime.run().expect("run program");
         assert!(result.halted);
@@ -3907,7 +3915,7 @@ mod tests {
         for index in query {
             memory[index] = rng.gen_range(-3..=3);
         }
-        memory[lookup].copy_from_slice(&PHASE12_LOOKUP_ROW_VALUES);
+        write_phase12_noncanonical_lookup_seed(&mut memory, lookup);
         memory[position_index] = rng.gen_range(0..=7);
         memory[position_increment_index] = 1;
         memory
@@ -3939,7 +3947,7 @@ mod tests {
                     memory[kv_cache_range].copy_from_slice(&kv_cache);
                     memory[incoming_range].copy_from_slice(&incoming);
                     memory[query_range].copy_from_slice(&query);
-                    memory[lookup_range].copy_from_slice(&PHASE12_LOOKUP_ROW_VALUES);
+                    write_phase12_noncanonical_lookup_seed(&mut memory, lookup_range);
                     memory[position_index] = position;
                     memory[position_increment_index] = 1;
                     (layout, memory)
@@ -4289,7 +4297,7 @@ mod tests {
             for memory in phase12_demo_initial_memories(&layout).expect("memories") {
                 let program =
                     decoding_step_v2_program_with_initial_memory(&layout, memory.clone()).expect("program");
-                let step_limit = decoding_program_step_limit(&program);
+                let step_limit = decoding_program_step_limit(&program).expect("step limit");
                 let mut runtime = NativeInterpreter::new(
                     program,
                     Attention2DMode::AverageHard,
@@ -4366,7 +4374,7 @@ mod tests {
             (layout, memory) in phase12_bounded_memory_strategy(),
         ) {
             let program = decoding_step_v2_program_with_initial_memory(&layout, memory.clone()).expect("program");
-            let step_limit = decoding_program_step_limit(&program);
+            let step_limit = decoding_program_step_limit(&program).expect("step limit");
             let mut runtime = NativeInterpreter::new(
                 program,
                 Attention2DMode::AverageHard,
@@ -4399,7 +4407,7 @@ mod tests {
                 let mut runtime = NativeInterpreter::new(
                     program.clone(),
                     Attention2DMode::AverageHard,
-                    decoding_program_step_limit(&program),
+                    decoding_program_step_limit(&program).expect("step limit"),
                 );
                 let result = runtime.run().expect("run program");
                 assert!(result.halted);
@@ -4408,7 +4416,7 @@ mod tests {
                 let model = ProgramCompiler
                     .compile_program(program, config.clone())
                     .expect("compile");
-                prove_execution_stark_with_backend_and_options(
+                let proof = prove_execution_stark_with_backend_and_options(
                     &model,
                     128,
                     StarkProofBackend::Stwo,
@@ -4420,6 +4428,11 @@ mod tests {
                         layout
                     )
                 });
+                assert_eq!(proof.claim.final_state.memory, expected_final_memory);
+                assert_eq!(
+                    phase12_shared_lookup_rows_from_proof_payload(&proof).expect("lookup rows from proof"),
+                    Some(expected_final_memory[layout.lookup_range().expect("lookup range")].to_vec())
+                );
             }
         }
     }
@@ -4692,7 +4705,7 @@ mod tests {
                 let next = &pair[1];
                 let program =
                     decoding_step_v2_program_with_initial_memory(&layout, current).expect("program");
-                let step_limit = decoding_program_step_limit(&program);
+                let step_limit = decoding_program_step_limit(&program).expect("step limit");
                 let mut runtime = NativeInterpreter::new(
                     program,
                     Attention2DMode::AverageHard,

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -23,30 +23,30 @@ use crate::stwo_backend::{
 pub const STWO_DECODING_CHAIN_VERSION_PHASE11: &str = "stwo-phase11-decoding-chain-v1";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE11: &str = "stwo_execution_proof_carrying_decoding_chain";
 pub const STWO_DECODING_STATE_VERSION_PHASE11: &str = "stwo-decoding-state-v1";
-pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v5";
+pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v6";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE12: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_chain";
-pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v7";
+pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v8";
 pub const STWO_DECODING_LAYOUT_VERSION_PHASE12: &str = "stwo-decoding-layout-v1";
 pub const STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13: &str =
-    "stwo-phase13-decoding-layout-matrix-v5";
+    "stwo-phase13-decoding-layout-matrix-v6";
 pub const STWO_DECODING_LAYOUT_MATRIX_SCOPE_PHASE13: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_layout_matrix";
 pub const STWO_DECODING_CHAIN_VERSION_PHASE14: &str =
-    "stwo-phase14-decoding-chunked-history-chain-v5";
+    "stwo-phase14-decoding-chunked-history-chain-v6";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE14: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_chunked_history_chain";
 pub const STWO_DECODING_STATE_VERSION_PHASE14: &str = "stwo-decoding-state-v6";
 pub const STWO_DECODING_SEGMENT_BUNDLE_VERSION_PHASE15: &str =
-    "stwo-phase15-decoding-history-segment-bundle-v5";
+    "stwo-phase15-decoding-history-segment-bundle-v6";
 pub const STWO_DECODING_SEGMENT_BUNDLE_SCOPE_PHASE15: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_history_segment_bundle";
 pub const STWO_DECODING_SEGMENT_ROLLUP_VERSION_PHASE16: &str =
-    "stwo-phase16-decoding-history-segment-rollup-v5";
+    "stwo-phase16-decoding-history-segment-rollup-v6";
 pub const STWO_DECODING_SEGMENT_ROLLUP_SCOPE_PHASE16: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_history_segment_rollup";
 pub const STWO_DECODING_ROLLUP_MATRIX_VERSION_PHASE17: &str =
-    "stwo-phase17-decoding-history-rollup-matrix-v5";
+    "stwo-phase17-decoding-history-rollup-matrix-v6";
 pub const STWO_DECODING_ROLLUP_MATRIX_SCOPE_PHASE17: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_history_rollup_matrix";
 const DECODING_KV_CACHE_RANGE: std::ops::Range<usize> = 0..6;
@@ -470,6 +470,9 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
     instructions.push(Instruction::Load((lookup.start + 3) as u8));
     instructions.push(Instruction::AddMemory((lookup.start + 7) as u8));
     instructions.push(Instruction::Store((output.start + 2) as u8));
+    instructions.push(Instruction::Load(output.start as u8));
+    instructions.push(Instruction::AddMemory((output.start + 2) as u8));
+    instructions.push(Instruction::Store(output.start as u8));
 
     let kv_cache = layout.kv_cache_range()?;
     for index in 0..(kv_cache.len().saturating_sub(layout.pair_width)) {
@@ -3853,11 +3856,15 @@ mod tests {
             .sum();
         let raw_accumulated =
             raw_dot + memory[incoming.clone()].iter().map(|&value| i32::from(value)).sum::<i32>();
+        let combined_output =
+            i32::from(memory[lookup.start + 3]) + i32::from(memory[lookup.start + 7]);
         [
-            raw_dot * i32::from(memory[lookup.start + 1]) + i32::from(memory[lookup.start + 3]),
+            raw_dot * i32::from(memory[lookup.start + 1])
+                + i32::from(memory[lookup.start + 3])
+                + combined_output,
             raw_accumulated * i32::from(memory[lookup.start + 5])
                 + i32::from(memory[lookup.start + 7]),
-            i32::from(memory[lookup.start + 3]) + i32::from(memory[lookup.start + 7]),
+            combined_output,
         ]
         .map(|value| i16::try_from(value).expect("bounded Phase 12 oracle output"))
     }
@@ -4221,6 +4228,24 @@ mod tests {
         assert_eq!(
             instructions.get(lookup_store_index + 15),
             Some(&Instruction::Store((output.start + 2) as u8))
+        );
+    }
+
+    #[test]
+    fn phase12_template_adds_combined_output_into_primary_output() {
+        let layout = phase12_default_decoding_layout();
+        let output = layout.output_range().expect("output range");
+        let program = decoding_step_v2_template_program(&layout).expect("program");
+        let instructions = program.instructions();
+        let expected = [
+            Instruction::Load(output.start as u8),
+            Instruction::AddMemory((output.start + 2) as u8),
+            Instruction::Store(output.start as u8),
+        ];
+        assert!(
+            instructions
+                .windows(expected.len())
+                .any(|window| window == expected.as_slice())
         );
     }
 

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -470,8 +470,7 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
     instructions.push(Instruction::Load((lookup.start + 3) as u8));
     instructions.push(Instruction::AddMemory((lookup.start + 7) as u8));
     instructions.push(Instruction::Store((output.start + 2) as u8));
-    instructions.push(Instruction::Load(output.start as u8));
-    instructions.push(Instruction::AddMemory((output.start + 2) as u8));
+    instructions.push(Instruction::AddMemory(output.start as u8));
     instructions.push(Instruction::Store(output.start as u8));
 
     let kv_cache = layout.kv_cache_range()?;
@@ -3561,8 +3560,14 @@ fn phase11_demo_initial_memories() -> Vec<Vec<i16>> {
 }
 
 fn write_phase12_noncanonical_lookup_seed(memory: &mut [i16], lookup: std::ops::Range<usize>) {
-    for (offset, cell) in memory[lookup].iter_mut().enumerate() {
-        *cell = PHASE12_LOOKUP_ROW_VALUES[offset] + 1;
+    let slice = &mut memory[lookup];
+    assert_eq!(
+        slice.len(),
+        PHASE12_LOOKUP_ROW_VALUES.len(),
+        "Phase 12 lookup seed length mismatch"
+    );
+    for (cell, &value) in slice.iter_mut().zip(PHASE12_LOOKUP_ROW_VALUES.iter()) {
+        *cell = value.saturating_add(1);
     }
 }
 
@@ -4237,15 +4242,17 @@ mod tests {
         let output = layout.output_range().expect("output range");
         let program = decoding_step_v2_template_program(&layout).expect("program");
         let instructions = program.instructions();
-        let expected = [
-            Instruction::Load(output.start as u8),
-            Instruction::AddMemory((output.start + 2) as u8),
-            Instruction::Store(output.start as u8),
-        ];
-        assert!(
-            instructions
-                .windows(expected.len())
-                .any(|window| window == expected.as_slice())
+        let combined_store_index = instructions
+            .iter()
+            .position(|instruction| *instruction == Instruction::Store((output.start + 2) as u8))
+            .expect("combined-output store");
+        assert_eq!(
+            instructions.get(combined_store_index + 1),
+            Some(&Instruction::AddMemory(output.start as u8))
+        );
+        assert_eq!(
+            instructions.get(combined_store_index + 2),
+            Some(&Instruction::Store(output.start as u8))
         );
     }
 

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -138,7 +138,7 @@ pub const STWO_BACKEND_VERSION_PHASE5: &str = "stwo-phase10-gemma-block-v4";
 /// Backend version label used by the fixed-shape proof-carrying decoding demo family.
 pub const STWO_BACKEND_VERSION_PHASE11: &str = "stwo-phase11-decoding-step-v1";
 /// Backend version label used by the parameterized proof-carrying decoding family.
-pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v5";
+pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v6";
 /// Cargo feature that enables the experimental S-two backend seam.
 pub const STWO_BACKEND_FEATURE_NAME: &str = "stwo-backend";
 


### PR DESCRIPTION
## Summary
- make the Phase 12 primary output absorb the bounded combined-output cell after both shared activation rows are materialized
- bump the Phase 12 family/state/chain and Phase 13 matrix versions for the new instruction family
- keep the change under the existing vanilla-AIR arithmetic limits and validate it against the replay stack

## Validation
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_template_adds_combined_output_into_primary_output --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_runtime_uses_shared_lookup_rows_across_layouts --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_semantic_oracle_matches_manifest_states_across_layouts --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_random_bounded_memories_accept_real_stwo_proof_and_match_oracle --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase13_real_stwo_prove_accepts_layout_matrix_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase14_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase15_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase16_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase17_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli stwo_decoding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated decoding specs and design docs: primary output now absorbs the combined output in Phase 12; narratives and transition wording aligned.

* **Tests**
  * Added/updated tests to confirm the primary output accumulates combined output and to verify final memory and lookup expectations.

* **Chores**
  * Bumped decoding/backend version labels across Phase 12–17 artifacts.

* **Bug Fixes**
  * Strengthened step-limit validation to return a clear error on overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->