### PR TITLE
[codex] Guard Phase 28 recursion posture

### DIFF
--- a/docs/design/phase28-proof-carrying-aggregation-spec.md
+++ b/docs/design/phase28-proof-carrying-aggregation-spec.md
@@ -19,9 +19,11 @@ The manifest makes that posture explicit:
 - `recursive_verification_claimed` defaults to `false`,
 - `cryptographic_compression_claimed` defaults to `false`.
 
-The public verifier rejects any Phase 28 manifest that changes the posture label
-or sets either claim bit. Older Phase 28 artifacts that omit these fields still
-deserialize to the same pre-recursive posture.
+The public verifier rejects any Phase 28 manifest where the effective
+`recursion_posture` after deserialization is not
+`pre-recursive-proof-carrying-aggregation`, or where either claim bit is set to
+`true`. Older Phase 28 artifacts that omit these fields still deserialize to the
+same pre-recursive posture.
 
 ## Inputs
 

--- a/docs/design/phase28-proof-carrying-aggregation-spec.md
+++ b/docs/design/phase28-proof-carrying-aggregation-spec.md
@@ -13,6 +13,16 @@ The object proved here is:
 This is still **not recursive verification** and **not cryptographic compression**.
 It is a proof-carrying outer aggregation layer that is honest about replaying verification of nested members.
 
+The manifest makes that posture explicit:
+
+- `recursion_posture` defaults to `pre-recursive-proof-carrying-aggregation`,
+- `recursive_verification_claimed` defaults to `false`,
+- `cryptographic_compression_claimed` defaults to `false`.
+
+The public verifier rejects any Phase 28 manifest that changes the posture label
+or sets either claim bit. Older Phase 28 artifacts that omit these fields still
+deserialize to the same pre-recursive posture.
+
 ## Inputs
 
 Each Phase 28 member is a fully materialized:
@@ -50,6 +60,11 @@ It aggregates only:
 4. one Phase 28 outer aggregation built from those already-verified Phase 27 chains.
 
 So the carried-state boundary exposed at the Phase 28 level is still anchored in real contiguous interval evidence, just across multiple chained bundles instead of one bundle.
+
+The anti-overclaiming guard is intentionally shallow: it runs before nested
+Phase 27 proof walks and before the expensive proof-checking mode. This keeps a
+bad artifact from spending verifier resources after it has already claimed a
+recursive or compressed proof posture that Phase 28 does not implement.
 
 ## Demo Construction
 

--- a/docs/design/phase28-proof-carrying-aggregation-spec.md
+++ b/docs/design/phase28-proof-carrying-aggregation-spec.md
@@ -63,10 +63,11 @@ It aggregates only:
 
 So the carried-state boundary exposed at the Phase 28 level is still anchored in real contiguous interval evidence, just across multiple chained bundles instead of one bundle.
 
-The anti-overclaiming guard is intentionally shallow: it runs before nested
-Phase 27 proof walks and before the expensive proof-checking mode. This keeps a
-bad artifact from spending verifier resources after it has already claimed a
-recursive or compressed proof posture that Phase 28 does not implement.
+The guard implementing these anti-overclaiming rejection criteria is
+intentionally shallow: it runs before nested Phase 27 proof walks and before the
+expensive proof-checking mode. This keeps a bad artifact from spending verifier
+resources after it has already claimed a recursive or compressed proof posture
+that Phase 28 does not implement.
 
 ## Demo Construction
 

--- a/docs/design/phase28-proof-carrying-aggregation-spec.md
+++ b/docs/design/phase28-proof-carrying-aggregation-spec.md
@@ -24,6 +24,10 @@ The public verifier rejects any Phase 28 manifest where the effective
 `pre-recursive-proof-carrying-aggregation`, or where either claim bit is set to
 `true`. Older Phase 28 artifacts that omit these fields still deserialize to the
 same pre-recursive posture.
+When a `recursion_posture` field is present, deserialization also rejects values
+larger than `128` bytes before the verifier compares the posture value or claim
+bits; this keeps oversized untrusted posture strings out of verifier error
+paths.
 
 ## Inputs
 

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -146,6 +146,63 @@ fn default_phase28_recursion_posture() -> String {
     STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE.to_string()
 }
 
+fn validate_phase28_recursion_posture_string<E>(value: &str) -> std::result::Result<(), E>
+where
+    E: serde::de::Error,
+{
+    if value.len() > MAX_PHASE28_RECURSION_POSTURE_BYTES {
+        return Err(E::custom(format!(
+            "aggregated chained folded intervalized decoding state relation recursion_posture_len={} exceeds the supported maximum {}",
+            value.len(),
+            MAX_PHASE28_RECURSION_POSTURE_BYTES
+        )));
+    }
+    Ok(())
+}
+
+fn deserialize_phase28_recursion_posture<'de, D>(
+    deserializer: D,
+) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct Phase28RecursionPostureVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for Phase28RecursionPostureVisitor {
+        type Value = String;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a bounded Phase 28 recursion posture string")
+        }
+
+        fn visit_borrowed_str<E>(self, value: &'de str) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            validate_phase28_recursion_posture_string::<E>(value)?;
+            Ok(value.to_string())
+        }
+
+        fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            validate_phase28_recursion_posture_string::<E>(value)?;
+            Ok(value.to_string())
+        }
+
+        fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            validate_phase28_recursion_posture_string::<E>(&value)?;
+            Ok(value)
+        }
+    }
+
+    deserializer.deserialize_str(Phase28RecursionPostureVisitor)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Phase11DecodingState {
     pub state_version: String,
@@ -739,7 +796,10 @@ pub struct Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManife
     pub statement_version: String,
     // Defaulted posture metadata preserves legacy Phase 28 v1 commitments while
     // making any new recursive/compressed claim fail at verifier entry.
-    #[serde(default = "default_phase28_recursion_posture")]
+    #[serde(
+        default = "default_phase28_recursion_posture",
+        deserialize_with = "deserialize_phase28_recursion_posture"
+    )]
     pub recursion_posture: String,
     #[serde(default)]
     pub recursive_verification_claimed: bool,
@@ -7814,7 +7874,7 @@ fn validate_phase28_aggregated_chained_folded_intervalized_decoding_state_relati
     }
     if manifest.recursion_posture != STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE {
         return Err(VmError::InvalidConfig(format!(
-            "aggregated chained folded intervalized decoding state relation recursion_posture_len={} is not the expected pre-recursive posture `{}`",
+            "aggregated chained folded intervalized decoding state relation recursion_posture mismatch (provided_len={}, expected `{}`)",
             manifest.recursion_posture.len(),
             STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE
         )));
@@ -20782,7 +20842,12 @@ mod tests {
     ) {
         let (mut manifest, summaries) =
             sample_phase28_aggregated_chained_folded_intervalized_decoding_state_relation();
-        manifest.recursion_posture = "x".repeat(MAX_PHASE28_RECURSION_POSTURE_BYTES + 1);
+        let untrusted_prefix = "untrusted-posture-prefix";
+        manifest.recursion_posture = format!(
+            "{}{}",
+            untrusted_prefix,
+            "x".repeat(MAX_PHASE28_RECURSION_POSTURE_BYTES)
+        );
         let err =
             verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_summaries(
                 &manifest,
@@ -20790,6 +20855,7 @@ mod tests {
             )
             .unwrap_err();
         assert!(err.to_string().contains("recursion_posture_len="));
+        assert!(!err.to_string().contains(untrusted_prefix));
         assert!(
             err.to_string().len() < 256,
             "error must not echo untrusted posture payload"
@@ -20855,6 +20921,36 @@ mod tests {
             &summaries,
         )
         .expect("legacy defaulted phase28 manifest stays verifiable");
+    }
+
+    #[test]
+    fn phase28_deserialization_rejects_long_recursive_posture_without_echoing_it() {
+        let (manifest, _) =
+            sample_phase28_aggregated_chained_folded_intervalized_decoding_state_relation();
+        let untrusted_prefix = "serde-untrusted-posture";
+        let mut value = serde_json::to_value(&manifest).expect("serialize manifest");
+        value
+            .as_object_mut()
+            .expect("manifest serializes to object")
+            .insert(
+                "recursion_posture".to_string(),
+                serde_json::Value::String(format!(
+                    "{}{}",
+                    untrusted_prefix,
+                    "x".repeat(MAX_PHASE28_RECURSION_POSTURE_BYTES)
+                )),
+            );
+
+        let err = serde_json::from_value::<
+            Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManifest,
+        >(value)
+        .unwrap_err();
+        assert!(err.to_string().contains("recursion_posture_len="));
+        assert!(!err.to_string().contains(untrusted_prefix));
+        assert!(
+            err.to_string().len() < 256,
+            "serde error must not echo untrusted posture payload"
+        );
     }
 
     #[test]

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -90,6 +90,8 @@ pub const STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VE
     &str = "stwo-phase28-aggregated-chained-folded-intervalized-decoding-state-relation-v1";
 pub const STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28:
     &str = "stwo_execution_parameterized_aggregated_chained_folded_intervalized_proof_carrying_decoding_state_relation";
+const STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE: &str =
+    "pre-recursive-proof-carrying-aggregation";
 const DECODING_KV_CACHE_RANGE: std::ops::Range<usize> = 0..6;
 const DECODING_OUTPUT_RANGE: std::ops::Range<usize> = 10..13;
 const DECODING_POSITION_INDEX: usize = 21;
@@ -138,6 +140,10 @@ const MAX_PHASE28_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_MEMBERS: usize = 128;
 const MAX_PHASE28_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_ROLLUPS: usize = 8_388_608;
 const MAX_PHASE28_TOTAL_NESTED_PHASE26_MEMBERS: usize = 8_192;
 const MAX_PHASE28_TOTAL_NESTED_PHASE25_MEMBERS: usize = 16_384;
+
+fn default_phase28_recursion_posture() -> String {
+    STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE.to_string()
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Phase11DecodingState {
@@ -730,6 +736,14 @@ pub struct Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManife
     pub semantic_scope: String,
     pub proof_backend_version: String,
     pub statement_version: String,
+    // Defaulted posture metadata preserves legacy Phase 28 v1 commitments while
+    // making any new recursive/compressed claim fail at verifier entry.
+    #[serde(default = "default_phase28_recursion_posture")]
+    pub recursion_posture: String,
+    #[serde(default)]
+    pub recursive_verification_claimed: bool,
+    #[serde(default)]
+    pub cryptographic_compression_claimed: bool,
     pub bounded_aggregation_arity: usize,
     pub member_count: usize,
     pub total_phase26_members: usize,
@@ -7790,6 +7804,23 @@ fn validate_phase28_aggregated_chained_folded_intervalized_decoding_state_relati
             manifest.statement_version
         )));
     }
+    if manifest.recursion_posture != STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE {
+        return Err(VmError::InvalidConfig(format!(
+            "aggregated chained folded intervalized decoding state relation recursion_posture `{}` is not `{}`",
+            manifest.recursion_posture,
+            STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE
+        )));
+    }
+    if manifest.recursive_verification_claimed {
+        return Err(VmError::InvalidConfig(
+            "aggregated chained folded intervalized decoding state relation must not claim recursive verification".to_string(),
+        ));
+    }
+    if manifest.cryptographic_compression_claimed {
+        return Err(VmError::InvalidConfig(
+            "aggregated chained folded intervalized decoding state relation must not claim cryptographic compression".to_string(),
+        ));
+    }
     if manifest.members.len() < 2 {
         return Err(VmError::InvalidConfig(
             "aggregated chained folded intervalized decoding state relation must contain at least two members"
@@ -8132,6 +8163,9 @@ pub fn phase28_prepare_aggregated_chained_folded_intervalized_decoding_state_rel
                 .to_string(),
         proof_backend_version: members[0].proof_backend_version.clone(),
         statement_version: members[0].statement_version.clone(),
+        recursion_posture: STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE.to_string(),
+        recursive_verification_claimed: false,
+        cryptographic_compression_claimed: false,
         bounded_aggregation_arity,
         member_count: members.len(),
         total_phase26_members: totals.total_phase26_members,
@@ -16237,6 +16271,9 @@ mod tests {
                     .to_string(),
             proof_backend_version: crate::stwo_backend::STWO_BACKEND_VERSION_PHASE12.to_string(),
             statement_version: crate::proof::CLAIM_STATEMENT_VERSION_V1.to_string(),
+            recursion_posture: STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE.to_string(),
+            recursive_verification_claimed: false,
+            cryptographic_compression_claimed: false,
             bounded_aggregation_arity: summaries.len(),
             member_count: summaries.len(),
             total_phase26_members: totals.total_phase26_members,
@@ -20712,6 +20749,85 @@ mod tests {
         assert!(err.to_string().contains(
             "unsupported aggregated chained folded intervalized decoding state relation statement version `statement-v2`"
         ));
+    }
+
+    #[test]
+    fn phase28_aggregated_chained_folded_intervalized_state_relation_rejects_recursive_posture_label(
+    ) {
+        let (mut manifest, summaries) =
+            sample_phase28_aggregated_chained_folded_intervalized_decoding_state_relation();
+        manifest.recursion_posture = "recursive-compressed".to_string();
+        let err =
+            verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_summaries(
+                &manifest,
+                &summaries,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("recursion_posture"));
+        assert!(err
+            .to_string()
+            .contains(STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE));
+    }
+
+    #[test]
+    fn phase28_aggregated_chained_folded_intervalized_state_relation_rejects_recursive_verification_claim(
+    ) {
+        let (mut manifest, summaries) =
+            sample_phase28_aggregated_chained_folded_intervalized_decoding_state_relation();
+        manifest.recursive_verification_claimed = true;
+        let err =
+            verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_summaries(
+                &manifest,
+                &summaries,
+            )
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must not claim recursive verification"));
+    }
+
+    #[test]
+    fn phase28_aggregated_chained_folded_intervalized_state_relation_rejects_cryptographic_compression_claim(
+    ) {
+        let (mut manifest, summaries) =
+            sample_phase28_aggregated_chained_folded_intervalized_decoding_state_relation();
+        manifest.cryptographic_compression_claimed = true;
+        let err =
+            verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_summaries(
+                &manifest,
+                &summaries,
+            )
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must not claim cryptographic compression"));
+    }
+
+    #[test]
+    fn phase28_deserialization_defaults_to_pre_recursive_posture() {
+        let (manifest, summaries) =
+            sample_phase28_aggregated_chained_folded_intervalized_decoding_state_relation();
+        let mut value = serde_json::to_value(&manifest).expect("serialize manifest");
+        let object = value
+            .as_object_mut()
+            .expect("manifest serializes to object");
+        object.remove("recursion_posture");
+        object.remove("recursive_verification_claimed");
+        object.remove("cryptographic_compression_claimed");
+
+        let decoded: Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManifest =
+            serde_json::from_value(value).expect("deserialize legacy phase28 manifest");
+        assert_eq!(
+            decoded.recursion_posture,
+            STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE
+        );
+        assert!(!decoded.recursive_verification_claimed);
+        assert!(!decoded.cryptographic_compression_claimed);
+        verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_summaries(
+            &decoded,
+            &summaries,
+        )
+        .expect("legacy defaulted phase28 manifest stays verifiable");
     }
 
     #[test]

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -140,6 +140,7 @@ const MAX_PHASE28_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_MEMBERS: usize = 128;
 const MAX_PHASE28_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_ROLLUPS: usize = 8_388_608;
 const MAX_PHASE28_TOTAL_NESTED_PHASE26_MEMBERS: usize = 8_192;
 const MAX_PHASE28_TOTAL_NESTED_PHASE25_MEMBERS: usize = 16_384;
+const MAX_PHASE28_RECURSION_POSTURE_BYTES: usize = 128;
 
 fn default_phase28_recursion_posture() -> String {
     STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE.to_string()
@@ -7804,10 +7805,17 @@ fn validate_phase28_aggregated_chained_folded_intervalized_decoding_state_relati
             manifest.statement_version
         )));
     }
+    if manifest.recursion_posture.len() > MAX_PHASE28_RECURSION_POSTURE_BYTES {
+        return Err(VmError::InvalidConfig(format!(
+            "aggregated chained folded intervalized decoding state relation recursion_posture_len={} exceeds the supported maximum {}",
+            manifest.recursion_posture.len(),
+            MAX_PHASE28_RECURSION_POSTURE_BYTES
+        )));
+    }
     if manifest.recursion_posture != STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE {
         return Err(VmError::InvalidConfig(format!(
-            "aggregated chained folded intervalized decoding state relation recursion_posture `{}` is not `{}`",
-            manifest.recursion_posture,
+            "aggregated chained folded intervalized decoding state relation recursion_posture_len={} is not the expected pre-recursive posture `{}`",
+            manifest.recursion_posture.len(),
             STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE
         )));
     }
@@ -20767,6 +20775,25 @@ mod tests {
         assert!(err
             .to_string()
             .contains(STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE));
+    }
+
+    #[test]
+    fn phase28_aggregated_chained_folded_intervalized_state_relation_rejects_long_recursive_posture_without_echoing_it(
+    ) {
+        let (mut manifest, summaries) =
+            sample_phase28_aggregated_chained_folded_intervalized_decoding_state_relation();
+        manifest.recursion_posture = "x".repeat(MAX_PHASE28_RECURSION_POSTURE_BYTES + 1);
+        let err =
+            verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_summaries(
+                &manifest,
+                &summaries,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("recursion_posture_len="));
+        assert!(
+            err.to_string().len() < 256,
+            "error must not echo untrusted posture payload"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add explicit Phase 28 recursion-posture metadata with legacy-compatible serde defaults
- reject manifests that claim recursive verification or cryptographic compression at shallow verifier entry
- bound untrusted posture deserialization and error reporting; document/test legacy defaulting plus claim tampering

## Validation
- [x] cargo +nightly-2025-06-23 test -q --features stwo-backend phase28_ --lib
- [x] cargo test -q --lib
- [x] cargo fmt --check
- [x] git diff --check
- [x] forbidden-repo scan over README.md docs scripts src tests

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Hardening notes:
- Oracle/differential: existing Phase 28 oracle tests were included in the phase28_ feature-gated test filter; this change is verifier claim-posture metadata, not a numeric relation oracle.
- Resource-bound/untrusted-input: the guard runs in shallow validation before nested Phase 27 proof walks and before proof-checking mode; oversized untrusted posture strings now fail through bounded deserialization/error output.
- Kani/formal-kernel: no scalar shape invariant changed; existing Phase 28 aggregation-shape harnesses remain applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Phase 28 manifest posture semantics, default posture/claim values, and verifier rejection criteria for unsupported postures or claimed features.

* **Bug Fixes / Improvements**
  * Manifests with oversized posture values or with unsupported recursion/compression claims are rejected early (before expensive verification), while legacy manifests lacking the new fields continue to be accepted via defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->