### PR TITLE
[codex] Harden workflow audits and merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - "tests/**"
       - "programs/**"
       - "scripts/*.sh"
+      - "scripts/**/*.sh"
       - "docs/engineering/hardening-policy.md"
       - "zizmor.yml"
       - "Cargo.toml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,21 @@ jobs:
       - name: Validate local merge gate script
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck
-          scripts/run_shellcheck_suite.sh
+          sudo apt-get install -y shellcheck python3-pip
+          bash scripts/run_shellcheck_suite.sh
+
+      - name: Run workflow audit when workflow surfaces change
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if ! git diff --name-only "$BASE_SHA...$HEAD_SHA" -- .github/workflows/ zizmor.yml | grep -q .; then
+            echo "workflow audit not required for this PR"
+            exit 0
+          fi
+          python3 -m pip install --user uv
+          export PATH="$HOME/.local/bin:$PATH"
+          bash scripts/run_workflow_audit_suite.sh
 
       - name: Run lightweight regression smoke
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,13 @@ permissions:
 on:
   pull_request:
     paths:
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
       - "src/**/*.rs"
       - "tests/**"
       - "programs/**"
-      - "scripts/local_merge_gate.sh"
-      - "docs/hardening-policy.md"
+      - "scripts/*.sh"
+      - "docs/engineering/hardening-policy.md"
+      - "zizmor.yml"
       - "Cargo.toml"
       - "Cargo.lock"
   workflow_dispatch:
@@ -25,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -47,8 +50,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck
-          bash -n scripts/local_merge_gate.sh
-          shellcheck scripts/local_merge_gate.sh
+          scripts/run_shellcheck_suite.sh
 
       - name: Run lightweight regression smoke
         run: |
@@ -73,6 +75,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -129,6 +133,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -137,7 +143,7 @@ jobs:
 
       - name: Install Python
         if: matrix.needs_python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -192,12 +198,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -248,6 +256,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Read fuzz toolchain
         id: fuzz-toolchain
@@ -268,10 +278,12 @@ jobs:
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Install cargo-fuzz
-        run: cargo +${{ steps.fuzz-toolchain.outputs.channel }} install cargo-fuzz --version 0.13.1 --locked
+        env:
+          FUZZ_TOOLCHAIN: ${{ steps.fuzz-toolchain.outputs.channel }}
+        run: cargo +"$FUZZ_TOOLCHAIN" install cargo-fuzz --version 0.13.1 --locked
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -279,4 +291,8 @@ jobs:
         run: python3 scripts/fuzz/generate_decoding_fuzz_corpus.py
 
       - name: Run fuzz smoke
-        run: cargo +${{ steps.fuzz-toolchain.outputs.channel }} fuzz run ${{ matrix.target }} ${{ matrix.corpus }} -- -runs=32
+        env:
+          FUZZ_TOOLCHAIN: ${{ steps.fuzz-toolchain.outputs.channel }}
+          FUZZ_TARGET: ${{ matrix.target }}
+          FUZZ_CORPUS: ${{ matrix.corpus }}
+        run: cargo +"$FUZZ_TOOLCHAIN" fuzz run "$FUZZ_TARGET" "$FUZZ_CORPUS" -- -runs=32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -58,7 +59,11 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if ! git diff --name-only "$BASE_SHA...$HEAD_SHA" -- .github/workflows/ zizmor.yml | grep -q .; then
+          changed_workflow_inputs="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- .github/workflows/ zizmor.yml)" || {
+            echo "workflow audit diff computation failed" >&2
+            exit 1
+          }
+          if [[ -z "$changed_workflow_inputs" ]]; then
             echo "workflow audit not required for this PR"
             exit 0
           fi

--- a/.github/workflows/formal-contracts.yml
+++ b/.github/workflows/formal-contracts.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9

--- a/.github/workflows/miri-sanitizers.yml
+++ b/.github/workflows/miri-sanitizers.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -44,6 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -53,12 +57,17 @@ jobs:
 
       - name: Read host target
         id: host-target
+        env:
+          HARDENING_TOOLCHAIN: ${{ env.HARDENING_TOOLCHAIN }}
         run: |
-          echo "target=$(rustc +${{ env.HARDENING_TOOLCHAIN }} -vV | awk '/^host: / { print $2 }')" >> "$GITHUB_OUTPUT"
+          echo "target=$(rustc +\"$HARDENING_TOOLCHAIN\" -vV | awk '/^host: / { print $2 }')" >> "$GITHUB_OUTPUT"
 
       - name: Install host target
+        env:
+          HARDENING_TOOLCHAIN: ${{ env.HARDENING_TOOLCHAIN }}
+          HOST_TARGET: ${{ steps.host-target.outputs.target }}
         run: |
-          rustup +${{ env.HARDENING_TOOLCHAIN }} target add ${{ steps.host-target.outputs.target }}
+          rustup +"$HARDENING_TOOLCHAIN" target add "$HOST_TARGET"
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
@@ -81,6 +90,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -51,38 +52,13 @@ jobs:
           rm -f "$CARGO_HOME/bin/cargo-mutants"
           cargo install cargo-mutants --version 27.0.0 --locked --force
 
-      - name: Build diff-scoped mutation input on pull requests
-        if: github.event_name == 'pull_request'
-        run: |
-          chmod +x scripts/run_mutation_suite.sh
-          git diff --no-ext-diff --unified=0 "origin/${{ github.base_ref }}...HEAD" -- \
-            src/stwo_backend/decoding.rs \
-            src/stwo_backend/shared_lookup_artifact.rs \
-            src/stwo_backend/arithmetic_subset_prover.rs > mutation.diff || true
-          if [[ -s mutation.diff ]]; then
-            echo "MUTATION_DIFF_FILE=$PWD/mutation.diff" >> "$GITHUB_ENV"
-          fi
-
-      - name: Run diff-scoped mutation slice on pull requests
-        if: github.event_name == 'pull_request' && env.MUTATION_DIFF_FILE != ''
-        run: |
-          chmod +x scripts/run_mutation_suite.sh
-          scripts/run_mutation_suite.sh
-
-      - name: Run mutation compile smoke when no target diff exists
-        if: github.event_name == 'pull_request' && env.MUTATION_DIFF_FILE == ''
-        run: |
-          chmod +x scripts/run_mutation_suite.sh
-          scripts/run_mutation_suite.sh --check
-
       - name: Run full targeted mutation suite
-        if: github.event_name != 'pull_request'
         run: |
           chmod +x scripts/run_mutation_suite.sh
           scripts/run_mutation_suite.sh
 
       - name: Upload mutation artifacts
-        if: always() && github.event_name != 'pull_request'
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: cargo-mutants-${{ matrix.label }}

--- a/.github/workflows/paper-preflight.yml
+++ b/.github/workflows/paper-preflight.yml
@@ -24,8 +24,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Run paper preflight checks
         run: |
           python3 scripts/paper/paper_preflight.py --repo-root .
-

--- a/.github/workflows/pr-hardening-contract.yml
+++ b/.github/workflows/pr-hardening-contract.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate PR hardening contract
         env:
@@ -66,7 +67,10 @@ jobs:
               "tests/",
               ".github/workflows/",
               "scripts/local_merge_gate.sh",
-              "docs/hardening-policy.md",
+              "scripts/run_",
+              "scripts/hardening_test_names.sh",
+              "docs/engineering/hardening-policy.md",
+              "zizmor.yml",
           )
 
           touches_trusted_core = any(

--- a/docs/engineering/hardening-policy.md
+++ b/docs/engineering/hardening-policy.md
@@ -86,6 +86,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 source "$HOME/.cargo/env"
 rustup toolchain install nightly-2025-07-14 --component miri,rust-src
 python3 -m pip install --user uv
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Then run the local commands above from the repository checkout mounted or cloned

--- a/docs/engineering/hardening-policy.md
+++ b/docs/engineering/hardening-policy.md
@@ -122,11 +122,11 @@ Available local command tiers:
   auditing and shellcheck, and the exact pinned-nightly `stwo-backend` smokes.
 - `--mode hardening`: runs the `full` tier, including the same conditional
   workflow auditing and shellcheck for `.github/workflows/**`, `zizmor.yml`,
-  and `scripts/**/*.sh`, plus diff-scoped mutation testing when the trusted-core
-  prover files change, curated fuzz smoke, UB checks, ASAN, Miri, and the
-  formal contract suite. The inherited whitespace gate is still scoped to the
-  committed PR delta, not the whole worktree. Prefer running this tier inside
-  Lima for Linux parity.
+  `scripts/*.sh`, and `scripts/**/*.sh`, plus diff-scoped mutation testing when
+  the trusted-core prover files change, curated fuzz smoke, UB checks, ASAN,
+  Miri, and the formal contract suite. The inherited whitespace gate is still
+  scoped to the committed PR delta, not the whole worktree. Prefer running this
+  tier inside Lima for Linux parity.
 - `--mode none`: only checks GitHub status, review-thread state, and the
   five-minute AI-review quiet window. Use this only after a prior evidence run
   for the same PR head SHA.

--- a/docs/engineering/hardening-policy.md
+++ b/docs/engineering/hardening-policy.md
@@ -120,11 +120,13 @@ Available local command tiers:
 - `--mode full`: runs the same PR-range whitespace and formatting hygiene, full
   library tests, integration tests, doctests, the same conditional workflow
   auditing and shellcheck, and the exact pinned-nightly `stwo-backend` smokes.
-- `--mode hardening`: runs the `full` tier plus workflow auditing, shellcheck,
-  diff-scoped mutation testing when the trusted-core prover files change,
-  curated fuzz smoke, UB checks, ASAN, Miri, and the formal contract suite.
-  The inherited whitespace gate is still scoped to the committed PR delta, not
-  the whole worktree. Prefer running this tier inside Lima for Linux parity.
+- `--mode hardening`: runs the `full` tier, including the same conditional
+  workflow auditing and shellcheck for `.github/workflows/**`, `zizmor.yml`,
+  and `scripts/**/*.sh`, plus diff-scoped mutation testing when the trusted-core
+  prover files change, curated fuzz smoke, UB checks, ASAN, Miri, and the
+  formal contract suite. The inherited whitespace gate is still scoped to the
+  committed PR delta, not the whole worktree. Prefer running this tier inside
+  Lima for Linux parity.
 - `--mode none`: only checks GitHub status, review-thread state, and the
   five-minute AI-review quiet window. Use this only after a prior evidence run
   for the same PR head SHA.

--- a/docs/engineering/hardening-policy.md
+++ b/docs/engineering/hardening-policy.md
@@ -45,6 +45,8 @@ RUSTUP_TOOLCHAIN=nightly-2025-07-14 cargo nextest run \
   --profile ci-stwo --no-fail-fast
 cargo fmt --check
 git diff --check
+scripts/run_shellcheck_suite.sh
+scripts/run_workflow_audit_suite.sh
 python3 scripts/fuzz/generate_decoding_fuzz_corpus.py
 FUZZ_TIME_PER_TARGET=20 scripts/run_fuzz_smoke_suite.sh
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh
@@ -79,10 +81,11 @@ Inside the VM:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y build-essential pkg-config libssl-dev git curl jq shellcheck
+sudo apt-get install -y build-essential pkg-config libssl-dev git curl jq shellcheck python3-pip
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 source "$HOME/.cargo/env"
 rustup toolchain install nightly-2025-07-14 --component miri,rust-src
+python3 -m pip install --user uv
 ```
 
 Then run the local commands above from the repository checkout mounted or cloned
@@ -108,17 +111,19 @@ Available local command tiers:
 
 - `--mode smoke`: default minimum gate for ordinary PRs. Runs PR-range
   whitespace hygiene as `git diff --check "$base_sha...$head_sha"`, `cargo fmt
-  --check`, the statement-spec contract, allowlisted integration smoke targets,
-  and exact pinned-nightly `stwo-backend` smokes for the Phase 28 aggregation
-  verifier, Phase 29 recursive-compression input contract, and non-heavy Phase
-  29 CLI artifact verification paths.
+  --check`, conditional workflow auditing and shellcheck when the PR touches
+  those surfaces, the statement-spec contract, allowlisted integration smoke
+  targets, and exact pinned-nightly `stwo-backend` smokes for the Phase 28
+  aggregation verifier, Phase 29 recursive-compression input contract, and
+  non-heavy Phase 29 CLI artifact verification paths.
 - `--mode full`: runs the same PR-range whitespace and formatting hygiene, full
-  library tests, integration tests, doctests, and the exact pinned-nightly
-  `stwo-backend` smokes.
-- `--mode hardening`: runs the `full` tier plus curated fuzz smoke, UB checks,
-  ASAN, Miri, and the formal contract suite. The inherited whitespace gate is
-  still scoped to the committed PR delta, not the whole worktree. Prefer
-  running this tier inside Lima for Linux parity.
+  library tests, integration tests, doctests, the same conditional workflow
+  auditing and shellcheck, and the exact pinned-nightly `stwo-backend` smokes.
+- `--mode hardening`: runs the `full` tier plus workflow auditing, shellcheck,
+  diff-scoped mutation testing when the trusted-core prover files change,
+  curated fuzz smoke, UB checks, ASAN, Miri, and the formal contract suite.
+  The inherited whitespace gate is still scoped to the committed PR delta, not
+  the whole worktree. Prefer running this tier inside Lima for Linux parity.
 - `--mode none`: only checks GitHub status, review-thread state, and the
   five-minute AI-review quiet window. Use this only after a prior evidence run
   for the same PR head SHA.

--- a/scripts/generate_article_artifacts.sh
+++ b/scripts/generate_article_artifacts.sh
@@ -8,6 +8,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OUT="$ROOT/docs/artifacts"
 mkdir -p "$OUT"
+GENERATED_ARTIFACTS=()
+
+record_artifact() {
+  GENERATED_ARTIFACTS+=("$1")
+}
 
 echo "=== Generating article artifacts ==="
 echo "Output directory: $OUT"
@@ -18,6 +23,7 @@ echo ""
 echo "--- addition: execution trace ---"
 cargo run --bin tvm -- run programs/addition.tvm --trace 2>/dev/null \
   > "$OUT/addition_execution.txt"
+record_artifact "$OUT/addition_execution.txt"
 cat "$OUT/addition_execution.txt"
 echo ""
 
@@ -25,12 +31,15 @@ echo "--- addition: prove-stark ---"
 cargo run --bin tvm -- prove-stark programs/addition.tvm \
   -o "$OUT/addition.proof.json" 2>/dev/null \
   > "$OUT/addition_prove_summary.txt"
+record_artifact "$OUT/addition.proof.json"
+record_artifact "$OUT/addition_prove_summary.txt"
 cat "$OUT/addition_prove_summary.txt"
 echo ""
 
 echo "--- addition: verify-stark ---"
 cargo run --bin tvm -- verify-stark "$OUT/addition.proof.json" 2>/dev/null \
   > "$OUT/addition_verify_summary.txt"
+record_artifact "$OUT/addition_verify_summary.txt"
 cat "$OUT/addition_verify_summary.txt"
 echo ""
 
@@ -39,6 +48,7 @@ echo ""
 echo "--- fibonacci: execution trace ---"
 cargo run --bin tvm -- run programs/fibonacci.tvm --trace 2>/dev/null \
   > "$OUT/fibonacci_execution.txt"
+record_artifact "$OUT/fibonacci_execution.txt"
 # Print only the summary (first lines before trace)
 head -20 "$OUT/fibonacci_execution.txt"
 echo ""
@@ -46,6 +56,7 @@ echo ""
 echo "--- fibonacci: verify-all (4 engines) ---"
 cargo run --features full --bin tvm -- run programs/fibonacci.tvm --verify-all 2>/dev/null \
   > "$OUT/fibonacci_verify_all.txt"
+record_artifact "$OUT/fibonacci_verify_all.txt"
 cat "$OUT/fibonacci_verify_all.txt"
 echo ""
 
@@ -53,12 +64,15 @@ echo "--- fibonacci: prove-stark ---"
 cargo run --bin tvm -- prove-stark programs/fibonacci.tvm \
   -o "$OUT/fibonacci.proof.json" 2>/dev/null \
   > "$OUT/fibonacci_prove_summary.txt"
+record_artifact "$OUT/fibonacci.proof.json"
+record_artifact "$OUT/fibonacci_prove_summary.txt"
 cat "$OUT/fibonacci_prove_summary.txt"
 echo ""
 
 echo "--- fibonacci: verify-stark ---"
 cargo run --bin tvm -- verify-stark "$OUT/fibonacci.proof.json" 2>/dev/null \
   > "$OUT/fibonacci_verify_summary.txt"
+record_artifact "$OUT/fibonacci_verify_summary.txt"
 cat "$OUT/fibonacci_verify_summary.txt"
 echo ""
 
@@ -67,6 +81,7 @@ echo ""
 echo "--- factorial_recursive: execution trace ---"
 cargo run --bin tvm -- run programs/factorial_recursive.tvm --trace 2>/dev/null \
   > "$OUT/factorial_execution.txt"
+record_artifact "$OUT/factorial_execution.txt"
 head -20 "$OUT/factorial_execution.txt"
 echo ""
 
@@ -74,12 +89,15 @@ echo "--- factorial_recursive: prove-stark ---"
 cargo run --bin tvm -- prove-stark programs/factorial_recursive.tvm \
   -o "$OUT/factorial.proof.json" 2>/dev/null \
   > "$OUT/factorial_prove_summary.txt"
+record_artifact "$OUT/factorial.proof.json"
+record_artifact "$OUT/factorial_prove_summary.txt"
 cat "$OUT/factorial_prove_summary.txt"
 echo ""
 
 echo "--- factorial_recursive: verify-stark ---"
 cargo run --bin tvm -- verify-stark "$OUT/factorial.proof.json" 2>/dev/null \
   > "$OUT/factorial_verify_summary.txt"
+record_artifact "$OUT/factorial_verify_summary.txt"
 cat "$OUT/factorial_verify_summary.txt"
 echo ""
 
@@ -88,6 +106,7 @@ echo ""
 echo "--- multiply: execution ---"
 cargo run --bin tvm -- run programs/multiply.tvm --trace 2>/dev/null \
   > "$OUT/multiply_execution.txt"
+record_artifact "$OUT/multiply_execution.txt"
 cat "$OUT/multiply_execution.txt"
 echo ""
 
@@ -95,14 +114,18 @@ echo ""
 
 echo "=== All artifacts generated ==="
 echo ""
-for f in "$OUT"/*.txt "$OUT"/*.json; do
-  [[ -e "$f" ]] || continue
+for f in "${GENERATED_ARTIFACTS[@]}"; do
+  [[ -e "$f" ]] || {
+    echo "Missing generated artifact: $f" >&2
+    exit 1
+  }
   bytes=$(wc -c < "$f" | tr -d ' ')
   echo "$bytes $f"
 done
 echo ""
 echo "Proof file sizes:"
 for f in "$OUT"/*.proof.json; do
+  [[ -e "$f" ]] || continue
   bytes=$(wc -c < "$f" | tr -d ' ')
   name=$(basename "$f")
   echo "  $name: $bytes bytes"

--- a/scripts/generate_article_artifacts.sh
+++ b/scripts/generate_article_artifacts.sh
@@ -95,7 +95,11 @@ echo ""
 
 echo "=== All artifacts generated ==="
 echo ""
-ls -lh "$OUT"/*.txt "$OUT"/*.json 2>/dev/null | awk '{print $5, $9}'
+for f in "$OUT"/*.txt "$OUT"/*.json; do
+  [[ -e "$f" ]] || continue
+  bytes=$(wc -c < "$f" | tr -d ' ')
+  echo "$bytes $f"
+done
 echo ""
 echo "Proof file sizes:"
 for f in "$OUT"/*.proof.json; do

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 
 hardening_base_test_filters=(
   "proof::tests::production_profile_v1_is_self_consistent"
@@ -57,9 +58,4 @@ hardening_stwo_test_filters=(
   "stwo_backend::recursion::tests::phase29_load_recursive_compression_input_contract_rejects_non_regular_file"
   "stwo_backend::recursion::tests::phase29_prepare_rejects_phase28_recursive_claim_before_contract_derivation"
   "stwo_backend::recursion::tests::phase29_prepare_rejects_phase28_synthetic_shell_without_nested_members"
-)
-
-hardening_test_filters=(
-  "${hardening_base_test_filters[@]}"
-  "${hardening_stwo_test_filters[@]}"
 )

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -374,7 +374,7 @@ changed_path_has_prefix() {
 changed_path_is_shell_script() {
   local path
   for path in "${changed_paths[@]}"; do
-    if [[ "$path" == scripts/* && "$path" == *.sh ]]; then
+    if [[ "$path" =~ ^scripts/.+\.sh$ ]]; then
       return 0
     fi
   done

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -358,11 +358,7 @@ stwo_cli_smoke_targets=(
   "cli_prepare_stwo_recursive_compression_input_contract_rejects_synthetic_phase28_shell"
   "cli_prepare_stwo_recursive_compression_input_contract_rejects_gzip_output_path"
 )
-mutation_targets=(
-  "src/stwo_backend/decoding.rs"
-  "src/stwo_backend/shared_lookup_artifact.rs"
-  "src/stwo_backend/arithmetic_subset_prover.rs"
-)
+mapfile -t mutation_targets < <(scripts/run_mutation_suite.sh --print-targets)
 
 changed_path_has_prefix() {
   local prefix="$1"
@@ -375,14 +371,12 @@ changed_path_has_prefix() {
   return 1
 }
 
-changed_path_matches_glob() {
-  local pattern="$1"
+changed_path_is_shell_script() {
   local path
   for path in "${changed_paths[@]}"; do
-    # shellcheck disable=SC2254
-    case "$path" in
-      $pattern) return 0 ;;
-    esac
+    if [[ "$path" == scripts/* && "$path" == *.sh ]]; then
+      return 0
+    fi
   done
   return 1
 }
@@ -431,29 +425,37 @@ run_research_v3_smoke_targets() {
 }
 
 run_conditional_quick_audits() {
-  if changed_path_has_prefix ".github/workflows/" || changed_path_matches_glob "zizmor.yml"; then
+  if changed_path_has_prefix ".github/workflows/" || changed_path_has_prefix "zizmor.yml"; then
     run_logged workflow-audit scripts/run_workflow_audit_suite.sh
   fi
 
-  if changed_path_matches_glob "scripts/*.sh"; then
+  if changed_path_is_shell_script; then
     run_logged shellcheck scripts/run_shellcheck_suite.sh
   fi
 }
 
 run_conditional_mutation_check() {
   local mutation_diff_file
+  local git_diff_status
 
   if ! changed_path_is_mutation_target; then
     return 0
   fi
 
   mutation_diff_file="$run_evidence_dir/mutation.diff"
-  git diff --no-ext-diff --unified=0 "$diff_range" -- "${mutation_targets[@]}" >"$mutation_diff_file" || true
+  set +e
+  git diff --no-ext-diff --unified=0 "$diff_range" -- "${mutation_targets[@]}" >"$mutation_diff_file"
+  git_diff_status=$?
+  set -e
+
+  if (( git_diff_status > 1 )); then
+    fail "git diff failed while building ${mutation_diff_file}"
+  fi
 
   if [[ -s "$mutation_diff_file" ]]; then
     run_logged mutation env MUTATION_DIFF_FILE="$mutation_diff_file" scripts/run_mutation_suite.sh
   else
-    run_logged mutation-check scripts/run_mutation_suite.sh --check
+    fail "mutation target changed but ${mutation_diff_file} is empty"
   fi
 }
 

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -344,6 +344,7 @@ mkdir -p "$LOG_DIR"
 pr_json="$run_evidence_dir/pr.json"
 cp "$tmp_pr_json" "$pr_json"
 diff_range="${base_sha}...${head_sha}"
+mapfile -t changed_paths < <(git diff --name-only "$diff_range")
 local_evidence_marker="$run_evidence_dir/local-evidence.json"
 completed_local_mode=""
 stwo_smoke_targets=(
@@ -357,6 +358,46 @@ stwo_cli_smoke_targets=(
   "cli_prepare_stwo_recursive_compression_input_contract_rejects_synthetic_phase28_shell"
   "cli_prepare_stwo_recursive_compression_input_contract_rejects_gzip_output_path"
 )
+mutation_targets=(
+  "src/stwo_backend/decoding.rs"
+  "src/stwo_backend/shared_lookup_artifact.rs"
+  "src/stwo_backend/arithmetic_subset_prover.rs"
+)
+
+changed_path_has_prefix() {
+  local prefix="$1"
+  local path
+  for path in "${changed_paths[@]}"; do
+    if [[ "$path" == "$prefix"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+changed_path_matches_glob() {
+  local pattern="$1"
+  local path
+  for path in "${changed_paths[@]}"; do
+    # shellcheck disable=SC2254
+    case "$path" in
+      $pattern) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+changed_path_is_mutation_target() {
+  local path target
+  for path in "${changed_paths[@]}"; do
+    for target in "${mutation_targets[@]}"; do
+      if [[ "$path" == "$target" ]]; then
+        return 0
+      fi
+    done
+  done
+  return 1
+}
 
 run_stwo_smoke_targets() {
   local stwo_smoke label
@@ -389,9 +430,37 @@ run_research_v3_smoke_targets() {
     --exact
 }
 
+run_conditional_quick_audits() {
+  if changed_path_has_prefix ".github/workflows/" || changed_path_matches_glob "zizmor.yml"; then
+    run_logged workflow-audit scripts/run_workflow_audit_suite.sh
+  fi
+
+  if changed_path_matches_glob "scripts/*.sh"; then
+    run_logged shellcheck scripts/run_shellcheck_suite.sh
+  fi
+}
+
+run_conditional_mutation_check() {
+  local mutation_diff_file
+
+  if ! changed_path_is_mutation_target; then
+    return 0
+  fi
+
+  mutation_diff_file="$run_evidence_dir/mutation.diff"
+  git diff --no-ext-diff --unified=0 "$diff_range" -- "${mutation_targets[@]}" >"$mutation_diff_file" || true
+
+  if [[ -s "$mutation_diff_file" ]]; then
+    run_logged mutation env MUTATION_DIFF_FILE="$mutation_diff_file" scripts/run_mutation_suite.sh
+  else
+    run_logged mutation-check scripts/run_mutation_suite.sh --check
+  fi
+}
+
 if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
   run_logged cargo-fmt-check cargo fmt --check
+  run_conditional_quick_audits
   run_logged lib-contract cargo test -q --lib statement_spec_contract_is_synced_with_constants
   smoke_targets=(assembly e2e interpreter runtime vanillastark_smoke)
   for test_target in "${smoke_targets[@]}"; do
@@ -403,6 +472,7 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
   run_logged cargo-fmt-check cargo fmt --check
+  run_conditional_quick_audits
   run_logged cargo-lib-tests cargo test -q --lib
   run_logged cargo-lib-and-integration-tests cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
@@ -413,12 +483,14 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
   run_logged cargo-fmt-check cargo fmt --check
+  run_conditional_quick_audits
   run_logged cargo-lib-tests cargo test -q --lib
   run_logged cargo-lib-and-integration-tests cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   run_research_v3_smoke_targets
+  run_conditional_mutation_check
   run_logged fuzz-smoke env FUZZ_TIME_PER_TARGET=20 scripts/run_fuzz_smoke_suite.sh
   run_logged ub-checks env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh
   run_logged asan env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_asan_suite.sh

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -358,7 +358,7 @@ stwo_cli_smoke_targets=(
   "cli_prepare_stwo_recursive_compression_input_contract_rejects_synthetic_phase28_shell"
   "cli_prepare_stwo_recursive_compression_input_contract_rejects_gzip_output_path"
 )
-mapfile -t mutation_targets < <(scripts/run_mutation_suite.sh --print-targets)
+mapfile -t mutation_targets < <(bash scripts/run_mutation_suite.sh --print-targets)
 
 changed_path_has_prefix() {
   local prefix="$1"
@@ -426,11 +426,11 @@ run_research_v3_smoke_targets() {
 
 run_conditional_quick_audits() {
   if changed_path_has_prefix ".github/workflows/" || changed_path_has_prefix "zizmor.yml"; then
-    run_logged workflow-audit scripts/run_workflow_audit_suite.sh
+    run_logged workflow-audit bash scripts/run_workflow_audit_suite.sh
   fi
 
   if changed_path_is_shell_script; then
-    run_logged shellcheck scripts/run_shellcheck_suite.sh
+    run_logged shellcheck bash scripts/run_shellcheck_suite.sh
   fi
 }
 

--- a/scripts/run_asan_suite.sh
+++ b/scripts/run_asan_suite.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 HARDENING_TOOLCHAIN="${HARDENING_TOOLCHAIN:-nightly-2025-07-14}"
-SANITIZER_TARGET="${SANITIZER_TARGET:-$(rustc +${HARDENING_TOOLCHAIN} -vV | awk '/^host: / { print $2 }')}"
+SANITIZER_TARGET="${SANITIZER_TARGET:-$(rustc +"${HARDENING_TOOLCHAIN}" -vV | awk '/^host: / { print $2 }')}"
 
 source "$ROOT_DIR/scripts/hardening_test_names.sh"
 

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -11,6 +11,11 @@ MUTATION_TARGETS=(
   src/stwo_backend/arithmetic_subset_prover.rs
 )
 
+if (($# > 0)) && [[ "$1" == "--print-targets" ]]; then
+  printf '%s\n' "${MUTATION_TARGETS[@]}"
+  exit 0
+fi
+
 missing_targets=()
 for target in "${MUTATION_TARGETS[@]}"; do
   if [[ ! -f "$target" ]]; then

--- a/scripts/run_shellcheck_suite.sh
+++ b/scripts/run_shellcheck_suite.sh
@@ -4,14 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-shellcheck -x \
-  scripts/local_merge_gate.sh \
-  scripts/run_shellcheck_suite.sh \
-  scripts/run_workflow_audit_suite.sh \
-  scripts/run_fuzz_smoke_suite.sh \
-  scripts/run_formal_contract_suite.sh \
-  scripts/run_miri_suite.sh \
-  scripts/run_mutation_suite.sh \
-  scripts/run_asan_suite.sh \
-  scripts/run_ub_checks_suite.sh \
-  scripts/hardening_test_names.sh
+mapfile -t shell_scripts < <(git ls-files 'scripts/*.sh' 'scripts/**/*.sh' | LC_ALL=C sort -u)
+if ((${#shell_scripts[@]} == 0)); then
+  echo "No tracked shell scripts found under scripts/; refusing to run empty shellcheck suite." >&2
+  exit 1
+fi
+
+shellcheck -x "${shell_scripts[@]}"

--- a/scripts/run_shellcheck_suite.sh
+++ b/scripts/run_shellcheck_suite.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+shellcheck -x \
+  scripts/local_merge_gate.sh \
+  scripts/run_shellcheck_suite.sh \
+  scripts/run_workflow_audit_suite.sh \
+  scripts/run_fuzz_smoke_suite.sh \
+  scripts/run_formal_contract_suite.sh \
+  scripts/run_miri_suite.sh \
+  scripts/run_mutation_suite.sh \
+  scripts/run_asan_suite.sh \
+  scripts/run_ub_checks_suite.sh \
+  scripts/hardening_test_names.sh

--- a/scripts/run_workflow_audit_suite.sh
+++ b/scripts/run_workflow_audit_suite.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if command -v zizmor >/dev/null 2>&1; then
+  exec zizmor .github/workflows --format plain
+fi
+
+if command -v uvx >/dev/null 2>&1; then
+  exec uvx --from zizmor zizmor .github/workflows --format plain
+fi
+
+echo "workflow audit requires zizmor or uvx (for 'uvx --from zizmor zizmor')." >&2
+exit 1

--- a/scripts/run_workflow_audit_suite.sh
+++ b/scripts/run_workflow_audit_suite.sh
@@ -9,16 +9,15 @@ ZIZMOR_SPEC="${ZIZMOR_SPEC:-zizmor==${ZIZMOR_VERSION}}"
 
 if command -v zizmor >/dev/null 2>&1; then
   installed_version="$(zizmor --version | awk '{print $2}')"
-  if [[ "$installed_version" != "$ZIZMOR_VERSION" ]]; then
-    echo "zizmor version mismatch: expected ${ZIZMOR_VERSION}, found ${installed_version}" >&2
-    exit 1
+  if [[ "$installed_version" == "$ZIZMOR_VERSION" ]]; then
+    exec zizmor .github/workflows --format plain
   fi
-  exec zizmor .github/workflows --format plain
+  echo "zizmor version mismatch: expected ${ZIZMOR_VERSION}, found ${installed_version}; falling back to uvx" >&2
 fi
 
 if command -v uvx >/dev/null 2>&1; then
   exec uvx --from "$ZIZMOR_SPEC" zizmor .github/workflows --format plain
 fi
 
-echo "workflow audit requires zizmor or uvx (for 'uvx --from zizmor zizmor')." >&2
+echo "workflow audit requires zizmor ${ZIZMOR_VERSION} or uvx (for 'uvx --from ${ZIZMOR_SPEC} zizmor')." >&2
 exit 1

--- a/scripts/run_workflow_audit_suite.sh
+++ b/scripts/run_workflow_audit_suite.sh
@@ -4,12 +4,20 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+ZIZMOR_VERSION="${ZIZMOR_VERSION:-1.23.1}"
+ZIZMOR_SPEC="${ZIZMOR_SPEC:-zizmor==${ZIZMOR_VERSION}}"
+
 if command -v zizmor >/dev/null 2>&1; then
+  installed_version="$(zizmor --version | awk '{print $2}')"
+  if [[ "$installed_version" != "$ZIZMOR_VERSION" ]]; then
+    echo "zizmor version mismatch: expected ${ZIZMOR_VERSION}, found ${installed_version}" >&2
+    exit 1
+  fi
   exec zizmor .github/workflows --format plain
 fi
 
 if command -v uvx >/dev/null 2>&1; then
-  exec uvx --from zizmor zizmor .github/workflows --format plain
+  exec uvx --from "$ZIZMOR_SPEC" zizmor .github/workflows --format plain
 fi
 
 echo "workflow audit requires zizmor or uvx (for 'uvx --from zizmor zizmor')." >&2

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,3 @@
+rules:
+  superfluous-actions:
+    disable: true


### PR DESCRIPTION
## Summary
- add local workflow-audit and shellcheck suites and make the merge gate invoke them on workflow/script changes
- harden GitHub workflows against credential persistence, unpinned `setup-python`, stale hardening-policy paths, and shell template injection findings from `zizmor`
- simplify the manual mutation workflow and document the new gate behavior in the hardening policy

## Validation
- `bash -n scripts/local_merge_gate.sh scripts/run_shellcheck_suite.sh scripts/run_workflow_audit_suite.sh scripts/run_fuzz_smoke_suite.sh scripts/run_formal_contract_suite.sh scripts/run_miri_suite.sh scripts/run_mutation_suite.sh scripts/run_asan_suite.sh scripts/run_ub_checks_suite.sh`
- `scripts/run_shellcheck_suite.sh`
- `scripts/run_workflow_audit_suite.sh`
- `cargo fmt --check`
- `cargo test -q --lib statement_spec_contract_is_synced_with_constants`
- `git diff --check`

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Notes:
- Targeted regression coverage comes from making `scripts/local_merge_gate.sh` exercise the new workflow/shell audit suites on the exact PR diff, rather than relying on documentation-only hardening.
- Oracle/differential checks are not applicable below the Rust proof logic for this PR; the relevant boundary here is static workflow/script auditing via `zizmor` and `shellcheck`.
- Resource-bound impact was reviewed: the new quick audits run only when workflow or shell-script paths change, while diff-scoped mutation remains restricted to hardening mode and only when the trusted prover files change.
- Kani/formal kernels were not modified, but the merge gate and policy were updated so the existing formal suite remains part of hardening mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI jobs now avoid persisting checkout credentials and pin Python setup to a fixed reference; fuzz jobs read toolchain/target/corpus from environment variables.
* **New Features**
  * Add conditional workflow-audit and shell-script linting suites that run automatically when relevant files change.
* **Tests**
  * Mutation testing and artifact uploads adjusted to run in broader scenarios and support diff-scoped execution; mutation tooling can emit target lists.
* **Documentation**
  * Hardening policy and local command guidance updated to include the new audit, lint, and mutation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->