### PR TITLE
paper: fix launch blockers (repo identity + Appendix C timing consistency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,11 +869,12 @@ but it is well past the old “dependency seam only” stage.
 
 ### Project Lineage
 
-`omarespejel/llm-provable-computer` is the maintained research fork used for the
-paper, the frozen reproducibility bundles, and the experimental `stwo` proof
-path. It builds directly on Abdelhamid Bakhta's original public repository,
-`AbdelStark/llm-provable-computer`, and extends that line with committed
-artifact bundles, research-oriented semantic agreement artifacts,
+The canonical launch repository is
+`omarespejel/provable-transformer-vm` (this repository). Earlier phases of the
+same research line were developed under the `llm-provable-computer` naming.
+This codebase builds directly on Abdelhamid Bakhta's original public
+repository, `AbdelStark/llm-provable-computer`, and extends that line with
+committed artifact bundles, research-oriented semantic agreement artifacts,
 transformer-shaped fixtures, shared-table lookup proofs, and proof-carrying
 decoding artifacts.
 

--- a/docs/paper/PUBLICATION_RELEASE.md
+++ b/docs/paper/PUBLICATION_RELEASE.md
@@ -8,6 +8,10 @@ Intended launch tag for the current paper-facing repository state:
 Canonical publication snapshot commit:
 `900ad5da657fb3b8085755657eb50c5f53580c23`
 
+Canonical launch repository:
+`https://github.com/omarespejel/provable-transformer-vm`
+(earlier phases of this research line used the `llm-provable-computer` project name).
+
 This repository state is the publication-facing package for the paper and its supporting
 artifacts. The package is intentionally split into evidence tiers rather than treated as one
 monolithic benchmark claim.

--- a/docs/paper/appendix-backend-artifact-comparison.md
+++ b/docs/paper/appendix-backend-artifact-comparison.md
@@ -18,12 +18,12 @@ artifact facts drawn from the committed bundle indices under
 | Artifact | Backend | Bundle | Prove | Verify | Proof size | Semantic scope |
 |---|---|---|---:|---:|---:|---|
 | `addition` | vanilla | `production-v1` | `71s` | `2s` | `7,644,769` bytes | arithmetic `statement-v1` execution proof |
-| `addition` | `stwo` | `stwo-experimental-v1` | `52s` | `2s` | `54,563` bytes | arithmetic `statement-v1` execution proof |
+| `addition` | `stwo` | `stwo-experimental-v1` | `2s` | `1s` | `54,563` bytes | arithmetic `statement-v1` execution proof |
 | `dot_product` | vanilla | `production-v1` | `430s` | `5s` | `12,835,175` bytes | neural-style arithmetic `statement-v1` execution proof |
 | `single_neuron` | vanilla | `production-v1` | `390s` | `4s` | `11,767,989` bytes | neural-style arithmetic `statement-v1` execution proof |
 | `shared-normalization-demo` | `stwo` | `stwo-experimental-v1` | `1s` | `1s` | `74,074` bytes | shared-table normalization lookup proof envelope |
 | `gemma_block_v4` | `stwo` | `stwo-experimental-v1` | `1s` | `1s` | `751,737` bytes | fixed-shape Gemma-inspired `statement-v1` proof with shared lookup bindings |
-| `decoding_demo` | `stwo` | `stwo-experimental-v1` | `2s` | `1s` | `4,032,182` bytes | three-step proof-carrying decoding chain |
+| `decoding_demo` | `stwo` | `stwo-experimental-v1` | `1s` | `1s` | `4,032,182` bytes | three-step proof-carrying decoding chain |
 
 ## How to read this appendix
 

--- a/docs/paper/appendix-system-comparison.md
+++ b/docs/paper/appendix-system-comparison.md
@@ -8,9 +8,9 @@ Sources: rows inherit the main paper’s source set from Sections 6 and 7, espec
 
 It should be read with one rule in mind: these are **not** matched end-to-end benchmarks on identical workloads. They are a structured comparison of public claims, committed artifacts, and implementation scope.
 
-## Table A1. DeepProve vs. BitSage stwo-ml vs. `llm-provable-computer`
+## Table A1. DeepProve vs. BitSage stwo-ml vs. `provable-transformer-vm`
 
-| Dimension | Lagrange DeepProve | BitSage stwo-ml | `llm-provable-computer` |
+| Dimension | Lagrange DeepProve | BitSage stwo-ml | `provable-transformer-vm` |
 |---|---|---|---|
 | Primary role | Production-oriented zkML system | Public STARK-native zkML stack | Semantics-and-proof research artifact |
 | Proof family | SNARK / SNARK-hybrid | STARK-native on S-two / STWO | Vanilla STARK by default; frozen narrow `stwo` artifact tier plus a broader experimental S-two backend with shared-table lookup demos and a fixed-shape proof-carrying decoding path |
@@ -30,4 +30,4 @@ Use this appendix when the main paper needs one concise comparison object, but k
 
 - DeepProve is the strongest counterexample to categorical anti-SNARK claims.
 - BitSage is the strongest public STARK-native comparator, but public evidence should be separated into benchmark claims, onchain demos, and broader roadmap scope.
-- `llm-provable-computer` is not a frontier zkML prover; it is a trace-semantics and proof-architecture artifact with reproducible evidence.
+- `provable-transformer-vm` is not a frontier zkML prover; it is a trace-semantics and proof-architecture artifact with reproducible evidence.

--- a/docs/paper/proof-carrying-decoding-2026.md
+++ b/docs/paper/proof-carrying-decoding-2026.md
@@ -9,7 +9,7 @@ Working draft, April 2026
 This paper studies a narrower question than full zkML inference: how far an
 experimental small-field transformer proof stack can be pushed toward
 proof-carrying decoding before recursion or accumulation are introduced. We
-present an extension of `llm-provable-computer` that preserves the existing
+present an extension of `provable-transformer-vm` that preserves the existing
 `statement-v1` execution claim while adding a parameterized decoding relation,
 multi-layout carried state, cumulative and frontier KV-history commitments, and
 cumulative and frontier lookup commitments. The same base `decoding_step_v2`
@@ -424,15 +424,16 @@ That is enough to justify a real systems paper. It is also enough to make the la
 
 ## Acknowledgments
 
-This draft builds on the maintained `omarespejel/llm-provable-computer`
-research fork and the earlier architecture paper that motivated the current
+This draft builds on the maintained `omarespejel/provable-transformer-vm`
+repository (earlier phases developed under the `llm-provable-computer`
+project name) and the earlier architecture paper that motivated the current
 implementation path.
 
 ## References
 
-- [1] Omar Espejel. *On the Structural Fit of Transformer Workloads and STARK Proof Systems*. Starknet Foundation, April 2026. Submission-prep snapshot commit `49004aea27a5e02c3732a798d32a32675f0a08b9`. <https://github.com/omarespejel/llm-provable-computer/blob/49004aea27a5e02c3732a798d32a32675f0a08b9/docs/paper/stark-transformer-alignment-2026.md>
-- [2] `omarespejel/llm-provable-computer`. Maintained research repository and implementation base for the system described here. Submission-prep snapshot commit `49004aea27a5e02c3732a798d32a32675f0a08b9`. <https://github.com/omarespejel/llm-provable-computer/tree/49004aea27a5e02c3732a798d32a32675f0a08b9>
-- [3] `omarespejel/llm-provable-computer`. *Appendix Artifact Index (S-two Experimental V1).* Commit `3970277d964a0a9a5326b0db364cf16822c1ccd4`. <https://github.com/omarespejel/llm-provable-computer/blob/3970277d964a0a9a5326b0db364cf16822c1ccd4/docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md>
+- [1] Omar Espejel. *On the Structural Fit of Transformer Workloads and STARK Proof Systems*. Starknet Foundation, April 2026. Submission-prep snapshot commit `49004aea27a5e02c3732a798d32a32675f0a08b9`. <https://github.com/omarespejel/provable-transformer-vm/blob/49004aea27a5e02c3732a798d32a32675f0a08b9/docs/paper/stark-transformer-alignment-2026.md>
+- [2] `omarespejel/provable-transformer-vm`. Maintained research repository and implementation base for the system described here (earlier phases used the `llm-provable-computer` project name). Submission-prep snapshot commit `49004aea27a5e02c3732a798d32a32675f0a08b9`. <https://github.com/omarespejel/provable-transformer-vm/tree/49004aea27a5e02c3732a798d32a32675f0a08b9>
+- [3] `omarespejel/provable-transformer-vm`. *Appendix Artifact Index (S-two Experimental V1).* Commit `3970277d964a0a9a5326b0db364cf16822c1ccd4`. <https://github.com/omarespejel/provable-transformer-vm/blob/3970277d964a0a9a5326b0db364cf16822c1ccd4/docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md>
 - [4] Eli Ben-Sasson, Iddo Bentov, Yinon Horesh, and Michael Riabzev. *Scalable, Transparent, and Post-Quantum Secure Computational Integrity*. IACR ePrint 2018/046. <https://eprint.iacr.org/2018/046>
 - [5] Ulrich Haböck, David Levit, and Valeria Papini. *Circle STARKs*. IACR ePrint 2024/278. <https://eprint.iacr.org/2024/278>
 - [6] StarkWare Industries. *STWO Prover*. <https://github.com/starkware-libs/stwo>

--- a/docs/paper/stark-transformer-alignment-2026.md
+++ b/docs/paper/stark-transformer-alignment-2026.md
@@ -10,7 +10,7 @@ April 2026
 
 This paper gives a transformer-specific symbolic cost comparison between SNARK constraints and STARK trace rows for verifiable inference. Under the worked constants used throughout (`C_exp = 300`, `C_norm = 30`, `C_nonlin = 150`), GPT-2 small (`d = 768`, `T = 1024`, `H = 12`, `L = 12`) yields about `157.8B` symbolic SNARK constraints versus `106.5B` symbolic STARK rows across 12 layers (`1.48x`). Over practical context ranges, the ratio rises and then approaches a finite architecture-dependent ceiling.
 
-We pair that analysis with a repository artifact, `llm-provable-computer`, that now includes a frozen baseline tier, a frozen narrow experimental `stwo` tier, and a broader commit-pinned parameterized proof-carrying decoding path (`decoding_step_v2`) with carried-state commitments [30]. This paper does not claim full standard-softmax inference on S-two, shared-table accumulation, or recursive compression. The claim is narrower: transformer workloads emphasize dimensions where STARK-native systems may compound advantages while SNARK systems remain strong competitors.
+We pair that analysis with a repository artifact, `provable-transformer-vm`, that now includes a frozen baseline tier, a frozen narrow experimental `stwo` tier, and a broader commit-pinned parameterized proof-carrying decoding path (`decoding_step_v2`) with carried-state commitments [30]. This paper does not claim full standard-softmax inference on S-two, shared-table accumulation, or recursive compression. The claim is narrower: transformer workloads emphasize dimensions where STARK-native systems may compound advantages while SNARK systems remain strong competitors.
 
 ---
 
@@ -245,7 +245,7 @@ With the analytic behavior established, we now turn to what the repository curre
 
 ## 5. Repository Artifact: From Trace-as-Witness to Parameterized Proof-Carrying Decoding
 
-The implementation artifact is `omarespejel/llm-provable-computer` [30]. In this paper it is treated as a **semantics-and-proof artifact**: deterministic transformer-relevant execution is compiled into AIR-consumable traces and packaged into carried-state proof objects for later recursion/accumulation work.
+The implementation artifact is `omarespejel/provable-transformer-vm` [30]. In this paper it is treated as a **semantics-and-proof artifact**: deterministic transformer-relevant execution is compiled into AIR-consumable traces and packaged into carried-state proof objects for later recursion/accumulation work. Earlier phases of this line were developed under the `llm-provable-computer` project name.
 
 ### 5.1 What the repository demonstrates today
 
@@ -406,7 +406,7 @@ The frontier is no longer “can transformers be proved?” It is: **which archi
 
 ## Acknowledgments
 
-This paper uses the maintained fork `omarespejel/llm-provable-computer`, which builds directly on Abdelhamid Bakhta’s upstream public repository `AbdelStark/llm-provable-computer`.
+This paper uses the maintained repository `omarespejel/provable-transformer-vm`, which builds directly on Abdelhamid Bakhta’s upstream public repository `AbdelStark/llm-provable-computer` and earlier project phases developed under the `llm-provable-computer` name.
 
 ---
 
@@ -441,8 +441,8 @@ This paper uses the maintained fork `omarespejel/llm-provable-computer`, which b
 27. BitSage Network. “elo-cairo-verifier/README.md.” GitHub documentation file. Accessed April 5, 2026. <https://github.com/Bitsage-Network/stwo-ml/blob/main/elo-cairo-verifier/README.md>
 28. Giza. *LuminAIR*. GitHub repository. Accessed April 5, 2026. <https://github.com/gizatechxyz/LuminAIR>
 29. StarkWare. “Giza x S-two: Powering Verifiable ML with LuminAIR.” *StarkWare Blog*. Accessed April 5, 2026. <https://starkware.co/blog/giza-x-s-two-powering-verifiable-ml-with-luminair/>
-30. `omarespejel/llm-provable-computer`. “Repository Snapshot Discussed in Sections 5 and 8.” GitHub repository snapshot, submission-prep commit `49004aea27a5e02c3732a798d32a32675f0a08b9`. <https://github.com/omarespejel/llm-provable-computer/tree/49004aea27a5e02c3732a798d32a32675f0a08b9>
-31. `omarespejel/llm-provable-computer`. “Appendix Artifact Index (Production V1).” GitHub artifact snapshot, commit `8d435d540b8e3cf33ec4381bb820a00b6fe7aae6`, documenting a bundle generated from execution/proof commit `58bb05fdd57ee9816e5935eb004396fea6a9fac3`. <https://github.com/omarespejel/llm-provable-computer/blob/8d435d540b8e3cf33ec4381bb820a00b6fe7aae6/docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md>
+30. `omarespejel/provable-transformer-vm`. “Repository Snapshot Discussed in Sections 5 and 8.” GitHub repository snapshot, submission-prep commit `49004aea27a5e02c3732a798d32a32675f0a08b9`. <https://github.com/omarespejel/provable-transformer-vm/tree/49004aea27a5e02c3732a798d32a32675f0a08b9>
+31. `omarespejel/provable-transformer-vm`. “Appendix Artifact Index (Production V1).” GitHub artifact snapshot, commit `8d435d540b8e3cf33ec4381bb820a00b6fe7aae6`, documenting a bundle generated from execution/proof commit `58bb05fdd57ee9816e5935eb004396fea6a9fac3`. <https://github.com/omarespejel/provable-transformer-vm/blob/8d435d540b8e3cf33ec4381bb820a00b6fe7aae6/docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md>
 32. Starknet Docs. “Accounts.” *Starknet Documentation*. Accessed April 5, 2026. <https://docs.starknet.io/architecture/accounts>
 33. Zhizhi Peng, Chonghe Zhao, Taotao Wang, Guofu Liao, Zibin Lin, Yifeng Liu, Bin Cao, Long Shi, Qing Yang, and Shengli Zhang. “A Survey of Zero-Knowledge Proof-Based Verifiable Machine Learning.” *Artificial Intelligence Review* (accepted manuscript), arXiv:2502.18535v2, 2026. <https://arxiv.org/abs/2502.18535>
 34. Ayush Nainwal, Atharva Kamble, and Nitin Awathare. “A Comparative Analysis of zk-SNARKs and zk-STARKs: Theory and Practice.” *arXiv preprint* arXiv:2512.10020, 2025. <https://arxiv.org/abs/2512.10020>
@@ -451,7 +451,7 @@ This paper uses the maintained fork `omarespejel/llm-provable-computer`, which b
 37. Hugo Touvron, Louis Martin, Kevin Stone, et al. “Llama 2: Open Foundation and Fine-Tuned Chat Models.” *arXiv preprint* arXiv:2307.09288, 2023. <https://arxiv.org/abs/2307.09288>
 38. Wyatt Benno, Alberto Centelles, Antoine Douchet, and Khalil Gibran. “Jolt Atlas: Verifiable Inference via Lookup Arguments in Zero Knowledge.” *arXiv preprint* arXiv:2602.17452, 2026. <https://arxiv.org/abs/2602.17452>
 39. Zhaohui Geoffrey Wang. “NANOZK: Layerwise Zero-Knowledge Proofs for Verifiable Large Language Model Inference.” *arXiv preprint* arXiv:2603.18046, 2026. <https://arxiv.org/abs/2603.18046>
-40. `omarespejel/llm-provable-computer`. “Appendix Artifact Index (S-two Experimental V1).” GitHub artifact snapshot, commit `3970277d964a0a9a5326b0db364cf16822c1ccd4`, at `docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md`. <https://github.com/omarespejel/llm-provable-computer/blob/3970277d964a0a9a5326b0db364cf16822c1ccd4/docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md>
+40. `omarespejel/provable-transformer-vm`. “Appendix Artifact Index (S-two Experimental V1).” GitHub artifact snapshot, commit `3970277d964a0a9a5326b0db364cf16822c1ccd4`, at `docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md`. <https://github.com/omarespejel/provable-transformer-vm/blob/3970277d964a0a9a5326b0db364cf16822c1ccd4/docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md>
 41. Wilson Nguyen and Srinath Setty. “Neo: Lattice-based folding scheme for CCS over small fields and pay-per-bit commitments.” *IACR Cryptology ePrint Archive*, Paper 2025/294, 2025. <https://eprint.iacr.org/2025/294>
 42. StarkWare. “How StarkWare Uses Formal Verification to Prove Tech Soundness.” *StarkWare Blog*, March 5, 2026. <https://starkware.co/blog/starkwares-gold-standard-of-soundness-with-formal-verification/>
 43. Abhiram Kothapalli and Srinath Setty. “HyperNova: Recursive Arguments for Customizable Constraint Systems.” *IACR Cryptology ePrint Archive*, Paper 2023/573, 2023. <https://eprint.iacr.org/2023/573>


### PR DESCRIPTION
## Summary
- standardize paper/release/bridge references on the launch repo `omarespejel/provable-transformer-vm`
- add explicit legacy-name note (`llm-provable-computer`) to avoid identity drift
- fix Appendix C1 timing rows so `stwo-experimental-v1` times match the frozen artifact index

## Validation
- `python3 scripts/paper/paper_preflight.py --repo-root .`
  - result: PASS
- manually cross-checked `docs/paper/appendix-backend-artifact-comparison.md` against:
  - `docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md`
  - corrected rows: `addition` and `decoding_demo`

## Notes
- no claim-scope expansion in this PR
- this is a release hygiene + consistency fix only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to reference the canonical repository with expanded artifact descriptions including transformer fixtures and proof-carrying decoding artifacts.
  * Refreshed backend performance benchmarks with improved prove and verify times for the `stwo` backend.
  * Standardized system naming conventions across technical appendices and research papers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->