### PR TITLE
Add formal contract pilot for decoding bindings

### DIFF
--- a/.github/workflows/formal-contracts.yml
+++ b/.github/workflows/formal-contracts.yml
@@ -1,0 +1,46 @@
+name: Formal Contracts
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/formal-contracts.yml"
+      - "scripts/run_formal_contract_suite.sh"
+      - "src/stwo_backend/decoding.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+jobs:
+  decoding-contract-kernel:
+    name: decoding formal contract kernel
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+
+      - name: Install Kani
+        run: cargo install kani-verifier --version 0.64.0 --locked
+
+      - name: Setup Kani
+        run: cargo kani setup
+
+      - name: Run formal contract kernel
+        run: |
+          chmod +x scripts/run_formal_contract_suite.sh
+          scripts/run_formal_contract_suite.sh

--- a/docs/design/formal-contract-pilot.md
+++ b/docs/design/formal-contract-pilot.md
@@ -1,0 +1,35 @@
+# Formal Contract Pilot
+
+This pilot formalizes the narrowest trust-critical decoding bindings we currently rely on in the `stwo` proof-carrying path.
+
+Scope:
+- Phase 12 claim bindings:
+  - `statement_version` must match the manifest
+  - `semantic_scope` must remain `CLAIM_SEMANTIC_SCOPE_V1`
+  - the manifest artifact commitment must match the proof-payload artifact commitment
+- Phase 12 state progress:
+  - history length must advance by exactly one
+  - position must advance by exactly one
+- Phase 14 claim bindings:
+  - `statement_version` must match the manifest
+  - `semantic_scope` must remain `CLAIM_SEMANTIC_SCOPE_V1`
+  - the manifest artifact commitment must match the proof-payload artifact commitment
+- Phase 14 state progress:
+  - history length must advance by exactly one
+  - lookup transcript entries must advance by exactly one
+  - position must advance by exactly one
+
+Mechanization:
+- Kani harnesses live in `/Users/espejelomar/StarkNet/zk-ai/llm-provable-computer-codex/src/stwo_backend/decoding.rs`
+- the Kani model deliberately reduces string/commitment equality into scalar match predicates so the solver checks the binding logic rather than spending proof budget on `memcmp`
+- the dedicated runner is `/Users/espejelomar/StarkNet/zk-ai/llm-provable-computer-codex/scripts/run_formal_contract_suite.sh`
+- CI entrypoint is `/Users/espejelomar/StarkNet/zk-ai/llm-provable-computer-codex/.github/workflows/formal-contracts.yml`
+
+Non-goals:
+- this does not prove the full decoding verifier
+- this does not prove the `stwo` backend itself
+- this does not replace fuzzing, mutation testing, or oracle checks
+
+Why this exists:
+- the decoding validator is now stable enough that its scalar binding kernel is worth machine-checking
+- these contracts cover the highest-value “do not silently drift” invariants before larger proof-carrying decoding work continues

--- a/scripts/run_formal_contract_suite.sh
+++ b/scripts/run_formal_contract_suite.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+KANI_ARGS=(
+  cargo
+  kani
+  --features
+  stwo-backend
+  --output-format
+  terse
+  --harness
+  kani_phase12_claim_bindings_accept_canonical_single_step
+  --harness
+  kani_phase12_claim_bindings_reject_any_binding_mismatch
+  --harness
+  kani_phase12_state_progress_accepts_canonical_single_step
+  --harness
+  kani_phase12_state_progress_rejects_any_progress_mismatch
+  --harness
+  kani_phase14_claim_bindings_accept_canonical_single_step
+  --harness
+  kani_phase14_claim_bindings_reject_any_binding_mismatch
+  --harness
+  kani_phase14_state_progress_accepts_canonical_single_step
+  --harness
+  kani_phase14_state_progress_rejects_any_progress_mismatch
+)
+
+"${KANI_ARGS[@]}"

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -4178,6 +4178,24 @@ mod kani_proofs {
             && kv_history_length_matches
     }
 
+    fn phase12_claim_bindings_are_valid(
+        statement_version_matches: bool,
+        semantic_scope_matches: bool,
+        artifact_commitment_matches: bool,
+    ) -> bool {
+        statement_version_matches && semantic_scope_matches && artifact_commitment_matches
+    }
+
+    fn phase12_state_progress_is_valid(
+        from_history_length: usize,
+        to_history_length: usize,
+        from_position: i16,
+        to_position: i16,
+    ) -> bool {
+        from_history_length.checked_add(1) == Some(to_history_length)
+            && from_position.checked_add(1) == Some(to_position)
+    }
+
     fn phase14_step_header_is_valid(
         from_state_version: &str,
         to_state_version: &str,
@@ -4256,6 +4274,27 @@ mod kani_proofs {
             && lookup_transcript_entries_matches
             && lookup_frontier_commitment_matches
             && lookup_frontier_entries_matches
+    }
+
+    fn phase14_claim_bindings_are_valid(
+        statement_version_matches: bool,
+        semantic_scope_matches: bool,
+        artifact_commitment_matches: bool,
+    ) -> bool {
+        statement_version_matches && semantic_scope_matches && artifact_commitment_matches
+    }
+
+    fn phase14_state_progress_is_valid(
+        from_history_length: usize,
+        to_history_length: usize,
+        from_lookup_transcript_entries: usize,
+        to_lookup_transcript_entries: usize,
+        from_position: i16,
+        to_position: i16,
+    ) -> bool {
+        from_history_length.checked_add(1) == Some(to_history_length)
+            && from_lookup_transcript_entries.checked_add(1) == Some(to_lookup_transcript_entries)
+            && from_position.checked_add(1) == Some(to_position)
     }
 
     fn kani_dummy_proof() -> VanillaStarkExecutionProof {
@@ -4466,6 +4505,48 @@ mod kani_proofs {
     }
 
     #[kani::proof]
+    fn kani_phase12_claim_bindings_accept_canonical_single_step() {
+        assert!(phase12_claim_bindings_are_valid(true, true, true));
+    }
+
+    #[kani::proof]
+    fn kani_phase12_claim_bindings_reject_any_binding_mismatch() {
+        let which = kani::any::<u8>();
+        kani::assume(which < 3);
+        let mut statement_version_matches = true;
+        let mut semantic_scope_matches = true;
+        let mut artifact_commitment_matches = true;
+        match which {
+            0 => statement_version_matches = false,
+            1 => semantic_scope_matches = false,
+            _ => artifact_commitment_matches = false,
+        }
+        assert!(!phase12_claim_bindings_are_valid(
+            statement_version_matches,
+            semantic_scope_matches,
+            artifact_commitment_matches,
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase12_state_progress_accepts_canonical_single_step() {
+        assert!(phase12_state_progress_is_valid(1, 2, 0, 1));
+    }
+
+    #[kani::proof]
+    fn kani_phase12_state_progress_rejects_any_progress_mismatch() {
+        let which = kani::any::<u8>();
+        kani::assume(which < 2);
+        let mut to_history_length = 2usize;
+        let mut to_position = 1i16;
+        match which {
+            0 => to_history_length = 3,
+            _ => to_position = 2,
+        }
+        assert!(!phase12_state_progress_is_valid(1, to_history_length, 0, to_position));
+    }
+
+    #[kani::proof]
     fn kani_phase14_validate_accepts_canonical_single_step() {
         assert!(phase14_step_header_is_valid(
             STWO_DECODING_STATE_VERSION_PHASE14,
@@ -4604,6 +4685,57 @@ mod kani_proofs {
         assert!(!phase14_link_is_valid(
             flags[0], flags[1], flags[2], flags[3], flags[4], flags[5], flags[6], flags[7],
             flags[8], flags[9], flags[10], flags[11], flags[12], flags[13], flags[14],
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase14_claim_bindings_accept_canonical_single_step() {
+        assert!(phase14_claim_bindings_are_valid(true, true, true));
+    }
+
+    #[kani::proof]
+    fn kani_phase14_claim_bindings_reject_any_binding_mismatch() {
+        let which = kani::any::<u8>();
+        kani::assume(which < 3);
+        let mut statement_version_matches = true;
+        let mut semantic_scope_matches = true;
+        let mut artifact_commitment_matches = true;
+        match which {
+            0 => statement_version_matches = false,
+            1 => semantic_scope_matches = false,
+            _ => artifact_commitment_matches = false,
+        }
+        assert!(!phase14_claim_bindings_are_valid(
+            statement_version_matches,
+            semantic_scope_matches,
+            artifact_commitment_matches,
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase14_state_progress_accepts_canonical_single_step() {
+        assert!(phase14_state_progress_is_valid(1, 2, 1, 2, 0, 1));
+    }
+
+    #[kani::proof]
+    fn kani_phase14_state_progress_rejects_any_progress_mismatch() {
+        let which = kani::any::<u8>();
+        kani::assume(which < 3);
+        let mut to_history_length = 2usize;
+        let mut to_lookup_transcript_entries = 2usize;
+        let mut to_position = 1i16;
+        match which {
+            0 => to_history_length = 3,
+            1 => to_lookup_transcript_entries = 3,
+            _ => to_position = 2,
+        }
+        assert!(!phase14_state_progress_is_valid(
+            1,
+            to_history_length,
+            1,
+            to_lookup_transcript_entries,
+            0,
+            to_position,
         ));
     }
 }


### PR DESCRIPTION
## Summary
- add a narrow formal contract pilot for Phase 12 and Phase 14 decoding bindings
- add dedicated Kani runner and workflow for the contract kernel
- document the pilot scope and non-goals

## Validation
- python3 YAML parse for `.github/workflows/formal-contracts.yml`
- `bash -n scripts/run_formal_contract_suite.sh`
- `cargo kani --features stwo-backend --harness kani_phase12_claim_bindings_accept_canonical_single_step`
- `cargo kani --features stwo-backend --harness kani_phase12_claim_bindings_reject_any_binding_mismatch`
- `cargo kani --features stwo-backend --harness kani_phase14_claim_bindings_accept_canonical_single_step`
- `cargo kani --features stwo-backend --harness kani_phase14_claim_bindings_reject_any_binding_mismatch`
- `cargo kani --features stwo-backend --harness kani_phase12_state_progress_accepts_canonical_single_step`
- `cargo kani --features stwo-backend --harness kani_phase12_state_progress_rejects_any_progress_mismatch`
- `cargo kani --features stwo-backend --harness kani_phase14_state_progress_accepts_canonical_single_step`
- `cargo kani --features stwo-backend --harness kani_phase14_state_progress_rejects_any_progress_mismatch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added formal contract verification capabilities for proof-carrying decoding with automated checks for Phase 12 and Phase 14 claim bindings and state progress invariants.

* **Documentation**
  * Added formal contract pilot documentation outlining verification scope, required invariants, and mechanization approach.

* **Chores**
  * Integrated formal verification into the CI/CD pipeline with automated verification checks on repository changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->