### PR TITLE
Add mutation testing for trusted validator core

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,52 @@
+name: Mutation Testing
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/mutation-testing.yml"
+      - "scripts/run_mutation_suite.sh"
+      - "src/stwo_backend/decoding.rs"
+      - "src/stwo_backend/shared_lookup_artifact.rs"
+      - "src/stwo_backend/arithmetic_subset_prover.rs"
+
+jobs:
+  cargo-mutants:
+    name: cargo-mutants (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ["1/2", "2/2"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-07-14
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants --locked
+
+      - name: Run targeted mutation suite
+        env:
+          MUTATION_SHARD: ${{ matrix.shard }}
+          MUTATION_BASELINE: skip
+          MUTATION_MIN_TEST_TIMEOUT: 120
+          MUTATION_TIMEOUT: 1800
+          MUTATION_JOBS: 2
+        run: |
+          chmod +x scripts/run_mutation_suite.sh
+          scripts/run_mutation_suite.sh

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -24,11 +24,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ["1/2", "2/2"]
+        shard: ["0/2", "1/2"]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -39,7 +39,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants --locked
+        run: cargo install cargo-mutants --version 27.0.0 --locked
 
       - name: Run mutation compile smoke on pull requests
         if: github.event_name == 'pull_request'
@@ -66,3 +66,11 @@ jobs:
         run: |
           chmod +x scripts/run_mutation_suite.sh
           scripts/run_mutation_suite.sh
+
+      - name: Upload mutation artifacts
+        if: always() && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: cargo-mutants-${{ matrix.shard }}
+          path: mutants.out/
+          if-no-files-found: ignore

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"
   pull_request:
     paths:
       - ".github/workflows/mutation-testing.yml"
@@ -19,13 +21,17 @@ env:
 
 jobs:
   cargo-mutants:
-    name: cargo-mutants (${{ matrix.shard }})
+    name: cargo-mutants (${{ matrix.label }})
     runs-on: ubuntu-22.04
     timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
-        shard: ["0/2", "1/2"]
+        include:
+          - shard: "0/2"
+            label: "0-of-2"
+          - shard: "1/2"
+            label: "1-of-2"
 
     steps:
       - name: Checkout
@@ -42,21 +48,7 @@ jobs:
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --version 27.0.0 --locked
 
-      - name: Run mutation compile smoke on pull requests
-        if: github.event_name == 'pull_request'
-        env:
-          MUTATION_SHARD: ${{ matrix.shard }}
-          MUTATION_TOOLCHAIN: ${{ env.MUTATION_TOOLCHAIN }}
-          MUTATION_BASELINE: skip
-          MUTATION_MIN_TEST_TIMEOUT: 60
-          MUTATION_TIMEOUT: 600
-          MUTATION_JOBS: 2
-        run: |
-          chmod +x scripts/run_mutation_suite.sh
-          scripts/run_mutation_suite.sh --check
-
-      - name: Run full targeted mutation suite
-        if: github.event_name != 'pull_request'
+      - name: Run targeted mutation suite
         env:
           MUTATION_SHARD: ${{ matrix.shard }}
           MUTATION_TOOLCHAIN: ${{ env.MUTATION_TOOLCHAIN }}
@@ -72,6 +64,6 @@ jobs:
         if: always() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: cargo-mutants-${{ matrix.shard }}
+          name: cargo-mutants-${{ matrix.label }}
           path: mutants.out/
           if-no-files-found: ignore

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -12,6 +12,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "src/stwo_backend/**"
+      - "tests/**"
 
 env:
   MUTATION_TOOLCHAIN: nightly-2025-07-14
@@ -19,7 +20,7 @@ env:
 jobs:
   cargo-mutants:
     name: cargo-mutants (${{ matrix.shard }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 360
     strategy:
       fail-fast: false
@@ -36,7 +37,7 @@ jobs:
           toolchain: ${{ env.MUTATION_TOOLCHAIN }}
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --version 27.0.0 --locked

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -7,19 +7,20 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - "Cargo.toml"
-      - "Cargo.lock"
       - ".github/workflows/mutation-testing.yml"
       - "scripts/run_mutation_suite.sh"
-      - "src/stwo_backend/decoding.rs"
-      - "src/stwo_backend/shared_lookup_artifact.rs"
-      - "src/stwo_backend/arithmetic_subset_prover.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/stwo_backend/**"
+
+env:
+  MUTATION_TOOLCHAIN: nightly-2025-07-14
 
 jobs:
   cargo-mutants:
     name: cargo-mutants (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
@@ -30,9 +31,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: nightly-2025-07-14
+          toolchain: ${{ env.MUTATION_TOOLCHAIN }}
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
@@ -40,12 +41,27 @@ jobs:
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
 
-      - name: Run targeted mutation suite
+      - name: Run mutation compile smoke on pull requests
+        if: github.event_name == 'pull_request'
         env:
           MUTATION_SHARD: ${{ matrix.shard }}
+          MUTATION_TOOLCHAIN: ${{ env.MUTATION_TOOLCHAIN }}
           MUTATION_BASELINE: skip
-          MUTATION_MIN_TEST_TIMEOUT: 120
-          MUTATION_TIMEOUT: 1800
+          MUTATION_MIN_TEST_TIMEOUT: 60
+          MUTATION_TIMEOUT: 600
+          MUTATION_JOBS: 2
+        run: |
+          chmod +x scripts/run_mutation_suite.sh
+          scripts/run_mutation_suite.sh --check
+
+      - name: Run full targeted mutation suite
+        if: github.event_name != 'pull_request'
+        env:
+          MUTATION_SHARD: ${{ matrix.shard }}
+          MUTATION_TOOLCHAIN: ${{ env.MUTATION_TOOLCHAIN }}
+          MUTATION_BASELINE: skip
+          MUTATION_MIN_TEST_TIMEOUT: 60
+          MUTATION_TIMEOUT: 600
           MUTATION_JOBS: 2
         run: |
           chmod +x scripts/run_mutation_suite.sh

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -24,6 +24,13 @@ jobs:
     name: cargo-mutants (${{ matrix.label }})
     runs-on: ubuntu-22.04
     timeout-minutes: 360
+    env:
+      MUTATION_SHARD: ${{ matrix.shard }}
+      MUTATION_TOOLCHAIN: ${{ env.MUTATION_TOOLCHAIN }}
+      MUTATION_BASELINE: skip
+      MUTATION_MIN_TEST_TIMEOUT: 60
+      MUTATION_TIMEOUT: 600
+      MUTATION_JOBS: 2
     strategy:
       fail-fast: false
       matrix:
@@ -52,14 +59,14 @@ jobs:
           rm -f "$CARGO_HOME/bin/cargo-mutants"
           cargo install cargo-mutants --version 27.0.0 --locked --force
 
-      - name: Run targeted mutation suite
-        env:
-          MUTATION_SHARD: ${{ matrix.shard }}
-          MUTATION_TOOLCHAIN: ${{ env.MUTATION_TOOLCHAIN }}
-          MUTATION_BASELINE: skip
-          MUTATION_MIN_TEST_TIMEOUT: 60
-          MUTATION_TIMEOUT: 600
-          MUTATION_JOBS: 2
+      - name: Run mutation compile smoke on pull requests
+        if: github.event_name == 'pull_request'
+        run: |
+          chmod +x scripts/run_mutation_suite.sh
+          scripts/run_mutation_suite.sh --check
+
+      - name: Run full targeted mutation suite
+        if: github.event_name != 'pull_request'
         run: |
           chmod +x scripts/run_mutation_suite.sh
           scripts/run_mutation_suite.sh

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -44,9 +44,13 @@ jobs:
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+        with:
+          cache-bin: false
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants --version 27.0.0 --locked
+        run: |
+          rm -f "$CARGO_HOME/bin/cargo-mutants"
+          cargo install cargo-mutants --version 27.0.0 --locked --force
 
       - name: Run targeted mutation suite
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ AI_REVIEW_BOTS_BEST_PRACTICES_*.md
 **/.tldrignore
 compiled/
 docs/artifacts/*.proof.json
+mutants.out/

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -5,14 +5,23 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 MUTATION_TOOLCHAIN="${MUTATION_TOOLCHAIN:-nightly-2025-07-14}"
+MUTATION_TARGETS=(
+  src/stwo_backend/decoding.rs
+  src/stwo_backend/shared_lookup_artifact.rs
+  src/stwo_backend/arithmetic_subset_prover.rs
+)
+
+for target in "${MUTATION_TARGETS[@]}"; do
+  if [[ ! -f "$target" ]]; then
+    echo "mutation target not found: $target" >&2
+    exit 1
+  fi
+done
 
 args=(
   cargo
   +"${MUTATION_TOOLCHAIN}"
   mutants
-  --file src/stwo_backend/decoding.rs
-  --file src/stwo_backend/shared_lookup_artifact.rs
-  --file src/stwo_backend/arithmetic_subset_prover.rs
   --features stwo-backend
   --test-tool cargo
   --cap-lints=true
@@ -23,6 +32,10 @@ args=(
   --jobs "${MUTATION_JOBS:-2}"
   --no-shuffle
 )
+
+for target in "${MUTATION_TARGETS[@]}"; do
+  args+=(--file "$target")
+done
 
 if [[ -n "${MUTATION_SHARD:-}" ]]; then
   args+=(--shard "$MUTATION_SHARD")

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -11,12 +11,18 @@ MUTATION_TARGETS=(
   src/stwo_backend/arithmetic_subset_prover.rs
 )
 
+missing_targets=()
 for target in "${MUTATION_TARGETS[@]}"; do
   if [[ ! -f "$target" ]]; then
-    echo "mutation target not found: $target" >&2
-    exit 1
+    missing_targets+=("$target")
   fi
 done
+
+if (( ${#missing_targets[@]} > 0 )); then
+  printf 'missing mutation targets:\n' >&2
+  printf '  %s\n' "${missing_targets[@]}" >&2
+  exit 1
+fi
 
 args=(
   cargo

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+args=(
+  cargo
+  +nightly-2025-07-14
+  mutants
+  --file src/stwo_backend/decoding.rs
+  --file src/stwo_backend/shared_lookup_artifact.rs
+  --file src/stwo_backend/arithmetic_subset_prover.rs
+  --features stwo-backend
+  --test-tool cargo
+  --cargo-arg=--lib
+  --cap-lints=true
+  --copy-target=true
+  --baseline "${MUTATION_BASELINE:-skip}"
+  --minimum-test-timeout "${MUTATION_MIN_TEST_TIMEOUT:-60}"
+  --timeout "${MUTATION_TIMEOUT:-900}"
+  --jobs "${MUTATION_JOBS:-2}"
+  --no-shuffle
+)
+
+if [[ -n "${MUTATION_SHARD:-}" ]]; then
+  args+=(--shard "$MUTATION_SHARD")
+fi
+
+"${args[@]}" "$@"

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -4,16 +4,17 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+MUTATION_TOOLCHAIN="${MUTATION_TOOLCHAIN:-nightly-2025-07-14}"
+
 args=(
   cargo
-  +nightly-2025-07-14
+  +"${MUTATION_TOOLCHAIN}"
   mutants
   --file src/stwo_backend/decoding.rs
   --file src/stwo_backend/shared_lookup_artifact.rs
   --file src/stwo_backend/arithmetic_subset_prover.rs
   --features stwo-backend
   --test-tool cargo
-  --cargo-arg=--lib
   --cap-lints=true
   --copy-target=true
   --baseline "${MUTATION_BASELINE:-skip}"

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -28,7 +28,7 @@ args=(
   --copy-target=true
   --baseline "${MUTATION_BASELINE:-skip}"
   --minimum-test-timeout "${MUTATION_MIN_TEST_TIMEOUT:-60}"
-  --timeout "${MUTATION_TIMEOUT:-900}"
+  --timeout "${MUTATION_TIMEOUT:-600}"
   --jobs "${MUTATION_JOBS:-2}"
   --no-shuffle
 )


### PR DESCRIPTION
## Summary
- add a focused cargo-mutants runner for the trusted validator files
- add a dedicated GitHub Actions workflow that shards mutation checks across two jobs
- ignore local mutation outputs in git

## Validation
- scripts/run_mutation_suite.sh --list-files
- MUTATION_JOBS=1 MUTATION_BASELINE=skip MUTATION_MIN_TEST_TIMEOUT=30 MUTATION_TIMEOUT=300 MUTATION_SHARD=1/64 scripts/run_mutation_suite.sh --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a mutation-testing CI workflow with manual and scheduled triggers, pinned toolchain and test runner version, sharded execution, per-shard artifact uploads, and PR vs full-run behaviors.

* **Chores**
  * Ignore generated mutation output in version control.
  * Added an executable helper to run the mutation test suite with environment-configurable options (sharding, timeouts, jobs) and strict failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->