### PR TITLE
Add Phase 29 recursive-compression input contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,6 +4122,7 @@ dependencies = [
  "crossterm",
  "flate2",
  "jsonschema",
+ "libc",
  "onnx-protobuf",
  "predicates",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/bin/tvm.rs"
 default = []
 burn-model = ["dep:burn"]
 onnx-export = ["dep:onnx-protobuf", "dep:protobuf", "dep:tract-onnx"]
-stwo-backend = ["dep:stwo", "dep:stwo-constraint-framework", "dep:flate2"]
+stwo-backend = ["dep:stwo", "dep:stwo-constraint-framework", "dep:flate2", "dep:libc"]
 full = ["burn-model", "onnx-export"]
 
 [dependencies]
@@ -29,6 +29,7 @@ burn = { version = "=0.20.1", features = ["ndarray"], optional = true }
 clap = { version = "4.5.38", features = ["derive"] }
 crossterm = "0.28.1"
 flate2 = { version = "1.1", optional = true }
+libc = { version = "0.2", optional = true }
 onnx-protobuf = { version = "0.2.3", optional = true }
 protobuf = { version = "=3.4.0", optional = true }
 ratatui = "0.29.0"

--- a/docs/design/phase29-recursive-compression-input-contract-spec.md
+++ b/docs/design/phase29-recursive-compression-input-contract-spec.md
@@ -1,0 +1,54 @@
+# Phase 29 Recursive-Compression Input Contract
+
+Phase 29 does not implement recursion. It defines the input contract that a later
+recursive-compression prover may consume from a Phase 28 proof-carrying
+aggregation artifact.
+
+The contract exists to avoid an easy false positive: a compact summary of an
+aggregation is not a recursive proof. Phase 29 is only valid when it is derived
+from a Phase 28 manifest that passes the Phase 28 verifier with nested proof
+checks enabled.
+
+## Accepted Input
+
+The preparer accepts a
+`Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManifest` only
+after calling
+`verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_proof_checks`.
+That check rejects synthetic member shells and requires the nested Phase 27
+proof-bearing evidence.
+
+The derived contract binds the following fields:
+
+- Phase 28 artifact version and semantic scope.
+- S-two proof backend and backend version.
+- Statement version.
+- Recursion posture.
+- Explicit recursive-verification and cryptographic-compression claim bits.
+- Aggregation arity, member count, member-summary count, and nested-member count.
+- Phase 26 and Phase 25 aggregate member totals.
+- Matrix, layout, rollup, segment, step, and lookup-frontier totals.
+- Source-template, global-start-state, global-end-state, aggregation-template,
+  and aggregate-accumulator commitments.
+- A BLAKE2b-256 input-contract commitment over the contract fields.
+
+## Rejected Input
+
+Phase 29 rejects:
+
+- Any Phase 28 artifact that claims recursive verification.
+- Any Phase 28 artifact that claims cryptographic compression.
+- Any Phase 28 artifact whose recursion posture is not
+  `pre-recursive-proof-carrying-aggregation`.
+- Any contract with empty critical commitments.
+- Any contract whose member summaries or nested members do not match the
+  declared Phase 28 member count.
+- Any contract whose input-contract commitment does not recompute.
+
+## Non-Goals
+
+Phase 29 does not verify a Phase 28 aggregate inside another proof. It also does
+not compress Phase 28 proof bytes into a smaller cryptographic proof. Those are
+Phase 30+ tasks. The only Phase 29 claim is that future recursion/compression
+must start from a proof-checked Phase 28 aggregation boundary with explicit
+commitments and non-recursive claim bits.

--- a/docs/design/phase29-recursive-compression-input-contract-spec.md
+++ b/docs/design/phase29-recursive-compression-input-contract-spec.md
@@ -30,7 +30,8 @@ The derived contract binds the following fields:
 - Matrix, layout, rollup, segment, step, and lookup-frontier totals.
 - Source-template, global-start-state, global-end-state, aggregation-template,
   and aggregate-accumulator commitments.
-- A BLAKE2b-256 input-contract commitment over the contract fields.
+- A BLAKE2b-256 input-contract commitment computed from the listed contract
+  fields except `input_contract_commitment`, then stored for recomputation.
 
 ## Rejected Input
 
@@ -42,10 +43,16 @@ Phase 29 rejects:
   `pre-recursive-proof-carrying-aggregation`.
 - Any contract whose Phase 28 backend version or statement version does not
   match the supported repository dialect.
-- Any contract with empty critical commitments.
-- Any contract whose member summaries or nested members do not match the
-  declared Phase 28 member count.
-- Any contract whose input-contract commitment does not recompute.
+- Any contract with an empty source-template, global-start-state,
+  global-end-state, aggregation-template, aggregate-accumulator, or
+  input-contract commitment.
+- Any contract whose `phase28_member_summaries != phase28_member_count` or
+  whose `phase28_nested_members != phase28_member_count`.
+- Any contract whose `phase28_bounded_aggregation_arity` is smaller than
+  `phase28_member_count`; the arity may be larger than the realized member
+  count, but not smaller.
+- Any contract whose stored `input_contract_commitment` does not recompute from
+  the other contract fields.
 
 Deserialization of `Phase29RecursiveCompressionInputContract` is a validating
 operation. The read helpers
@@ -55,7 +62,10 @@ the same Phase 29 verifier accepts the parsed fields. Validation failures are
 reported as invalid contract configuration, not as generic JSON serialization
 failures. The file loader uses the repository's bounded JSON read path: it only
 accepts regular files and rejects compressed or uncompressed inputs above the
-Phase 29 JSON byte budget before parsing.
+Phase 29 JSON byte budget before parsing. The string parser applies the same
+byte budget to in-memory JSON, and deserialization rejects unknown fields. The
+commitment encodes length and counter fields with fixed-width unsigned bytes
+rather than platform-width `usize` bytes.
 
 ## Non-Goals
 

--- a/docs/design/phase29-recursive-compression-input-contract-spec.md
+++ b/docs/design/phase29-recursive-compression-input-contract-spec.md
@@ -54,8 +54,8 @@ operation. The read helpers
 the same Phase 29 verifier accepts the parsed fields. Validation failures are
 reported as invalid contract configuration, not as generic JSON serialization
 failures. The file loader uses the repository's bounded JSON read path: it only
-accepts regular files and rejects inputs above the Phase 29 JSON byte budget
-before parsing.
+accepts regular files and rejects compressed or uncompressed inputs above the
+Phase 29 JSON byte budget before parsing.
 
 ## Non-Goals
 

--- a/docs/design/phase29-recursive-compression-input-contract-spec.md
+++ b/docs/design/phase29-recursive-compression-input-contract-spec.md
@@ -51,7 +51,11 @@ Deserialization of `Phase29RecursiveCompressionInputContract` is a validating
 operation. The read helpers
 `parse_phase29_recursive_compression_input_contract_json` and
 `load_phase29_recursive_compression_input_contract` return a contract only after
-the same Phase 29 verifier accepts the parsed fields.
+the same Phase 29 verifier accepts the parsed fields. Validation failures are
+reported as invalid contract configuration, not as generic JSON serialization
+failures. The file loader uses the repository's bounded JSON read path: it only
+accepts regular files and rejects inputs above the Phase 29 JSON byte budget
+before parsing.
 
 ## Non-Goals
 

--- a/docs/design/phase29-recursive-compression-input-contract-spec.md
+++ b/docs/design/phase29-recursive-compression-input-contract-spec.md
@@ -21,8 +21,8 @@ proof-bearing evidence.
 The derived contract binds the following fields:
 
 - Phase 28 artifact version and semantic scope.
-- S-two proof backend and backend version.
-- Statement version.
+- S-two proof backend and the supported Phase 28 backend version.
+- The supported statement version.
 - Recursion posture.
 - Explicit recursive-verification and cryptographic-compression claim bits.
 - Aggregation arity, member count, member-summary count, and nested-member count.
@@ -40,10 +40,18 @@ Phase 29 rejects:
 - Any Phase 28 artifact that claims cryptographic compression.
 - Any Phase 28 artifact whose recursion posture is not
   `pre-recursive-proof-carrying-aggregation`.
+- Any contract whose Phase 28 backend version or statement version does not
+  match the supported repository dialect.
 - Any contract with empty critical commitments.
 - Any contract whose member summaries or nested members do not match the
   declared Phase 28 member count.
 - Any contract whose input-contract commitment does not recompute.
+
+Deserialization of `Phase29RecursiveCompressionInputContract` is a validating
+operation. The read helpers
+`parse_phase29_recursive_compression_input_contract_json` and
+`load_phase29_recursive_compression_input_contract` return a contract only after
+the same Phase 29 verifier accepts the parsed fields.
 
 ## Non-Goals
 

--- a/docs/design/phase29-recursive-compression-input-contract-spec.md
+++ b/docs/design/phase29-recursive-compression-input-contract-spec.md
@@ -30,8 +30,52 @@ The derived contract binds the following fields:
 - Matrix, layout, rollup, segment, step, and lookup-frontier totals.
 - Source-template, global-start-state, global-end-state, aggregation-template,
   and aggregate-accumulator commitments.
-- A BLAKE2b-256 input-contract commitment computed from the listed contract
-  fields except `input_contract_commitment`, then stored for recomputation.
+- A BLAKE2b-256 input-contract commitment computed by the algorithm below,
+  then stored in `input_contract_commitment` for recomputation.
+
+## Commitment Recompute
+
+`input_contract_commitment` is the lowercase hexadecimal BLAKE2b-256 digest of
+the following byte stream. It does not hash `input_contract_commitment` itself.
+
+Strings are UTF-8 bytes with no BOM and are encoded as a 16-byte little-endian
+unsigned byte length followed by the string bytes. The domain tag is encoded the
+same way as a string. Counters and length prefixes are 16-byte little-endian
+unsigned integers. Booleans are one byte: `0` for false and `1` for true.
+
+The exact hash input order is:
+
+- Domain tag: `phase29-contract`.
+- `proof_backend` as its string value.
+- `contract_version`.
+- `semantic_scope`.
+- `phase28_artifact_version`.
+- `phase28_semantic_scope`.
+- `phase28_proof_backend_version`.
+- `statement_version`.
+- `required_recursion_posture`.
+- `recursive_verification_claimed`.
+- `cryptographic_compression_claimed`.
+- `phase28_bounded_aggregation_arity`.
+- `phase28_member_count`.
+- `phase28_member_summaries`.
+- `phase28_nested_members`.
+- `total_phase26_members`.
+- `total_phase25_members`.
+- `max_nested_chain_arity`.
+- `max_nested_fold_arity`.
+- `total_matrices`.
+- `total_layouts`.
+- `total_rollups`.
+- `total_segments`.
+- `total_steps`.
+- `lookup_delta_entries`.
+- `max_lookup_frontier_entries`.
+- `source_template_commitment`.
+- `global_start_state_commitment`.
+- `global_end_state_commitment`.
+- `aggregation_template_commitment`.
+- `aggregated_chained_folded_interval_accumulator_commitment`.
 
 ## Rejected Input
 
@@ -46,6 +90,7 @@ Phase 29 rejects:
 - Any contract with an empty source-template, global-start-state,
   global-end-state, aggregation-template, aggregate-accumulator, or
   input-contract commitment.
+- Any contract whose `phase28_member_count < 2`.
 - Any contract whose `phase28_member_summaries != phase28_member_count` or
   whose `phase28_nested_members != phase28_member_count`.
 - Any contract whose `phase28_bounded_aggregation_arity` is smaller than

--- a/docs/hardening-policy.md
+++ b/docs/hardening-policy.md
@@ -102,10 +102,11 @@ Available local command tiers:
 - `--mode smoke`: default minimum gate for ordinary PRs. Runs PR-range
   whitespace hygiene as `git diff --check "$base_sha...$head_sha"`, `cargo fmt
   --check`, the statement-spec contract, allowlisted integration smoke targets,
-  and one exact pinned-nightly `stwo-backend` smoke.
+  and exact pinned-nightly `stwo-backend` smokes for the Phase 28 aggregation
+  verifier and Phase 29 recursive-compression input contract.
 - `--mode full`: runs the same PR-range whitespace and formatting hygiene, full
   library tests, integration tests, doctests, and the exact pinned-nightly
-  `stwo-backend` smoke.
+  `stwo-backend` smokes.
 - `--mode hardening`: runs the `full` tier plus UB checks, ASAN, Miri, and the
   formal contract suite. The inherited whitespace gate is still scoped to the
   committed PR delta, not the whole worktree. Prefer running this tier inside

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -48,6 +48,8 @@ hardening_stwo_test_filters=(
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_wrong_statement_version"
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_deserialization_verifies_contract"
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_parse_reports_validation_error_as_invalid_config"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_parse_rejects_unknown_fields"
+  "stwo_backend::recursion::tests::phase29_parse_recursive_compression_input_contract_rejects_oversized_json"
   "stwo_backend::recursion::tests::phase29_load_recursive_compression_input_contract_rejects_oversized_file"
   "stwo_backend::recursion::tests::phase29_load_recursive_compression_input_contract_rejects_oversized_gzip_file"
   "stwo_backend::recursion::tests::phase29_load_recursive_compression_input_contract_rejects_non_regular_file"

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -44,6 +44,9 @@ hardening_stwo_test_filters=(
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_compression_claim"
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_empty_commitments"
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_tampered_commitment"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_wrong_phase28_dialect"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_wrong_statement_version"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_deserialization_verifies_contract"
   "stwo_backend::recursion::tests::phase29_prepare_rejects_phase28_recursive_claim_before_contract_derivation"
   "stwo_backend::recursion::tests::phase29_prepare_rejects_phase28_synthetic_shell_without_nested_members"
 )

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -39,6 +39,13 @@ hardening_stwo_test_filters=(
   "stwo_backend::decoding::tests::phase28_public_verifier_rejects_synthetic_member_shells_without_nested_phase27_evidence"
   "stwo_backend::decoding::tests::phase28_member_proof_checks_reject_synthetic_member_shells_without_nested_phase27_evidence"
   "stwo_backend::decoding::tests::phase28_proof_checks_reject_synthetic_member_shells_without_nested_phase27_evidence"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_accepts_committed_shape"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_recursive_claim"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_compression_claim"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_empty_commitments"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_tampered_commitment"
+  "stwo_backend::recursion::tests::phase29_prepare_rejects_phase28_recursive_claim_before_contract_derivation"
+  "stwo_backend::recursion::tests::phase29_prepare_rejects_phase28_synthetic_shell_without_nested_members"
 )
 
 hardening_test_filters=(

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -47,6 +47,9 @@ hardening_stwo_test_filters=(
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_wrong_phase28_dialect"
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_wrong_statement_version"
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_deserialization_verifies_contract"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_parse_reports_validation_error_as_invalid_config"
+  "stwo_backend::recursion::tests::phase29_load_recursive_compression_input_contract_rejects_oversized_file"
+  "stwo_backend::recursion::tests::phase29_load_recursive_compression_input_contract_rejects_non_regular_file"
   "stwo_backend::recursion::tests::phase29_prepare_rejects_phase28_recursive_claim_before_contract_derivation"
   "stwo_backend::recursion::tests::phase29_prepare_rejects_phase28_synthetic_shell_without_nested_members"
 )

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -49,6 +49,7 @@ hardening_stwo_test_filters=(
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_deserialization_verifies_contract"
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_parse_reports_validation_error_as_invalid_config"
   "stwo_backend::recursion::tests::phase29_load_recursive_compression_input_contract_rejects_oversized_file"
+  "stwo_backend::recursion::tests::phase29_load_recursive_compression_input_contract_rejects_oversized_gzip_file"
   "stwo_backend::recursion::tests::phase29_load_recursive_compression_input_contract_rejects_non_regular_file"
   "stwo_backend::recursion::tests::phase29_prepare_rejects_phase28_recursive_claim_before_contract_derivation"
   "stwo_backend::recursion::tests::phase29_prepare_rejects_phase28_synthetic_shell_without_nested_members"

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -346,6 +346,22 @@ cp "$tmp_pr_json" "$pr_json"
 diff_range="${base_sha}...${head_sha}"
 local_evidence_marker="$run_evidence_dir/local-evidence.json"
 completed_local_mode=""
+stwo_smoke_targets=(
+  "stwo_backend::decoding::tests::phase28_aggregated_chained_folded_intervalized_state_relation_rejects_header_mismatch_before_nested_checks"
+  "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_tampered_commitment"
+)
+
+run_stwo_smoke_targets() {
+  local stwo_smoke label
+  for stwo_smoke in "${stwo_smoke_targets[@]}"; do
+    label="${stwo_smoke##*::}"
+    run_logged "stwo-backend-smoke-${label}" cargo +nightly-2025-07-14 test -q \
+      --features stwo-backend \
+      --lib "$stwo_smoke" \
+      -- \
+      --exact
+  done
+}
 
 if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -355,12 +371,7 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   for test_target in "${smoke_targets[@]}"; do
     run_logged "integration-${test_target}" cargo test -q --test "$test_target"
   done
-  stwo_smoke=stwo_backend::decoding::tests::phase28_aggregated_chained_folded_intervalized_state_relation_rejects_header_mismatch_before_nested_checks
-  run_logged stwo-backend-smoke cargo +nightly-2025-07-14 test -q \
-    --features stwo-backend \
-    --lib "$stwo_smoke" \
-    -- \
-    --exact
+  run_stwo_smoke_targets
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -368,12 +379,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged cargo-lib-tests cargo test -q --lib
   run_logged cargo-lib-and-integration-tests cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
-  stwo_smoke=stwo_backend::decoding::tests::phase28_aggregated_chained_folded_intervalized_state_relation_rejects_header_mismatch_before_nested_checks
-  run_logged stwo-backend-smoke cargo +nightly-2025-07-14 test -q \
-    --features stwo-backend \
-    --lib "$stwo_smoke" \
-    -- \
-    --exact
+  run_stwo_smoke_targets
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -381,12 +387,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged cargo-lib-tests cargo test -q --lib
   run_logged cargo-lib-and-integration-tests cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
-  stwo_smoke=stwo_backend::decoding::tests::phase28_aggregated_chained_folded_intervalized_state_relation_rejects_header_mismatch_before_nested_checks
-  run_logged stwo-backend-smoke cargo +nightly-2025-07-14 test -q \
-    --features stwo-backend \
-    --lib "$stwo_smoke" \
-    -- \
-    --exact
+  run_stwo_smoke_targets
   run_logged ub-checks env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh
   run_logged asan env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_asan_suite.sh
   run_logged miri env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ pub use state::{decode_state, encode_state, MachineState, MIN_D_MODEL};
 #[cfg(feature = "stwo-backend")]
 pub use stwo_backend::{
     commit_phase29_recursive_compression_input_contract,
+    load_phase29_recursive_compression_input_contract,
+    parse_phase29_recursive_compression_input_contract_json,
     phase29_prepare_recursive_compression_input_contract,
     verify_phase29_recursive_compression_input_contract, Phase29RecursiveCompressionInputContract,
     STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,14 @@ pub use runtime::ExecutionRuntime;
 pub use state::{decode_state, encode_state, MachineState, MIN_D_MODEL};
 #[cfg(feature = "stwo-backend")]
 pub use stwo_backend::{
+    commit_phase29_recursive_compression_input_contract,
+    phase29_prepare_recursive_compression_input_contract,
+    verify_phase29_recursive_compression_input_contract, Phase29RecursiveCompressionInputContract,
+    STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29,
+    STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29,
+};
+#[cfg(feature = "stwo-backend")]
+pub use stwo_backend::{
     decoding_step_v1_program_with_initial_memory, decoding_step_v1_template_program,
     decoding_step_v2_program_with_initial_memory, decoding_step_v2_template_program,
     load_phase10_shared_binary_step_lookup_proof, load_phase10_shared_normalization_lookup_proof,
@@ -200,9 +208,9 @@ pub use stwo_backend::{
     STWO_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE25, STWO_LOOKUP_PROOF_VERSION_PHASE3,
     STWO_LOOKUP_SEMANTIC_SCOPE_PHASE3, STWO_LOOKUP_STATEMENT_VERSION_PHASE3,
     STWO_NORMALIZATION_PROOF_VERSION_PHASE5, STWO_NORMALIZATION_SEMANTIC_SCOPE_PHASE5,
-    STWO_NORMALIZATION_STATEMENT_VERSION_PHASE5, STWO_SHARED_LOOKUP_PROOF_VERSION_PHASE10,
-    STWO_SHARED_LOOKUP_SEMANTIC_SCOPE_PHASE10, STWO_SHARED_LOOKUP_STATEMENT_VERSION_PHASE10,
-    STWO_SHARED_NORMALIZATION_PROOF_VERSION_PHASE10,
+    STWO_NORMALIZATION_STATEMENT_VERSION_PHASE5, STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE,
+    STWO_SHARED_LOOKUP_PROOF_VERSION_PHASE10, STWO_SHARED_LOOKUP_SEMANTIC_SCOPE_PHASE10,
+    STWO_SHARED_LOOKUP_STATEMENT_VERSION_PHASE10, STWO_SHARED_NORMALIZATION_PROOF_VERSION_PHASE10,
     STWO_SHARED_NORMALIZATION_SEMANTIC_SCOPE_PHASE10,
     STWO_SHARED_NORMALIZATION_STATEMENT_VERSION_PHASE10,
 };

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -1128,7 +1128,11 @@ fn validate_phase12_shared_lookup_artifact_resource_bounds(
     Ok(())
 }
 
-fn read_json_bytes_with_limit(path: &Path, max_bytes: usize, label: &str) -> Result<Vec<u8>> {
+pub(super) fn read_json_bytes_with_limit(
+    path: &Path,
+    max_bytes: usize,
+    label: &str,
+) -> Result<Vec<u8>> {
     let metadata = fs::symlink_metadata(path).map_err(|error| {
         VmError::InvalidConfig(format!(
             "{label} `{}` could not be inspected before reading: io_kind={:?}: {error}",

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -1146,6 +1146,14 @@ pub(super) fn read_json_bytes_with_limit(
             path.display()
         )));
     }
+    if metadata.len() > max_bytes as u64 {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} `{}` is {} bytes, exceeding the limit of {} bytes",
+            path.display(),
+            metadata.len(),
+            max_bytes
+        )));
+    }
     let file = fs::File::open(path).map_err(|error| {
         VmError::InvalidConfig(format!(
             "{label} `{}` could not be opened for reading: io_kind={:?}: {error}",
@@ -1172,14 +1180,6 @@ pub(super) fn read_json_bytes_with_limit(
             )));
         }
         return Ok(bytes);
-    }
-    if metadata.len() > max_bytes as u64 {
-        return Err(VmError::InvalidConfig(format!(
-            "{label} `{}` is {} bytes, exceeding the limit of {} bytes",
-            path.display(),
-            metadata.len(),
-            max_bytes
-        )));
     }
     let mut limited = file.take((max_bytes as u64).saturating_add(1));
     let mut bytes = Vec::with_capacity(metadata.len().min(max_bytes as u64) as usize);

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -1154,13 +1154,7 @@ pub(super) fn read_json_bytes_with_limit(
             max_bytes
         )));
     }
-    let file = fs::File::open(path).map_err(|error| {
-        VmError::InvalidConfig(format!(
-            "{label} `{}` could not be opened for reading: io_kind={:?}: {error}",
-            path.display(),
-            error.kind()
-        ))
-    })?;
+    let file = open_json_file_for_read(path, label)?;
     let opened_metadata = file.metadata().map_err(|error| {
         VmError::InvalidConfig(format!(
             "{label} `{}` could not be inspected after opening: io_kind={:?}: {error}",
@@ -1231,6 +1225,35 @@ pub(super) fn read_json_bytes_with_limit(
         )));
     }
     Ok(bytes)
+}
+
+#[cfg(unix)]
+fn open_json_file_for_read(path: &Path, label: &str) -> Result<fs::File> {
+    use std::fs::OpenOptions;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .map_err(|error| {
+            VmError::InvalidConfig(format!(
+                "{label} `{}` could not be opened for reading without following symlinks or blocking: io_kind={:?}: {error}",
+                path.display(),
+                error.kind()
+            ))
+        })
+}
+
+#[cfg(not(unix))]
+fn open_json_file_for_read(path: &Path, label: &str) -> Result<fs::File> {
+    fs::File::open(path).map_err(|error| {
+        VmError::InvalidConfig(format!(
+            "{label} `{}` could not be opened for reading: io_kind={:?}: {error}",
+            path.display(),
+            error.kind()
+        ))
+    })
 }
 
 fn write_json_with_limit<T: Serialize>(

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -1161,6 +1161,38 @@ pub(super) fn read_json_bytes_with_limit(
             error.kind()
         ))
     })?;
+    let opened_metadata = file.metadata().map_err(|error| {
+        VmError::InvalidConfig(format!(
+            "{label} `{}` could not be inspected after opening: io_kind={:?}: {error}",
+            path.display(),
+            error.kind()
+        ))
+    })?;
+    if !opened_metadata.file_type().is_file() {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} `{}` is not a regular file after opening",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        if metadata.dev() != opened_metadata.dev() || metadata.ino() != opened_metadata.ino() {
+            return Err(VmError::InvalidConfig(format!(
+                "{label} `{}` changed between metadata inspection and open",
+                path.display()
+            )));
+        }
+    }
+    if opened_metadata.len() > max_bytes as u64 {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} `{}` is {} bytes after opening, exceeding the limit of {} bytes",
+            path.display(),
+            opened_metadata.len(),
+            max_bytes
+        )));
+    }
     let is_gzip = matches!(path.extension().and_then(|ext| ext.to_str()), Some("gz"));
     if is_gzip {
         let mut limited = GzDecoder::new(file).take((max_bytes as u64).saturating_add(1));

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -90,7 +90,7 @@ pub const STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VE
     &str = "stwo-phase28-aggregated-chained-folded-intervalized-decoding-state-relation-v1";
 pub const STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28:
     &str = "stwo_execution_parameterized_aggregated_chained_folded_intervalized_proof_carrying_decoding_state_relation";
-const STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE: &str =
+pub const STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE: &str =
     "pre-recursive-proof-carrying-aggregation";
 const DECODING_KV_CACHE_RANGE: std::ops::Range<usize> = 0..6;
 const DECODING_OUTPUT_RANGE: std::ops::Range<usize> = 10..13;

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -155,6 +155,7 @@ pub use decoding::{
     STWO_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE26,
     STWO_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE25,
     STWO_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE25,
+    STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE,
 };
 pub use layout::{
     phase2_fixture_matrix, phase2_module_layout, phase2_supported_mnemonics,
@@ -196,6 +197,14 @@ pub use normalization_prover::{
     STWO_NORMALIZATION_STATEMENT_VERSION_PHASE5, STWO_SHARED_NORMALIZATION_PROOF_VERSION_PHASE10,
     STWO_SHARED_NORMALIZATION_SEMANTIC_SCOPE_PHASE10,
     STWO_SHARED_NORMALIZATION_STATEMENT_VERSION_PHASE10,
+};
+#[cfg(feature = "stwo-backend")]
+pub use recursion::{
+    commit_phase29_recursive_compression_input_contract,
+    phase29_prepare_recursive_compression_input_contract,
+    verify_phase29_recursive_compression_input_contract, Phase29RecursiveCompressionInputContract,
+    STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29,
+    STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29,
 };
 pub use recursion::{
     phase6_prepare_recursion_batch, Phase6RecursionBatchEntry, Phase6RecursionBatchManifest,

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -201,6 +201,8 @@ pub use normalization_prover::{
 #[cfg(feature = "stwo-backend")]
 pub use recursion::{
     commit_phase29_recursive_compression_input_contract,
+    load_phase29_recursive_compression_input_contract,
+    parse_phase29_recursive_compression_input_contract_json,
     phase29_prepare_recursive_compression_input_contract,
     verify_phase29_recursive_compression_input_contract, Phase29RecursiveCompressionInputContract,
     STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29,

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -1,10 +1,13 @@
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "stwo-backend")]
+use std::path::Path;
 
 use crate::error::{Result, VmError};
 use crate::proof::{ExecutionClaimCommitments, StarkProofBackend, VanillaStarkExecutionProof};
 
 #[cfg(feature = "stwo-backend")]
 use super::decoding::{
+    read_json_bytes_with_limit,
     verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_proof_checks,
     Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManifest,
     STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28,
@@ -30,6 +33,8 @@ pub const STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29: &str =
 #[cfg(feature = "stwo-backend")]
 pub const STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29: &str =
     "stwo_phase28_recursive_compression_input_contract";
+#[cfg(feature = "stwo-backend")]
+const MAX_PHASE29_RECURSIVE_COMPRESSION_INPUT_CONTRACT_JSON_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Phase6RecursionBatchEntry {
@@ -321,15 +326,27 @@ pub fn phase29_prepare_recursive_compression_input_contract(
 pub fn parse_phase29_recursive_compression_input_contract_json(
     json: &str,
 ) -> Result<Phase29RecursiveCompressionInputContract> {
-    serde_json::from_str(json).map_err(|err| VmError::Serialization(err.to_string()))
+    serde_json::from_str(json).map_err(phase29_json_error)
 }
 
 #[cfg(feature = "stwo-backend")]
 pub fn load_phase29_recursive_compression_input_contract(
-    path: &std::path::Path,
+    path: &Path,
 ) -> Result<Phase29RecursiveCompressionInputContract> {
-    let bytes = std::fs::read(path)?;
-    serde_json::from_slice(&bytes).map_err(|err| VmError::Serialization(err.to_string()))
+    let bytes = read_json_bytes_with_limit(
+        path,
+        MAX_PHASE29_RECURSIVE_COMPRESSION_INPUT_CONTRACT_JSON_BYTES,
+        "Phase 29 recursive-compression input contract",
+    )?;
+    serde_json::from_slice(&bytes).map_err(phase29_json_error)
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase29_json_error(error: serde_json::Error) -> VmError {
+    match error.classify() {
+        serde_json::error::Category::Data => VmError::InvalidConfig(error.to_string()),
+        _ => VmError::Serialization(error.to_string()),
+    }
 }
 
 #[cfg(feature = "stwo-backend")]
@@ -800,6 +817,66 @@ mod tests {
         let err = serde_json::from_value::<Phase29RecursiveCompressionInputContract>(tampered)
             .expect_err("tampered deserialized contract must be rejected");
         assert!(err.to_string().contains("commitment"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_recursive_compression_input_contract_parse_reports_validation_error_as_invalid_config(
+    ) {
+        let contract = sample_phase29_contract();
+        let mut tampered = serde_json::to_value(&contract).expect("serialize value");
+        tampered["total_steps"] = serde_json::json!(contract.total_steps + 1);
+        let json = serde_json::to_string(&tampered).expect("tampered json");
+
+        let err = parse_phase29_recursive_compression_input_contract_json(&json)
+            .expect_err("validation failure must surface as invalid config");
+        assert!(
+            matches!(err, VmError::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+        assert!(err.to_string().contains("commitment"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_load_recursive_compression_input_contract_rejects_oversized_file() {
+        let path = std::env::temp_dir().join(format!(
+            "phase29-recursive-compression-input-contract-oversized-{}.json",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            vec![b'x'; MAX_PHASE29_RECURSIVE_COMPRESSION_INPUT_CONTRACT_JSON_BYTES + 1],
+        )
+        .expect("write");
+
+        let err = load_phase29_recursive_compression_input_contract(&path)
+            .expect_err("oversized Phase 29 contract should fail");
+        assert!(
+            matches!(err, VmError::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+        assert!(err.to_string().contains("exceeding the limit"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_load_recursive_compression_input_contract_rejects_non_regular_file() {
+        let path = std::env::temp_dir().join(format!(
+            "phase29-recursive-compression-input-contract-dir-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&path).expect("create dir");
+
+        let err = load_phase29_recursive_compression_input_contract(&path)
+            .expect_err("directory path should fail");
+        assert!(
+            matches!(err, VmError::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+        assert!(err.to_string().contains("is not a regular file"));
+        let _ = std::fs::remove_dir_all(path);
     }
 
     #[cfg(feature = "stwo-backend")]

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -32,7 +32,7 @@ pub const STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29: &str =
     "stwo-phase29-recursive-compression-input-contract-v1";
 #[cfg(feature = "stwo-backend")]
 pub const STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29: &str =
-    "stwo_phase28_recursive_compression_input_contract";
+    "stwo_phase29_recursive_compression_input_contract";
 #[cfg(feature = "stwo-backend")]
 const MAX_PHASE29_RECURSIVE_COMPRESSION_INPUT_CONTRACT_JSON_BYTES: usize = 1024 * 1024;
 
@@ -852,6 +852,36 @@ mod tests {
 
         let err = load_phase29_recursive_compression_input_contract(&path)
             .expect_err("oversized Phase 29 contract should fail");
+        assert!(
+            matches!(err, VmError::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+        assert!(err.to_string().contains("exceeding the limit"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_load_recursive_compression_input_contract_rejects_oversized_gzip_file() {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+
+        let path = std::env::temp_dir().join(format!(
+            "phase29-recursive-compression-input-contract-oversized-{}.json.gz",
+            std::process::id()
+        ));
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::none());
+        let payload = vec![b'x'; MAX_PHASE29_RECURSIVE_COMPRESSION_INPUT_CONTRACT_JSON_BYTES];
+        encoder.write_all(&payload).expect("write gzip payload");
+        let bytes = encoder.finish().expect("finish gzip payload");
+        assert!(
+            bytes.len() > MAX_PHASE29_RECURSIVE_COMPRESSION_INPUT_CONTRACT_JSON_BYTES,
+            "gzip fixture must exceed the compressed-byte budget"
+        );
+        std::fs::write(&path, bytes).expect("write");
+
+        let err = load_phase29_recursive_compression_input_contract(&path)
+            .expect_err("oversized compressed Phase 29 contract should fail");
         assert!(
             matches!(err, VmError::InvalidConfig(_)),
             "expected InvalidConfig, got {err:?}"

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -12,6 +12,10 @@ use super::decoding::{
     STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE,
 };
 #[cfg(feature = "stwo-backend")]
+use super::STWO_BACKEND_VERSION_PHASE12;
+#[cfg(feature = "stwo-backend")]
+use crate::proof::CLAIM_STATEMENT_VERSION_V1;
+#[cfg(feature = "stwo-backend")]
 use blake2::{
     digest::{Update, VariableOutput},
     Blake2bVar,
@@ -53,6 +57,7 @@ pub struct Phase6RecursionBatchManifest {
 
 #[cfg(feature = "stwo-backend")]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "Phase29RecursiveCompressionInputContractUnchecked")]
 pub struct Phase29RecursiveCompressionInputContract {
     pub proof_backend: StarkProofBackend,
     pub contract_version: String,
@@ -85,6 +90,90 @@ pub struct Phase29RecursiveCompressionInputContract {
     pub aggregation_template_commitment: String,
     pub aggregated_chained_folded_interval_accumulator_commitment: String,
     pub input_contract_commitment: String,
+}
+
+#[cfg(feature = "stwo-backend")]
+#[derive(Debug, Clone, Deserialize)]
+struct Phase29RecursiveCompressionInputContractUnchecked {
+    pub proof_backend: StarkProofBackend,
+    pub contract_version: String,
+    pub semantic_scope: String,
+    pub phase28_artifact_version: String,
+    pub phase28_semantic_scope: String,
+    pub phase28_proof_backend_version: String,
+    pub statement_version: String,
+    pub required_recursion_posture: String,
+    pub recursive_verification_claimed: bool,
+    pub cryptographic_compression_claimed: bool,
+    pub phase28_bounded_aggregation_arity: usize,
+    pub phase28_member_count: usize,
+    pub phase28_member_summaries: usize,
+    pub phase28_nested_members: usize,
+    pub total_phase26_members: usize,
+    pub total_phase25_members: usize,
+    pub max_nested_chain_arity: usize,
+    pub max_nested_fold_arity: usize,
+    pub total_matrices: usize,
+    pub total_layouts: usize,
+    pub total_rollups: usize,
+    pub total_segments: usize,
+    pub total_steps: usize,
+    pub lookup_delta_entries: usize,
+    pub max_lookup_frontier_entries: usize,
+    pub source_template_commitment: String,
+    pub global_start_state_commitment: String,
+    pub global_end_state_commitment: String,
+    pub aggregation_template_commitment: String,
+    pub aggregated_chained_folded_interval_accumulator_commitment: String,
+    pub input_contract_commitment: String,
+}
+
+#[cfg(feature = "stwo-backend")]
+impl TryFrom<Phase29RecursiveCompressionInputContractUnchecked>
+    for Phase29RecursiveCompressionInputContract
+{
+    type Error = VmError;
+
+    fn try_from(
+        unchecked: Phase29RecursiveCompressionInputContractUnchecked,
+    ) -> std::result::Result<Self, Self::Error> {
+        let contract = Self {
+            proof_backend: unchecked.proof_backend,
+            contract_version: unchecked.contract_version,
+            semantic_scope: unchecked.semantic_scope,
+            phase28_artifact_version: unchecked.phase28_artifact_version,
+            phase28_semantic_scope: unchecked.phase28_semantic_scope,
+            phase28_proof_backend_version: unchecked.phase28_proof_backend_version,
+            statement_version: unchecked.statement_version,
+            required_recursion_posture: unchecked.required_recursion_posture,
+            recursive_verification_claimed: unchecked.recursive_verification_claimed,
+            cryptographic_compression_claimed: unchecked.cryptographic_compression_claimed,
+            phase28_bounded_aggregation_arity: unchecked.phase28_bounded_aggregation_arity,
+            phase28_member_count: unchecked.phase28_member_count,
+            phase28_member_summaries: unchecked.phase28_member_summaries,
+            phase28_nested_members: unchecked.phase28_nested_members,
+            total_phase26_members: unchecked.total_phase26_members,
+            total_phase25_members: unchecked.total_phase25_members,
+            max_nested_chain_arity: unchecked.max_nested_chain_arity,
+            max_nested_fold_arity: unchecked.max_nested_fold_arity,
+            total_matrices: unchecked.total_matrices,
+            total_layouts: unchecked.total_layouts,
+            total_rollups: unchecked.total_rollups,
+            total_segments: unchecked.total_segments,
+            total_steps: unchecked.total_steps,
+            lookup_delta_entries: unchecked.lookup_delta_entries,
+            max_lookup_frontier_entries: unchecked.max_lookup_frontier_entries,
+            source_template_commitment: unchecked.source_template_commitment,
+            global_start_state_commitment: unchecked.global_start_state_commitment,
+            global_end_state_commitment: unchecked.global_end_state_commitment,
+            aggregation_template_commitment: unchecked.aggregation_template_commitment,
+            aggregated_chained_folded_interval_accumulator_commitment: unchecked
+                .aggregated_chained_folded_interval_accumulator_commitment,
+            input_contract_commitment: unchecked.input_contract_commitment,
+        };
+        verify_phase29_recursive_compression_input_contract(&contract)?;
+        Ok(contract)
+    }
 }
 
 pub fn phase6_prepare_recursion_batch(
@@ -229,6 +318,21 @@ pub fn phase29_prepare_recursive_compression_input_contract(
 }
 
 #[cfg(feature = "stwo-backend")]
+pub fn parse_phase29_recursive_compression_input_contract_json(
+    json: &str,
+) -> Result<Phase29RecursiveCompressionInputContract> {
+    serde_json::from_str(json).map_err(|err| VmError::Serialization(err.to_string()))
+}
+
+#[cfg(feature = "stwo-backend")]
+pub fn load_phase29_recursive_compression_input_contract(
+    path: &std::path::Path,
+) -> Result<Phase29RecursiveCompressionInputContract> {
+    let bytes = std::fs::read(path)?;
+    serde_json::from_slice(&bytes).map_err(|err| VmError::Serialization(err.to_string()))
+}
+
+#[cfg(feature = "stwo-backend")]
 pub fn verify_phase29_recursive_compression_input_contract(
     contract: &Phase29RecursiveCompressionInputContract,
 ) -> Result<()> {
@@ -349,6 +453,19 @@ pub fn verify_phase29_recursive_compression_input_contract(
                 "Phase 29 recursive-compression input contract `{label}` must be non-empty"
             )));
         }
+    }
+
+    if contract.phase28_proof_backend_version != STWO_BACKEND_VERSION_PHASE12 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract requires Phase 28 proof backend version `{}`, got `{}`",
+            STWO_BACKEND_VERSION_PHASE12, contract.phase28_proof_backend_version
+        )));
+    }
+    if contract.statement_version != CLAIM_STATEMENT_VERSION_V1 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract requires statement version `{}`, got `{}`",
+            CLAIM_STATEMENT_VERSION_V1, contract.statement_version
+        )));
     }
 
     let expected = commit_phase29_recursive_compression_input_contract(contract)?;
@@ -644,6 +761,44 @@ mod tests {
         contract.total_steps += 1;
         let err = verify_phase29_recursive_compression_input_contract(&contract)
             .expect_err("tampered contract must be rejected");
+        assert!(err.to_string().contains("commitment"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_recursive_compression_input_contract_rejects_wrong_phase28_dialect() {
+        let mut contract = sample_phase29_contract();
+        contract.phase28_proof_backend_version = "unsupported-stwo-dialect".to_string();
+        let err = verify_phase29_recursive_compression_input_contract(&contract)
+            .expect_err("wrong Phase 28 dialect must be rejected");
+        assert!(err
+            .to_string()
+            .contains("requires Phase 28 proof backend version"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_recursive_compression_input_contract_rejects_wrong_statement_version() {
+        let mut contract = sample_phase29_contract();
+        contract.statement_version = "unsupported-statement".to_string();
+        let err = verify_phase29_recursive_compression_input_contract(&contract)
+            .expect_err("wrong statement version must be rejected");
+        assert!(err.to_string().contains("requires statement version"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_recursive_compression_input_contract_deserialization_verifies_contract() {
+        let contract = sample_phase29_contract();
+        let json = serde_json::to_string(&contract).expect("serialize contract");
+        let parsed =
+            parse_phase29_recursive_compression_input_contract_json(&json).expect("parse contract");
+        assert_eq!(parsed, contract);
+
+        let mut tampered = serde_json::to_value(&contract).expect("serialize value");
+        tampered["total_steps"] = serde_json::json!(contract.total_steps + 1);
+        let err = serde_json::from_value::<Phase29RecursiveCompressionInputContract>(tampered)
+            .expect_err("tampered deserialized contract must be rejected");
         assert!(err.to_string().contains("commitment"));
     }
 

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -99,6 +99,7 @@ pub struct Phase29RecursiveCompressionInputContract {
 
 #[cfg(feature = "stwo-backend")]
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Phase29RecursiveCompressionInputContractUnchecked {
     pub proof_backend: StarkProofBackend,
     pub contract_version: String,
@@ -326,6 +327,13 @@ pub fn phase29_prepare_recursive_compression_input_contract(
 pub fn parse_phase29_recursive_compression_input_contract_json(
     json: &str,
 ) -> Result<Phase29RecursiveCompressionInputContract> {
+    if json.len() > MAX_PHASE29_RECURSIVE_COMPRESSION_INPUT_CONTRACT_JSON_BYTES {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract JSON is {} bytes, exceeding the limit of {} bytes",
+            json.len(),
+            MAX_PHASE29_RECURSIVE_COMPRESSION_INPUT_CONTRACT_JSON_BYTES
+        )));
+    }
     serde_json::from_str(json).map_err(phase29_json_error)
 }
 
@@ -561,7 +569,7 @@ pub fn commit_phase29_recursive_compression_input_contract(
 
 #[cfg(feature = "stwo-backend")]
 fn phase29_update_len_prefixed(hasher: &mut Blake2bVar, bytes: &[u8]) {
-    hasher.update(&(bytes.len() as u64).to_le_bytes());
+    phase29_update_usize(hasher, bytes.len());
     hasher.update(bytes);
 }
 
@@ -572,7 +580,7 @@ fn phase29_update_bool(hasher: &mut Blake2bVar, value: bool) {
 
 #[cfg(feature = "stwo-backend")]
 fn phase29_update_usize(hasher: &mut Blake2bVar, value: usize) {
-    hasher.update(&(value as u64).to_le_bytes());
+    hasher.update(&(value as u128).to_le_bytes());
 }
 
 #[cfg(feature = "stwo-backend")]
@@ -835,6 +843,36 @@ mod tests {
             "expected InvalidConfig, got {err:?}"
         );
         assert!(err.to_string().contains("commitment"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_recursive_compression_input_contract_parse_rejects_unknown_fields() {
+        let contract = sample_phase29_contract();
+        let mut value = serde_json::to_value(&contract).expect("serialize value");
+        value["unexpected_phase29_field"] = serde_json::json!(true);
+        let json = serde_json::to_string(&value).expect("json with unknown field");
+
+        let err = parse_phase29_recursive_compression_input_contract_json(&json)
+            .expect_err("unknown fields must be rejected");
+        assert!(
+            matches!(err, VmError::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_parse_recursive_compression_input_contract_rejects_oversized_json() {
+        let json = " ".repeat(MAX_PHASE29_RECURSIVE_COMPRESSION_INPUT_CONTRACT_JSON_BYTES + 1);
+        let err = parse_phase29_recursive_compression_input_contract_json(&json)
+            .expect_err("oversized JSON must fail before serde parsing");
+        assert!(
+            matches!(err, VmError::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+        assert!(err.to_string().contains("exceeding the limit"));
     }
 
     #[cfg(feature = "stwo-backend")]

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -3,9 +3,29 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Result, VmError};
 use crate::proof::{ExecutionClaimCommitments, StarkProofBackend, VanillaStarkExecutionProof};
 
+#[cfg(feature = "stwo-backend")]
+use super::decoding::{
+    verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_proof_checks,
+    Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManifest,
+    STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28,
+    STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE28,
+    STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE,
+};
+#[cfg(feature = "stwo-backend")]
+use blake2::{
+    digest::{Update, VariableOutput},
+    Blake2bVar,
+};
+
 pub const STWO_RECURSION_BATCH_VERSION_PHASE6: &str = "stwo-phase6-recursion-batch-v1";
 pub const STWO_RECURSION_BATCH_SCOPE_PHASE6: &str =
     "stwo_execution_proof_batch_preaggregation_manifest";
+#[cfg(feature = "stwo-backend")]
+pub const STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29: &str =
+    "stwo-phase29-recursive-compression-input-contract-v1";
+#[cfg(feature = "stwo-backend")]
+pub const STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29: &str =
+    "stwo_phase28_recursive_compression_input_contract";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Phase6RecursionBatchEntry {
@@ -29,6 +49,42 @@ pub struct Phase6RecursionBatchManifest {
     pub total_steps: usize,
     pub total_proof_bytes: usize,
     pub entries: Vec<Phase6RecursionBatchEntry>,
+}
+
+#[cfg(feature = "stwo-backend")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Phase29RecursiveCompressionInputContract {
+    pub proof_backend: StarkProofBackend,
+    pub contract_version: String,
+    pub semantic_scope: String,
+    pub phase28_artifact_version: String,
+    pub phase28_semantic_scope: String,
+    pub phase28_proof_backend_version: String,
+    pub statement_version: String,
+    pub required_recursion_posture: String,
+    pub recursive_verification_claimed: bool,
+    pub cryptographic_compression_claimed: bool,
+    pub phase28_bounded_aggregation_arity: usize,
+    pub phase28_member_count: usize,
+    pub phase28_member_summaries: usize,
+    pub phase28_nested_members: usize,
+    pub total_phase26_members: usize,
+    pub total_phase25_members: usize,
+    pub max_nested_chain_arity: usize,
+    pub max_nested_fold_arity: usize,
+    pub total_matrices: usize,
+    pub total_layouts: usize,
+    pub total_rollups: usize,
+    pub total_segments: usize,
+    pub total_steps: usize,
+    pub lookup_delta_entries: usize,
+    pub max_lookup_frontier_entries: usize,
+    pub source_template_commitment: String,
+    pub global_start_state_commitment: String,
+    pub global_end_state_commitment: String,
+    pub aggregation_template_commitment: String,
+    pub aggregated_chained_folded_interval_accumulator_commitment: String,
+    pub input_contract_commitment: String,
 }
 
 pub fn phase6_prepare_recursion_batch(
@@ -123,6 +179,279 @@ fn first_commitment_stark_options_hash(proof: &VanillaStarkExecutionProof) -> Re
     Ok(required_commitments(proof)?.stark_options_hash.clone())
 }
 
+#[cfg(feature = "stwo-backend")]
+pub fn phase29_prepare_recursive_compression_input_contract(
+    phase28: &Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManifest,
+) -> Result<Phase29RecursiveCompressionInputContract> {
+    verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_proof_checks(
+        phase28,
+    )?;
+
+    let mut contract = Phase29RecursiveCompressionInputContract {
+        proof_backend: StarkProofBackend::Stwo,
+        contract_version: STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29.to_string(),
+        semantic_scope: STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29.to_string(),
+        phase28_artifact_version: phase28.artifact_version.clone(),
+        phase28_semantic_scope: phase28.semantic_scope.clone(),
+        phase28_proof_backend_version: phase28.proof_backend_version.clone(),
+        statement_version: phase28.statement_version.clone(),
+        required_recursion_posture: phase28.recursion_posture.clone(),
+        recursive_verification_claimed: phase28.recursive_verification_claimed,
+        cryptographic_compression_claimed: phase28.cryptographic_compression_claimed,
+        phase28_bounded_aggregation_arity: phase28.bounded_aggregation_arity,
+        phase28_member_count: phase28.member_count,
+        phase28_member_summaries: phase28.member_summaries.len(),
+        phase28_nested_members: phase28.members.len(),
+        total_phase26_members: phase28.total_phase26_members,
+        total_phase25_members: phase28.total_phase25_members,
+        max_nested_chain_arity: phase28.max_nested_chain_arity,
+        max_nested_fold_arity: phase28.max_nested_fold_arity,
+        total_matrices: phase28.total_matrices,
+        total_layouts: phase28.total_layouts,
+        total_rollups: phase28.total_rollups,
+        total_segments: phase28.total_segments,
+        total_steps: phase28.total_steps,
+        lookup_delta_entries: phase28.lookup_delta_entries,
+        max_lookup_frontier_entries: phase28.max_lookup_frontier_entries,
+        source_template_commitment: phase28.source_template_commitment.clone(),
+        global_start_state_commitment: phase28.global_start_state_commitment.clone(),
+        global_end_state_commitment: phase28.global_end_state_commitment.clone(),
+        aggregation_template_commitment: phase28.aggregation_template_commitment.clone(),
+        aggregated_chained_folded_interval_accumulator_commitment: phase28
+            .aggregated_chained_folded_interval_accumulator_commitment
+            .clone(),
+        input_contract_commitment: String::new(),
+    };
+    contract.input_contract_commitment =
+        commit_phase29_recursive_compression_input_contract(&contract)?;
+    verify_phase29_recursive_compression_input_contract(&contract)?;
+    Ok(contract)
+}
+
+#[cfg(feature = "stwo-backend")]
+pub fn verify_phase29_recursive_compression_input_contract(
+    contract: &Phase29RecursiveCompressionInputContract,
+) -> Result<()> {
+    if contract.proof_backend != StarkProofBackend::Stwo {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract requires `stwo` backend, got `{}`",
+            contract.proof_backend
+        )));
+    }
+    if contract.contract_version != STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract version `{}` does not match expected `{}`",
+            contract.contract_version, STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29
+        )));
+    }
+    if contract.semantic_scope != STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract scope `{}` does not match expected `{}`",
+            contract.semantic_scope, STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29
+        )));
+    }
+    if contract.phase28_artifact_version
+        != STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE28
+    {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract requires Phase 28 artifact version `{}`, got `{}`",
+            STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE28,
+            contract.phase28_artifact_version
+        )));
+    }
+    if contract.phase28_semantic_scope
+        != STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28
+    {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract requires Phase 28 scope `{}`, got `{}`",
+            STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28,
+            contract.phase28_semantic_scope
+        )));
+    }
+    if contract.required_recursion_posture != STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract requires Phase 28 posture `{}`, got `{}`",
+            STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE,
+            contract.required_recursion_posture
+        )));
+    }
+    if contract.recursive_verification_claimed {
+        return Err(VmError::InvalidConfig(
+            "Phase 29 recursive-compression input contract must not claim recursive verification"
+                .to_string(),
+        ));
+    }
+    if contract.cryptographic_compression_claimed {
+        return Err(VmError::InvalidConfig(
+            "Phase 29 recursive-compression input contract must not claim cryptographic compression"
+                .to_string(),
+        ));
+    }
+    if contract.phase28_member_count < 2 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract requires at least two Phase 28 members, got {}",
+            contract.phase28_member_count
+        )));
+    }
+    if contract.phase28_bounded_aggregation_arity < contract.phase28_member_count {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract bounded arity {} is smaller than member count {}",
+            contract.phase28_bounded_aggregation_arity, contract.phase28_member_count
+        )));
+    }
+    if contract.phase28_member_summaries != contract.phase28_member_count {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract summarizes {} members but declares {}",
+            contract.phase28_member_summaries, contract.phase28_member_count
+        )));
+    }
+    if contract.phase28_nested_members != contract.phase28_member_count {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract carries {} nested members but declares {}",
+            contract.phase28_nested_members, contract.phase28_member_count
+        )));
+    }
+    for (label, value) in [
+        (
+            "phase28_proof_backend_version",
+            contract.phase28_proof_backend_version.as_str(),
+        ),
+        ("statement_version", contract.statement_version.as_str()),
+        (
+            "source_template_commitment",
+            contract.source_template_commitment.as_str(),
+        ),
+        (
+            "global_start_state_commitment",
+            contract.global_start_state_commitment.as_str(),
+        ),
+        (
+            "global_end_state_commitment",
+            contract.global_end_state_commitment.as_str(),
+        ),
+        (
+            "aggregation_template_commitment",
+            contract.aggregation_template_commitment.as_str(),
+        ),
+        (
+            "aggregated_chained_folded_interval_accumulator_commitment",
+            contract
+                .aggregated_chained_folded_interval_accumulator_commitment
+                .as_str(),
+        ),
+        (
+            "input_contract_commitment",
+            contract.input_contract_commitment.as_str(),
+        ),
+    ] {
+        if value.is_empty() {
+            return Err(VmError::InvalidConfig(format!(
+                "Phase 29 recursive-compression input contract `{label}` must be non-empty"
+            )));
+        }
+    }
+
+    let expected = commit_phase29_recursive_compression_input_contract(contract)?;
+    if contract.input_contract_commitment != expected {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 29 recursive-compression input contract commitment `{}` does not match recomputed `{}`",
+            contract.input_contract_commitment, expected
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "stwo-backend")]
+pub fn commit_phase29_recursive_compression_input_contract(
+    contract: &Phase29RecursiveCompressionInputContract,
+) -> Result<String> {
+    let mut hasher = Blake2bVar::new(32).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to initialize Phase 29 input contract commitment hash: {err}"
+        ))
+    })?;
+    phase29_update_len_prefixed(&mut hasher, b"phase29-contract");
+    phase29_update_len_prefixed(&mut hasher, contract.proof_backend.to_string().as_bytes());
+    phase29_update_len_prefixed(&mut hasher, contract.contract_version.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, contract.semantic_scope.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, contract.phase28_artifact_version.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, contract.phase28_semantic_scope.as_bytes());
+    phase29_update_len_prefixed(
+        &mut hasher,
+        contract.phase28_proof_backend_version.as_bytes(),
+    );
+    phase29_update_len_prefixed(&mut hasher, contract.statement_version.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, contract.required_recursion_posture.as_bytes());
+    phase29_update_bool(&mut hasher, contract.recursive_verification_claimed);
+    phase29_update_bool(&mut hasher, contract.cryptographic_compression_claimed);
+    phase29_update_usize(&mut hasher, contract.phase28_bounded_aggregation_arity);
+    phase29_update_usize(&mut hasher, contract.phase28_member_count);
+    phase29_update_usize(&mut hasher, contract.phase28_member_summaries);
+    phase29_update_usize(&mut hasher, contract.phase28_nested_members);
+    phase29_update_usize(&mut hasher, contract.total_phase26_members);
+    phase29_update_usize(&mut hasher, contract.total_phase25_members);
+    phase29_update_usize(&mut hasher, contract.max_nested_chain_arity);
+    phase29_update_usize(&mut hasher, contract.max_nested_fold_arity);
+    phase29_update_usize(&mut hasher, contract.total_matrices);
+    phase29_update_usize(&mut hasher, contract.total_layouts);
+    phase29_update_usize(&mut hasher, contract.total_rollups);
+    phase29_update_usize(&mut hasher, contract.total_segments);
+    phase29_update_usize(&mut hasher, contract.total_steps);
+    phase29_update_usize(&mut hasher, contract.lookup_delta_entries);
+    phase29_update_usize(&mut hasher, contract.max_lookup_frontier_entries);
+    phase29_update_len_prefixed(&mut hasher, contract.source_template_commitment.as_bytes());
+    phase29_update_len_prefixed(
+        &mut hasher,
+        contract.global_start_state_commitment.as_bytes(),
+    );
+    phase29_update_len_prefixed(&mut hasher, contract.global_end_state_commitment.as_bytes());
+    phase29_update_len_prefixed(
+        &mut hasher,
+        contract.aggregation_template_commitment.as_bytes(),
+    );
+    phase29_update_len_prefixed(
+        &mut hasher,
+        contract
+            .aggregated_chained_folded_interval_accumulator_commitment
+            .as_bytes(),
+    );
+    let mut out = [0u8; 32];
+    hasher.finalize_variable(&mut out).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to finalize Phase 29 input contract commitment hash: {err}"
+        ))
+    })?;
+    Ok(phase29_lower_hex(&out))
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase29_update_len_prefixed(hasher: &mut Blake2bVar, bytes: &[u8]) {
+    hasher.update(&(bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase29_update_bool(hasher: &mut Blake2bVar, value: bool) {
+    hasher.update(&[u8::from(value)]);
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase29_update_usize(hasher: &mut Blake2bVar, value: usize) {
+    hasher.update(&(value as u64).to_le_bytes());
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase29_lower_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,5 +506,167 @@ mod tests {
         assert_eq!(manifest.total_proof_bytes, 6);
         assert_eq!(manifest.entries[0].commitment_program_hash, "hash-a");
         assert_eq!(manifest.entries[1].commitment_program_hash, "hash-b");
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    fn sample_phase29_contract() -> Phase29RecursiveCompressionInputContract {
+        let mut contract = Phase29RecursiveCompressionInputContract {
+            proof_backend: StarkProofBackend::Stwo,
+            contract_version: STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29.to_string(),
+            semantic_scope: STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29.to_string(),
+            phase28_artifact_version:
+                STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE28
+                    .to_string(),
+            phase28_semantic_scope:
+                STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28
+                    .to_string(),
+            phase28_proof_backend_version: crate::stwo_backend::STWO_BACKEND_VERSION_PHASE12
+                .to_string(),
+            statement_version: CLAIM_STATEMENT_VERSION_V1.to_string(),
+            required_recursion_posture: STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE.to_string(),
+            recursive_verification_claimed: false,
+            cryptographic_compression_claimed: false,
+            phase28_bounded_aggregation_arity: 2,
+            phase28_member_count: 2,
+            phase28_member_summaries: 2,
+            phase28_nested_members: 2,
+            total_phase26_members: 4,
+            total_phase25_members: 8,
+            max_nested_chain_arity: 2,
+            max_nested_fold_arity: 2,
+            total_matrices: 16,
+            total_layouts: 16,
+            total_rollups: 8,
+            total_segments: 8,
+            total_steps: 32,
+            lookup_delta_entries: 12,
+            max_lookup_frontier_entries: 4,
+            source_template_commitment: "phase28-source-template".to_string(),
+            global_start_state_commitment: "phase28-start".to_string(),
+            global_end_state_commitment: "phase28-end".to_string(),
+            aggregation_template_commitment: "phase28-aggregation-template".to_string(),
+            aggregated_chained_folded_interval_accumulator_commitment:
+                "phase28-aggregate-accumulator".to_string(),
+            input_contract_commitment: String::new(),
+        };
+        contract.input_contract_commitment =
+            commit_phase29_recursive_compression_input_contract(&contract)
+                .expect("commit Phase 29 contract");
+        contract
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    fn empty_phase28_shell(
+    ) -> Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManifest {
+        Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManifest {
+            proof_backend: StarkProofBackend::Stwo,
+            artifact_version:
+                STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE28
+                    .to_string(),
+            semantic_scope:
+                STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28
+                    .to_string(),
+            proof_backend_version: crate::stwo_backend::STWO_BACKEND_VERSION_PHASE12.to_string(),
+            statement_version: CLAIM_STATEMENT_VERSION_V1.to_string(),
+            recursion_posture: STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE.to_string(),
+            recursive_verification_claimed: false,
+            cryptographic_compression_claimed: false,
+            bounded_aggregation_arity: 2,
+            member_count: 0,
+            total_phase26_members: 0,
+            total_phase25_members: 0,
+            max_nested_chain_arity: 0,
+            max_nested_fold_arity: 0,
+            total_matrices: 0,
+            total_layouts: 0,
+            total_rollups: 0,
+            total_segments: 0,
+            total_steps: 0,
+            lookup_delta_entries: 0,
+            max_lookup_frontier_entries: 0,
+            source_template_commitment: "phase28-source-template".to_string(),
+            global_start_state_commitment: "phase28-start".to_string(),
+            global_end_state_commitment: "phase28-end".to_string(),
+            aggregation_template_commitment: "phase28-aggregation-template".to_string(),
+            aggregated_chained_folded_interval_accumulator_commitment:
+                "phase28-aggregate-accumulator".to_string(),
+            member_summaries: Vec::new(),
+            members: Vec::new(),
+        }
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_recursive_compression_input_contract_accepts_committed_shape() {
+        let contract = sample_phase29_contract();
+        verify_phase29_recursive_compression_input_contract(&contract)
+            .expect("verify Phase 29 contract");
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_recursive_compression_input_contract_rejects_recursive_claim() {
+        let mut contract = sample_phase29_contract();
+        contract.recursive_verification_claimed = true;
+        let err = verify_phase29_recursive_compression_input_contract(&contract)
+            .expect_err("recursive claim must be rejected");
+        assert!(err
+            .to_string()
+            .contains("must not claim recursive verification"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_recursive_compression_input_contract_rejects_compression_claim() {
+        let mut contract = sample_phase29_contract();
+        contract.cryptographic_compression_claimed = true;
+        let err = verify_phase29_recursive_compression_input_contract(&contract)
+            .expect_err("compression claim must be rejected");
+        assert!(err
+            .to_string()
+            .contains("must not claim cryptographic compression"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_recursive_compression_input_contract_rejects_empty_commitments() {
+        let mut contract = sample_phase29_contract();
+        contract.source_template_commitment.clear();
+        let err = verify_phase29_recursive_compression_input_contract(&contract)
+            .expect_err("empty source commitment must be rejected");
+        assert!(err.to_string().contains("source_template_commitment"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_recursive_compression_input_contract_rejects_tampered_commitment() {
+        let mut contract = sample_phase29_contract();
+        contract.total_steps += 1;
+        let err = verify_phase29_recursive_compression_input_contract(&contract)
+            .expect_err("tampered contract must be rejected");
+        assert!(err.to_string().contains("commitment"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_prepare_rejects_phase28_recursive_claim_before_contract_derivation() {
+        let mut phase28 = empty_phase28_shell();
+        phase28.recursive_verification_claimed = true;
+        let err = phase29_prepare_recursive_compression_input_contract(&phase28)
+            .expect_err("recursive Phase 28 claim must be rejected");
+        assert!(err
+            .to_string()
+            .contains("must not claim recursive verification"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase29_prepare_rejects_phase28_synthetic_shell_without_nested_members() {
+        let phase28 = empty_phase28_shell();
+        let err = phase29_prepare_recursive_compression_input_contract(&phase28)
+            .expect_err("empty Phase 28 shell must be rejected");
+        assert!(err
+            .to_string()
+            .contains("must contain at least two members"));
     }
 }


### PR DESCRIPTION
# Summary

- add a Phase 29 recursive-compression input contract derived from Phase 28 proof-carrying aggregation manifests
- require Phase 28 verification with nested proof checks before deriving the Phase 29 contract
- bind the derived contract with a BLAKE2b-256 commitment and reject recursive/compression claim bits, bad posture, empty commitments, count mismatches, and commitment tampering
- validate Phase 29 deserialization/parse/load paths, pin the supported Phase 28 dialect, and read contract JSON through the bounded regular-file loader
- add a Phase 29 design note and wire Phase 29 smokes into the local merge gate and hardening test list

## Validation

- [x] `cargo +nightly-2025-07-14 check --quiet --features stwo-backend`
- [x] targeted tests listed below

Commands run:

```text
cargo fmt
cargo +nightly-2025-07-14 test --features stwo-backend phase29 --lib
cargo test phase6_recursion_batch_manifest --lib
bash -n scripts/local_merge_gate.sh scripts/hardening_test_names.sh && git diff --check
cargo +nightly-2025-07-14 test -q --features stwo-backend --lib stwo_backend::decoding::tests::phase28_aggregated_chained_folded_intervalized_state_relation_rejects_header_mismatch_before_nested_checks -- --exact
cargo +nightly-2025-07-14 test -q --features stwo-backend --lib stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_tampered_commitment -- --exact
cargo test --lib
cargo fmt --check && git diff --check && git status --short --branch
cargo +nightly-2025-07-14 check --quiet --features stwo-backend
cargo fmt && git diff -- src/stwo_backend/recursion.rs src/stwo_backend/decoding.rs scripts/hardening_test_names.sh docs/design/phase29-recursive-compression-input-contract-spec.md
cargo +nightly-2025-07-14 check --quiet --features stwo-backend
cargo test phase6_recursion_batch_manifest --lib
cargo fmt --check
git diff --check
bash -n scripts/local_merge_gate.sh scripts/hardening_test_names.sh
```

Note: `cargo test --features stwo-backend phase29 --lib` was also attempted on the default stable toolchain and failed before reaching this crate because the upstream `stwo` dependency requires nightly-only features. The pinned-nightly run above passed.

Observed local results:

```text
cargo +nightly-2025-07-14 test --features stwo-backend phase29 --lib: 16 passed; 0 failed
cargo test phase6_recursion_batch_manifest --lib: 1 passed; 0 failed
exact Phase 28 + Phase 29 stwo smokes: 2 passed; 0 failed
cargo test --lib: 190 passed; 0 failed; finished in 670.55s
cargo +nightly-2025-07-14 check --quiet --features stwo-backend: passed
cargo fmt --check: passed
git diff --check: passed
bash -n scripts/local_merge_gate.sh scripts/hardening_test_names.sh: passed
```

Review follow-up: commit `ff3065a` addresses Qodo feedback by validating Phase 29 deserialization through `serde(try_from = ...)`, adding validated parse/load helpers, and pinning Phase 28 backend/statement dialect checks in the Phase 29 verifier.

Review follow-up: commit `b0cd976` addresses Qodo feedback by using the repo's bounded JSON reader for Phase 29 contract files, rejecting non-regular and oversized inputs before parsing, and classifying serde data/validation failures as `InvalidConfig`.

Review follow-up: commit `602bf40` addresses Qodo and Greptile feedback by correcting the Phase 29 semantic scope string and enforcing the JSON byte budget for compressed `.gz` files before decompression.

## Hardening

Complete this section for changes touching trusted-core paths such as `src/stwo_backend/**`,
`src/proof.rs`, `src/verification.rs`, `src/bin/tvm.rs`, `tests/**`, or `.github/workflows/**`.

- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Not applicable notes:

```text
Oracle/differential: not applicable for this boundary contract; the contract is deterministic and tested through exact rejection/tamper cases plus reuse of the Phase 28 proof-check verifier.
Resource/untrusted input: reviewed. Phase 29 validates deserialized contracts, maps validation failures to invalid configuration, and uses the existing bounded regular-file JSON loader for file input.
Kani/formal-kernel: not applicable. This PR does not add or change a formal kernel harness; it updates the hardening test list so Phase 29 is covered by the local UB/ASAN hardening path.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 29 Recursive-Compression Input Contract design spec and updated hardening policy guidance.

* **New Features**
  * Introduced Phase 29 recursive-compression input-contract support with prepare/verify/load/parse/commit flows and exposed Phase 28 recursion posture to callers.

* **Tests**
  * Expanded smoke and unit tests covering Phase 29 acceptance, rejections, deserialization behavior, size/format limits, and edge cases.

* **Chores**
  * Updated local merge-gate scripts and test filters to include Phase 28/29 smoke and hardening scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



Review follow-up: commit `6670b91` addresses CodeRabbit feedback by rejecting unknown Phase 29 JSON fields, enforcing the parse helper byte ceiling, narrowing the bounded-loader TOCTOU window with opened-file metadata checks, switching Phase 29 length/counter commitment encoding to fixed-width unsigned bytes, and clarifying the spec invariants.


Review follow-up: commit `1eb9fab` addresses Qodo and CodeRabbit feedback by documenting the exact Phase 29 commitment byte stream and minimum member-count invariant, and by opening bounded JSON files with Unix `O_NOFOLLOW | O_NONBLOCK` before post-open metadata validation.
