### PR TITLE
Phase 24: extend the validator hardening stack

### DIFF
--- a/.github/workflows/miri-sanitizers.yml
+++ b/.github/workflows/miri-sanitizers.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/hardening_test_names.sh"
       - "scripts/run_miri_suite.sh"
       - "scripts/run_asan_suite.sh"
+      - "scripts/run_ub_checks_suite.sh"
       - "src/**/*.rs"
       - "Cargo.toml"
       - "Cargo.lock"
@@ -84,3 +85,28 @@ jobs:
         run: |
           chmod +x scripts/run_asan_suite.sh scripts/hardening_test_names.sh
           scripts/run_asan_suite.sh
+
+  ub-checks:
+    name: undefined-behavior checks validator subset
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: ${{ env.HARDENING_TOOLCHAIN }}
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+        with:
+          cache-bin: false
+          cache-targets: false
+
+      - name: Run UB-checks suite
+        run: |
+          chmod +x scripts/run_ub_checks_suite.sh scripts/hardening_test_names.sh
+          scripts/run_ub_checks_suite.sh

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          fetch-depth: 0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -59,8 +61,26 @@ jobs:
           rm -f "$CARGO_HOME/bin/cargo-mutants"
           cargo install cargo-mutants --version 27.0.0 --locked --force
 
-      - name: Run mutation compile smoke on pull requests
+      - name: Build diff-scoped mutation input on pull requests
         if: github.event_name == 'pull_request'
+        run: |
+          chmod +x scripts/run_mutation_suite.sh
+          git diff --no-ext-diff --unified=0 "origin/${{ github.base_ref }}...HEAD" -- \
+            src/stwo_backend/decoding.rs \
+            src/stwo_backend/shared_lookup_artifact.rs \
+            src/stwo_backend/arithmetic_subset_prover.rs > mutation.diff || true
+          if [[ -s mutation.diff ]]; then
+            echo "MUTATION_DIFF_FILE=$PWD/mutation.diff" >> "$GITHUB_ENV"
+          fi
+
+      - name: Run diff-scoped mutation slice on pull requests
+        if: github.event_name == 'pull_request' && env.MUTATION_DIFF_FILE != ''
+        run: |
+          chmod +x scripts/run_mutation_suite.sh
+          scripts/run_mutation_suite.sh
+
+      - name: Run mutation compile smoke when no target diff exists
+        if: github.event_name == 'pull_request' && env.MUTATION_DIFF_FILE == ''
         run: |
           chmod +x scripts/run_mutation_suite.sh
           scripts/run_mutation_suite.sh --check

--- a/best_practices.md
+++ b/best_practices.md
@@ -18,7 +18,7 @@
   - oracle or differential checks,
   - resource-bound verification tests,
   - Kani / formal-kernel checks when the invariant is bounded,
-  - Miri / sanitizer coverage when parser or validator glue changes.
+  - Miri / ASAN / UB-check coverage when parser or validator glue changes.
 - If a layer is not applicable, explain that explicitly in the PR body instead of silently skipping it.
 
 ## Documentation And Claim Discipline

--- a/docs/paper/stark-transformer-alignment-2026.md
+++ b/docs/paper/stark-transformer-alignment-2026.md
@@ -256,7 +256,7 @@ The snapshot provides:
 - two frozen evidence tiers: `production-v1` (vanilla) and `stwo-experimental-v1` (narrow experimental),
 - a parameterized proof-carrying decoding family (`decoding_step_v2`) over multiple public layouts,
 - carried-state packaging (chain, segment, rollup, multi-layout matrix) with KV/lookup cumulative and frontier commitments, plus experimental pre-recursive template-bound and lookup-side accumulators,
-- a verification-hardening stack: oracle/differential checks, fuzz smoke targets, mutation tests, Miri/ASAN, and bounded Kani contracts.
+- a verification-hardening stack: oracle/differential checks, fuzz smoke targets, mutation tests, Miri/ASAN/UB-checks, and bounded Kani contracts.
 
 This supports a stronger systems statement than earlier drafts: the same decode relation survives progressively more composable manifest layers without changing statement boundaries.
 

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-hardening_test_filters=(
+hardening_base_test_filters=(
   "proof::tests::production_profile_v1_is_self_consistent"
   "proof::tests::commitment_hash_matches_blake2b_256_test_vector"
   "proof::tests::conjectured_security_bits_handles_large_query_counts"
@@ -8,4 +8,22 @@ hardening_test_filters=(
   "vanillastark::proof_stream::tests::test_deserialize_rejects_huge_object_count"
   "vanillastark::proof_stream::tests::test_deserialize_rejects_huge_segment_length"
   "vanillastark::proof_stream::tests::test_deserialize_rejects_truncated_stream"
+)
+
+# Keep the heavier `stwo-backend` verifier gates on the sanitizer path. They are
+# intentionally excluded from the Miri loop because feature-enabled Miri builds
+# are too expensive for the fast hardening cycle on this repo.
+hardening_stwo_test_filters=(
+  "stwo_backend::decoding::tests::phase23_cross_step_lookup_accumulator_rejects_oversized_manifest_before_nested_checks"
+  "stwo_backend::decoding::tests::phase23_cross_step_lookup_accumulator_rejects_header_mismatch_before_nested_checks"
+  "stwo_backend::decoding::tests::phase24_state_relation_accumulator_rejects_oversized_manifest_before_nested_checks"
+  "stwo_backend::decoding::tests::phase24_state_relation_accumulator_rejects_excess_total_nested_phase23_members_before_deep_walk"
+  "stwo_backend::decoding::tests::phase24_state_relation_accumulator_rejects_oversized_nested_phase23_before_deep_walk"
+  "stwo_backend::decoding::tests::phase24_state_relation_accumulator_rejects_empty_commitments_before_nested_checks"
+  "stwo_backend::decoding::tests::phase24_state_relation_accumulator_rejects_header_mismatch_before_nested_checks"
+)
+
+hardening_test_filters=(
+  "${hardening_base_test_filters[@]}"
+  "${hardening_stwo_test_filters[@]}"
 )

--- a/scripts/run_asan_suite.sh
+++ b/scripts/run_asan_suite.sh
@@ -9,8 +9,8 @@ SANITIZER_TARGET="${SANITIZER_TARGET:-$(rustc +${HARDENING_TOOLCHAIN} -vV | awk 
 
 source "$ROOT_DIR/scripts/hardening_test_names.sh"
 
-if ((${#hardening_test_filters[@]} == 0)); then
-  echo "hardening_test_filters is empty; refusing to run an empty hardening suite" >&2
+if ((${#hardening_base_test_filters[@]} == 0 && ${#hardening_stwo_test_filters[@]} == 0)); then
+  echo "hardening test filter lists are empty; refusing to run an empty hardening suite" >&2
   exit 1
 fi
 
@@ -18,10 +18,20 @@ export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=1:leak_check_at_exit=0}"
 export RUSTFLAGS="${RUSTFLAGS:-} -Zsanitizer=address"
 export RUSTDOCFLAGS="${RUSTDOCFLAGS:-} -Zsanitizer=address"
 
-for test_filter in "${hardening_test_filters[@]}"; do
+for test_filter in "${hardening_base_test_filters[@]}"; do
   cargo +"${HARDENING_TOOLCHAIN}" test \
     -Zbuild-std \
     --target "${SANITIZER_TARGET}" \
+    --lib "${test_filter}" \
+    -- \
+    --exact
+done
+
+for test_filter in "${hardening_stwo_test_filters[@]}"; do
+  cargo +"${HARDENING_TOOLCHAIN}" test \
+    -Zbuild-std \
+    --target "${SANITIZER_TARGET}" \
+    --features stwo-backend \
     --lib "${test_filter}" \
     -- \
     --exact

--- a/scripts/run_miri_suite.sh
+++ b/scripts/run_miri_suite.sh
@@ -9,13 +9,13 @@ export MIRIFLAGS="${MIRIFLAGS:-"-Zmiri-strict-provenance -Zmiri-symbolic-alignme
 
 source "$ROOT_DIR/scripts/hardening_test_names.sh"
 
-if ((${#hardening_test_filters[@]} == 0)); then
-  echo "hardening_test_filters is empty; refusing to run an empty hardening suite" >&2
+if ((${#hardening_base_test_filters[@]} == 0)); then
+  echo "hardening_base_test_filters is empty; refusing to run an empty Miri suite" >&2
   exit 1
 fi
 
 cargo +"${HARDENING_TOOLCHAIN}" miri setup
 
-for test_filter in "${hardening_test_filters[@]}"; do
+for test_filter in "${hardening_base_test_filters[@]}"; do
   cargo +"${HARDENING_TOOLCHAIN}" miri test --lib "${test_filter}" -- --exact
 done

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -24,6 +24,17 @@ if (( ${#missing_targets[@]} > 0 )); then
   exit 1
 fi
 
+if [[ -n "${MUTATION_DIFF_FILE:-}" ]]; then
+  if [[ ! -f "${MUTATION_DIFF_FILE}" ]]; then
+    echo "MUTATION_DIFF_FILE points to a missing file: ${MUTATION_DIFF_FILE}" >&2
+    exit 1
+  fi
+  if [[ ! -s "${MUTATION_DIFF_FILE}" ]]; then
+    echo "MUTATION_DIFF_FILE is empty; refusing to run a zero-diff mutation slice" >&2
+    exit 1
+  fi
+fi
+
 args=(
   cargo
   +"${MUTATION_TOOLCHAIN}"
@@ -45,6 +56,10 @@ done
 
 if [[ -n "${MUTATION_SHARD:-}" ]]; then
   args+=(--shard "$MUTATION_SHARD")
+fi
+
+if [[ -n "${MUTATION_DIFF_FILE:-}" ]]; then
+  args+=(--in-diff "${MUTATION_DIFF_FILE}")
 fi
 
 "${args[@]}" "$@"

--- a/scripts/run_ub_checks_suite.sh
+++ b/scripts/run_ub_checks_suite.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+HARDENING_TOOLCHAIN="${HARDENING_TOOLCHAIN:-nightly-2025-07-14}"
+
+source "$ROOT_DIR/scripts/hardening_test_names.sh"
+
+if ((${#hardening_base_test_filters[@]} == 0 && ${#hardening_stwo_test_filters[@]} == 0)); then
+  echo "hardening test filter lists are empty; refusing to run an empty UB-checks suite" >&2
+  exit 1
+fi
+
+export RUSTFLAGS="${RUSTFLAGS:-} -Zub-checks=yes"
+export RUSTDOCFLAGS="${RUSTDOCFLAGS:-} -Zub-checks=yes"
+
+for test_filter in "${hardening_base_test_filters[@]}"; do
+  cargo +"${HARDENING_TOOLCHAIN}" test --lib "${test_filter}" -- --exact
+done
+
+for test_filter in "${hardening_stwo_test_filters[@]}"; do
+  cargo +"${HARDENING_TOOLCHAIN}" test \
+    --features stwo-backend \
+    --lib "${test_filter}" \
+    -- \
+    --exact
+done


### PR DESCRIPTION
## Summary
- add the repo hardening contract and deterministic nextest/mutation/sanitizer plumbing on top of the Phase 24 validator path
- add an explicit UB-checks validator subset alongside Miri and ASAN
- document the hardening surface so the repo and paper describe the same stack

## Validation
- HARDENING_TOOLCHAIN=nightly-2025-07-14 /tmp/llm-ptv-phase24-hardening-v1/scripts/run_ub_checks_suite.sh
- python3 /tmp/llm-ptv-phase24-hardening-v1/scripts/paper/paper_preflight.py --repo-root /tmp/llm-ptv-phase24-hardening-v1

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below
- The new UB-check lane reuses the bounded validator subset instead of widening to unreviewed end-to-end tests.
- Oracle/differential logic is unchanged in this PR; existing oracle paths are exercised by the same validator subset.
- Resource-bound impact is explicit: the lane reuses bounded filters from scripts/hardening_test_names.sh and refuses an empty suite.
- Kani/formal impact is unchanged in implementation, but this PR widens the runtime hardening stack around the same trusted validator core.