### PR TITLE
paper: enforce appendix C artifact consistency in preflight

### DIFF
--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -442,6 +442,10 @@ def check_backend_appendix_consistency(repo_root: pathlib.Path, findings: Findin
     if missing_prod_timing or missing_prod_sizes or missing_stwo_timing or missing_stwo_sizes:
         return
 
+    # NOTE: This mapping is intentionally strict for frozen-artifact validation.
+    # Table C1 artifact/backend labels (after backtick stripping) and frozen index
+    # timing/size keys must match these entries exactly. If naming conventions or
+    # compared artifact rows change, update this mapping explicitly.
     expected: dict[tuple[str, str], tuple[int, int, int]] = {
         ("addition", "vanilla"): (
             prod_timings["prove_addition"],

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -212,12 +212,13 @@ def check_appendix_source_note(repo_root: pathlib.Path, findings: Findings) -> N
 def parse_markdown_table_after_heading(text: str, heading: str) -> list[list[str]]:
     lines = text.splitlines()
     start = None
+    normalized_heading = heading.strip().lower()
     for i, line in enumerate(lines):
-        if line.strip() == heading:
+        if line.strip().lower() == normalized_heading:
             start = i + 1
             break
     if start is None:
-        return []
+        raise ValueError(f"heading not found: {heading}")
 
     rows: list[list[str]] = []
     in_table = False
@@ -238,14 +239,15 @@ def parse_markdown_table_after_heading(text: str, heading: str) -> list[list[str
 
 
 def normalize_table_header(cell: str) -> str:
-    normalized = cell.strip().strip("`").lower()
-    normalized = re.sub(r"\s+", " ", normalized)
-    return normalized
+    return re.sub(r"\s+", " ", cell.strip().strip("`").lower())
 
 
 def parse_index_sizes(index_text: str) -> dict[str, int]:
-    rows = parse_markdown_table_after_heading(index_text, "## Primary Artifacts")
     out: dict[str, int] = {}
+    try:
+        rows = parse_markdown_table_after_heading(index_text, "## Primary Artifacts")
+    except ValueError:
+        return out
     if len(rows) < 3:
         return out
     header_map = {
@@ -270,8 +272,11 @@ def parse_index_sizes(index_text: str) -> dict[str, int]:
 
 
 def parse_index_timings(index_text: str) -> dict[str, int]:
-    rows = parse_markdown_table_after_heading(index_text, "## Timing Summary (seconds)")
     out: dict[str, int] = {}
+    try:
+        rows = parse_markdown_table_after_heading(index_text, "## Timing Summary (seconds)")
+    except ValueError:
+        return out
     if len(rows) < 3:
         return out
     header_map = {
@@ -296,10 +301,13 @@ def parse_index_timings(index_text: str) -> dict[str, int]:
 
 
 def parse_appendix_backend_rows(appendix_text: str) -> dict[tuple[str, str], tuple[int, int, int]]:
-    rows = parse_markdown_table_after_heading(
-        appendix_text, "## Table C1. Frozen artifact comparison by backend and scope"
-    )
     out: dict[tuple[str, str], tuple[int, int, int]] = {}
+    try:
+        rows = parse_markdown_table_after_heading(
+            appendix_text, "## Table C1. Frozen artifact comparison by backend and scope"
+        )
+    except ValueError:
+        return out
     if len(rows) < 3:
         return out
     header_map = {

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -266,12 +266,18 @@ def parse_index_timings(index_text: str) -> dict[str, int]:
     out: dict[str, int] = {}
     if len(rows) < 3:
         return out
+    header = rows[0]
+    try:
+        label_idx = header.index("Label")
+        seconds_idx = header.index("Seconds")
+    except ValueError:
+        return out
     # Skip header + separator.
     for row in rows[2:]:
-        if len(row) < 2:
+        if len(row) <= max(label_idx, seconds_idx):
             continue
-        label = row[0].strip("`")
-        seconds_cell = row[1]
+        label = row[label_idx].strip("`")
+        seconds_cell = row[seconds_idx]
         digits = re.sub(r"[^0-9]", "", seconds_cell)
         if not digits:
             continue
@@ -286,15 +292,24 @@ def parse_appendix_backend_rows(appendix_text: str) -> dict[tuple[str, str], tup
     out: dict[tuple[str, str], tuple[int, int, int]] = {}
     if len(rows) < 3:
         return out
+    header = rows[0]
+    try:
+        artifact_idx = header.index("Artifact")
+        backend_idx = header.index("Backend")
+        prove_idx = header.index("Prove")
+        verify_idx = header.index("Verify")
+        size_idx = header.index("Proof size")
+    except ValueError:
+        return out
     # Skip header + separator.
     for row in rows[2:]:
-        if len(row) < 6:
+        if len(row) <= max(artifact_idx, backend_idx, prove_idx, verify_idx, size_idx):
             continue
-        artifact = row[0].strip().strip("`")
-        backend = row[1].strip().strip("`")
-        prove_digits = re.sub(r"[^0-9]", "", row[3])
-        verify_digits = re.sub(r"[^0-9]", "", row[4])
-        size_digits = re.sub(r"[^0-9]", "", row[5])
+        artifact = row[artifact_idx].strip().strip("`")
+        backend = row[backend_idx].strip().strip("`")
+        prove_digits = re.sub(r"[^0-9]", "", row[prove_idx])
+        verify_digits = re.sub(r"[^0-9]", "", row[verify_idx])
+        size_digits = re.sub(r"[^0-9]", "", row[size_idx])
         if not (prove_digits and verify_digits and size_digits):
             continue
         out[(artifact, backend)] = (int(prove_digits), int(verify_digits), int(size_digits))
@@ -327,6 +342,63 @@ def check_backend_appendix_consistency(repo_root: pathlib.Path, findings: Findin
     prod_timings = parse_index_timings(prod_text)
     stwo_sizes = parse_index_sizes(stwo_text)
     stwo_timings = parse_index_timings(stwo_text)
+
+    required_prod_timing_keys = [
+        "prove_addition",
+        "verify_addition",
+        "prove_dot_product",
+        "verify_dot_product",
+        "prove_single_neuron",
+        "verify_single_neuron",
+    ]
+    required_prod_size_keys = [
+        "addition.proof.json",
+        "dot_product.proof.json",
+        "single_neuron.proof.json",
+    ]
+    required_stwo_timing_keys = [
+        "prove_addition_stwo",
+        "verify_addition_stwo",
+        "prove_shared_normalization_stwo",
+        "verify_shared_normalization_stwo",
+        "prove_gemma_block_v4_stwo",
+        "verify_gemma_block_v4_stwo",
+        "prove_decoding_demo_stwo",
+        "verify_decoding_demo_stwo",
+    ]
+    required_stwo_size_keys = [
+        "addition.stwo.proof.json",
+        "shared-normalization.stwo.proof.json",
+        "gemma_block_v4.stwo.proof.json",
+        "decoding.stwo.chain.json",
+    ]
+
+    missing_prod_timing = sorted(k for k in required_prod_timing_keys if k not in prod_timings)
+    missing_prod_sizes = sorted(k for k in required_prod_size_keys if k not in prod_sizes)
+    missing_stwo_timing = sorted(k for k in required_stwo_timing_keys if k not in stwo_timings)
+    missing_stwo_sizes = sorted(k for k in required_stwo_size_keys if k not in stwo_sizes)
+    if missing_prod_timing:
+        findings.error(
+            f"{prod_index_path}: missing timing keys required for Appendix C consistency check: "
+            f"{missing_prod_timing}"
+        )
+    if missing_prod_sizes:
+        findings.error(
+            f"{prod_index_path}: missing artifact-size keys required for Appendix C consistency check: "
+            f"{missing_prod_sizes}"
+        )
+    if missing_stwo_timing:
+        findings.error(
+            f"{stwo_index_path}: missing timing keys required for Appendix C consistency check: "
+            f"{missing_stwo_timing}"
+        )
+    if missing_stwo_sizes:
+        findings.error(
+            f"{stwo_index_path}: missing artifact-size keys required for Appendix C consistency check: "
+            f"{missing_stwo_sizes}"
+        )
+    if missing_prod_timing or missing_prod_sizes or missing_stwo_timing or missing_stwo_sizes:
+        return
 
     expected: dict[tuple[str, str], tuple[int, int, int]] = {
         ("addition", "vanilla"): (

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -237,16 +237,24 @@ def parse_markdown_table_after_heading(text: str, heading: str) -> list[list[str
     return rows
 
 
+def normalize_table_header(cell: str) -> str:
+    normalized = cell.strip().strip("`").lower()
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized
+
+
 def parse_index_sizes(index_text: str) -> dict[str, int]:
     rows = parse_markdown_table_after_heading(index_text, "## Primary Artifacts")
     out: dict[str, int] = {}
     if len(rows) < 3:
         return out
-    header = rows[0]
+    header_map = {
+        normalize_table_header(name): idx for idx, name in enumerate(rows[0])
+    }
     try:
-        artifact_idx = header.index("Artifact")
-        size_idx = header.index("Size (bytes)")
-    except ValueError:
+        artifact_idx = header_map["artifact"]
+        size_idx = header_map["size (bytes)"]
+    except KeyError:
         return out
     # Skip header + separator.
     for row in rows[2:]:
@@ -266,11 +274,13 @@ def parse_index_timings(index_text: str) -> dict[str, int]:
     out: dict[str, int] = {}
     if len(rows) < 3:
         return out
-    header = rows[0]
+    header_map = {
+        normalize_table_header(name): idx for idx, name in enumerate(rows[0])
+    }
     try:
-        label_idx = header.index("Label")
-        seconds_idx = header.index("Seconds")
-    except ValueError:
+        label_idx = header_map["label"]
+        seconds_idx = header_map["seconds"]
+    except KeyError:
         return out
     # Skip header + separator.
     for row in rows[2:]:
@@ -292,14 +302,24 @@ def parse_appendix_backend_rows(appendix_text: str) -> dict[tuple[str, str], tup
     out: dict[tuple[str, str], tuple[int, int, int]] = {}
     if len(rows) < 3:
         return out
-    header = rows[0]
+    header_map = {
+        normalize_table_header(name): idx for idx, name in enumerate(rows[0])
+    }
+
+    def first_matching_header(*aliases: str) -> int:
+        for alias in aliases:
+            key = normalize_table_header(alias)
+            if key in header_map:
+                return header_map[key]
+        raise KeyError(aliases[0])
+
     try:
-        artifact_idx = header.index("Artifact")
-        backend_idx = header.index("Backend")
-        prove_idx = header.index("Prove")
-        verify_idx = header.index("Verify")
-        size_idx = header.index("Proof size")
-    except ValueError:
+        artifact_idx = first_matching_header("Artifact")
+        backend_idx = first_matching_header("Backend")
+        prove_idx = first_matching_header("Prove")
+        verify_idx = first_matching_header("Verify")
+        size_idx = first_matching_header("Proof size", "Proof size (bytes)", "Size (bytes)")
+    except KeyError:
         return out
     # Skip header + separator.
     for row in rows[2:]:

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -5,7 +5,8 @@ Checks:
 1) citation integrity (numeric in-text citations must exist in local references section),
 2) immutable-link policy for this repository's GitHub links (commit-pinned only),
 3) figure/link cross-reference existence for local file links,
-4) source-note presence in appendix-system-comparison.
+4) source-note presence in appendix-system-comparison,
+5) backend appendix timing/size consistency against frozen artifact indices.
 """
 
 from __future__ import annotations
@@ -208,6 +209,177 @@ def check_appendix_source_note(repo_root: pathlib.Path, findings: Findings) -> N
         findings.error(f"{path}: missing standalone source note (expected 'Sources: ...').")
 
 
+def parse_markdown_table_after_heading(text: str, heading: str) -> list[list[str]]:
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == heading:
+            start = i + 1
+            break
+    if start is None:
+        return []
+
+    rows: list[list[str]] = []
+    in_table = False
+    for line in lines[start:]:
+        stripped = line.strip()
+        if not stripped:
+            if in_table:
+                break
+            continue
+        if not stripped.startswith("|"):
+            if in_table:
+                break
+            continue
+        in_table = True
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        rows.append(cells)
+    return rows
+
+
+def parse_index_sizes(index_text: str) -> dict[str, int]:
+    rows = parse_markdown_table_after_heading(index_text, "## Primary Artifacts")
+    out: dict[str, int] = {}
+    if len(rows) < 3:
+        return out
+    header = rows[0]
+    try:
+        artifact_idx = header.index("Artifact")
+        size_idx = header.index("Size (bytes)")
+    except ValueError:
+        return out
+    # Skip header + separator.
+    for row in rows[2:]:
+        if len(row) <= max(artifact_idx, size_idx):
+            continue
+        artifact = row[artifact_idx].strip("`")
+        size_cell = row[size_idx]
+        digits = re.sub(r"[^0-9]", "", size_cell)
+        if not digits:
+            continue
+        out[artifact] = int(digits)
+    return out
+
+
+def parse_index_timings(index_text: str) -> dict[str, int]:
+    rows = parse_markdown_table_after_heading(index_text, "## Timing Summary (seconds)")
+    out: dict[str, int] = {}
+    if len(rows) < 3:
+        return out
+    # Skip header + separator.
+    for row in rows[2:]:
+        if len(row) < 2:
+            continue
+        label = row[0].strip("`")
+        seconds_cell = row[1]
+        digits = re.sub(r"[^0-9]", "", seconds_cell)
+        if not digits:
+            continue
+        out[label] = int(digits)
+    return out
+
+
+def parse_appendix_backend_rows(appendix_text: str) -> dict[tuple[str, str], tuple[int, int, int]]:
+    rows = parse_markdown_table_after_heading(
+        appendix_text, "## Table C1. Frozen artifact comparison by backend and scope"
+    )
+    out: dict[tuple[str, str], tuple[int, int, int]] = {}
+    if len(rows) < 3:
+        return out
+    # Skip header + separator.
+    for row in rows[2:]:
+        if len(row) < 6:
+            continue
+        artifact = row[0].strip().strip("`")
+        backend = row[1].strip().strip("`")
+        prove_digits = re.sub(r"[^0-9]", "", row[3])
+        verify_digits = re.sub(r"[^0-9]", "", row[4])
+        size_digits = re.sub(r"[^0-9]", "", row[5])
+        if not (prove_digits and verify_digits and size_digits):
+            continue
+        out[(artifact, backend)] = (int(prove_digits), int(verify_digits), int(size_digits))
+    return out
+
+
+def check_backend_appendix_consistency(repo_root: pathlib.Path, findings: Findings) -> None:
+    appendix_path = repo_root / "docs/paper/appendix-backend-artifact-comparison.md"
+    prod_index_path = (
+        repo_root
+        / "docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md"
+    )
+    stwo_index_path = (
+        repo_root
+        / "docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md"
+    )
+
+    appendix_text = appendix_path.read_text(encoding="utf-8")
+    prod_text = prod_index_path.read_text(encoding="utf-8")
+    stwo_text = stwo_index_path.read_text(encoding="utf-8")
+
+    appendix_rows = parse_appendix_backend_rows(appendix_text)
+    if not appendix_rows:
+        findings.error(
+            f"{appendix_path}: failed to parse Table C1 rows for backend artifact consistency checks."
+        )
+        return
+
+    prod_sizes = parse_index_sizes(prod_text)
+    prod_timings = parse_index_timings(prod_text)
+    stwo_sizes = parse_index_sizes(stwo_text)
+    stwo_timings = parse_index_timings(stwo_text)
+
+    expected: dict[tuple[str, str], tuple[int, int, int]] = {
+        ("addition", "vanilla"): (
+            prod_timings["prove_addition"],
+            prod_timings["verify_addition"],
+            prod_sizes["addition.proof.json"],
+        ),
+        ("dot_product", "vanilla"): (
+            prod_timings["prove_dot_product"],
+            prod_timings["verify_dot_product"],
+            prod_sizes["dot_product.proof.json"],
+        ),
+        ("single_neuron", "vanilla"): (
+            prod_timings["prove_single_neuron"],
+            prod_timings["verify_single_neuron"],
+            prod_sizes["single_neuron.proof.json"],
+        ),
+        ("addition", "stwo"): (
+            stwo_timings["prove_addition_stwo"],
+            stwo_timings["verify_addition_stwo"],
+            stwo_sizes["addition.stwo.proof.json"],
+        ),
+        ("shared-normalization-demo", "stwo"): (
+            stwo_timings["prove_shared_normalization_stwo"],
+            stwo_timings["verify_shared_normalization_stwo"],
+            stwo_sizes["shared-normalization.stwo.proof.json"],
+        ),
+        ("gemma_block_v4", "stwo"): (
+            stwo_timings["prove_gemma_block_v4_stwo"],
+            stwo_timings["verify_gemma_block_v4_stwo"],
+            stwo_sizes["gemma_block_v4.stwo.proof.json"],
+        ),
+        ("decoding_demo", "stwo"): (
+            stwo_timings["prove_decoding_demo_stwo"],
+            stwo_timings["verify_decoding_demo_stwo"],
+            stwo_sizes["decoding.stwo.chain.json"],
+        ),
+    }
+
+    for key, expected_values in expected.items():
+        if key not in appendix_rows:
+            findings.error(
+                f"{appendix_path}: missing Table C1 row for artifact/backend {key!r}."
+            )
+            continue
+        found_values = appendix_rows[key]
+        if found_values != expected_values:
+            findings.error(
+                f"{appendix_path}: Table C1 mismatch for {key!r}: found prove/verify/size={found_values}, "
+                f"expected={expected_values} from frozen artifact indices."
+            )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run publication preflight checks for docs/paper.")
     parser.add_argument(
@@ -228,6 +400,7 @@ def main() -> int:
         run_file_checks(path, repo_root, findings)
 
     check_appendix_source_note(repo_root, findings)
+    check_backend_appendix_consistency(repo_root, findings)
 
     if findings.warnings:
         print("Warnings:")

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -327,9 +327,23 @@ def check_backend_appendix_consistency(repo_root: pathlib.Path, findings: Findin
         / "docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md"
     )
 
-    appendix_text = appendix_path.read_text(encoding="utf-8")
-    prod_text = prod_index_path.read_text(encoding="utf-8")
-    stwo_text = stwo_index_path.read_text(encoding="utf-8")
+    for required_path in (appendix_path, prod_index_path, stwo_index_path):
+        if not required_path.exists():
+            findings.error(
+                f"{required_path}: missing required file for backend artifact consistency check."
+            )
+            return
+
+    try:
+        appendix_text = appendix_path.read_text(encoding="utf-8")
+        prod_text = prod_index_path.read_text(encoding="utf-8")
+        stwo_text = stwo_index_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        findings.error(
+            "failed to read backend artifact consistency inputs "
+            f"({appendix_path}, {prod_index_path}, {stwo_index_path}): {exc}"
+        )
+        return
 
     appendix_rows = parse_appendix_backend_rows(appendix_text)
     if not appendix_rows:

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -493,6 +493,13 @@ def check_backend_appendix_consistency(repo_root: pathlib.Path, findings: Findin
                 f"expected={expected_values} from frozen artifact indices."
             )
 
+    unexpected_keys = sorted(set(appendix_rows) - set(expected))
+    for key in unexpected_keys:
+        findings.error(
+            f"{appendix_path}: unexpected Table C1 row for artifact/backend {key!r}; "
+            "no matching frozen artifact index entry."
+        )
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run publication preflight checks for docs/paper.")

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -1,0 +1,154 @@
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+def load_preflight_module():
+    root = pathlib.Path(__file__).resolve().parents[3]
+    module_path = root / "scripts/paper/paper_preflight.py"
+    spec = importlib.util.spec_from_file_location("paper_preflight", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load paper_preflight module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MOD = load_preflight_module()
+
+
+def write_text(path: pathlib.Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def valid_appendix_table() -> str:
+    return """# Appendix: Frozen Backend Artifact Comparison
+
+## Table C1. Frozen artifact comparison by backend and scope
+| Artifact | Backend | Bundle | Prove | Verify | Proof size | Semantic scope |
+|---|---|---|---:|---:|---:|---|
+| `addition` | vanilla | `production-v1` | `71s` | `2s` | `7,644,769` bytes | x |
+| `addition` | `stwo` | `stwo-experimental-v1` | `2s` | `1s` | `54,563` bytes | x |
+| `dot_product` | vanilla | `production-v1` | `430s` | `5s` | `12,835,175` bytes | x |
+| `single_neuron` | vanilla | `production-v1` | `390s` | `4s` | `11,767,989` bytes | x |
+| `shared-normalization-demo` | `stwo` | `stwo-experimental-v1` | `1s` | `1s` | `74,074` bytes | x |
+| `gemma_block_v4` | `stwo` | `stwo-experimental-v1` | `1s` | `1s` | `751,737` bytes | x |
+| `decoding_demo` | `stwo` | `stwo-experimental-v1` | `1s` | `1s` | `4,032,182` bytes | x |
+"""
+
+
+def valid_prod_index() -> str:
+    return """# Appendix Artifact Index (Production V1)
+
+## Primary Artifacts
+| Artifact | Purpose | Size (bytes) | SHA-256 |
+|---|---|---:|---|
+| addition.proof.json | x | 7644769 | a |
+| dot_product.proof.json | x | 12835175 | b |
+| single_neuron.proof.json | x | 11767989 | c |
+
+## Timing Summary (seconds)
+| Label | Seconds |
+|---|---:|
+| prove_addition | 71 |
+| verify_addition | 2 |
+| prove_dot_product | 430 |
+| verify_dot_product | 5 |
+| prove_single_neuron | 390 |
+| verify_single_neuron | 4 |
+"""
+
+
+def valid_stwo_index() -> str:
+    return """# Appendix Artifact Index (S-two Experimental V1)
+
+## Primary Artifacts
+| Artifact | Purpose | Semantic scope | Size (bytes) | SHA-256 |
+|---|---|---|---:|---|
+| addition.stwo.proof.json | x | arithmetic | 54563 | a |
+| shared-normalization.stwo.proof.json | x | lookup-backed component | 74074 | b |
+| gemma_block_v4.stwo.proof.json | x | transformer-shaped checksum fixture | 751737 | c |
+| decoding.stwo.chain.json | x | proof-carrying decoding | 4032182 | d |
+
+## Timing Summary (seconds)
+| Label | Seconds |
+|---|---:|
+| prove_addition_stwo | 2 |
+| verify_addition_stwo | 1 |
+| prove_shared_normalization_stwo | 1 |
+| verify_shared_normalization_stwo | 1 |
+| prove_gemma_block_v4_stwo | 1 |
+| verify_gemma_block_v4_stwo | 1 |
+| prove_decoding_demo_stwo | 1 |
+| verify_decoding_demo_stwo | 1 |
+"""
+
+
+class PaperPreflightTests(unittest.TestCase):
+    def test_parse_appendix_rows_handles_reordered_columns(self):
+        text = """## Table C1. Frozen artifact comparison by backend and scope
+| Backend | Artifact | Verify | Prove | Semantic scope | Proof size | Bundle |
+|---|---|---:|---:|---|---:|---|
+| vanilla | `addition` | `2s` | `71s` | x | `7,644,769` bytes | production-v1 |
+"""
+        rows = MOD.parse_appendix_backend_rows(text)
+        self.assertEqual(rows[("addition", "vanilla")], (71, 2, 7644769))
+
+    def test_check_backend_consistency_reports_missing_required_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            findings = MOD.Findings()
+            MOD.check_backend_appendix_consistency(repo, findings)
+            self.assertTrue(findings.errors)
+            self.assertIn("missing required file", findings.errors[0])
+
+    def test_check_backend_consistency_passes_for_valid_fixture_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(
+                repo / "docs/paper/appendix-backend-artifact-comparison.md",
+                valid_appendix_table(),
+            )
+            write_text(
+                repo / "docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md",
+                valid_prod_index(),
+            )
+            write_text(
+                repo / "docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md",
+                valid_stwo_index(),
+            )
+            findings = MOD.Findings()
+            MOD.check_backend_appendix_consistency(repo, findings)
+            self.assertEqual(findings.errors, [])
+
+    def test_check_backend_consistency_reports_missing_timing_keys_without_exception(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(
+                repo / "docs/paper/appendix-backend-artifact-comparison.md",
+                valid_appendix_table(),
+            )
+            write_text(
+                repo / "docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md",
+                valid_prod_index(),
+            )
+            broken_stwo = valid_stwo_index().replace("| verify_decoding_demo_stwo | 1 |\n", "")
+            write_text(
+                repo / "docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md",
+                broken_stwo,
+            )
+            findings = MOD.Findings()
+            MOD.check_backend_appendix_consistency(repo, findings)
+            self.assertTrue(findings.errors)
+            self.assertTrue(
+                any("missing timing keys" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -160,6 +160,32 @@ class PaperPreflightTests(unittest.TestCase):
             MOD.check_backend_appendix_consistency(repo, findings)
             self.assertEqual(findings.errors, [])
 
+    def test_check_backend_consistency_reports_table_value_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            tampered_appendix = valid_appendix_table().replace(
+                "| `addition` | `stwo` | `stwo-experimental-v1` | `2s` | `1s` | `54,563` bytes | x |\n",
+                "| `addition` | `stwo` | `stwo-experimental-v1` | `52s` | `2s` | `54,563` bytes | x |\n",
+            )
+            write_text(
+                repo / "docs/paper/appendix-backend-artifact-comparison.md",
+                tampered_appendix,
+            )
+            write_text(
+                repo / "docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md",
+                valid_prod_index(),
+            )
+            write_text(
+                repo / "docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md",
+                valid_stwo_index(),
+            )
+            findings = MOD.Findings()
+            MOD.check_backend_appendix_consistency(repo, findings)
+            self.assertTrue(
+                any("Table C1 mismatch for ('addition', 'stwo')" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
     def test_check_backend_consistency_reports_missing_timing_keys_without_exception(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo = pathlib.Path(tmp)

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -186,6 +186,35 @@ class PaperPreflightTests(unittest.TestCase):
                 findings.errors,
             )
 
+    def test_check_backend_consistency_reports_unexpected_table_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            tampered_appendix = valid_appendix_table() + (
+                "| `unexpected_artifact` | `stwo` | `stwo-experimental-v1` | `1s` | `1s` | `1,111` bytes | x |\n"
+            )
+            write_text(
+                repo / "docs/paper/appendix-backend-artifact-comparison.md",
+                tampered_appendix,
+            )
+            write_text(
+                repo / "docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md",
+                valid_prod_index(),
+            )
+            write_text(
+                repo / "docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md",
+                valid_stwo_index(),
+            )
+            findings = MOD.Findings()
+            MOD.check_backend_appendix_consistency(repo, findings)
+            self.assertTrue(
+                any(
+                    "unexpected Table C1 row for artifact/backend ('unexpected_artifact', 'stwo')"
+                    in msg
+                    for msg in findings.errors
+                ),
+                findings.errors,
+            )
+
     def test_check_backend_consistency_reports_missing_timing_keys_without_exception(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo = pathlib.Path(tmp)

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -239,6 +239,33 @@ class PaperPreflightTests(unittest.TestCase):
                 findings.errors,
             )
 
+    def test_check_backend_consistency_reports_missing_size_keys_without_exception(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(
+                repo / "docs/paper/appendix-backend-artifact-comparison.md",
+                valid_appendix_table(),
+            )
+            write_text(
+                repo / "docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md",
+                valid_prod_index(),
+            )
+            broken_stwo = valid_stwo_index().replace(
+                "| addition.stwo.proof.json | x | arithmetic | 54563 | a |\n",
+                "",
+            )
+            write_text(
+                repo / "docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md",
+                broken_stwo,
+            )
+            findings = MOD.Findings()
+            MOD.check_backend_appendix_consistency(repo, findings)
+            self.assertTrue(findings.errors)
+            self.assertTrue(
+                any("missing artifact-size keys" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 def load_preflight_module():
@@ -90,13 +91,19 @@ def valid_stwo_index() -> str:
 
 class PaperPreflightTests(unittest.TestCase):
     def test_parse_appendix_rows_handles_reordered_columns(self):
-        text = """## Table C1. Frozen artifact comparison by backend and scope
-| Backend | Artifact | Verify | Prove | Semantic scope | Proof size | Bundle |
+        variants = [
+            ("Proof size", "`Artifact`", "backend"),
+            ("Proof size (bytes)", "artifact", "Backend"),
+            ("Size (bytes)", "ARTIFACT", "BACKEND"),
+        ]
+        for size_header, artifact_header, backend_header in variants:
+            text = f"""## Table C1. Frozen artifact comparison by backend and scope
+| {backend_header} | {artifact_header} | Verify | Prove | Semantic Scope | {size_header} | Bundle |
 |---|---|---:|---:|---|---:|---|
 | vanilla | `addition` | `2s` | `71s` | x | `7,644,769` bytes | production-v1 |
 """
-        rows = MOD.parse_appendix_backend_rows(text)
-        self.assertEqual(rows[("addition", "vanilla")], (71, 2, 7644769))
+            rows = MOD.parse_appendix_backend_rows(text)
+            self.assertEqual(rows[("addition", "vanilla")], (71, 2, 7644769))
 
     def test_check_backend_consistency_reports_missing_required_files(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -104,7 +111,35 @@ class PaperPreflightTests(unittest.TestCase):
             findings = MOD.Findings()
             MOD.check_backend_appendix_consistency(repo, findings)
             self.assertTrue(findings.errors)
-            self.assertIn("missing required file", findings.errors[0])
+            expected_missing = (
+                repo / "docs/paper/appendix-backend-artifact-comparison.md"
+            )
+            self.assertEqual(
+                findings.errors[0],
+                f"{expected_missing}: missing required file for backend artifact consistency check.",
+            )
+
+    def test_check_backend_consistency_reports_read_failures_without_exception(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(
+                repo / "docs/paper/appendix-backend-artifact-comparison.md",
+                valid_appendix_table(),
+            )
+            write_text(
+                repo / "docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md",
+                valid_prod_index(),
+            )
+            write_text(
+                repo / "docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md",
+                valid_stwo_index(),
+            )
+            findings = MOD.Findings()
+            with mock.patch.object(pathlib.Path, "read_text", side_effect=OSError("boom")):
+                MOD.check_backend_appendix_consistency(repo, findings)
+            self.assertTrue(findings.errors)
+            self.assertIn("failed to read backend artifact consistency inputs", findings.errors[0])
+            self.assertIn("boom", findings.errors[0])
 
     def test_check_backend_consistency_passes_for_valid_fixture_files(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- extend paper preflight with a strict Appendix C consistency check against frozen artifact indices
- validate Table C prove/verify seconds and proof-size bytes for production-v1 and stwo-experimental-v1 rows
- parse markdown tables by header names to avoid column-layout drift between artifact indices

## Validation
- python3 scripts/paper/paper_preflight.py --repo-root .
- python3 -m py_compile scripts/paper/paper_preflight.py

## Hardening
- [x] targeted regression and tamper-path coverage added or updated (preflight now catches appendix timing/size drift)
- [x] oracle or differential checks added/updated, or marked not applicable below (appendix rows are checked against independent frozen index sources)
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below (N/A; local paper-only parsing, no runtime untrusted input path)
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below (N/A; documentation/preflight tooling change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a backend appendix consistency check enforcing exact timing/size matches between the Appendix and two frozen backend index documents; reports mismatches, missing keys, unexpected appendix rows, and read failures.

* **Tests**
  * Added tests covering parsing of appendix/index tables (including reordered columns), missing/unreadable input files, detection of timing/size mismatches, and unexpected appendix rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->