### PR TITLE
Add research v3 equivalence kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ No sampling. No stochastic output. Same input, same output, every time.
 | `statement-v1` | Stable | Vanilla STARK proof of native ISA execution, plus enforced transformer/native semantic agreement checks |
 | `stwo-backend` | Experimental | Narrow `statement-v1` proving surface for shipped fixtures, lookup demos, transformer-shaped fixtures, and decoding artifacts |
 | `research-v2` | Artifact-only | Semantic agreement artifacts for transformer vs ONNX, not yet a full STARK claim |
+| `research-v3` | Artifact-only | Multi-engine transformer/native/Burn/ONNX equivalence-kernel artifacts with explicit non-e-graph/non-SMT limits |
 
 The important boundary is explicit: this repo does **not** yet prove full
 standard-softmax transformer inference on `stwo`.
@@ -647,6 +648,15 @@ cargo test --quiet statement_spec_contract_is_synced_with_constants
 - These artifacts are publication evidence and regression guards, but they are not
   currently embedded into the `statement-v1` STARK proof relation.
 
+`research-v3` (research artifacts, not yet a full implementation-equivalence proof):
+
+- `research-v3-equivalence` checks transformer, native, Burn, and ONNX/Tract
+  runtimes in lockstep and emits an equivalence-kernel artifact with rule
+  witnesses and commitment hashes.
+- The artifact is deliberately bounded: it is not an e-graph saturation result,
+  SMT-backed rewrite proof, randomized opaque-kernel test suite, or
+  cryptographic proof of implementation equivalence.
+
 ### Production Profile (v1)
 
 `production-v1` is a practical local proving profile intended for routine CI/integration checks:
@@ -743,6 +753,27 @@ Additional matrix spec files:
 - `spec/statement-v2-matrix-research.json`
 - `spec/statement-v2-matrix-certificate.schema.json`
 
+### Research V3 Multi-Engine Equivalence Kernel
+
+For the first Emerge-style hardening step, generate a bounded multi-engine
+equivalence-kernel artifact:
+
+```bash
+cargo run --features full --bin tvm -- research-v3-equivalence programs/addition.tvm \
+  -o compiled/research-v3-addition-equivalence.json --max-steps 8
+```
+
+This checks transformer, native, Burn, and ONNX/Tract runtimes in lockstep,
+then emits a JSON artifact with engine summaries, deterministic rule witnesses,
+and commitment hashes. It intentionally does not claim e-graph saturation,
+SMT-backed rewrite synthesis, randomized opaque-kernel testing, or a
+cryptographic implementation-equivalence proof.
+
+Canonical research-v3 spec files:
+
+- `spec/statement-v3-equivalence-kernel-research.json`
+- `spec/statement-v3-equivalence-kernel.schema.json`
+
 ### Reproducibility Bundle
 
 For publication-ready artifacts (benchmarks, proofs, semantic agreement artifacts, hashes),
@@ -757,7 +788,7 @@ Outputs are written to `compiled/repro-bundle/`:
 - `manifest.txt` (commit + toolchain + environment)
 - `benchmarks.tsv` (timings by command)
 - `sha256sums.txt` (hashes for generated artifacts)
-- STARK proof files and `research-v2` certificates used for evidence sections
+- STARK proof files and `research-v2` / `research-v3` certificates used for evidence sections
 
 Additional committed transformer-shaped semantic artifacts live under:
 

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -60,6 +60,8 @@ The script writes to `compiled/repro-bundle/` by default and produces:
 - `sha256sums.txt`: hashes for artifacts and command outputs
 - `*.proof.json`: STARK proofs for representative programs
 - `research-v2-*.json`: semantic equivalence certificates (step/trace/matrix)
+- `research-v3-*.json`: multi-engine equivalence-kernel artifacts with explicit
+  non-e-graph/non-SMT limits
 - `*.out` / `*.err`: full stdout/stderr capture for each command
 
 The accumulation bundle script writes under
@@ -78,7 +80,7 @@ produces:
 
 - Attach `manifest.txt`, `benchmarks.tsv`, and `sha256sums.txt` in paper/blog
   appendices.
-- Link generated `research-v2` artifacts as evidence for semantic-equivalence
+- Link generated `research-v2` / `research-v3` artifacts as evidence for semantic-equivalence
   claims.
 - Link generated `*.proof.json` files for statement-v1 proof demonstrations.
 - Use `artifact_summary.tsv` from the accumulation bundle when comparing base,
@@ -90,6 +92,10 @@ produces:
 - `research-v2` artifacts are structured semantic certificates with commitments,
   used as evidence and regression checks, but are not yet part of the STARK
   claim relation.
+- `research-v3` artifacts extend that evidence to transformer/native/Burn/ONNX
+  lockstep plus rule witnesses, but they are not e-graph saturation results,
+  SMT rewrite proofs, randomized opaque-kernel tests, or cryptographic
+  implementation-equivalence proofs.
 
 ## Paper figure regeneration
 

--- a/scripts/generate_repro_bundle.sh
+++ b/scripts/generate_repro_bundle.sh
@@ -97,6 +97,10 @@ run_and_capture "research_v2_matrix_default_suite" \
   cargo run --features onnx-export --bin tvm -- research-v2-matrix \
     -o "$OUT/research-v2-matrix-default-suite.json" --include-default-suite --max-steps 64
 
+run_and_capture "research_v3_equivalence_addition" \
+  cargo run --features full --bin tvm -- research-v3-equivalence \
+    programs/addition.tvm -o "$OUT/research-v3-addition-equivalence.json" --max-steps 8
+
 (
   cd "$OUT"
   LC_ALL=C LANG=C shasum -a 256 \

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -433,18 +433,22 @@ checks_json="$run_evidence_dir/checks.json"
 check_runs_json="$run_evidence_dir/check-runs.json"
 statuses_json="$run_evidence_dir/statuses.json"
 gh api --paginate "repos/${REPO}/commits/${head_sha}/check-runs?per_page=100" \
-  --jq '.check_runs[] | {name, started_at, completed_at, status: (.status | ascii_upcase), conclusion: ((.conclusion // "") | ascii_upcase)}' \
+  --jq '.check_runs[] | {name, id, created_at, started_at, completed_at, status: (.status | ascii_upcase), conclusion: ((.conclusion // "") | ascii_upcase)}' \
   | jq -s '
-      sort_by(.started_at // .completed_at // "")
+      sort_by((.created_at // .started_at // .completed_at // ""), (.id // 0))
       | reduce .[] as $check ({}; .[$check.name] = $check)
-      | [.[]]
+      | to_entries
+      | sort_by(.key)
+      | map(.value)
     ' >"$check_runs_json"
 gh api --paginate "repos/${REPO}/commits/${head_sha}/statuses?per_page=100" \
   --jq '.[] | {name: .context, created_at: .created_at, status: (if .state == "pending" then "IN_PROGRESS" else "COMPLETED" end), conclusion: (if .state == "success" then "SUCCESS" elif .state == "pending" then "" elif .state == "error" then "FAILURE" else (.state | ascii_upcase) end)}' \
   | jq -s '
       sort_by(.created_at)
       | reduce .[] as $status ({}; .[$status.name] = $status)
-      | [.[]]
+      | to_entries
+      | sort_by(.key)
+      | map(.value)
     ' >"$statuses_json"
 jq -s '.[0] + .[1]' "$check_runs_json" "$statuses_json" >"$checks_json"
 

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -553,7 +553,7 @@ jq -n \
 jq --argjson now "$now_epoch" '
     .data.repository.pullRequest as $pull
     | ["coderabbitai", "greptile-apps", "qodo-code-review"] as $ai_reviewers
-    | [ $pull.reviewThreads.nodes[]? | select(.isResolved == false) ] as $active
+    | [ $pull.reviewThreads.nodes[]? | select((.isResolved // false) == false and (.isOutdated // false) == false) ] as $active
     | ([
         ($pull.comments.nodes[]? | select(.author.login as $login | $ai_reviewers | index($login)) | {author:.author.login, createdAt}),
         ($pull.reviews.nodes[]? | select(.author.login as $login | $ai_reviewers | index($login)) | {author:.author.login, createdAt}),

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -363,6 +363,14 @@ run_stwo_smoke_targets() {
   done
 }
 
+run_research_v3_smoke_targets() {
+  run_logged research-v3-equivalence-cli cargo test -q \
+    --features full \
+    --test cli cli_supports_research_v3_equivalence_command \
+    -- \
+    --exact
+}
+
 if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
   run_logged cargo-fmt-check cargo fmt --check
@@ -380,6 +388,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged cargo-lib-and-integration-tests cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
   run_stwo_smoke_targets
+  run_research_v3_smoke_targets
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -388,6 +397,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged cargo-lib-and-integration-tests cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
   run_stwo_smoke_targets
+  run_research_v3_smoke_targets
   run_logged ub-checks env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh
   run_logged asan env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_asan_suite.sh
   run_logged miri env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -433,8 +433,12 @@ checks_json="$run_evidence_dir/checks.json"
 check_runs_json="$run_evidence_dir/check-runs.json"
 statuses_json="$run_evidence_dir/statuses.json"
 gh api --paginate "repos/${REPO}/commits/${head_sha}/check-runs?per_page=100" \
-  --jq '.check_runs[] | {name, status: (.status | ascii_upcase), conclusion: ((.conclusion // "") | ascii_upcase)}' \
-  | jq -s '.' >"$check_runs_json"
+  --jq '.check_runs[] | {name, started_at, completed_at, status: (.status | ascii_upcase), conclusion: ((.conclusion // "") | ascii_upcase)}' \
+  | jq -s '
+      sort_by(.started_at // .completed_at // "")
+      | reduce .[] as $check ({}; .[$check.name] = $check)
+      | [.[]]
+    ' >"$check_runs_json"
 gh api --paginate "repos/${REPO}/commits/${head_sha}/statuses?per_page=100" \
   --jq '.[] | {name: .context, created_at: .created_at, status: (if .state == "pending" then "IN_PROGRESS" else "COMPLETED" end), conclusion: (if .state == "success" then "SUCCESS" elif .state == "pending" then "" elif .state == "error" then "FAILURE" else (.state | ascii_upcase) end)}' \
   | jq -s '

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -516,6 +516,7 @@ query($owner:String!,$name:String!,$number:Int!,$cursor:String){
         pageInfo{ hasNextPage endCursor }
         nodes{
           isResolved
+          isOutdated
           comments(first:100){
             pageInfo{ hasNextPage endCursor }
             nodes{ author{login} createdAt }

--- a/spec/statement-v3-equivalence-kernel-research.json
+++ b/spec/statement-v3-equivalence-kernel-research.json
@@ -1,0 +1,8 @@
+{
+  "statement_version": "statement-v3-research-draft",
+  "semantic_scope": "multi_engine_trace_equivalence_kernel_with_rule_witnesses",
+  "fixed_point_profile_ref": "spec/fixed-point-semantics-v2.json",
+  "onnx_op_subset_ref": "spec/onnx-op-subset-v2.json",
+  "artifact_schema_ref": "spec/statement-v3-equivalence-kernel.schema.json",
+  "notes": "Research-stage multi-engine equivalence-kernel artifact over transformer/native/Burn/ONNX lockstep evidence. This is not an e-graph saturation result, SMT-backed rewrite proof, randomized opaque-kernel test suite, or cryptographic proof of implementation equivalence."
+}

--- a/spec/statement-v3-equivalence-kernel.schema.json
+++ b/spec/statement-v3-equivalence-kernel.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://llm-provable-computer/spec/statement-v3-equivalence-kernel.schema.json",
+  "title": "Statement V3 Multi-Engine Equivalence Kernel Certificate",
+  "type": "object",
+  "required": [
+    "statement_version",
+    "semantic_scope",
+    "relation_format",
+    "fixed_point_profile",
+    "onnx_op_subset_version",
+    "onnx_op_subset_size",
+    "program_path",
+    "requested_max_steps",
+    "checked_steps",
+    "matched",
+    "engines",
+    "rule_witnesses",
+    "limitations",
+    "commitments"
+  ],
+  "properties": {
+    "statement_version": { "type": "string" },
+    "semantic_scope": { "type": "string" },
+    "relation_format": { "type": "string" },
+    "fixed_point_profile": { "type": "string" },
+    "onnx_op_subset_version": { "type": "string" },
+    "onnx_op_subset_size": { "type": "integer", "minimum": 1 },
+    "program_path": { "type": "string" },
+    "requested_max_steps": { "type": "integer", "minimum": 1 },
+    "checked_steps": { "type": "integer", "minimum": 0 },
+    "matched": { "type": "boolean" },
+    "engines": {
+      "type": "array",
+      "minItems": 4,
+      "items": { "$ref": "#/$defs/engine_summary" }
+    },
+    "rule_witnesses": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/rule_witness" }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "commitments": {
+      "type": "object",
+      "required": [
+        "hash_function",
+        "statement_spec_hash",
+        "fixed_point_spec_hash",
+        "onnx_op_subset_hash",
+        "artifact_schema_hash",
+        "program_hash",
+        "transformer_config_hash",
+        "onnx_metadata_hash",
+        "engine_summaries_hash",
+        "rule_witnesses_hash"
+      ],
+      "properties": {
+        "hash_function": { "type": "string" },
+        "statement_spec_hash": { "type": "string" },
+        "fixed_point_spec_hash": { "type": "string" },
+        "onnx_op_subset_hash": { "type": "string" },
+        "artifact_schema_hash": { "type": "string" },
+        "program_hash": { "type": "string" },
+        "transformer_config_hash": { "type": "string" },
+        "onnx_metadata_hash": { "type": "string" },
+        "engine_summaries_hash": { "type": "string" },
+        "rule_witnesses_hash": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "engine_summary": {
+      "type": "object",
+      "required": [
+        "name",
+        "steps",
+        "halted",
+        "trace_len",
+        "events_len",
+        "final_state",
+        "trace_hash",
+        "event_relation_hash",
+        "final_state_hash"
+      ],
+      "properties": {
+        "name": { "type": "string" },
+        "steps": { "type": "integer", "minimum": 0 },
+        "halted": { "type": "boolean" },
+        "trace_len": { "type": "integer", "minimum": 1 },
+        "events_len": { "type": "integer", "minimum": 0 },
+        "final_state": { "$ref": "#/$defs/machine_state" },
+        "trace_hash": { "type": "string" },
+        "event_relation_hash": { "type": "string" },
+        "final_state_hash": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "rule_witness": {
+      "type": "object",
+      "required": [
+        "step",
+        "rule_id",
+        "relation",
+        "instruction",
+        "participating_engines",
+        "state_before_hash",
+        "state_after_hash",
+        "validation"
+      ],
+      "properties": {
+        "step": { "type": "integer", "minimum": 1 },
+        "rule_id": { "type": "string" },
+        "relation": { "type": "string" },
+        "instruction": { "type": "string" },
+        "participating_engines": {
+          "type": "array",
+          "minItems": 4,
+          "items": { "type": "string" }
+        },
+        "state_before_hash": { "type": "string" },
+        "state_after_hash": { "type": "string" },
+        "validation": {
+          "type": "object",
+          "required": [
+            "differential_lockstep",
+            "egraph_status",
+            "smt_status",
+            "randomized_testing_status"
+          ],
+          "properties": {
+            "differential_lockstep": { "type": "boolean" },
+            "egraph_status": { "type": "string" },
+            "smt_status": { "type": "string" },
+            "randomized_testing_status": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "machine_state": {
+      "type": "object",
+      "required": [
+        "pc",
+        "acc",
+        "sp",
+        "zero_flag",
+        "carry_flag",
+        "halted",
+        "memory"
+      ],
+      "properties": {
+        "pc": { "type": "integer", "minimum": 0 },
+        "acc": { "type": "integer" },
+        "sp": { "type": "integer", "minimum": 0 },
+        "zero_flag": { "type": "boolean" },
+        "carry_flag": { "type": "boolean" },
+        "halted": { "type": "boolean" },
+        "memory": {
+          "type": "array",
+          "items": { "type": "integer" }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/spec/statement-v3-equivalence-kernel.schema.json
+++ b/spec/statement-v3-equivalence-kernel.schema.json
@@ -60,22 +60,28 @@
       ],
       "properties": {
         "hash_function": { "type": "string" },
-        "statement_spec_hash": { "type": "string" },
-        "fixed_point_spec_hash": { "type": "string" },
-        "onnx_op_subset_hash": { "type": "string" },
-        "artifact_schema_hash": { "type": "string" },
-        "relation_format_hash": { "type": "string" },
-        "limitations_hash": { "type": "string" },
-        "program_hash": { "type": "string" },
-        "transformer_config_hash": { "type": "string" },
-        "onnx_metadata_hash": { "type": "string" },
-        "engine_summaries_hash": { "type": "string" },
-        "rule_witnesses_hash": { "type": "string" }
+        "statement_spec_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "fixed_point_spec_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "onnx_op_subset_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "artifact_schema_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "relation_format_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "limitations_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "program_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "transformer_config_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "onnx_metadata_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "engine_summaries_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "rule_witnesses_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" }
       },
       "additionalProperties": false
     }
   },
   "$defs": {
+    "hash_blake2b_256_hex": {
+      "type": "string",
+      "minLength": 64,
+      "maxLength": 64,
+      "pattern": "^[0-9a-f]{64}$"
+    },
     "engine_summary": {
       "type": "object",
       "required": [
@@ -96,9 +102,9 @@
         "trace_len": { "type": "integer", "minimum": 1 },
         "events_len": { "type": "integer", "minimum": 0 },
         "final_state": { "$ref": "#/$defs/machine_state" },
-        "trace_hash": { "type": "string" },
-        "event_relation_hash": { "type": "string" },
-        "final_state_hash": { "type": "string" }
+        "trace_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "event_relation_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "final_state_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" }
       },
       "additionalProperties": false
     },
@@ -127,12 +133,12 @@
         "state_before_hashes": {
           "type": "object",
           "minProperties": 4,
-          "additionalProperties": { "type": "string" }
+          "additionalProperties": { "$ref": "#/$defs/hash_blake2b_256_hex" }
         },
         "state_after_hashes": {
           "type": "object",
           "minProperties": 4,
-          "additionalProperties": { "type": "string" }
+          "additionalProperties": { "$ref": "#/$defs/hash_blake2b_256_hex" }
         },
         "validation": {
           "type": "object",

--- a/spec/statement-v3-equivalence-kernel.schema.json
+++ b/spec/statement-v3-equivalence-kernel.schema.json
@@ -13,7 +13,6 @@
     "program_path",
     "requested_max_steps",
     "checked_steps",
-    "matched",
     "engines",
     "rule_witnesses",
     "limitations",
@@ -29,7 +28,6 @@
     "program_path": { "type": "string" },
     "requested_max_steps": { "type": "integer", "minimum": 1 },
     "checked_steps": { "type": "integer", "minimum": 0 },
-    "matched": { "type": "boolean" },
     "engines": {
       "type": "array",
       "minItems": 4,
@@ -52,6 +50,8 @@
         "fixed_point_spec_hash",
         "onnx_op_subset_hash",
         "artifact_schema_hash",
+        "relation_format_hash",
+        "limitations_hash",
         "program_hash",
         "transformer_config_hash",
         "onnx_metadata_hash",
@@ -64,6 +64,8 @@
         "fixed_point_spec_hash": { "type": "string" },
         "onnx_op_subset_hash": { "type": "string" },
         "artifact_schema_hash": { "type": "string" },
+        "relation_format_hash": { "type": "string" },
+        "limitations_hash": { "type": "string" },
         "program_hash": { "type": "string" },
         "transformer_config_hash": { "type": "string" },
         "onnx_metadata_hash": { "type": "string" },
@@ -108,8 +110,8 @@
         "relation",
         "instruction",
         "participating_engines",
-        "state_before_hash",
-        "state_after_hash",
+        "state_before_hashes",
+        "state_after_hashes",
         "validation"
       ],
       "properties": {
@@ -122,8 +124,16 @@
           "minItems": 4,
           "items": { "type": "string" }
         },
-        "state_before_hash": { "type": "string" },
-        "state_after_hash": { "type": "string" },
+        "state_before_hashes": {
+          "type": "object",
+          "minProperties": 4,
+          "additionalProperties": { "type": "string" }
+        },
+        "state_after_hashes": {
+          "type": "object",
+          "minProperties": 4,
+          "additionalProperties": { "type": "string" }
+        },
         "validation": {
           "type": "object",
           "required": [

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4452,14 +4452,28 @@ fn write_bytes_atomically(path: &Path, bytes: &[u8]) -> llm_provable_computer::R
                 )
             {
                 // POSIX rename replaces atomically. Some platforms reject existing destinations.
-                if let Err(remove_err) = fs::remove_file(path) {
+                // Use a same-directory backup so a failed fallback publish can restore the old artifact.
+                let backup_path =
+                    dir.join(format!(".{file_name}.bak-{}-{attempt}", std::process::id()));
+                if let Err(backup_err) = fs::rename(path, &backup_path) {
                     let _ = fs::remove_file(&temp_path);
-                    return Err(remove_err.into());
+                    if backup_err.kind() == std::io::ErrorKind::AlreadyExists {
+                        continue;
+                    }
+                    return Err(backup_err.into());
                 }
                 if let Err(rename_err) = fs::rename(&temp_path, path) {
+                    let restore_result = fs::rename(&backup_path, path);
                     let _ = fs::remove_file(&temp_path);
+                    if let Err(restore_err) = restore_result {
+                        return Err(VmError::InvalidConfig(format!(
+                            "failed to publish {}; restore failed after publish error: {restore_err}; publish error: {rename_err}",
+                            path.display()
+                        )));
+                    }
                     return Err(rename_err.into());
                 }
+                let _ = fs::remove_file(&backup_path);
             } else {
                 let _ = fs::remove_file(&temp_path);
                 return Err(err.into());

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4444,8 +4444,26 @@ fn write_bytes_atomically(path: &Path, bytes: &[u8]) -> llm_provable_computer::R
         drop(file);
 
         if let Err(err) = fs::rename(&temp_path, path) {
-            let _ = fs::remove_file(&temp_path);
-            return Err(err.into());
+            let destination_exists = path.try_exists().unwrap_or(false);
+            if destination_exists
+                && matches!(
+                    err.kind(),
+                    std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::PermissionDenied
+                )
+            {
+                // POSIX rename replaces atomically. Some platforms reject existing destinations.
+                if let Err(remove_err) = fs::remove_file(path) {
+                    let _ = fs::remove_file(&temp_path);
+                    return Err(remove_err.into());
+                }
+                if let Err(rename_err) = fs::rename(&temp_path, path) {
+                    let _ = fs::remove_file(&temp_path);
+                    return Err(rename_err.into());
+                }
+            } else {
+                let _ = fs::remove_file(&temp_path);
+                return Err(err.into());
+            }
         }
 
         return Ok(());
@@ -4501,6 +4519,18 @@ mod tests {
         assert!(suite.contains(&PathBuf::from("programs/dot_product.tvm")));
         assert!(suite.contains(&PathBuf::from("programs/matmul_2x2.tvm")));
         assert!(suite.contains(&PathBuf::from("programs/single_neuron.tvm")));
+    }
+
+    #[test]
+    fn atomic_write_replaces_existing_output() {
+        let path = std::env::temp_dir().join(format!(
+            "llm-provable-computer-atomic-write-replace-{}.json",
+            std::process::id()
+        ));
+        fs::write(&path, b"old").expect("seed output");
+        write_bytes_atomically(&path, b"new").expect("replace output");
+        assert_eq!(fs::read(&path).expect("read replaced output"), b"new");
+        let _ = fs::remove_file(path);
     }
 }
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -915,8 +915,8 @@ struct ResearchV3RuleWitness {
     relation: String,
     instruction: String,
     participating_engines: Vec<String>,
-    state_before_hash: String,
-    state_after_hash: String,
+    state_before_hashes: std::collections::BTreeMap<String, String>,
+    state_after_hashes: std::collections::BTreeMap<String, String>,
     validation: ResearchV3RuleValidation,
 }
 
@@ -928,6 +928,8 @@ struct ResearchV3EquivalenceCommitments {
     fixed_point_spec_hash: String,
     onnx_op_subset_hash: String,
     artifact_schema_hash: String,
+    relation_format_hash: String,
+    limitations_hash: String,
     program_hash: String,
     transformer_config_hash: String,
     onnx_metadata_hash: String,
@@ -947,7 +949,6 @@ struct ResearchV3EquivalenceArtifact {
     program_path: String,
     requested_max_steps: usize,
     checked_steps: usize,
-    matched: bool,
     engines: Vec<ResearchV3EngineSummary>,
     rule_witnesses: Vec<ResearchV3RuleWitness>,
     limitations: Vec<String>,
@@ -3896,36 +3897,45 @@ fn research_v3_equivalence_command_impl(
             &verified_onnx.result,
         )?,
     ];
-    let rule_witnesses = research_v3_rule_witnesses(transformer.events(), &engine_names)?;
-    let engine_summaries_hash = hash_json_hex(&engines)?;
-    let rule_witnesses_hash = hash_json_hex(&rule_witnesses)?;
+    let rule_witnesses = research_v3_rule_witnesses(&[
+        (verified_transformer.name.as_str(), transformer.events()),
+        (verified_native.name.as_str(), native.events()),
+        (verified_burn.name.as_str(), burn.events()),
+        (verified_onnx.name.as_str(), onnx.events()),
+    ])?;
+    let engine_summaries_hash = hash_json_projection_hex(&engines)?;
+    let rule_witnesses_hash = hash_json_projection_hex(&rule_witnesses)?;
+    let relation_format = RESEARCH_V3_RELATION_FORMAT.to_string();
+    let limitations = vec![
+        "e-graph saturation is not implemented in this artifact".to_string(),
+        "SMT-backed rewrite synthesis is not implemented in this artifact".to_string(),
+        "randomized opaque-kernel testing is not implemented in this artifact".to_string(),
+        "the current evidence is deterministic multi-engine lockstep over the shipped VM/ONNX/Burn/native surfaces".to_string(),
+    ];
+    let relation_format_hash = hash_json_hex(&relation_format)?;
+    let limitations_hash = hash_json_hex(&limitations)?;
 
     let artifact = ResearchV3EquivalenceArtifact {
         statement_version: bundle.statement_version.clone(),
         semantic_scope: bundle.semantic_scope.clone(),
-        relation_format: RESEARCH_V3_RELATION_FORMAT.to_string(),
+        relation_format,
         fixed_point_profile: bundle.fixed_point_profile.clone(),
         onnx_op_subset_version: bundle.onnx_op_subset_version.clone(),
         onnx_op_subset_size: bundle.onnx_op_subset_size,
         program_path: program.display().to_string(),
         requested_max_steps: max_steps,
         checked_steps: verification.checked_steps,
-        // Artifact construction is reached only after verify_engines accepts the full lockstep run.
-        matched: true,
         engines,
         rule_witnesses,
-        limitations: vec![
-            "e-graph saturation is not implemented in this artifact".to_string(),
-            "SMT-backed rewrite synthesis is not implemented in this artifact".to_string(),
-            "randomized opaque-kernel testing is not implemented in this artifact".to_string(),
-            "the current evidence is deterministic multi-engine lockstep over the shipped VM/ONNX/Burn/native surfaces".to_string(),
-        ],
+        limitations,
         commitments: ResearchV3EquivalenceCommitments {
             hash_function: RESEARCH_V2_HASH_FUNCTION.to_string(),
             statement_spec_hash: bundle.statement_spec_hash,
             fixed_point_spec_hash: bundle.fixed_point_spec_hash,
             onnx_op_subset_hash: bundle.onnx_op_subset_hash,
             artifact_schema_hash: bundle.artifact_schema_hash,
+            relation_format_hash,
+            limitations_hash,
             program_hash: hash_json_hex(model.program())?,
             transformer_config_hash: hash_json_hex(model.config())?,
             onnx_metadata_hash: hash_json_hex(&onnx_metadata)?,
@@ -3936,14 +3946,13 @@ fn research_v3_equivalence_command_impl(
 
     let bytes = serde_json::to_vec_pretty(&artifact)
         .map_err(|err| VmError::Serialization(format!("failed to serialize artifact: {err}")))?;
-    fs::write(output, bytes)?;
+    write_bytes_atomically(output, &bytes)?;
 
     println!("research_v3_equivalence_artifact: {}", output.display());
     println!("statement_version: {}", artifact.statement_version);
     println!("semantic_scope: {}", artifact.semantic_scope);
     println!("relation_format: {}", artifact.relation_format);
     println!("checked_steps: {}", artifact.checked_steps);
-    println!("matched: {}", artifact.matched);
     println!("engines: {}", engine_names.join(","));
     println!("rule_witnesses: {}", artifact.rule_witnesses.len());
     println!(
@@ -3999,21 +4008,56 @@ fn research_v3_canonical_events(
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 fn research_v3_rule_witnesses(
-    reference_events: &[ExecutionTraceEntry],
-    engine_names: &[String],
+    engine_events: &[(&str, &[ExecutionTraceEntry])],
 ) -> llm_provable_computer::Result<Vec<ResearchV3RuleWitness>> {
+    let (reference_name, reference_events) = engine_events.first().ok_or_else(|| {
+        VmError::InvalidConfig("research-v3-equivalence requires engine events".to_string())
+    })?;
+    let participating_engines = engine_events
+        .iter()
+        .map(|(engine_name, _)| (*engine_name).to_string())
+        .collect::<Vec<_>>();
+
     reference_events
         .iter()
-        .map(|event| {
-            let instruction = event.instruction.to_string();
+        .enumerate()
+        .map(|(event_idx, reference_event)| {
+            let instruction = reference_event.instruction.to_string();
+            let mut state_before_hashes = std::collections::BTreeMap::new();
+            let mut state_after_hashes = std::collections::BTreeMap::new();
+            for (engine_name, events) in engine_events {
+                let event = events.get(event_idx).ok_or_else(|| {
+                    VmError::InvalidConfig(format!(
+                        "research-v3-equivalence missing event {} for {}",
+                        event_idx + 1,
+                        engine_name
+                    ))
+                })?;
+                if event.step != reference_event.step || event.instruction != reference_event.instruction {
+                    return Err(VmError::InvalidConfig(format!(
+                        "research-v3-equivalence event mismatch at index {}: {} step={} instruction=`{}` vs {} step={} instruction=`{}`",
+                        event_idx,
+                        reference_name,
+                        reference_event.step,
+                        reference_event.instruction,
+                        engine_name,
+                        event.step,
+                        event.instruction
+                    )));
+                }
+                state_before_hashes
+                    .insert((*engine_name).to_string(), hash_json_hex(&event.state_before)?);
+                state_after_hashes
+                    .insert((*engine_name).to_string(), hash_json_hex(&event.state_after)?);
+            }
             Ok(ResearchV3RuleWitness {
-                step: event.step,
+                step: reference_event.step,
                 rule_id: research_v3_rule_id(&instruction),
                 relation: "same-instruction-same-state-transition".to_string(),
                 instruction,
-                participating_engines: engine_names.to_vec(),
-                state_before_hash: hash_json_hex(&event.state_before)?,
-                state_after_hash: hash_json_hex(&event.state_after)?,
+                participating_engines: participating_engines.clone(),
+                state_before_hashes,
+                state_after_hashes,
                 validation: ResearchV3RuleValidation {
                     differential_lockstep: true,
                     egraph_status: "not-attempted".to_string(),
@@ -4349,6 +4393,16 @@ fn hash_json_hex<T: Serialize + ?Sized>(value: &T) -> llm_provable_computer::Res
 }
 
 #[cfg(feature = "onnx-export")]
+fn hash_json_projection_hex<T: Serialize + ?Sized>(
+    value: &T,
+) -> llm_provable_computer::Result<String> {
+    let projection = serde_json::to_value(value).map_err(|err| {
+        VmError::Serialization(format!("failed to serialize hash projection: {err}"))
+    })?;
+    hash_json_hex(&projection)
+}
+
+#[cfg(feature = "onnx-export")]
 fn hash_bytes_hex(bytes: &[u8]) -> String {
     let mut output = [0u8; 32];
     let mut hasher = Blake2bVar::new(output.len()).expect("blake2b-256 hasher");
@@ -4357,6 +4411,40 @@ fn hash_bytes_hex(bytes: &[u8]) -> String {
         .finalize_variable(&mut output)
         .expect("blake2b-256 finalization");
     output.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(feature = "onnx-export")]
+fn write_bytes_atomically(path: &Path, bytes: &[u8]) -> llm_provable_computer::Result<()> {
+    use std::io::Write;
+
+    let parent = path.parent().filter(|dir| !dir.as_os_str().is_empty());
+    let dir = parent.unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "artifact".into());
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| VmError::InvalidConfig(format!("system clock error: {err}")))?
+        .as_nanos();
+    let temp_path = dir.join(format!(".{file_name}.tmp-{}-{suffix}", std::process::id()));
+
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)?;
+    if let Err(err) = file.write_all(bytes).and_then(|()| file.sync_all()) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(err.into());
+    }
+    drop(file);
+
+    if let Err(err) = fs::rename(&temp_path, path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(err.into());
+    }
+
+    Ok(())
 }
 
 #[cfg(all(test, feature = "onnx-export"))]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -3907,9 +3907,12 @@ fn research_v3_equivalence_command_impl(
     let rule_witnesses_hash = hash_json_projection_hex(&rule_witnesses)?;
     let relation_format = RESEARCH_V3_RELATION_FORMAT.to_string();
     let limitations = vec![
+        "Emerge reproduction is not implemented in this artifact".to_string(),
         "e-graph saturation is not implemented in this artifact".to_string(),
         "SMT-backed rewrite synthesis is not implemented in this artifact".to_string(),
         "randomized opaque-kernel testing is not implemented in this artifact".to_string(),
+        "recursive accumulation is not implemented in this artifact".to_string(),
+        "this artifact is not a cryptographic implementation-equivalence proof".to_string(),
         "the current evidence is deterministic multi-engine lockstep over the shipped VM/ONNX/Burn/native surfaces".to_string(),
     ];
     let relation_format_hash = hash_json_hex(&relation_format)?;
@@ -4423,28 +4426,35 @@ fn write_bytes_atomically(path: &Path, bytes: &[u8]) -> llm_provable_computer::R
         .file_name()
         .map(|name| name.to_string_lossy())
         .unwrap_or_else(|| "artifact".into());
-    let suffix = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|err| VmError::InvalidConfig(format!("system clock error: {err}")))?
-        .as_nanos();
-    let temp_path = dir.join(format!(".{file_name}.tmp-{}-{suffix}", std::process::id()));
+    for attempt in 0..1024u16 {
+        let temp_path = dir.join(format!(".{file_name}.tmp-{}-{attempt}", std::process::id()));
+        let mut file = match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+        {
+            Ok(file) => file,
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err.into()),
+        };
+        if let Err(err) = file.write_all(bytes).and_then(|()| file.sync_all()) {
+            let _ = fs::remove_file(&temp_path);
+            return Err(err.into());
+        }
+        drop(file);
 
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&temp_path)?;
-    if let Err(err) = file.write_all(bytes).and_then(|()| file.sync_all()) {
-        let _ = fs::remove_file(&temp_path);
-        return Err(err.into());
+        if let Err(err) = fs::rename(&temp_path, path) {
+            let _ = fs::remove_file(&temp_path);
+            return Err(err.into());
+        }
+
+        return Ok(());
     }
-    drop(file);
 
-    if let Err(err) = fs::rename(&temp_path, path) {
-        let _ = fs::remove_file(&temp_path);
-        return Err(err.into());
-    }
-
-    Ok(())
+    Err(VmError::InvalidConfig(format!(
+        "failed to allocate atomic temp path for {}",
+        path.display()
+    )))
 }
 
 #[cfg(all(test, feature = "onnx-export"))]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4467,8 +4467,9 @@ fn write_bytes_atomically(path: &Path, bytes: &[u8]) -> llm_provable_computer::R
                     let _ = fs::remove_file(&temp_path);
                     if let Err(restore_err) = restore_result {
                         return Err(VmError::InvalidConfig(format!(
-                            "failed to publish {}; restore failed after publish error: {restore_err}; publish error: {rename_err}",
-                            path.display()
+                            "failed to publish {}; restore from {} failed after publish error: {restore_err}; publish error: {rename_err}",
+                            path.display(),
+                            backup_path.display()
                         )));
                     }
                     return Err(rename_err.into());

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -563,6 +563,27 @@ enum Command {
         #[arg(long)]
         allow_mismatch: bool,
     },
+    /// Generate a research v3 multi-engine equivalence-kernel artifact.
+    ResearchV3Equivalence {
+        /// Path to the source `.tvm` program.
+        program: PathBuf,
+        /// File where the equivalence-kernel artifact JSON will be written.
+        #[arg(short = 'o', long = "output")]
+        output: PathBuf,
+        /// Maximum number of execution steps to check.
+        #[arg(long, default_value_t = 32)]
+        max_steps: usize,
+        /// Number of transformer layers to distribute instructions across.
+        #[arg(long, default_value_t = 1)]
+        layers: usize,
+        /// Attention mode to use for memory reads.
+        #[arg(
+            long,
+            default_value = "average-hard",
+            value_parser = parse_attention_mode
+        )]
+        attention_mode: Attention2DMode,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -682,6 +703,9 @@ const STATEMENT_V2_TRACE_SPEC_PATH: &str = "spec/statement-v2-trace-research.jso
 #[cfg(feature = "onnx-export")]
 const STATEMENT_V2_MATRIX_SPEC_PATH: &str = "spec/statement-v2-matrix-research.json";
 #[cfg(feature = "onnx-export")]
+const STATEMENT_V3_EQUIVALENCE_SPEC_PATH: &str =
+    "spec/statement-v3-equivalence-kernel-research.json";
+#[cfg(feature = "onnx-export")]
 const FIXED_POINT_SPEC_PATH: &str = "spec/fixed-point-semantics-v2.json";
 #[cfg(feature = "onnx-export")]
 const ONNX_OP_SUBSET_SPEC_PATH: &str = "spec/onnx-op-subset-v2.json";
@@ -695,7 +719,12 @@ const STATEMENT_V2_TRACE_ARTIFACT_SCHEMA_PATH: &str =
 const STATEMENT_V2_MATRIX_ARTIFACT_SCHEMA_PATH: &str =
     "spec/statement-v2-matrix-certificate.schema.json";
 #[cfg(feature = "onnx-export")]
+const STATEMENT_V3_EQUIVALENCE_ARTIFACT_SCHEMA_PATH: &str =
+    "spec/statement-v3-equivalence-kernel.schema.json";
+#[cfg(feature = "onnx-export")]
 const RESEARCH_V2_HASH_FUNCTION: &str = "blake2b-256";
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+const RESEARCH_V3_RELATION_FORMAT: &str = "multi-engine-trace-relation-v1-no-egraph-no-smt";
 
 #[cfg(feature = "onnx-export")]
 #[derive(Debug, Deserialize)]
@@ -843,6 +872,86 @@ struct ResearchV2MatrixArtifact {
     mismatched_programs: usize,
     entries: Vec<ResearchV2MatrixEntry>,
     commitments: ResearchV2MatrixCommitments,
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+#[derive(Debug, Serialize)]
+struct ResearchV3CanonicalEvent {
+    step: usize,
+    layer_idx: Option<usize>,
+    instruction: String,
+    state_before_hash: String,
+    state_after_hash: String,
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+#[derive(Debug, Serialize)]
+struct ResearchV3EngineSummary {
+    name: String,
+    steps: usize,
+    halted: bool,
+    trace_len: usize,
+    events_len: usize,
+    final_state: MachineState,
+    trace_hash: String,
+    event_relation_hash: String,
+    final_state_hash: String,
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+#[derive(Debug, Serialize)]
+struct ResearchV3RuleValidation {
+    differential_lockstep: bool,
+    egraph_status: String,
+    smt_status: String,
+    randomized_testing_status: String,
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+#[derive(Debug, Serialize)]
+struct ResearchV3RuleWitness {
+    step: usize,
+    rule_id: String,
+    relation: String,
+    instruction: String,
+    participating_engines: Vec<String>,
+    state_before_hash: String,
+    state_after_hash: String,
+    validation: ResearchV3RuleValidation,
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+#[derive(Debug, Serialize)]
+struct ResearchV3EquivalenceCommitments {
+    hash_function: String,
+    statement_spec_hash: String,
+    fixed_point_spec_hash: String,
+    onnx_op_subset_hash: String,
+    artifact_schema_hash: String,
+    program_hash: String,
+    transformer_config_hash: String,
+    onnx_metadata_hash: String,
+    engine_summaries_hash: String,
+    rule_witnesses_hash: String,
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+#[derive(Debug, Serialize)]
+struct ResearchV3EquivalenceArtifact {
+    statement_version: String,
+    semantic_scope: String,
+    relation_format: String,
+    fixed_point_profile: String,
+    onnx_op_subset_version: String,
+    onnx_op_subset_size: usize,
+    program_path: String,
+    requested_max_steps: usize,
+    checked_steps: usize,
+    matched: bool,
+    engines: Vec<ResearchV3EngineSummary>,
+    rule_witnesses: Vec<ResearchV3RuleWitness>,
+    limitations: Vec<String>,
+    commitments: ResearchV3EquivalenceCommitments,
 }
 
 #[cfg(feature = "onnx-export")]
@@ -1132,6 +1241,13 @@ fn run() -> llm_provable_computer::Result<()> {
             attention_mode,
             allow_mismatch,
         )?,
+        Command::ResearchV3Equivalence {
+            program,
+            output,
+            max_steps,
+            layers,
+            attention_mode,
+        } => research_v3_equivalence_command(&program, &output, max_steps, layers, attention_mode)?,
     }
 
     Ok(())
@@ -3349,6 +3465,16 @@ fn research_v2_matrix_command(
     )
 }
 
+fn research_v3_equivalence_command(
+    program: &Path,
+    output: &Path,
+    max_steps: usize,
+    layers: usize,
+    attention_mode: Attention2DMode,
+) -> llm_provable_computer::Result<()> {
+    research_v3_equivalence_command_impl(program, output, max_steps, layers, attention_mode)
+}
+
 #[cfg(feature = "onnx-export")]
 fn research_v2_step_command_impl(
     program: &Path,
@@ -3692,6 +3818,223 @@ fn research_v2_matrix_command_impl(
     Ok(())
 }
 
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn research_v3_equivalence_command_impl(
+    program: &Path,
+    output: &Path,
+    max_steps: usize,
+    layers: usize,
+    attention_mode: Attention2DMode,
+) -> llm_provable_computer::Result<()> {
+    if max_steps < 1 {
+        return Err(VmError::InvalidConfig(
+            "research-v3-equivalence requires max_steps >= 1".to_string(),
+        ));
+    }
+
+    let bundle = load_research_v2_spec_bundle(
+        STATEMENT_V3_EQUIVALENCE_SPEC_PATH,
+        STATEMENT_V3_EQUIVALENCE_ARTIFACT_SCHEMA_PATH,
+    )?;
+    let model = compile_model(program, layers, attention_mode)?;
+    let export_dir = ScopedTempDir::new("research-v3-equivalence")?;
+    let onnx_metadata = export_program_onnx(&model, export_dir.path())?;
+    let device = Default::default();
+    let burn_model = BurnTransformerVm::<CliBurnBackend>::from_compiled(&model, &device)?;
+
+    let mut transformer = ExecutionRuntime::new(model.clone(), max_steps);
+    let mut native = NativeInterpreter::new(
+        model.program().clone(),
+        model.config().attention_mode.clone(),
+        max_steps,
+    );
+    let mut burn = BurnExecutionRuntime::new(burn_model, device, max_steps);
+    let mut onnx = OnnxExecutionRuntime::from_export_dir(export_dir.path(), max_steps)?;
+
+    let verification = verify_engines(&mut [&mut transformer, &mut native, &mut burn, &mut onnx])?;
+
+    let engine_names = verification
+        .engines
+        .iter()
+        .map(|engine| engine.name.clone())
+        .collect::<Vec<_>>();
+    let verified_transformer = verification.engines.first().ok_or_else(|| {
+        VmError::InvalidConfig("research-v3-equivalence missing transformer result".to_string())
+    })?;
+    let verified_native = verification.engines.get(1).ok_or_else(|| {
+        VmError::InvalidConfig("research-v3-equivalence missing native result".to_string())
+    })?;
+    let verified_burn = verification.engines.get(2).ok_or_else(|| {
+        VmError::InvalidConfig("research-v3-equivalence missing burn result".to_string())
+    })?;
+    let verified_onnx = verification.engines.get(3).ok_or_else(|| {
+        VmError::InvalidConfig("research-v3-equivalence missing ONNX result".to_string())
+    })?;
+    let engines = vec![
+        research_v3_engine_summary(
+            &verified_transformer.name,
+            transformer.trace(),
+            transformer.events(),
+            &verified_transformer.result,
+        )?,
+        research_v3_engine_summary(
+            &verified_native.name,
+            native.trace(),
+            native.events(),
+            &verified_native.result,
+        )?,
+        research_v3_engine_summary(
+            &verified_burn.name,
+            burn.trace(),
+            burn.events(),
+            &verified_burn.result,
+        )?,
+        research_v3_engine_summary(
+            &verified_onnx.name,
+            onnx.trace(),
+            onnx.events(),
+            &verified_onnx.result,
+        )?,
+    ];
+    let rule_witnesses = research_v3_rule_witnesses(transformer.events(), &engine_names)?;
+    let engine_summaries_hash = hash_json_hex(&engines)?;
+    let rule_witnesses_hash = hash_json_hex(&rule_witnesses)?;
+
+    let artifact = ResearchV3EquivalenceArtifact {
+        statement_version: bundle.statement_version.clone(),
+        semantic_scope: bundle.semantic_scope.clone(),
+        relation_format: RESEARCH_V3_RELATION_FORMAT.to_string(),
+        fixed_point_profile: bundle.fixed_point_profile.clone(),
+        onnx_op_subset_version: bundle.onnx_op_subset_version.clone(),
+        onnx_op_subset_size: bundle.onnx_op_subset_size,
+        program_path: program.display().to_string(),
+        requested_max_steps: max_steps,
+        checked_steps: verification.checked_steps,
+        // Artifact construction is reached only after verify_engines accepts the full lockstep run.
+        matched: true,
+        engines,
+        rule_witnesses,
+        limitations: vec![
+            "e-graph saturation is not implemented in this artifact".to_string(),
+            "SMT-backed rewrite synthesis is not implemented in this artifact".to_string(),
+            "randomized opaque-kernel testing is not implemented in this artifact".to_string(),
+            "the current evidence is deterministic multi-engine lockstep over the shipped VM/ONNX/Burn/native surfaces".to_string(),
+        ],
+        commitments: ResearchV3EquivalenceCommitments {
+            hash_function: RESEARCH_V2_HASH_FUNCTION.to_string(),
+            statement_spec_hash: bundle.statement_spec_hash,
+            fixed_point_spec_hash: bundle.fixed_point_spec_hash,
+            onnx_op_subset_hash: bundle.onnx_op_subset_hash,
+            artifact_schema_hash: bundle.artifact_schema_hash,
+            program_hash: hash_json_hex(model.program())?,
+            transformer_config_hash: hash_json_hex(model.config())?,
+            onnx_metadata_hash: hash_json_hex(&onnx_metadata)?,
+            engine_summaries_hash,
+            rule_witnesses_hash,
+        },
+    };
+
+    let bytes = serde_json::to_vec_pretty(&artifact)
+        .map_err(|err| VmError::Serialization(format!("failed to serialize artifact: {err}")))?;
+    fs::write(output, bytes)?;
+
+    println!("research_v3_equivalence_artifact: {}", output.display());
+    println!("statement_version: {}", artifact.statement_version);
+    println!("semantic_scope: {}", artifact.semantic_scope);
+    println!("relation_format: {}", artifact.relation_format);
+    println!("checked_steps: {}", artifact.checked_steps);
+    println!("matched: {}", artifact.matched);
+    println!("engines: {}", engine_names.join(","));
+    println!("rule_witnesses: {}", artifact.rule_witnesses.len());
+    println!(
+        "commitment_engine_summaries_hash: {}",
+        artifact.commitments.engine_summaries_hash
+    );
+    println!(
+        "commitment_rule_witnesses_hash: {}",
+        artifact.commitments.rule_witnesses_hash
+    );
+
+    Ok(())
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn research_v3_engine_summary(
+    name: &str,
+    trace: &[MachineState],
+    events: &[ExecutionTraceEntry],
+    result: &ExecutionResult,
+) -> llm_provable_computer::Result<ResearchV3EngineSummary> {
+    let canonical_events = research_v3_canonical_events(events)?;
+    Ok(ResearchV3EngineSummary {
+        name: name.to_string(),
+        steps: result.steps,
+        halted: result.halted,
+        trace_len: trace.len(),
+        events_len: events.len(),
+        final_state: result.final_state.clone(),
+        trace_hash: hash_json_hex(trace)?,
+        event_relation_hash: hash_json_hex(&canonical_events)?,
+        final_state_hash: hash_json_hex(&result.final_state)?,
+    })
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn research_v3_canonical_events(
+    events: &[ExecutionTraceEntry],
+) -> llm_provable_computer::Result<Vec<ResearchV3CanonicalEvent>> {
+    events
+        .iter()
+        .map(|event| {
+            Ok(ResearchV3CanonicalEvent {
+                step: event.step,
+                layer_idx: event.layer_idx,
+                instruction: event.instruction.to_string(),
+                state_before_hash: hash_json_hex(&event.state_before)?,
+                state_after_hash: hash_json_hex(&event.state_after)?,
+            })
+        })
+        .collect()
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn research_v3_rule_witnesses(
+    reference_events: &[ExecutionTraceEntry],
+    engine_names: &[String],
+) -> llm_provable_computer::Result<Vec<ResearchV3RuleWitness>> {
+    reference_events
+        .iter()
+        .map(|event| {
+            let instruction = event.instruction.to_string();
+            Ok(ResearchV3RuleWitness {
+                step: event.step,
+                rule_id: research_v3_rule_id(&instruction),
+                relation: "same-instruction-same-state-transition".to_string(),
+                instruction,
+                participating_engines: engine_names.to_vec(),
+                state_before_hash: hash_json_hex(&event.state_before)?,
+                state_after_hash: hash_json_hex(&event.state_after)?,
+                validation: ResearchV3RuleValidation {
+                    differential_lockstep: true,
+                    egraph_status: "not-attempted".to_string(),
+                    smt_status: "not-attempted".to_string(),
+                    randomized_testing_status: "not-attempted".to_string(),
+                },
+            })
+        })
+        .collect()
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn research_v3_rule_id(instruction: &str) -> String {
+    let opcode = instruction
+        .split_whitespace()
+        .next()
+        .unwrap_or("unknown")
+        .to_ascii_lowercase();
+    format!("lockstep-{opcode}-v1")
+}
+
 #[cfg(feature = "onnx-export")]
 fn enforce_research_v2_trace_mismatch_policy(
     matched: bool,
@@ -3972,6 +4315,20 @@ fn research_v2_matrix_command_impl(
     Err(feature_required_error(
         "`research-v2-matrix`",
         &["onnx-export"],
+    ))
+}
+
+#[cfg(not(all(feature = "burn-model", feature = "onnx-export")))]
+fn research_v3_equivalence_command_impl(
+    _program: &Path,
+    _output: &Path,
+    _max_steps: usize,
+    _layers: usize,
+    _attention_mode: Attention2DMode,
+) -> llm_provable_computer::Result<()> {
+    Err(feature_required_error(
+        "`research-v3-equivalence`",
+        &["burn-model", "onnx-export"],
     ))
 }
 
@@ -4467,6 +4824,7 @@ fn needs_run_subcommand(first_arg: &str) -> bool {
                 | "research-v2-step"
                 | "research-v2-trace"
                 | "research-v2-matrix"
+                | "research-v3-equivalence"
                 | "help"
         )
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3658,6 +3658,23 @@ fn cli_reports_missing_onnx_feature_for_research_v2_matrix() {
         ));
 }
 
+#[cfg(not(all(feature = "burn-model", feature = "onnx-export")))]
+#[test]
+fn cli_reports_missing_features_for_research_v3_equivalence() {
+    let output_path = unique_temp_dir("cli-research-v3-equivalence-missing").with_extension("json");
+    let mut command = tvm_command();
+    command
+        .arg("research-v3-equivalence")
+        .arg("programs/addition.tvm")
+        .arg("-o")
+        .arg(&output_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`research-v3-equivalence` requires the `burn-model` and `onnx-export` features",
+        ));
+}
+
 #[cfg(feature = "onnx-export")]
 #[test]
 fn cli_supports_export_onnx_command() {
@@ -3867,6 +3884,93 @@ fn cli_supports_research_v2_matrix_command() {
             .and_then(serde_json::Value::as_u64),
         Some(0)
     );
+    let _ = std::fs::remove_file(output_path);
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+#[test]
+fn cli_supports_research_v3_equivalence_command() {
+    let output_path = unique_temp_dir("cli-research-v3-equivalence").with_extension("json");
+    let mut command = tvm_command();
+    command
+        .arg("research-v3-equivalence")
+        .arg("programs/addition.tvm")
+        .arg("-o")
+        .arg(&output_path)
+        .arg("--max-steps")
+        .arg("8")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "semantic_scope: multi_engine_trace_equivalence_kernel_with_rule_witnesses",
+        ))
+        .stdout(predicate::str::contains(
+            "relation_format: multi-engine-trace-relation-v1-no-egraph-no-smt",
+        ))
+        .stdout(predicate::str::contains(
+            "engines: transformer,native,burn,onnx/tract",
+        ))
+        .stdout(predicate::str::contains("rule_witnesses: 3"))
+        .stdout(predicate::str::contains("matched: true"));
+
+    assert!(output_path.exists());
+    let artifact_bytes = std::fs::read(&output_path).expect("artifact");
+    let artifact_json: serde_json::Value =
+        serde_json::from_slice(&artifact_bytes).expect("artifact json");
+    validate_json_against_schema(
+        &artifact_json,
+        "spec/statement-v3-equivalence-kernel.schema.json",
+    );
+    assert_research_v2_spec_commitments(
+        &artifact_json,
+        "spec/statement-v3-equivalence-kernel-research.json",
+        "spec/statement-v3-equivalence-kernel.schema.json",
+    );
+    assert_eq!(
+        artifact_json
+            .get("statement_version")
+            .and_then(serde_json::Value::as_str),
+        Some("statement-v3-research-draft")
+    );
+    assert_eq!(
+        artifact_json
+            .get("engines")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::len),
+        Some(4)
+    );
+    let engine_names = artifact_json
+        .get("engines")
+        .and_then(serde_json::Value::as_array)
+        .expect("engines")
+        .iter()
+        .map(|entry| {
+            entry
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .expect("engine name")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        engine_names,
+        ["transformer", "native", "burn", "onnx/tract"]
+    );
+    assert_eq!(
+        artifact_json
+            .get("rule_witnesses")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::len),
+        Some(3)
+    );
+    assert!(artifact_json
+        .get("limitations")
+        .and_then(serde_json::Value::as_array)
+        .expect("limitations")
+        .iter()
+        .any(|entry| entry
+            .as_str()
+            .is_some_and(|text| text.contains("SMT-backed rewrite synthesis is not implemented"))));
+
     let _ = std::fs::remove_file(output_path);
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3706,6 +3706,8 @@ fn cli_reports_missing_features_for_research_v3_equivalence() {
         .stderr(predicate::str::contains(
             "`research-v3-equivalence` requires the `burn-model` and `onnx-export` features",
         ));
+
+    assert!(!output_path.exists());
 }
 
 #[cfg(feature = "onnx-export")]
@@ -4027,19 +4029,43 @@ fn cli_supports_research_v3_equivalence_command() {
             assert_eq!(hash.len(), 64);
         }
     }
-    assert!(artifact_json
+    let limitations = artifact_json
         .get("limitations")
         .and_then(serde_json::Value::as_array)
-        .expect("limitations")
-        .iter()
-        .any(|entry| entry
-            .as_str()
-            .is_some_and(|text| text.contains("SMT-backed rewrite synthesis is not implemented"))));
+        .expect("limitations");
+    for expected in [
+        "Emerge reproduction",
+        "e-graph saturation",
+        "SMT-backed rewrite synthesis",
+        "randomized opaque-kernel testing",
+        "recursive accumulation",
+        "cryptographic implementation-equivalence proof",
+    ] {
+        assert!(
+            limitations
+                .iter()
+                .any(|entry| entry.as_str().is_some_and(|text| text.contains(expected))),
+            "missing limitation covering {expected}",
+        );
+    }
     let mut tampered = artifact_json.clone();
     tampered["commitments"]["engine_summaries_hash"] = serde_json::Value::String("0".repeat(64));
     assert!(
         std::panic::catch_unwind(|| assert_research_v3_runtime_commitments(&tampered)).is_err()
     );
+
+    let mut malformed_hash = artifact_json.clone();
+    malformed_hash["commitments"]["relation_format_hash"] =
+        serde_json::Value::String("not-a-blake2b-hash".to_string());
+    malformed_hash["rule_witnesses"][0]["state_before_hashes"]["transformer"] =
+        serde_json::Value::String("also-not-a-blake2b-hash".to_string());
+    assert!(std::panic::catch_unwind(|| {
+        validate_json_against_schema(
+            &malformed_hash,
+            "spec/statement-v3-equivalence-kernel.schema.json",
+        );
+    })
+    .is_err());
 
     let mut missing_relation = artifact_json.clone();
     missing_relation

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -318,6 +318,39 @@ fn assert_research_v2_spec_commitments(
     );
 }
 
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn hash_json_value(value: &serde_json::Value) -> String {
+    blake2b_256_hex(&serde_json::to_vec(value).expect("json hash payload"))
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn assert_research_v3_runtime_commitments(artifact: &serde_json::Value) {
+    let expected_relation_format_hash =
+        hash_json_value(artifact.get("relation_format").expect("relation_format"));
+    let expected_limitations_hash =
+        hash_json_value(artifact.get("limitations").expect("limitations"));
+    let expected_engine_summaries_hash = hash_json_value(artifact.get("engines").expect("engines"));
+    let expected_rule_witnesses_hash =
+        hash_json_value(artifact.get("rule_witnesses").expect("rule_witnesses"));
+
+    assert_eq!(
+        json_string_at(artifact, &["commitments", "relation_format_hash"]),
+        Some(expected_relation_format_hash.as_str())
+    );
+    assert_eq!(
+        json_string_at(artifact, &["commitments", "limitations_hash"]),
+        Some(expected_limitations_hash.as_str())
+    );
+    assert_eq!(
+        json_string_at(artifact, &["commitments", "engine_summaries_hash"]),
+        Some(expected_engine_summaries_hash.as_str())
+    );
+    assert_eq!(
+        json_string_at(artifact, &["commitments", "rule_witnesses_hash"]),
+        Some(expected_rule_witnesses_hash.as_str())
+    );
+}
+
 #[test]
 fn cli_runs_addition_program() {
     let mut command = tvm_command();
@@ -3909,9 +3942,7 @@ fn cli_supports_research_v3_equivalence_command() {
         ))
         .stdout(predicate::str::contains(
             "engines: transformer,native,burn,onnx/tract",
-        ))
-        .stdout(predicate::str::contains("rule_witnesses: 3"))
-        .stdout(predicate::str::contains("matched: true"));
+        ));
 
     assert!(output_path.exists());
     let artifact_bytes = std::fs::read(&output_path).expect("artifact");
@@ -3926,6 +3957,8 @@ fn cli_supports_research_v3_equivalence_command() {
         "spec/statement-v3-equivalence-kernel-research.json",
         "spec/statement-v3-equivalence-kernel.schema.json",
     );
+    assert_research_v3_runtime_commitments(&artifact_json);
+    assert!(artifact_json.get("matched").is_none());
     assert_eq!(
         artifact_json
             .get("statement_version")
@@ -3955,13 +3988,45 @@ fn cli_supports_research_v3_equivalence_command() {
         engine_names,
         ["transformer", "native", "burn", "onnx/tract"]
     );
+    let checked_steps = artifact_json
+        .get("checked_steps")
+        .and_then(serde_json::Value::as_u64)
+        .expect("checked_steps") as usize;
     assert_eq!(
         artifact_json
             .get("rule_witnesses")
             .and_then(serde_json::Value::as_array)
             .map(Vec::len),
-        Some(3)
+        Some(checked_steps)
     );
+    let rule_witnesses = artifact_json
+        .get("rule_witnesses")
+        .and_then(serde_json::Value::as_array)
+        .expect("rule_witnesses");
+    let first_witness = rule_witnesses.first().expect("first rule witness");
+    assert_eq!(
+        first_witness
+            .get("participating_engines")
+            .and_then(serde_json::Value::as_array)
+            .expect("participating engines")
+            .iter()
+            .map(|entry| entry.as_str().expect("engine name"))
+            .collect::<Vec<_>>(),
+        ["transformer", "native", "burn", "onnx/tract"]
+    );
+    for hashes_key in ["state_before_hashes", "state_after_hashes"] {
+        let hashes = first_witness
+            .get(hashes_key)
+            .and_then(serde_json::Value::as_object)
+            .expect("per-engine witness hashes");
+        for engine_name in ["transformer", "native", "burn", "onnx/tract"] {
+            let hash = hashes
+                .get(engine_name)
+                .and_then(serde_json::Value::as_str)
+                .expect("per-engine state hash");
+            assert_eq!(hash.len(), 64);
+        }
+    }
     assert!(artifact_json
         .get("limitations")
         .and_then(serde_json::Value::as_array)
@@ -3970,8 +4035,48 @@ fn cli_supports_research_v3_equivalence_command() {
         .any(|entry| entry
             .as_str()
             .is_some_and(|text| text.contains("SMT-backed rewrite synthesis is not implemented"))));
+    let mut tampered = artifact_json.clone();
+    tampered["commitments"]["engine_summaries_hash"] = serde_json::Value::String("0".repeat(64));
+    assert!(
+        std::panic::catch_unwind(|| assert_research_v3_runtime_commitments(&tampered)).is_err()
+    );
+
+    let mut missing_relation = artifact_json.clone();
+    missing_relation
+        .as_object_mut()
+        .expect("artifact object")
+        .remove("relation_format");
+    assert!(std::panic::catch_unwind(|| {
+        validate_json_against_schema(
+            &missing_relation,
+            "spec/statement-v3-equivalence-kernel.schema.json",
+        );
+    })
+    .is_err());
 
     let _ = std::fs::remove_file(output_path);
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+#[test]
+fn cli_research_v3_equivalence_rejects_zero_max_steps() {
+    let output_path =
+        unique_temp_dir("cli-research-v3-equivalence-zero-steps").with_extension("json");
+    let mut command = tvm_command();
+    command
+        .arg("research-v3-equivalence")
+        .arg("programs/addition.tvm")
+        .arg("-o")
+        .arg(&output_path)
+        .arg("--max-steps")
+        .arg("0")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "research-v3-equivalence requires max_steps >= 1",
+        ));
+
+    assert!(!output_path.exists());
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]


### PR DESCRIPTION
## Summary
- add `research-v3-equivalence`, a bounded multi-engine equivalence-kernel artifact over transformer, native, Burn, and ONNX/Tract lockstep execution
- add the statement-v3 research spec/schema and bind engine summaries, rule witnesses, relation format, and limitation strings with hash commitments
- include the artifact in the repro bundle and document the claim boundary in `README.md` / `docs/reproducibility.md`
- add the exact full-feature CLI test to the local `full` and `hardening` merge gates without expanding the cheaper smoke gate

## Claim Discipline
This does not claim Emerge reproduction, e-graph saturation, SMT-backed rewrite synthesis, randomized opaque-kernel testing, recursive accumulation, or a cryptographic implementation-equivalence proof. It is the first bounded engineering layer: deterministic lockstep equivalence evidence plus rule-witness metadata over the shipped VM/ONNX/Burn/native surfaces.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `python3 -m json.tool spec/statement-v3-equivalence-kernel-research.json >/dev/null`
- `python3 -m json.tool spec/statement-v3-equivalence-kernel.schema.json >/dev/null`
- `bash -n scripts/local_merge_gate.sh`
- latest-check-run dedupe probe via `gh api ... check-runs` and `jq`
- `bash -n scripts/generate_repro_bundle.sh`
- `cargo check -q --bin tvm`
- `cargo test -q --test cli cli_reports_missing_features_for_research_v3_equivalence -- --exact`
- `cargo test -q --bin tvm cli_dispatch_tests::intervalized_phase25_commands_do_not_fall_back_to_run_shorthand -- --exact`
- `cargo test -q --features full --test cli cli_supports_research_v3_equivalence_command -- --exact`
- `cargo test -q --features full --test cli research_v3_equivalence`
- direct sanity run: `cargo run -q --features full --bin tvm -- research-v3-equivalence programs/addition.tvm -o <tmp>.json --max-steps 8`

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

The local merge gate now deduplicates superseded GitHub check runs by newest timestamp before evaluating failures, matching the PR-body-edit behavior observed on this PR. The full-feature tests validate the emitted artifact against `spec/statement-v3-equivalence-kernel.schema.json`, check spec and runtime commitment hashes, confirm all four exact runtime names (`transformer,native,burn,onnx/tract`), assert rule-witness count equals `checked_steps`, verify per-engine witness state hashes, confirm the always-true `matched` field is absent, cover the `--max-steps 0` rejection path, and assert the explicit non-SMT limitation string is present. This PR adds a deterministic multi-engine differential oracle; the Kani/formal-kernel impact is reviewed as not applicable because no verifier kernel or formal contract is changed.

## Review Hardening Added After Bot Feedback
- rule witnesses now carry per-engine `state_before_hashes` and `state_after_hashes`, not only transformer-side hashes
- `engine_summaries_hash` and `rule_witnesses_hash` are computed from the JSON projection verifiers can recompute from the emitted artifact
- `relation_format_hash` and `limitations_hash` are included in the v3 commitments
- the v3 artifact no longer exposes an always-true `matched` field
- artifact output uses write-sync-rename atomic file publication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a research-v3 equivalence command to produce multi-engine equivalence artifacts (transformer/native/Burn/ONNX lockstep) with configurable step limits and artifact output.

* **Documentation**
  * Added research-v3 proof surface, claim boundaries, canonical spec guidance, and updated reproducibility guidance; bundles now include research-v3 artifacts alongside research-v2.

* **Tests**
  * Added positive and negative CLI tests for feature gating, validation, artifact schema, commitment/hash checks, and corruption scenarios.

* **Chores**
  * Integrated research-v3 outputs into reproducibility bundle generation and local smoke-test flow; improved CI check-run evidence aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
