### PR TITLE
[codex] Reduce duplicate hardening CI spend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
           for test_target in "${smoke_targets[@]}"; do
             cargo test -q --test "$test_target"
           done
+          rustup toolchain install nightly-2025-07-14 --profile minimal
+          stwo_smoke=stwo_backend::decoding::tests::phase28_aggregated_chained_folded_intervalized_state_relation_rejects_header_mismatch_before_nested_checks
+          cargo +nightly-2025-07-14 test -q \
+            --features stwo-backend \
+            --lib "$stwo_smoke" \
+            -- \
+            --exact
 
   statement-spec:
     name: statement spec contract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
 
   fuzz-smoke:
     name: fuzz smoke (${{ matrix.target }})
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   pull_request:
     paths:
+      - ".github/workflows/ci.yml"
       - "src/**/*.rs"
       - "tests/**"
       - "Cargo.toml"
@@ -28,10 +29,10 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Run lightweight library smoke
-        run: cargo test -q --lib
+        run: cargo test -q --lib --tests
 
   statement-spec:
     name: statement spec contract
@@ -48,7 +49,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Validate statement spec constants contract
         run: |
@@ -116,7 +117,7 @@ jobs:
           python -m pip install -r scripts/requirements.txt
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@80e6af7a2ec7f280fffe2d0a9d3a12a9d11d86e9
@@ -175,7 +176,7 @@ jobs:
           python -m pip install -r scripts/requirements.txt
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Export ONNX from CLI
         run: cargo run --features onnx-export --bin tvm -- export-onnx programs/fibonacci.tvm -o compiled/fibonacci
@@ -230,7 +231,7 @@ jobs:
           toolchain: ${{ steps.fuzz-toolchain.outputs.channel }}
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Install cargo-fuzz
         run: cargo +${{ steps.fuzz-toolchain.outputs.channel }} install cargo-fuzz --version 0.13.1 --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,7 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   statement-spec:
@@ -75,8 +72,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-        with:
-          toolchain: stable
         with:
           toolchain: ${{ matrix.rust_toolchain }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/ci.yml"
       - "src/**/*.rs"
       - "tests/**"
+      - "programs/**"
       - "Cargo.toml"
       - "Cargo.lock"
   workflow_dispatch:
@@ -34,8 +35,9 @@ jobs:
       - name: Run lightweight regression smoke
         run: |
           cargo test -q --lib statement_spec_contract_is_synced_with_constants
-          for test_target in tests/*.rs; do
-            cargo test -q --test "$(basename "$test_target" .rs)"
+          smoke_targets=(assembly e2e interpreter runtime vanillastark_smoke)
+          for test_target in "${smoke_targets[@]}"; do
+            cargo test -q --test "$test_target"
           done
 
   statement-spec:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
+      - name: Restore pinned nightly toolchain cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: |
+            ~/.rustup/toolchains/nightly-2025-07-14-*
+            ~/.rustup/downloads
+            ~/.rustup/update-hashes
+          key: rustup-nightly-2025-07-14-${{ runner.os }}-${{ runner.arch }}
+
       - name: Run lightweight regression smoke
         run: |
           cargo test -q --lib statement_spec_contract_is_synced_with_constants

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,12 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
-      - name: Run lightweight library smoke
-        run: cargo test -q --lib --tests
+      - name: Run lightweight regression smoke
+        run: |
+          cargo test -q --lib statement_spec_contract_is_synced_with_constants
+          for test_target in tests/*.rs; do
+            cargo test -q --test "$(basename "$test_target" .rs)"
+          done
 
   statement-spec:
     name: statement spec contract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,38 @@ permissions:
   contents: read
 
 on:
+  pull_request:
+    paths:
+      - "src/**/*.rs"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
   workflow_dispatch:
 
 jobs:
+  pr-smoke:
+    name: lightweight PR lib smoke
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run lightweight library smoke
+        run: cargo test -q --lib
+
   statement-spec:
     name: statement spec contract
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +57,7 @@ jobs:
 
   cargo-test:
     name: cargo nextest (${{ matrix.name }})
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -126,6 +154,7 @@ jobs:
 
   milestone-1-proof:
     name: export and validate ONNX workflow
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/formal-contracts.yml
+++ b/.github/workflows/formal-contracts.yml
@@ -5,13 +5,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - ".github/workflows/formal-contracts.yml"
-      - "scripts/run_formal_contract_suite.sh"
-      - "src/stwo_backend/decoding.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
 
 jobs:
   decoding-contract-kernel:

--- a/.github/workflows/formal-contracts.yml
+++ b/.github/workflows/formal-contracts.yml
@@ -4,9 +4,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
   pull_request:
     paths:

--- a/.github/workflows/miri-sanitizers.yml
+++ b/.github/workflows/miri-sanitizers.yml
@@ -5,16 +5,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - ".github/workflows/miri-sanitizers.yml"
-      - "scripts/hardening_test_names.sh"
-      - "scripts/run_miri_suite.sh"
-      - "scripts/run_asan_suite.sh"
-      - "scripts/run_ub_checks_suite.sh"
-      - "src/**/*.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
 
 env:
   HARDENING_TOOLCHAIN: nightly-2025-07-14

--- a/.github/workflows/miri-sanitizers.yml
+++ b/.github/workflows/miri-sanitizers.yml
@@ -4,9 +4,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
   pull_request:
     paths:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -5,16 +5,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 3 * * 1"
-  pull_request:
-    paths:
-      - ".github/workflows/mutation-testing.yml"
-      - "scripts/run_mutation_suite.sh"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "src/stwo_backend/**"
-      - "tests/**"
 
 env:
   MUTATION_TOOLCHAIN: nightly-2025-07-14

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ If you want the shortest successful path, start on stable Rust with the default
 runtime and vanilla STARK commands. Move to `stwo` only when you need the
 experimental backend surface.
 
-Hardening policy: trusted-core work must run the matching Miri, sanitizer, and
-formal suites locally, preferably in Lima Ubuntu 22.04 for Linux parity. See
-`docs/hardening-policy.md`.
+Local CI and hardening policy: trusted-core work must run matching tests, Miri,
+sanitizer, and formal suites locally, preferably in Lima Ubuntu 22.04 for Linux
+parity. See `docs/hardening-policy.md`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ If you want the shortest successful path, start on stable Rust with the default
 runtime and vanilla STARK commands. Move to `stwo` only when you need the
 experimental backend surface.
 
+Hardening policy: trusted-core work must run the matching Miri, sanitizer, and
+formal suites locally, preferably in Lima Ubuntu 22.04 for Linux parity. See
+`docs/hardening-policy.md`.
+
 ---
 
 ## Why This Works

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -11,7 +11,7 @@ expensive GitHub Actions compute.
 - Keep any automatic PR GitHub Actions compute lightweight and path-scoped; the
   CI workflow only runs a core library contract plus integration-test smoke for
   Rust, Cargo, program fixture, or CI workflow changes, plus one exact
-  pinned-nightly `stwo-backend` smoke.
+  pinned-nightly `stwo-backend` smoke with the pinned nightly toolchain cached.
 - Keep heavyweight GitHub Actions workflows available through
   `workflow_dispatch` for intentional release, baseline, or emergency
   GitHub-hosted validation.

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -9,8 +9,8 @@ expensive GitHub Actions compute.
   heavyweight GitHub Actions compute such as full CI matrix, mutation testing,
   Miri, sanitizers, or formal contracts.
 - Keep any automatic PR GitHub Actions compute lightweight and path-scoped; the
-  CI workflow only runs a library-and-tests smoke for Rust, Cargo, or CI
-  workflow changes.
+  CI workflow only runs a core library contract plus integration-test smoke for
+  Rust, Cargo, or CI workflow changes.
 - Keep heavyweight GitHub Actions workflows available through
   `workflow_dispatch` for intentional release, baseline, or emergency
   GitHub-hosted validation.

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -1,0 +1,55 @@
+# Local Hardening Policy
+
+Trusted-core work must preserve the hardening discipline without spending a
+duplicate GitHub Actions run after merge.
+
+## Rule
+
+- Do not use `push: main` triggers for the expensive hardening workflows.
+- Keep expensive hardening available on `pull_request` and `workflow_dispatch`.
+- Before opening or merging trusted-core PRs, run the matching hardening suite
+  locally, preferably inside a Lima Ubuntu 22.04 environment for Linux parity.
+- Keep CodeRabbit, Greptile, Qodo, and the PR hardening contract as GitHub PR
+  gates.
+- If a PR cannot run a local hardening command, document the blocker in the PR
+  validation notes and use `workflow_dispatch` intentionally.
+
+## Local Commands
+
+Run the relevant subset from the repository root:
+
+```bash
+cargo test -q --lib
+cargo +nightly-2025-06-23 test -q --features stwo-backend <relevant_filter> --lib
+cargo fmt --check
+git diff --check
+HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh
+HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh
+HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_asan_suite.sh
+scripts/run_formal_contract_suite.sh
+```
+
+For Phase 28 work, the current targeted `stwo-backend` filter is `phase28_`.
+
+## Lima Baseline
+
+For sanitizer parity with GitHub's Ubuntu runners, prefer running the hardening
+suite inside Lima:
+
+```bash
+limactl start template://ubuntu-22.04 --name ptv-ci
+limactl shell ptv-ci
+```
+
+Inside the VM:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential pkg-config libssl-dev git curl
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source "$HOME/.cargo/env"
+rustup toolchain install nightly-2025-07-14 --component miri,rust-src
+```
+
+Then run the local commands above from the repository checkout mounted or cloned
+inside the VM.

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -6,8 +6,10 @@ expensive GitHub Actions compute.
 ## Rule
 
 - Do not use automatic `push`, `pull_request`, or `schedule` triggers for
-  heavyweight GitHub Actions compute such as CI matrix, mutation testing, Miri,
-  sanitizers, or formal contracts.
+  heavyweight GitHub Actions compute such as full CI matrix, mutation testing,
+  Miri, sanitizers, or formal contracts.
+- Keep any automatic PR GitHub Actions compute lightweight and path-scoped; the
+  CI workflow only runs a library smoke test for Rust or Cargo changes.
 - Keep heavyweight GitHub Actions workflows available through
   `workflow_dispatch` for intentional release, baseline, or emergency
   GitHub-hosted validation.
@@ -32,8 +34,6 @@ cargo test -q --lib
 cargo nextest run \
   --workspace --all-targets --profile ci --no-fail-fast
 cargo test --workspace --doc
-TEST_FILTER=phase28_
-cargo +nightly-2025-07-14 test -q --features stwo-backend --lib "$TEST_FILTER"
 RUSTUP_TOOLCHAIN=nightly-2025-07-14 cargo nextest run \
   --workspace --all-targets --features stwo-backend \
   --profile ci-stwo --no-fail-fast
@@ -45,7 +45,9 @@ HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_asan_suite.sh
 scripts/run_formal_contract_suite.sh
 ```
 
-For Phase 28 work, the current targeted `stwo-backend` filter is `phase28_`.
+The sanitizer and UB hardening scripts use the curated exact test lists in
+`scripts/hardening_test_names.sh`; update that file when adding new trusted-core
+phase gates.
 Install the `cargo-nextest` version pinned in `.config/nextest.toml` if it is
 missing. Run the relevant feature rows from `.github/workflows/ci.yml` when the
 change touches broader runtime, export, or backend behavior.

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -9,7 +9,8 @@ expensive GitHub Actions compute.
   heavyweight GitHub Actions compute such as full CI matrix, mutation testing,
   Miri, sanitizers, or formal contracts.
 - Keep any automatic PR GitHub Actions compute lightweight and path-scoped; the
-  CI workflow only runs a library smoke test for Rust or Cargo changes.
+  CI workflow only runs a library-and-tests smoke for Rust, Cargo, or CI
+  workflow changes.
 - Keep heavyweight GitHub Actions workflows available through
   `workflow_dispatch` for intentional release, baseline, or emergency
   GitHub-hosted validation.

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -9,8 +9,11 @@ duplicate GitHub Actions run after merge.
 - Keep expensive hardening available on `pull_request` and `workflow_dispatch`.
 - Before opening or merging trusted-core PRs, run the matching hardening suite
   locally, preferably inside a Lima Ubuntu 22.04 environment for Linux parity.
-- Keep CodeRabbit, Greptile, Qodo, and the PR hardening contract as GitHub PR
-  gates.
+- Keep CodeRabbit, Greptile, and Qodo as GitHub PR review signals, and keep the
+  PR hardening contract as the enforced PR policy gate.
+- `main` does not get automatic post-merge runs for the expensive hardening
+  workflows; dispatch those workflows manually when release or baseline
+  validation needs a GitHub-hosted run on the merge commit.
 - If a PR cannot run a local hardening command, document the blocker in the PR
   validation notes and use `workflow_dispatch` intentionally.
 
@@ -20,7 +23,7 @@ Run the relevant subset from the repository root:
 
 ```bash
 cargo test -q --lib
-cargo +nightly-2025-06-23 test -q --features stwo-backend <relevant_filter> --lib
+cargo +nightly-2025-07-14 test -q --features stwo-backend <relevant_filter> --lib
 cargo fmt --check
 git diff --check
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -10,7 +10,7 @@ expensive GitHub Actions compute.
   Miri, sanitizers, or formal contracts.
 - Keep any automatic PR GitHub Actions compute lightweight and path-scoped; the
   CI workflow only runs a core library contract plus integration-test smoke for
-  Rust, Cargo, or CI workflow changes.
+  Rust, Cargo, program fixture, or CI workflow changes.
 - Keep heavyweight GitHub Actions workflows available through
   `workflow_dispatch` for intentional release, baseline, or emergency
   GitHub-hosted validation.

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -1,18 +1,23 @@
-# Local Hardening Policy
+# Local CI and Hardening Policy
 
-Trusted-core work must preserve the hardening discipline without spending a
-duplicate GitHub Actions run after merge.
+Trusted-core work must preserve the hardening discipline without defaulting to
+expensive GitHub Actions compute.
 
 ## Rule
 
-- Do not use `push: main` triggers for the expensive hardening workflows.
-- Keep expensive hardening available on `pull_request` and `workflow_dispatch`.
-- Before opening or merging trusted-core PRs, run the matching hardening suite
-  locally, preferably inside a Lima Ubuntu 22.04 environment for Linux parity.
+- Do not use automatic `push`, `pull_request`, or `schedule` triggers for
+  heavyweight GitHub Actions compute such as CI matrix, mutation testing, Miri,
+  sanitizers, or formal contracts.
+- Keep heavyweight GitHub Actions workflows available through
+  `workflow_dispatch` for intentional release, baseline, or emergency
+  GitHub-hosted validation.
+- Before opening or merging trusted-core PRs, run the matching tests and
+  hardening suite locally, preferably inside a Lima Ubuntu 22.04 environment for
+  Linux parity.
 - Keep CodeRabbit, Greptile, and Qodo as GitHub PR review signals, and keep the
   PR hardening contract workflow (`.github/workflows/pr-hardening-contract.yml`)
   as the enforced PR-body checklist gate.
-- `main` does not get automatic post-merge runs for the expensive hardening
+- `main` does not get automatic post-merge runs for heavyweight GitHub Actions
   workflows; dispatch those workflows manually when release or baseline
   validation needs a GitHub-hosted run on the merge commit.
 - If a PR cannot run a local hardening command, document the blocker in the PR
@@ -24,8 +29,14 @@ Run the relevant subset from the repository root:
 
 ```bash
 cargo test -q --lib
+cargo nextest run \
+  --workspace --all-targets --profile ci --no-fail-fast
+cargo test --workspace --doc
 TEST_FILTER=phase28_
 cargo +nightly-2025-07-14 test -q --features stwo-backend --lib "$TEST_FILTER"
+RUSTUP_TOOLCHAIN=nightly-2025-07-14 cargo nextest run \
+  --workspace --all-targets --features stwo-backend \
+  --profile ci-stwo --no-fail-fast
 cargo fmt --check
 git diff --check
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh
@@ -35,6 +46,9 @@ scripts/run_formal_contract_suite.sh
 ```
 
 For Phase 28 work, the current targeted `stwo-backend` filter is `phase28_`.
+Install the `cargo-nextest` version pinned in `.config/nextest.toml` if it is
+missing. Run the relevant feature rows from `.github/workflows/ci.yml` when the
+change touches broader runtime, export, or backend behavior.
 
 ## Lima Baseline
 

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -10,7 +10,8 @@ duplicate GitHub Actions run after merge.
 - Before opening or merging trusted-core PRs, run the matching hardening suite
   locally, preferably inside a Lima Ubuntu 22.04 environment for Linux parity.
 - Keep CodeRabbit, Greptile, and Qodo as GitHub PR review signals, and keep the
-  PR hardening contract as the enforced PR policy gate.
+  PR hardening contract workflow (`.github/workflows/pr-hardening-contract.yml`)
+  as the enforced PR-body checklist gate.
 - `main` does not get automatic post-merge runs for the expensive hardening
   workflows; dispatch those workflows manually when release or baseline
   validation needs a GitHub-hosted run on the merge commit.
@@ -23,7 +24,8 @@ Run the relevant subset from the repository root:
 
 ```bash
 cargo test -q --lib
-cargo +nightly-2025-07-14 test -q --features stwo-backend <relevant_filter> --lib
+TEST_FILTER=phase28_
+cargo +nightly-2025-07-14 test -q --features stwo-backend "$TEST_FILTER" --lib
 cargo fmt --check
 git diff --check
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -10,7 +10,8 @@ expensive GitHub Actions compute.
   Miri, sanitizers, or formal contracts.
 - Keep any automatic PR GitHub Actions compute lightweight and path-scoped; the
   CI workflow only runs a core library contract plus integration-test smoke for
-  Rust, Cargo, program fixture, or CI workflow changes.
+  Rust, Cargo, program fixture, or CI workflow changes, plus one exact
+  pinned-nightly `stwo-backend` smoke.
 - Keep heavyweight GitHub Actions workflows available through
   `workflow_dispatch` for intentional release, baseline, or emergency
   GitHub-hosted validation.

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -25,7 +25,7 @@ Run the relevant subset from the repository root:
 ```bash
 cargo test -q --lib
 TEST_FILTER=phase28_
-cargo +nightly-2025-07-14 test -q --features stwo-backend "$TEST_FILTER" --lib
+cargo +nightly-2025-07-14 test -q --features stwo-backend --lib "$TEST_FILTER"
 cargo fmt --check
 git diff --check
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh


### PR DESCRIPTION
## Summary

- make heavyweight GitHub Actions compute manual-only by default: full CI matrix, mutation testing, Miri/sanitizers, formal contracts, ONNX workflow, and fuzz smoke now require intentional dispatch or are skipped on PRs
- keep a cheap, path-scoped PR smoke for Rust/test/Cargo/program-fixture/CI-workflow changes: one core lib contract, an allowlisted integration smoke set, and one exact cached pinned-nightly `stwo-backend` smoke
- keep the PR hardening contract automatic, and keep CodeRabbit, Greptile, and Qodo as PR review signals
- codify the local/Lima validation rule in docs, including curated hardening scripts and pinned nightly behavior
- fix the existing duplicate `with:` block in the CI Rust toolchain step and pin `rust-cache` usages to a commit SHA

## Validation

- [x] `git diff --check`
- [x] Ruby YAML parse for all `.github/workflows/*.yml` files; only local Ruby gem-extension warnings were printed
- [x] `cargo fmt --check`
- [x] `cargo test -q --lib` (`190 passed; 0 failed`; finished in `456.02s`)
- [x] exact local PR smoke: `cargo test -q --lib statement_spec_contract_is_synced_with_constants`, allowlisted integration targets `assembly`, `e2e`, `interpreter`, `runtime`, `vanillastark_smoke`, and the exact pinned-nightly `stwo-backend` smoke all passed
- [x] GitHub latest head: hardening contract passed, CodeRabbit passed, Greptile passed, lightweight PR smoke passed in `1m41s`
- [x] GitHub latest head: full nextest matrix, ONNX workflow, fuzz smoke, and statement-spec jobs were skipped on PR by design
- [x] `actionlint` checked for availability; not installed locally

## Hardening

- [x] targeted regression and tamper-path coverage added or updated
  - Reviewed: automatic PR smoke now includes a cheap stwo-backend exact test and local full-lib validation passed.
- [x] oracle or differential checks added/updated, or marked not applicable below
  - N/A: no oracle semantics changed.
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
  - Reviewed: this reduces default GitHub runner spend while retaining a cheap PR smoke and moving heavyweight compute to local/Lima or intentional `workflow_dispatch` runs.
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below
  - Reviewed: formal contract execution remains available through `workflow_dispatch`; local formal execution is documented as the default gate.

