### PR TITLE
Enrich Phase 12 combined output with bounded lookup row

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,11 +517,12 @@ matrix/rollup-style packaging layers described in the next-paper track.
   transition itself, with the latest carried KV-cache pair now updated from
   lookup-backed values rather than only forwarded incoming values, with three
   carried lanes now driven by the bounded combined-output cell and one by the
-  lookup-backed primary output on the wider public layouts, and with the primary
-  output itself now absorbing that bounded combined-output cell so both shared
-  activation rows influence the carried primary lane and output commitment, plus
-  exact semantic tests and real-backend proving coverage over all default demo
-  steps
+  lookup-backed primary output on the wider public layouts, with that
+  combined-output cell now also absorbing one additional bounded shared lookup
+  row before it is carried forward, and with the primary and secondary outputs
+  both absorbing that combined-output cell so both shared activation rows
+  influence the carried output frontier and output commitment, plus exact
+  semantic tests and real-backend proving coverage over all default demo steps
 - Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend proving coverage across the default layout matrix
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries
@@ -836,8 +837,9 @@ both shared normalization scale rows and both shared activation output rows in
 executed decoding semantics, not only as carried proof metadata, and feeds
 lookup-backed values into the latest carried KV-cache pair on the public demo
 layouts, with the current wider layout frontier now mostly output-derived
-rather than forwarded-input-derived, while the primary output now also absorbs
-the bounded combined-output cell before being carried forward.
+rather than forwarded-input-derived, while the bounded combined-output cell
+itself now absorbs one additional shared lookup row before both final output
+lanes carry it forward.
 
 #### Phase Highlights
 

--- a/docs/design/stwo-backend-design.md
+++ b/docs/design/stwo-backend-design.md
@@ -208,9 +208,10 @@ Delivered:
   activation output rows inside the executed `decoding_step_v2` program instead of treating those
   lookup rows as write-only metadata, feeding bounded lookup-backed values into the latest carried
   KV-cache pair on the public demo layouts, with three carried lanes now bound to the combined
-  output cell and one to the lookup-backed primary output on the wider layouts, with that primary
-  output now also absorbing the bounded combined-output cell before it is carried forward, and
-  with exact tests plus real-backend proving coverage over all default demo steps and the default
+  output cell and one to the lookup-backed primary output on the wider layouts, with that
+  combined-output cell now also absorbing one additional bounded shared lookup row before it is
+  carried forward, with both final output lanes absorbing that combined-output cell, and with
+  exact tests plus real-backend proving coverage over all default demo steps and the default
   layout matrix.
 
 Current limitation:

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -23,30 +23,30 @@ use crate::stwo_backend::{
 pub const STWO_DECODING_CHAIN_VERSION_PHASE11: &str = "stwo-phase11-decoding-chain-v1";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE11: &str = "stwo_execution_proof_carrying_decoding_chain";
 pub const STWO_DECODING_STATE_VERSION_PHASE11: &str = "stwo-decoding-state-v1";
-pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v7";
+pub const STWO_DECODING_CHAIN_VERSION_PHASE12: &str = "stwo-phase12-decoding-chain-v8";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE12: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_chain";
-pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v9";
+pub const STWO_DECODING_STATE_VERSION_PHASE12: &str = "stwo-decoding-state-v10";
 pub const STWO_DECODING_LAYOUT_VERSION_PHASE12: &str = "stwo-decoding-layout-v1";
 pub const STWO_DECODING_LAYOUT_MATRIX_VERSION_PHASE13: &str =
-    "stwo-phase13-decoding-layout-matrix-v7";
+    "stwo-phase13-decoding-layout-matrix-v8";
 pub const STWO_DECODING_LAYOUT_MATRIX_SCOPE_PHASE13: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_layout_matrix";
 pub const STWO_DECODING_CHAIN_VERSION_PHASE14: &str =
-    "stwo-phase14-decoding-chunked-history-chain-v7";
+    "stwo-phase14-decoding-chunked-history-chain-v8";
 pub const STWO_DECODING_CHAIN_SCOPE_PHASE14: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_chunked_history_chain";
 pub const STWO_DECODING_STATE_VERSION_PHASE14: &str = "stwo-decoding-state-v6";
 pub const STWO_DECODING_SEGMENT_BUNDLE_VERSION_PHASE15: &str =
-    "stwo-phase15-decoding-history-segment-bundle-v7";
+    "stwo-phase15-decoding-history-segment-bundle-v8";
 pub const STWO_DECODING_SEGMENT_BUNDLE_SCOPE_PHASE15: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_history_segment_bundle";
 pub const STWO_DECODING_SEGMENT_ROLLUP_VERSION_PHASE16: &str =
-    "stwo-phase16-decoding-history-segment-rollup-v7";
+    "stwo-phase16-decoding-history-segment-rollup-v8";
 pub const STWO_DECODING_SEGMENT_ROLLUP_SCOPE_PHASE16: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_history_segment_rollup";
 pub const STWO_DECODING_ROLLUP_MATRIX_VERSION_PHASE17: &str =
-    "stwo-phase17-decoding-history-rollup-matrix-v7";
+    "stwo-phase17-decoding-history-rollup-matrix-v8";
 pub const STWO_DECODING_ROLLUP_MATRIX_SCOPE_PHASE17: &str =
     "stwo_execution_parameterized_proof_carrying_decoding_history_rollup_matrix";
 const DECODING_KV_CACHE_RANGE: std::ops::Range<usize> = 0..6;
@@ -469,6 +469,7 @@ pub fn decoding_step_v2_template_program(layout: &Phase12DecodingLayout) -> Resu
     instructions.push(Instruction::Store((output.start + 1) as u8));
     instructions.push(Instruction::Load((lookup.start + 3) as u8));
     instructions.push(Instruction::AddMemory((lookup.start + 7) as u8));
+    instructions.push(Instruction::AddMemory((lookup.start + 4) as u8));
     instructions.push(Instruction::Store((output.start + 2) as u8));
     instructions.push(Instruction::Load((output.start + 1) as u8));
     instructions.push(Instruction::AddMemory((output.start + 2) as u8));
@@ -3865,8 +3866,9 @@ mod tests {
             .sum();
         let raw_accumulated =
             raw_dot + memory[incoming.clone()].iter().map(|&value| i32::from(value)).sum::<i32>();
-        let combined_output =
-            i32::from(memory[lookup.start + 3]) + i32::from(memory[lookup.start + 7]);
+        let combined_output = i32::from(memory[lookup.start + 3])
+            + i32::from(memory[lookup.start + 7])
+            + i32::from(memory[lookup.start + 4]);
         [
             raw_dot * i32::from(memory[lookup.start + 1])
                 + i32::from(memory[lookup.start + 3])
@@ -4237,6 +4239,10 @@ mod tests {
         );
         assert_eq!(
             instructions.get(lookup_store_index + 15),
+            Some(&Instruction::AddMemory((lookup.start + 4) as u8))
+        );
+        assert_eq!(
+            instructions.get(lookup_store_index + 16),
             Some(&Instruction::Store((output.start + 2) as u8))
         );
     }
@@ -4286,24 +4292,6 @@ mod tests {
         assert_eq!(
             instructions.get(combined_store_index + 3),
             Some(&Instruction::Store((output.start + 1) as u8))
-        );
-    }
-
-    #[test]
-    fn phase12_template_adds_combined_output_into_secondary_output() {
-        let layout = phase12_default_decoding_layout();
-        let output = layout.output_range().expect("output range");
-        let program = decoding_step_v2_template_program(&layout).expect("program");
-        let instructions = program.instructions();
-        let expected = [
-            Instruction::Load((output.start + 1) as u8),
-            Instruction::AddMemory((output.start + 2) as u8),
-            Instruction::Store((output.start + 1) as u8),
-        ];
-        assert!(
-            instructions
-                .windows(expected.len())
-                .any(|window| window == expected.as_slice())
         );
     }
 

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -4290,6 +4290,24 @@ mod tests {
     }
 
     #[test]
+    fn phase12_template_adds_combined_output_into_secondary_output() {
+        let layout = phase12_default_decoding_layout();
+        let output = layout.output_range().expect("output range");
+        let program = decoding_step_v2_template_program(&layout).expect("program");
+        let instructions = program.instructions();
+        let expected = [
+            Instruction::Load((output.start + 1) as u8),
+            Instruction::AddMemory((output.start + 2) as u8),
+            Instruction::Store((output.start + 1) as u8),
+        ];
+        assert!(
+            instructions
+                .windows(expected.len())
+                .any(|window| window == expected.as_slice())
+        );
+    }
+
+    #[test]
     fn phase12_template_writes_primary_output_into_fourth_cache_lane_when_available() {
         let layout = phase12_default_decoding_layout();
         let latest_cached = layout.latest_cached_pair_range().expect("latest cached");

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -138,7 +138,7 @@ pub const STWO_BACKEND_VERSION_PHASE5: &str = "stwo-phase10-gemma-block-v4";
 /// Backend version label used by the fixed-shape proof-carrying decoding demo family.
 pub const STWO_BACKEND_VERSION_PHASE11: &str = "stwo-phase11-decoding-step-v1";
 /// Backend version label used by the parameterized proof-carrying decoding family.
-pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v7";
+pub const STWO_BACKEND_VERSION_PHASE12: &str = "stwo-phase12-decoding-family-v8";
 /// Cargo feature that enables the experimental S-two backend seam.
 pub const STWO_BACKEND_FEATURE_NAME: &str = "stwo-backend";
 


### PR DESCRIPTION
## Summary
- add one more bounded shared lookup row into the Phase 12 combined-output cell
- preserve the current cache mapping and Phase 14 replay model
- keep the change inside the current arithmetic envelope while strengthening the lookup-backed non-arithmetic relation
- tighten the primary and secondary instruction-placement tests around the combined-output store

## Validation
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_template_consumes_shared_lookup_rows --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_template_adds_combined_output_into_primary_output --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_template_adds_combined_output_into_secondary_output --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_runtime_uses_shared_lookup_rows_across_layouts --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_semantic_oracle_matches_manifest_states_across_layouts --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_random_bounded_memories_accept_real_stwo_proof_and_match_oracle --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase12_real_stwo_prove_accepts_default_layout_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase13_real_stwo_prove_accepts_layout_matrix_demo_memories --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase14_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase15_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase16_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend phase17_ --lib
- cargo +nightly-2025-07-14 test --quiet --features stwo-backend --test cli stwo_decoding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design documentation and README to reflect current phase capabilities and decoding pipeline semantics.

* **Chores**
  * Updated version identifiers for decoding phases 12–17 to reflect pipeline changes.
  * Incremented backend version identifier for phase 12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->