### PR TITLE
Add Miri and sanitizer hardening jobs

### DIFF
--- a/.github/workflows/miri-sanitizers.yml
+++ b/.github/workflows/miri-sanitizers.yml
@@ -39,6 +39,9 @@ jobs:
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+        with:
+          cache-bin: false
+          cache-targets: false
 
       - name: Run Miri suite
         run: |
@@ -71,6 +74,9 @@ jobs:
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+        with:
+          cache-bin: false
+          cache-targets: false
 
       - name: Run address sanitizer suite
         env:

--- a/.github/workflows/miri-sanitizers.yml
+++ b/.github/workflows/miri-sanitizers.yml
@@ -4,6 +4,9 @@ permissions:
   contents: read
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
   pull_request:
     paths:
@@ -26,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -49,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9

--- a/.github/workflows/miri-sanitizers.yml
+++ b/.github/workflows/miri-sanitizers.yml
@@ -11,8 +11,7 @@ on:
       - "scripts/hardening_test_names.sh"
       - "scripts/run_miri_suite.sh"
       - "scripts/run_asan_suite.sh"
-      - "src/proof.rs"
-      - "src/vanillastark/proof_stream.rs"
+      - "src/**/*.rs"
       - "Cargo.toml"
       - "Cargo.lock"
 
@@ -22,7 +21,7 @@ env:
 jobs:
   miri:
     name: miri validator subset
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
 
     steps:
@@ -36,7 +35,7 @@ jobs:
           components: miri
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Run Miri suite
         run: |
@@ -45,7 +44,7 @@ jobs:
 
   address-sanitizer:
     name: address sanitizer validator subset
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
 
     steps:
@@ -57,12 +56,22 @@ jobs:
         with:
           toolchain: ${{ env.HARDENING_TOOLCHAIN }}
           components: rust-src
-          targets: x86_64-unknown-linux-gnu
+
+      - name: Read host target
+        id: host-target
+        run: |
+          echo "target=$(rustc +${{ env.HARDENING_TOOLCHAIN }} -vV | awk '/^host: / { print $2 }')" >> "$GITHUB_OUTPUT"
+
+      - name: Install host target
+        run: |
+          rustup +${{ env.HARDENING_TOOLCHAIN }} target add ${{ steps.host-target.outputs.target }}
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Run address sanitizer suite
+        env:
+          SANITIZER_TARGET: ${{ steps.host-target.outputs.target }}
         run: |
           chmod +x scripts/run_asan_suite.sh scripts/hardening_test_names.sh
           scripts/run_asan_suite.sh

--- a/.github/workflows/miri-sanitizers.yml
+++ b/.github/workflows/miri-sanitizers.yml
@@ -1,0 +1,68 @@
+name: Miri and Sanitizers
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/miri-sanitizers.yml"
+      - "scripts/hardening_test_names.sh"
+      - "scripts/run_miri_suite.sh"
+      - "scripts/run_asan_suite.sh"
+      - "src/proof.rs"
+      - "src/vanillastark/proof_stream.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+env:
+  HARDENING_TOOLCHAIN: nightly-2025-07-14
+
+jobs:
+  miri:
+    name: miri validator subset
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: ${{ env.HARDENING_TOOLCHAIN }}
+          components: miri
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Miri suite
+        run: |
+          chmod +x scripts/run_miri_suite.sh scripts/hardening_test_names.sh
+          scripts/run_miri_suite.sh
+
+  address-sanitizer:
+    name: address sanitizer validator subset
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: ${{ env.HARDENING_TOOLCHAIN }}
+          components: rust-src
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run address sanitizer suite
+        run: |
+          chmod +x scripts/run_asan_suite.sh scripts/hardening_test_names.sh
+          scripts/run_asan_suite.sh

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+hardening_test_filters=(
+  "proof::tests::production_profile_v1_is_self_consistent"
+  "proof::tests::commitment_hash_matches_blake2b_256_test_vector"
+  "proof::tests::conjectured_security_bits_handles_large_query_counts"
+  "proof::tests::canonical_json_hash_is_key_order_invariant"
+  "vanillastark::proof_stream::tests::test_deserialize_rejects_huge_object_count"
+  "vanillastark::proof_stream::tests::test_deserialize_rejects_huge_segment_length"
+  "vanillastark::proof_stream::tests::test_deserialize_rejects_truncated_stream"
+)

--- a/scripts/run_asan_suite.sh
+++ b/scripts/run_asan_suite.sh
@@ -14,7 +14,7 @@ if ((${#hardening_test_filters[@]} == 0)); then
   exit 1
 fi
 
-export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=0}"
+export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=1:leak_check_at_exit=0}"
 export RUSTFLAGS="${RUSTFLAGS:-} -Zsanitizer=address"
 export RUSTDOCFLAGS="${RUSTDOCFLAGS:-} -Zsanitizer=address"
 

--- a/scripts/run_asan_suite.sh
+++ b/scripts/run_asan_suite.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+HARDENING_TOOLCHAIN="${HARDENING_TOOLCHAIN:-nightly-2025-07-14}"
+SANITIZER_TARGET="${SANITIZER_TARGET:-$(rustc +${HARDENING_TOOLCHAIN} -vV | awk '/^host: / { print $2 }')}"
+
+source "$ROOT_DIR/scripts/hardening_test_names.sh"
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=0}"
+export RUSTFLAGS="${RUSTFLAGS:-} -Zsanitizer=address"
+export RUSTDOCFLAGS="${RUSTDOCFLAGS:-} -Zsanitizer=address"
+
+for test_filter in "${hardening_test_filters[@]}"; do
+  cargo +"${HARDENING_TOOLCHAIN}" test \
+    -Zbuild-std \
+    --target "${SANITIZER_TARGET}" \
+    --lib "${test_filter}" \
+    -- \
+    --exact
+done

--- a/scripts/run_asan_suite.sh
+++ b/scripts/run_asan_suite.sh
@@ -9,6 +9,11 @@ SANITIZER_TARGET="${SANITIZER_TARGET:-$(rustc +${HARDENING_TOOLCHAIN} -vV | awk 
 
 source "$ROOT_DIR/scripts/hardening_test_names.sh"
 
+if ((${#hardening_test_filters[@]} == 0)); then
+  echo "hardening_test_filters is empty; refusing to run an empty hardening suite" >&2
+  exit 1
+fi
+
 export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=0}"
 export RUSTFLAGS="${RUSTFLAGS:-} -Zsanitizer=address"
 export RUSTDOCFLAGS="${RUSTDOCFLAGS:-} -Zsanitizer=address"

--- a/scripts/run_miri_suite.sh
+++ b/scripts/run_miri_suite.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+HARDENING_TOOLCHAIN="${HARDENING_TOOLCHAIN:-nightly-2025-07-14}"
+export MIRIFLAGS="${MIRIFLAGS:-"-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation"}"
+
+source "$ROOT_DIR/scripts/hardening_test_names.sh"
+
+cargo +"${HARDENING_TOOLCHAIN}" miri setup
+
+for test_filter in "${hardening_test_filters[@]}"; do
+  cargo +"${HARDENING_TOOLCHAIN}" miri test --lib "${test_filter}" -- --exact
+done

--- a/scripts/run_miri_suite.sh
+++ b/scripts/run_miri_suite.sh
@@ -9,6 +9,11 @@ export MIRIFLAGS="${MIRIFLAGS:-"-Zmiri-strict-provenance -Zmiri-symbolic-alignme
 
 source "$ROOT_DIR/scripts/hardening_test_names.sh"
 
+if ((${#hardening_test_filters[@]} == 0)); then
+  echo "hardening_test_filters is empty; refusing to run an empty hardening suite" >&2
+  exit 1
+fi
+
 cargo +"${HARDENING_TOOLCHAIN}" miri setup
 
 for test_filter in "${hardening_test_filters[@]}"; do


### PR DESCRIPTION
## Summary
- add a bounded Miri workflow for pure validator-core serializer/hash/proof-stream tests
- add a bounded address-sanitizer workflow for the same trusted-core subset
- centralize the selected hardening test names in one script so both tools stay aligned

## Validation
- bash -n scripts/hardening_test_names.sh scripts/run_miri_suite.sh scripts/run_asan_suite.sh
- python3 - <<'PY'
import yaml
from pathlib import Path
with Path('.github/workflows/miri-sanitizers.yml').open() as f:
    yaml.safe_load(f)
print('syntax-ok')
PY
- HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh
- TARGET=$(rustc +nightly-2025-07-14 -vV | awk '/^host: / { print $2 }') && HARDENING_TOOLCHAIN=nightly-2025-07-14 SANITIZER_TARGET="$TARGET" scripts/run_asan_suite.sh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to run Miri and AddressSanitizer hardening suites (manual trigger, PRs for relevant changes, and main-branch runs).
  * Added executable tooling to run the Miri and ASan suites and a curated list of hardening-oriented test filters for targeted safety checks.
  * Workflow pins a nightly toolchain to ensure consistent hardening runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->