### PR TITLE
[codex] Add research v3 semantics registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,8 +766,8 @@ cargo run --features full --bin tvm -- research-v3-equivalence programs/addition
 This checks transformer, native, Burn, and ONNX/Tract runtimes in lockstep,
 then emits a JSON artifact with engine summaries, deterministic rule witnesses,
 and commitment hashes. The artifact also carries a frontend/runtime semantics
-registry that separates currently checked lanes from research-watch lanes such
-as `torch.export`, ExecuTorch, StableHLO, IREE, ONNX-MLIR, TVM Unity
+registry that separates currently checked lanes from these research-watch lanes:
+`torch.export`, ExecuTorch, StableHLO, IREE, ONNX-MLIR, TVM Unity
 (`tvm-unity`), vLLM, SGLang, and egg/Emerge-style equivalence. It intentionally
 does not claim support for those watch lanes, e-graph saturation, SMT-backed
 rewrite synthesis, randomized

--- a/README.md
+++ b/README.md
@@ -765,14 +765,18 @@ cargo run --features full --bin tvm -- research-v3-equivalence programs/addition
 
 This checks transformer, native, Burn, and ONNX/Tract runtimes in lockstep,
 then emits a JSON artifact with engine summaries, deterministic rule witnesses,
-and commitment hashes. It intentionally does not claim e-graph saturation,
-SMT-backed rewrite synthesis, randomized opaque-kernel testing, or a
-cryptographic implementation-equivalence proof.
+and commitment hashes. The artifact also carries a frontend/runtime semantics
+registry that separates currently checked lanes from research-watch lanes such
+as `torch.export`, ExecuTorch, StableHLO, IREE, ONNX-MLIR, vLLM, SGLang, and
+egg/Emerge-style equivalence. It intentionally does not claim support for those
+watch lanes, e-graph saturation, SMT-backed rewrite synthesis, randomized
+opaque-kernel testing, or a cryptographic implementation-equivalence proof.
 
 Canonical research-v3 spec files:
 
 - `spec/statement-v3-equivalence-kernel-research.json`
 - `spec/statement-v3-equivalence-kernel.schema.json`
+- `spec/frontend-runtime-semantics-registry-v1.json`
 
 ### Reproducibility Bundle
 

--- a/README.md
+++ b/README.md
@@ -767,10 +767,9 @@ This checks transformer, native, Burn, and ONNX/Tract runtimes in lockstep,
 then emits a JSON artifact with engine summaries, deterministic rule witnesses,
 and commitment hashes. The artifact also carries a frontend/runtime semantics
 registry that separates currently checked lanes from these research-watch lanes:
-`torch.export`, ExecuTorch, StableHLO, IREE, ONNX-MLIR, TVM Unity
-(`tvm-unity`), vLLM, SGLang, and egg/Emerge-style equivalence. It intentionally
-does not claim support for those watch lanes, e-graph saturation, SMT-backed
-rewrite synthesis, randomized
+`torch-export`, `executorch`, `stablehlo`, `iree`, `onnx-mlir`, `tvm-unity`,
+`vllm`, `sglang`, and `egg-emerge`. It intentionally does not claim support for
+those watch lanes, e-graph saturation, SMT-backed rewrite synthesis, randomized
 opaque-kernel testing, or a cryptographic implementation-equivalence proof.
 
 Canonical research-v3 spec files:

--- a/README.md
+++ b/README.md
@@ -767,9 +767,10 @@ This checks transformer, native, Burn, and ONNX/Tract runtimes in lockstep,
 then emits a JSON artifact with engine summaries, deterministic rule witnesses,
 and commitment hashes. The artifact also carries a frontend/runtime semantics
 registry that separates currently checked lanes from research-watch lanes such
-as `torch.export`, ExecuTorch, StableHLO, IREE, ONNX-MLIR, TVM, vLLM, SGLang,
-and egg/Emerge-style equivalence. It intentionally does not claim support for
-those watch lanes, e-graph saturation, SMT-backed rewrite synthesis, randomized
+as `torch.export`, ExecuTorch, StableHLO, IREE, ONNX-MLIR, TVM Unity
+(`tvm-unity`), vLLM, SGLang, and egg/Emerge-style equivalence. It intentionally
+does not claim support for those watch lanes, e-graph saturation, SMT-backed
+rewrite synthesis, randomized
 opaque-kernel testing, or a cryptographic implementation-equivalence proof.
 
 Canonical research-v3 spec files:

--- a/README.md
+++ b/README.md
@@ -767,9 +767,9 @@ This checks transformer, native, Burn, and ONNX/Tract runtimes in lockstep,
 then emits a JSON artifact with engine summaries, deterministic rule witnesses,
 and commitment hashes. The artifact also carries a frontend/runtime semantics
 registry that separates currently checked lanes from research-watch lanes such
-as `torch.export`, ExecuTorch, StableHLO, IREE, ONNX-MLIR, vLLM, SGLang, and
-egg/Emerge-style equivalence. It intentionally does not claim support for those
-watch lanes, e-graph saturation, SMT-backed rewrite synthesis, randomized
+as `torch.export`, ExecuTorch, StableHLO, IREE, ONNX-MLIR, TVM, vLLM, SGLang,
+and egg/Emerge-style equivalence. It intentionally does not claim support for
+those watch lanes, e-graph saturation, SMT-backed rewrite synthesis, randomized
 opaque-kernel testing, or a cryptographic implementation-equivalence proof.
 
 Canonical research-v3 spec files:

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -61,7 +61,8 @@ The script writes to `compiled/repro-bundle/` by default and produces:
 - `*.proof.json`: STARK proofs for representative programs
 - `research-v2-*.json`: semantic equivalence certificates (step/trace/matrix)
 - `research-v3-*.json`: multi-engine equivalence-kernel artifacts with explicit
-  non-e-graph/non-SMT limits
+  non-e-graph/non-SMT limits and a frontend/runtime semantics registry for
+  implemented versus research-watch lanes
 - `*.out` / `*.err`: full stdout/stderr capture for each command
 
 The accumulation bundle script writes under
@@ -93,9 +94,11 @@ produces:
   used as evidence and regression checks, but are not yet part of the STARK
   claim relation.
 - `research-v3` artifacts extend that evidence to transformer/native/Burn/ONNX
-  lockstep plus rule witnesses, but they are not e-graph saturation results,
-  SMT rewrite proofs, randomized opaque-kernel tests, or cryptographic
-  implementation-equivalence proofs.
+  lockstep plus rule witnesses. Their frontend/runtime semantics registry keeps
+  PyTorch `torch.export`, ExecuTorch, StableHLO, IREE, ONNX-MLIR, TVM, vLLM,
+  SGLang, and egg/Emerge-style paths as explicit research-watch lanes; these
+  artifacts are not e-graph saturation results, SMT rewrite proofs, randomized
+  opaque-kernel tests, or cryptographic implementation-equivalence proofs.
 
 ## Paper figure regeneration
 

--- a/spec/frontend-runtime-semantics-registry-v1.json
+++ b/spec/frontend-runtime-semantics-registry-v1.json
@@ -1,0 +1,125 @@
+{
+  "registry_version": "frontend-runtime-semantics-registry-v1",
+  "semantic_scope": "research_v3_frontend_runtime_claim_boundary",
+  "purpose": "Machine-readable boundary for frontend, runtime, compiler, and equivalence-method lanes considered by the research-v3 artifact.",
+  "implemented_statuses": [
+    "implemented"
+  ],
+  "non_claim_statuses": [
+    "research_watch",
+    "not_implemented"
+  ],
+  "lanes": [
+    {
+      "lane_id": "transformer-vm",
+      "ecosystem": "provable-transformer-vm",
+      "role": "reference execution runtime",
+      "status": "implemented",
+      "artifact_binding": "Included in research-v3-equivalence engine summaries and rule witnesses.",
+      "claim_boundary": "Deterministic local execution is checked in lockstep for the selected .tvm program and max_steps."
+    },
+    {
+      "lane_id": "native-isa",
+      "ecosystem": "provable-transformer-vm",
+      "role": "native interpreter runtime",
+      "status": "implemented",
+      "artifact_binding": "Included in research-v3-equivalence engine summaries and rule witnesses.",
+      "claim_boundary": "Native interpreter execution is checked in lockstep for the selected .tvm program and max_steps."
+    },
+    {
+      "lane_id": "burn",
+      "ecosystem": "Burn",
+      "role": "tensor runtime cross-check",
+      "status": "implemented",
+      "artifact_binding": "Included in research-v3-equivalence engine summaries and rule witnesses when the burn-model feature is enabled.",
+      "claim_boundary": "Burn execution is checked in lockstep for the selected .tvm program and max_steps."
+    },
+    {
+      "lane_id": "onnx-tract",
+      "ecosystem": "ONNX/Tract",
+      "role": "exported graph runtime cross-check",
+      "status": "implemented",
+      "artifact_binding": "Included in research-v3-equivalence engine summaries and rule witnesses when the onnx-export feature is enabled.",
+      "claim_boundary": "The exported ONNX/Tract execution is checked in lockstep for the selected .tvm program and max_steps."
+    },
+    {
+      "lane_id": "torch-export",
+      "ecosystem": "PyTorch",
+      "role": "future canonical graph-capture candidate",
+      "status": "research_watch",
+      "artifact_binding": "No artifact binding in research-v3-equivalence.",
+      "claim_boundary": "This artifact does not ingest, hash, or execute torch.export ExportedProgram graphs."
+    },
+    {
+      "lane_id": "executorch",
+      "ecosystem": "PyTorch ExecuTorch",
+      "role": "future stateful decode-runtime reference",
+      "status": "research_watch",
+      "artifact_binding": "No artifact binding in research-v3-equivalence.",
+      "claim_boundary": "This artifact does not execute ExecuTorch programs or compare ExecuTorch stateful runtime traces."
+    },
+    {
+      "lane_id": "stablehlo",
+      "ecosystem": "OpenXLA StableHLO",
+      "role": "future compiler-portability IR candidate",
+      "status": "research_watch",
+      "artifact_binding": "No artifact binding in research-v3-equivalence.",
+      "claim_boundary": "This artifact does not export, import, hash, or execute StableHLO modules."
+    },
+    {
+      "lane_id": "iree",
+      "ecosystem": "IREE",
+      "role": "future compiler/runtime cross-check candidate",
+      "status": "research_watch",
+      "artifact_binding": "No artifact binding in research-v3-equivalence.",
+      "claim_boundary": "This artifact does not compile or execute IREE modules."
+    },
+    {
+      "lane_id": "onnx-mlir",
+      "ecosystem": "ONNX-MLIR",
+      "role": "future ONNX native-code lowering candidate",
+      "status": "research_watch",
+      "artifact_binding": "No artifact binding in research-v3-equivalence.",
+      "claim_boundary": "This artifact does not lower ONNX through ONNX-MLIR or compare native-code outputs."
+    },
+    {
+      "lane_id": "tvm-unity",
+      "ecosystem": "Apache TVM Unity",
+      "role": "future optimization/codegen experiment candidate",
+      "status": "research_watch",
+      "artifact_binding": "No artifact binding in research-v3-equivalence.",
+      "claim_boundary": "This artifact does not compile or execute TVM artifacts."
+    },
+    {
+      "lane_id": "vllm",
+      "ecosystem": "vLLM",
+      "role": "future decode scheduling and prefix-cache semantics reference",
+      "status": "research_watch",
+      "artifact_binding": "No artifact binding in research-v3-equivalence.",
+      "claim_boundary": "This artifact does not ingest vLLM graphs, KV-cache block traces, or prefix-cache schedules."
+    },
+    {
+      "lane_id": "sglang",
+      "ecosystem": "SGLang",
+      "role": "future decode scheduling and prefix-cache semantics reference",
+      "status": "research_watch",
+      "artifact_binding": "No artifact binding in research-v3-equivalence.",
+      "claim_boundary": "This artifact does not ingest SGLang runtime traces, prefix-cache schedules, or prefill/decode disaggregation traces."
+    },
+    {
+      "lane_id": "egg-emerge",
+      "ecosystem": "egg/Emerge-style equivalence",
+      "role": "future e-graph and rewrite-validation method candidate",
+      "status": "research_watch",
+      "artifact_binding": "No artifact binding in research-v3-equivalence beyond explicit non-claim limitations.",
+      "claim_boundary": "This artifact does not run equality saturation, infer rewrite rules, perform SMT validation, or run randomized opaque-kernel testing."
+    }
+  ],
+  "global_non_claims": [
+    "No torch.export ingestion or ExportedProgram hashing is implemented.",
+    "No ExecuTorch runtime execution is implemented.",
+    "No StableHLO, IREE, ONNX-MLIR, or TVM compiler-runtime lane is implemented.",
+    "No vLLM or SGLang decode-scheduler trace is implemented.",
+    "No egg/Emerge-style e-graph saturation, SMT rewrite validation, or randomized opaque-kernel testing is implemented."
+  ]
+}

--- a/spec/statement-v3-equivalence-kernel.schema.json
+++ b/spec/statement-v3-equivalence-kernel.schema.json
@@ -15,6 +15,7 @@
     "checked_steps",
     "engines",
     "rule_witnesses",
+    "frontend_runtime_semantics_registry",
     "limitations",
     "commitments"
   ],
@@ -37,6 +38,9 @@
       "type": "array",
       "items": { "$ref": "#/$defs/rule_witness" }
     },
+    "frontend_runtime_semantics_registry": {
+      "$ref": "#/$defs/frontend_runtime_semantics_registry"
+    },
     "limitations": {
       "type": "array",
       "minItems": 1,
@@ -50,6 +54,7 @@
         "fixed_point_spec_hash",
         "onnx_op_subset_hash",
         "artifact_schema_hash",
+        "frontend_runtime_semantics_registry_hash",
         "relation_format_hash",
         "limitations_hash",
         "program_hash",
@@ -64,6 +69,9 @@
         "fixed_point_spec_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "onnx_op_subset_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "artifact_schema_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "frontend_runtime_semantics_registry_hash": {
+          "$ref": "#/$defs/hash_blake2b_256_hex"
+        },
         "relation_format_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "limitations_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "program_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
@@ -81,6 +89,64 @@
       "minLength": 64,
       "maxLength": 64,
       "pattern": "^[0-9a-f]{64}$"
+    },
+    "frontend_runtime_semantics_registry": {
+      "type": "object",
+      "required": [
+        "registry_version",
+        "semantic_scope",
+        "purpose",
+        "implemented_statuses",
+        "non_claim_statuses",
+        "lanes",
+        "global_non_claims"
+      ],
+      "properties": {
+        "registry_version": { "const": "frontend-runtime-semantics-registry-v1" },
+        "semantic_scope": { "const": "research_v3_frontend_runtime_claim_boundary" },
+        "purpose": { "type": "string" },
+        "implemented_statuses": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "const": "implemented" }
+        },
+        "non_claim_statuses": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "enum": ["research_watch", "not_implemented"] }
+        },
+        "lanes": {
+          "type": "array",
+          "minItems": 8,
+          "items": { "$ref": "#/$defs/frontend_runtime_lane" }
+        },
+        "global_non_claims": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "frontend_runtime_lane": {
+      "type": "object",
+      "required": [
+        "lane_id",
+        "ecosystem",
+        "role",
+        "status",
+        "artifact_binding",
+        "claim_boundary"
+      ],
+      "properties": {
+        "lane_id": { "type": "string", "minLength": 1 },
+        "ecosystem": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["implemented", "research_watch", "not_implemented"] },
+        "artifact_binding": { "type": "string", "minLength": 1 },
+        "claim_boundary": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
     },
     "engine_summary": {
       "type": "object",

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -3847,6 +3847,11 @@ fn research_v3_equivalence_command_impl(
         STATEMENT_V3_EQUIVALENCE_SPEC_PATH,
         STATEMENT_V3_EQUIVALENCE_ARTIFACT_SCHEMA_PATH,
     )?;
+    let frontend_runtime_semantics_registry =
+        read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH)?;
+    validate_frontend_runtime_semantics_registry(&frontend_runtime_semantics_registry)?;
+    let frontend_runtime_semantics_registry_hash =
+        hash_json_hex(&frontend_runtime_semantics_registry)?;
     let model = compile_model(program, layers, attention_mode)?;
     let export_dir = ScopedTempDir::new("research-v3-equivalence")?;
     let onnx_metadata = export_program_onnx(&model, export_dir.path())?;
@@ -3915,11 +3920,6 @@ fn research_v3_equivalence_command_impl(
     ])?;
     let engine_summaries_hash = hash_json_projection_hex(&engines)?;
     let rule_witnesses_hash = hash_json_projection_hex(&rule_witnesses)?;
-    let frontend_runtime_semantics_registry =
-        read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH)?;
-    validate_frontend_runtime_semantics_registry(&frontend_runtime_semantics_registry)?;
-    let frontend_runtime_semantics_registry_hash =
-        hash_json_hex(&frontend_runtime_semantics_registry)?;
     let relation_format = RESEARCH_V3_RELATION_FORMAT.to_string();
     let limitations = vec![
         "Emerge reproduction is not implemented in this artifact".to_string(),
@@ -4736,10 +4736,19 @@ mod tests {
             .get_mut("lanes")
             .and_then(serde_json::Value::as_array_mut)
             .expect("registry lanes");
-        let duplicate = lanes.first().expect("first lane").clone();
+        let duplicate_lane_id = "transformer-vm";
+        let duplicate = lanes
+            .iter()
+            .find(|lane| {
+                lane.get("lane_id").and_then(serde_json::Value::as_str) == Some(duplicate_lane_id)
+            })
+            .unwrap_or_else(|| panic!("missing {duplicate_lane_id} lane"))
+            .clone();
         lanes.push(duplicate);
         let err = validate_frontend_runtime_semantics_registry(&registry).unwrap_err();
-        assert!(err.to_string().contains("duplicate lane_id transformer-vm"));
+        assert!(err
+            .to_string()
+            .contains(&format!("duplicate lane_id {duplicate_lane_id}")));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4459,6 +4459,43 @@ fn validate_frontend_runtime_semantics_registry(
                 "frontend runtime semantics registry missing lanes array".to_string(),
             )
         })?;
+
+    let implemented_allowlist = ["transformer-vm", "native-isa", "burn", "onnx-tract"];
+    let mut lane_statuses = std::collections::BTreeMap::new();
+    for lane in lanes {
+        let lane_id = lane
+            .get("lane_id")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                VmError::InvalidConfig(
+                    "frontend runtime semantics registry lane missing lane_id".to_string(),
+                )
+            })?;
+        let status = lane
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                VmError::InvalidConfig(format!(
+                    "frontend runtime semantics registry lane {lane_id} missing status"
+                ))
+            })?;
+        if !matches!(status, "implemented" | "research_watch" | "not_implemented") {
+            return Err(VmError::InvalidConfig(format!(
+                "frontend runtime semantics registry lane {lane_id} has invalid status {status}"
+            )));
+        }
+        if status == "implemented" && !implemented_allowlist.contains(&lane_id) {
+            return Err(VmError::InvalidConfig(format!(
+                "frontend runtime semantics registry unexpected implemented lane {lane_id}"
+            )));
+        }
+        if lane_statuses.insert(lane_id, status).is_some() {
+            return Err(VmError::InvalidConfig(format!(
+                "frontend runtime semantics registry duplicate lane_id {lane_id}"
+            )));
+        }
+    }
+
     for (lane_id, expected_status) in [
         ("transformer-vm", "implemented"),
         ("native-isa", "implemented"),
@@ -4474,15 +4511,11 @@ fn validate_frontend_runtime_semantics_registry(
         ("sglang", "research_watch"),
         ("egg-emerge", "research_watch"),
     ] {
-        let status = lanes
-            .iter()
-            .find(|lane| lane.get("lane_id").and_then(serde_json::Value::as_str) == Some(lane_id))
-            .and_then(|lane| lane.get("status").and_then(serde_json::Value::as_str))
-            .ok_or_else(|| {
-                VmError::InvalidConfig(format!(
-                    "frontend runtime semantics registry missing lane {lane_id}"
-                ))
-            })?;
+        let status = lane_statuses.get(lane_id).copied().ok_or_else(|| {
+            VmError::InvalidConfig(format!(
+                "frontend runtime semantics registry missing lane {lane_id}"
+            ))
+        })?;
         if status != expected_status {
             return Err(VmError::InvalidConfig(format!(
                 "frontend runtime semantics registry lane {lane_id} status mismatch: expected {expected_status}, got {status}"
@@ -4671,6 +4704,42 @@ mod tests {
         torch_export["status"] = serde_json::Value::String("not_implemented".to_string());
         let err = validate_frontend_runtime_semantics_registry(&registry).unwrap_err();
         assert!(err.to_string().contains("torch-export status mismatch"));
+    }
+
+    #[test]
+    fn frontend_runtime_registry_validation_rejects_unknown_implemented_lane() {
+        let mut registry =
+            read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH).expect("registry json");
+        registry
+            .get_mut("lanes")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("registry lanes")
+            .push(serde_json::json!({
+                "lane_id": "surprise-runtime",
+                "ecosystem": "surprise",
+                "role": "unexpected implementation claim",
+                "status": "implemented",
+                "artifact_binding": "No artifact binding in research-v3-equivalence.",
+                "claim_boundary": "This lane must not be claimed without an allowlist update."
+            }));
+        let err = validate_frontend_runtime_semantics_registry(&registry).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("unexpected implemented lane surprise-runtime"));
+    }
+
+    #[test]
+    fn frontend_runtime_registry_validation_rejects_duplicate_lane_id() {
+        let mut registry =
+            read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH).expect("registry json");
+        let lanes = registry
+            .get_mut("lanes")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("registry lanes");
+        let duplicate = lanes.first().expect("first lane").clone();
+        lanes.push(duplicate);
+        let err = validate_frontend_runtime_semantics_registry(&registry).unwrap_err();
+        assert!(err.to_string().contains("duplicate lane_id transformer-vm"));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -709,6 +709,11 @@ const STATEMENT_V3_EQUIVALENCE_SPEC_PATH: &str =
 const FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH: &str =
     "spec/frontend-runtime-semantics-registry-v1.json";
 #[cfg(feature = "onnx-export")]
+const FRONTEND_RUNTIME_SEMANTICS_REGISTRY_VERSION: &str = "frontend-runtime-semantics-registry-v1";
+#[cfg(feature = "onnx-export")]
+const FRONTEND_RUNTIME_SEMANTICS_REGISTRY_SCOPE: &str =
+    "research_v3_frontend_runtime_claim_boundary";
+#[cfg(feature = "onnx-export")]
 const FIXED_POINT_SPEC_PATH: &str = "spec/fixed-point-semantics-v2.json";
 #[cfg(feature = "onnx-export")]
 const ONNX_OP_SUBSET_SPEC_PATH: &str = "spec/onnx-op-subset-v2.json";
@@ -3912,6 +3917,7 @@ fn research_v3_equivalence_command_impl(
     let rule_witnesses_hash = hash_json_projection_hex(&rule_witnesses)?;
     let frontend_runtime_semantics_registry =
         read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH)?;
+    validate_frontend_runtime_semantics_registry(&frontend_runtime_semantics_registry)?;
     let frontend_runtime_semantics_registry_hash =
         hash_json_hex(&frontend_runtime_semantics_registry)?;
     let relation_format = RESEARCH_V3_RELATION_FORMAT.to_string();
@@ -4412,6 +4418,82 @@ fn read_repo_json_value(relative_path: &str) -> llm_provable_computer::Result<se
 }
 
 #[cfg(feature = "onnx-export")]
+fn validate_frontend_runtime_semantics_registry(
+    registry: &serde_json::Value,
+) -> llm_provable_computer::Result<()> {
+    let version = registry
+        .get("registry_version")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            VmError::InvalidConfig(
+                "frontend runtime semantics registry missing registry_version".to_string(),
+            )
+        })?;
+    if version != FRONTEND_RUNTIME_SEMANTICS_REGISTRY_VERSION {
+        return Err(VmError::InvalidConfig(format!(
+            "frontend runtime semantics registry version mismatch: expected {}, got {}",
+            FRONTEND_RUNTIME_SEMANTICS_REGISTRY_VERSION, version
+        )));
+    }
+
+    let scope = registry
+        .get("semantic_scope")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            VmError::InvalidConfig(
+                "frontend runtime semantics registry missing semantic_scope".to_string(),
+            )
+        })?;
+    if scope != FRONTEND_RUNTIME_SEMANTICS_REGISTRY_SCOPE {
+        return Err(VmError::InvalidConfig(format!(
+            "frontend runtime semantics registry scope mismatch: expected {}, got {}",
+            FRONTEND_RUNTIME_SEMANTICS_REGISTRY_SCOPE, scope
+        )));
+    }
+
+    let lanes = registry
+        .get("lanes")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            VmError::InvalidConfig(
+                "frontend runtime semantics registry missing lanes array".to_string(),
+            )
+        })?;
+    for (lane_id, expected_status) in [
+        ("transformer-vm", "implemented"),
+        ("native-isa", "implemented"),
+        ("burn", "implemented"),
+        ("onnx-tract", "implemented"),
+        ("torch-export", "research_watch"),
+        ("executorch", "research_watch"),
+        ("stablehlo", "research_watch"),
+        ("iree", "research_watch"),
+        ("onnx-mlir", "research_watch"),
+        ("tvm-unity", "research_watch"),
+        ("vllm", "research_watch"),
+        ("sglang", "research_watch"),
+        ("egg-emerge", "research_watch"),
+    ] {
+        let status = lanes
+            .iter()
+            .find(|lane| lane.get("lane_id").and_then(serde_json::Value::as_str) == Some(lane_id))
+            .and_then(|lane| lane.get("status").and_then(serde_json::Value::as_str))
+            .ok_or_else(|| {
+                VmError::InvalidConfig(format!(
+                    "frontend runtime semantics registry missing lane {lane_id}"
+                ))
+            })?;
+        if status != expected_status {
+            return Err(VmError::InvalidConfig(format!(
+                "frontend runtime semantics registry lane {lane_id} status mismatch: expected {expected_status}, got {status}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "onnx-export")]
 fn hash_json_hex<T: Serialize + ?Sized>(value: &T) -> llm_provable_computer::Result<String> {
     let bytes = serde_json::to_vec(value).map_err(|err| {
         VmError::Serialization(format!("failed to serialize hash payload: {err}"))
@@ -4558,6 +4640,37 @@ mod tests {
         assert!(suite.contains(&PathBuf::from("programs/dot_product.tvm")));
         assert!(suite.contains(&PathBuf::from("programs/matmul_2x2.tvm")));
         assert!(suite.contains(&PathBuf::from("programs/single_neuron.tvm")));
+    }
+
+    #[test]
+    fn frontend_runtime_registry_validation_rejects_missing_version() {
+        let mut registry =
+            read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH).expect("registry json");
+        registry
+            .as_object_mut()
+            .expect("registry object")
+            .remove("registry_version");
+        let err = validate_frontend_runtime_semantics_registry(&registry).unwrap_err();
+        assert!(err.to_string().contains("missing registry_version"));
+    }
+
+    #[test]
+    fn frontend_runtime_registry_validation_rejects_lane_status_drift() {
+        let mut registry =
+            read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH).expect("registry json");
+        let lanes = registry
+            .get_mut("lanes")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("registry lanes");
+        let torch_export = lanes
+            .iter_mut()
+            .find(|lane| {
+                lane.get("lane_id").and_then(serde_json::Value::as_str) == Some("torch-export")
+            })
+            .expect("torch-export lane");
+        torch_export["status"] = serde_json::Value::String("not_implemented".to_string());
+        let err = validate_frontend_runtime_semantics_registry(&registry).unwrap_err();
+        assert!(err.to_string().contains("torch-export status mismatch"));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -706,6 +706,9 @@ const STATEMENT_V2_MATRIX_SPEC_PATH: &str = "spec/statement-v2-matrix-research.j
 const STATEMENT_V3_EQUIVALENCE_SPEC_PATH: &str =
     "spec/statement-v3-equivalence-kernel-research.json";
 #[cfg(feature = "onnx-export")]
+const FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH: &str =
+    "spec/frontend-runtime-semantics-registry-v1.json";
+#[cfg(feature = "onnx-export")]
 const FIXED_POINT_SPEC_PATH: &str = "spec/fixed-point-semantics-v2.json";
 #[cfg(feature = "onnx-export")]
 const ONNX_OP_SUBSET_SPEC_PATH: &str = "spec/onnx-op-subset-v2.json";
@@ -928,6 +931,7 @@ struct ResearchV3EquivalenceCommitments {
     fixed_point_spec_hash: String,
     onnx_op_subset_hash: String,
     artifact_schema_hash: String,
+    frontend_runtime_semantics_registry_hash: String,
     relation_format_hash: String,
     limitations_hash: String,
     program_hash: String,
@@ -951,6 +955,7 @@ struct ResearchV3EquivalenceArtifact {
     checked_steps: usize,
     engines: Vec<ResearchV3EngineSummary>,
     rule_witnesses: Vec<ResearchV3RuleWitness>,
+    frontend_runtime_semantics_registry: serde_json::Value,
     limitations: Vec<String>,
     commitments: ResearchV3EquivalenceCommitments,
 }
@@ -3905,6 +3910,10 @@ fn research_v3_equivalence_command_impl(
     ])?;
     let engine_summaries_hash = hash_json_projection_hex(&engines)?;
     let rule_witnesses_hash = hash_json_projection_hex(&rule_witnesses)?;
+    let frontend_runtime_semantics_registry =
+        read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH)?;
+    let frontend_runtime_semantics_registry_hash =
+        hash_json_hex(&frontend_runtime_semantics_registry)?;
     let relation_format = RESEARCH_V3_RELATION_FORMAT.to_string();
     let limitations = vec![
         "Emerge reproduction is not implemented in this artifact".to_string(),
@@ -3930,6 +3939,7 @@ fn research_v3_equivalence_command_impl(
         checked_steps: verification.checked_steps,
         engines,
         rule_witnesses,
+        frontend_runtime_semantics_registry,
         limitations,
         commitments: ResearchV3EquivalenceCommitments {
             hash_function: RESEARCH_V2_HASH_FUNCTION.to_string(),
@@ -3937,6 +3947,7 @@ fn research_v3_equivalence_command_impl(
             fixed_point_spec_hash: bundle.fixed_point_spec_hash,
             onnx_op_subset_hash: bundle.onnx_op_subset_hash,
             artifact_schema_hash: bundle.artifact_schema_hash,
+            frontend_runtime_semantics_registry_hash,
             relation_format_hash,
             limitations_hash,
             program_hash: hash_json_hex(model.program())?,
@@ -3961,6 +3972,12 @@ fn research_v3_equivalence_command_impl(
     println!(
         "commitment_engine_summaries_hash: {}",
         artifact.commitments.engine_summaries_hash
+    );
+    println!(
+        "commitment_frontend_runtime_semantics_registry_hash: {}",
+        artifact
+            .commitments
+            .frontend_runtime_semantics_registry_hash
     );
     println!(
         "commitment_rule_witnesses_hash: {}",
@@ -4385,6 +4402,13 @@ fn read_repo_file(relative_path: &str) -> llm_provable_computer::Result<Vec<u8>>
     fs::read(&path).map_err(|io_error| {
         VmError::InvalidConfig(format!("failed to read {}: {io_error}", path.display()))
     })
+}
+
+#[cfg(feature = "onnx-export")]
+fn read_repo_json_value(relative_path: &str) -> llm_provable_computer::Result<serde_json::Value> {
+    let bytes = read_repo_file(relative_path)?;
+    serde_json::from_slice(&bytes)
+        .map_err(|err| VmError::Serialization(format!("failed to parse {relative_path}: {err}")))
 }
 
 #[cfg(feature = "onnx-export")]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4707,6 +4707,45 @@ mod tests {
     }
 
     #[test]
+    fn frontend_runtime_registry_validation_rejects_watch_lane_promoted_to_implemented() {
+        let mut registry =
+            read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH).expect("registry json");
+        let lanes = registry
+            .get_mut("lanes")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("registry lanes");
+        let torch_export = lanes
+            .iter_mut()
+            .find(|lane| {
+                lane.get("lane_id").and_then(serde_json::Value::as_str) == Some("torch-export")
+            })
+            .expect("torch-export lane");
+        torch_export["status"] = serde_json::Value::String("implemented".to_string());
+        let err = validate_frontend_runtime_semantics_registry(&registry).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("unexpected implemented lane torch-export"));
+    }
+
+    #[test]
+    fn frontend_runtime_registry_validation_rejects_missing_required_lane() {
+        let mut registry =
+            read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH).expect("registry json");
+        let lanes = registry
+            .get_mut("lanes")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("registry lanes");
+        let before_len = lanes.len();
+        lanes
+            .retain(|lane| lane.get("lane_id").and_then(serde_json::Value::as_str) != Some("vllm"));
+        assert_eq!(lanes.len(), before_len - 1, "expected to remove vllm lane");
+        let err = validate_frontend_runtime_semantics_registry(&registry).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("frontend runtime semantics registry missing lane vllm"));
+    }
+
+    #[test]
     fn frontend_runtime_registry_validation_rejects_unknown_implemented_lane() {
         let mut registry =
             read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH).expect("registry json");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4012,10 +4012,10 @@ fn cli_supports_research_v3_equivalence_command() {
         "sglang",
         "egg-emerge",
     ] {
-        assert_ne!(
+        assert_eq!(
             research_v3_registry_lane_status(frontend_runtime_registry, lane_id),
-            "implemented",
-            "research-watch lane {lane_id} must not be claimed as implemented"
+            "research_watch",
+            "expected research-watch lane {lane_id} to remain research_watch"
         );
     }
     assert_eq!(
@@ -4110,6 +4110,13 @@ fn cli_supports_research_v3_equivalence_command() {
     assert!(
         std::panic::catch_unwind(|| assert_research_v3_runtime_commitments(&tampered)).is_err()
     );
+    let mut tampered_registry_hash = artifact_json.clone();
+    tampered_registry_hash["commitments"]["frontend_runtime_semantics_registry_hash"] =
+        serde_json::Value::String("0".repeat(64));
+    assert!(std::panic::catch_unwind(|| {
+        assert_research_v3_runtime_commitments(&tampered_registry_hash)
+    })
+    .is_err());
 
     let mut malformed_hash = artifact_json.clone();
     malformed_hash["commitments"]["relation_format_hash"] =

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -329,6 +329,11 @@ fn assert_research_v3_runtime_commitments(artifact: &serde_json::Value) {
         hash_json_value(artifact.get("relation_format").expect("relation_format"));
     let expected_limitations_hash =
         hash_json_value(artifact.get("limitations").expect("limitations"));
+    let expected_frontend_runtime_semantics_registry_hash = hash_json_value(
+        artifact
+            .get("frontend_runtime_semantics_registry")
+            .expect("frontend runtime semantics registry"),
+    );
     let expected_engine_summaries_hash = hash_json_value(artifact.get("engines").expect("engines"));
     let expected_rule_witnesses_hash =
         hash_json_value(artifact.get("rule_witnesses").expect("rule_witnesses"));
@@ -342,6 +347,13 @@ fn assert_research_v3_runtime_commitments(artifact: &serde_json::Value) {
         Some(expected_limitations_hash.as_str())
     );
     assert_eq!(
+        json_string_at(
+            artifact,
+            &["commitments", "frontend_runtime_semantics_registry_hash"]
+        ),
+        Some(expected_frontend_runtime_semantics_registry_hash.as_str())
+    );
+    assert_eq!(
         json_string_at(artifact, &["commitments", "engine_summaries_hash"]),
         Some(expected_engine_summaries_hash.as_str())
     );
@@ -349,6 +361,18 @@ fn assert_research_v3_runtime_commitments(artifact: &serde_json::Value) {
         json_string_at(artifact, &["commitments", "rule_witnesses_hash"]),
         Some(expected_rule_witnesses_hash.as_str())
     );
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn research_v3_registry_lane_status<'a>(registry: &'a serde_json::Value, lane_id: &str) -> &'a str {
+    registry
+        .get("lanes")
+        .and_then(serde_json::Value::as_array)
+        .expect("registry lanes")
+        .iter()
+        .find(|lane| lane.get("lane_id").and_then(serde_json::Value::as_str) == Some(lane_id))
+        .and_then(|lane| lane.get("status").and_then(serde_json::Value::as_str))
+        .unwrap_or_else(|| panic!("missing registry lane {lane_id}"))
 }
 
 #[test]
@@ -3961,6 +3985,39 @@ fn cli_supports_research_v3_equivalence_command() {
     );
     assert_research_v3_runtime_commitments(&artifact_json);
     assert!(artifact_json.get("matched").is_none());
+    let frontend_runtime_registry = artifact_json
+        .get("frontend_runtime_semantics_registry")
+        .expect("frontend runtime semantics registry");
+    assert_eq!(
+        frontend_runtime_registry
+            .get("registry_version")
+            .and_then(serde_json::Value::as_str),
+        Some("frontend-runtime-semantics-registry-v1")
+    );
+    for lane_id in ["transformer-vm", "native-isa", "burn", "onnx-tract"] {
+        assert_eq!(
+            research_v3_registry_lane_status(frontend_runtime_registry, lane_id),
+            "implemented",
+            "expected current lane {lane_id} to be implemented"
+        );
+    }
+    for lane_id in [
+        "torch-export",
+        "executorch",
+        "stablehlo",
+        "iree",
+        "onnx-mlir",
+        "tvm-unity",
+        "vllm",
+        "sglang",
+        "egg-emerge",
+    ] {
+        assert_ne!(
+            research_v3_registry_lane_status(frontend_runtime_registry, lane_id),
+            "implemented",
+            "research-watch lane {lane_id} must not be claimed as implemented"
+        );
+    }
     assert_eq!(
         artifact_json
             .get("statement_version")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -364,15 +364,34 @@ fn assert_research_v3_runtime_commitments(artifact: &serde_json::Value) {
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
-fn research_v3_registry_lane_status<'a>(registry: &'a serde_json::Value, lane_id: &str) -> &'a str {
-    registry
+fn research_v3_registry_lane_statuses(
+    registry: &serde_json::Value,
+) -> std::collections::BTreeMap<&str, &str> {
+    let lanes = registry
         .get("lanes")
         .and_then(serde_json::Value::as_array)
-        .expect("registry lanes")
-        .iter()
-        .find(|lane| lane.get("lane_id").and_then(serde_json::Value::as_str) == Some(lane_id))
-        .and_then(|lane| lane.get("status").and_then(serde_json::Value::as_str))
-        .unwrap_or_else(|| panic!("missing registry lane {lane_id}"))
+        .expect("registry lanes");
+    let mut lane_statuses = std::collections::BTreeMap::new();
+    for lane in lanes {
+        let lane_id = lane
+            .get("lane_id")
+            .and_then(serde_json::Value::as_str)
+            .expect("registry lane_id");
+        let status = lane
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .expect("registry lane status");
+        assert!(
+            lane_statuses.insert(lane_id, status).is_none(),
+            "registry contains duplicate lane_id {lane_id}"
+        );
+    }
+    assert_eq!(
+        lane_statuses.len(),
+        lanes.len(),
+        "registry contains duplicate lane_id entries"
+    );
+    lane_statuses
 }
 
 #[test]
@@ -3994,30 +4013,26 @@ fn cli_supports_research_v3_equivalence_command() {
             .and_then(serde_json::Value::as_str),
         Some("frontend-runtime-semantics-registry-v1")
     );
-    for lane_id in ["transformer-vm", "native-isa", "burn", "onnx-tract"] {
-        assert_eq!(
-            research_v3_registry_lane_status(frontend_runtime_registry, lane_id),
-            "implemented",
-            "expected current lane {lane_id} to be implemented"
-        );
-    }
-    for lane_id in [
-        "torch-export",
-        "executorch",
-        "stablehlo",
-        "iree",
-        "onnx-mlir",
-        "tvm-unity",
-        "vllm",
-        "sglang",
-        "egg-emerge",
-    ] {
-        assert_eq!(
-            research_v3_registry_lane_status(frontend_runtime_registry, lane_id),
-            "research_watch",
-            "expected research-watch lane {lane_id} to remain research_watch"
-        );
-    }
+    let expected_registry_lanes = std::collections::BTreeMap::from([
+        ("transformer-vm", "implemented"),
+        ("native-isa", "implemented"),
+        ("burn", "implemented"),
+        ("onnx-tract", "implemented"),
+        ("torch-export", "research_watch"),
+        ("executorch", "research_watch"),
+        ("stablehlo", "research_watch"),
+        ("iree", "research_watch"),
+        ("onnx-mlir", "research_watch"),
+        ("tvm-unity", "research_watch"),
+        ("vllm", "research_watch"),
+        ("sglang", "research_watch"),
+        ("egg-emerge", "research_watch"),
+    ]);
+    assert_eq!(
+        research_v3_registry_lane_statuses(frontend_runtime_registry),
+        expected_registry_lanes,
+        "frontend/runtime semantics registry lane boundary drifted"
+    );
     assert_eq!(
         artifact_json
             .get("statement_version")


### PR DESCRIPTION
## Summary

Adds a machine-readable frontend/runtime semantics registry to the `research-v3-equivalence` artifact so the current claim boundary is explicit and hash-committed.

Implemented lanes remain limited to the existing checked engines:

- `transformer-vm`
- `native-isa`
- `burn`
- `onnx-tract`

Research-watch lanes are recorded but not claimed as implemented:

- `torch-export`
- `executorch`
- `stablehlo`
- `iree`
- `onnx-mlir`
- `tvm-unity`
- `vllm`
- `sglang`
- `egg-emerge`

## Why

The next Emerge-style equivalence work should not pretend that PyTorch/ExecuTorch/StableHLO/IREE/vLLM/SGLang/e-graph support already exists. This PR makes that boundary falsifiable in the artifact schema, the generated artifact, and CLI tests.

## Validation

- [x] `python3 -m json.tool spec/frontend-runtime-semantics-registry-v1.json >/dev/null`
- [x] `python3 -m json.tool spec/statement-v3-equivalence-kernel.schema.json >/dev/null`
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] `cargo test -q --features full --test cli cli_supports_research_v3_equivalence_command -- --exact`
- [x] `cargo test -q --test cli cli_reports_missing_features_for_research_v3_equivalence -- --exact`
- [x] `cargo test -q --features full --test cli research_v3_equivalence`
- [x] `cargo run -q --features full --bin tvm -- research-v3-equivalence programs/addition.tvm -o "$tmp_artifact" --max-steps 8` plus direct registry inspection
- [x] `cargo test -q --features full --test cli`
- [x] `cargo test -q --lib`
- [x] `cargo test -q --workspace --doc`
- [x] `cargo test -q --test assembly`
- [x] `cargo test -q --test e2e`
- [x] `cargo test -q --test interpreter`
- [x] `cargo test -q --test runtime`
- [x] `cargo test -q --test vanillastark_smoke`
- [x] `cargo +nightly-2025-07-14 test -q --features stwo-backend --lib stwo_backend::decoding::tests::phase28_aggregated_chained_folded_intervalized_state_relation_rejects_header_mismatch_before_nested_checks -- --exact`
- [x] `cargo +nightly-2025-07-14 test -q --features stwo-backend --lib stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_tampered_commitment -- --exact`
- [x] `scripts/local_merge_gate.sh --repo omarespejel/provable-transformer-vm --pr 106 --mode smoke` local commands completed, then stopped on the PR-body hardening contract before this body update

## Hardening

- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Not applicable notes:

```text
This is an artifact/schema/CLI claim-boundary change. The regression coverage asserts the new registry commitment hash recomputes from the artifact, the schema requires the registry and hash, and current versus research-watch lanes are checked so future runtime claims cannot silently flip to implemented. No new untrusted parser beyond an in-repo JSON spec file was added; the CLI fails if that file cannot be parsed. Kani/formal kernels are not changed.
```

## Local hardening note

`limactl` is available and currently has `bitsage-isolation` running. I did not run this branch inside Lima before opening the PR; after AI review comments settle, the repo merge gate should be run on the exact PR head and can be repeated in Lima if we decide this artifact/schema-only change needs Linux parity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a frontend/runtime semantics registry that distinguishes "currently checked" lanes from "research-watch" lanes
  * Enumerated watch lanes (torch.export, ExecuTorch, StableHLO, IREE, ONNX-MLIR, TVM, vLLM, SGLang, egg/Emerge)
  * Registry includes an integrity-checked, tamper-detectable hash commitment

* **Documentation**
  * Updated README and reproducibility docs to describe the registry, lane statuses, canonical spec reference, and clarified non-goals

* **Tests**
  * Extended validation and commitment checks to cover registry contents, lane statuses, and tamper cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->