### PR TITLE
[codex] Final paper package polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,15 @@
 
 **A deterministic transformer runtime with a repository-backed proof stack.**
 
-This repository compiles a compact assembly language into a transformer-shaped
-runtime, executes it deterministically, records the execution trace, and proves
-the claimed computation with a transparent STARK. The same program can also run
-through independent native, Burn, and ONNX paths so semantic drift is caught
-before proof generation.
+This repository compiles a compact assembly language into a transformer-shaped runtime,
+executes it deterministically, records the execution trace, and proves the claimed
+computation with a transparent STARK. The same program can also run through independent
+native, Burn, and ONNX paths so semantic drift is caught before proof generation.
 
 The execution model builds on Percepta's
-[*Can LLMs Be Computers?*](https://www.percepta.ai/blog/can-llms-be-computers),
-then pushes it into a maintained Rust implementation with proof artifacts and
-frozen publication bundles.
+[*Can LLMs Be Computers?*](https://www.percepta.ai/blog/can-llms-be-computers), then
+pushes it into a maintained Rust implementation with proof artifacts and frozen
+publication bundles.
 
 ```text
          .tvm program
@@ -39,28 +38,27 @@ No sampling. No stochastic output. Same input, same output, every time.
 ## At A Glance
 
 - Compile `.tvm` assembly into a deterministic transformer-style runtime.
-- Run the same program through up to four engines and optionally fail on the
-  first semantic divergence when verification paths are enabled.
+- Run the same program through up to four engines and optionally fail on the first
+  semantic divergence when verification paths are enabled.
 - Prove `statement-v1` native ISA execution with the in-repo vanilla STARK.
-- Exercise an experimental `stwo` backend for shipped arithmetic fixtures,
-  shared-table lookup demos, transformer-shaped fixtures, and bounded
-  proof-carrying decoding artifacts.
-- Regenerate frozen paper bundles, artifact manifests, and figure inputs from
-  committed scripts.
+- Exercise an experimental `stwo` backend for shipped arithmetic fixtures, shared-table
+  lookup demos, transformer-shaped fixtures, and bounded proof-carrying decoding
+  artifacts.
+- Regenerate frozen paper bundles, artifact manifests, and figure inputs from committed
+  scripts.
 
 ## Proof Surfaces
 
-| Surface | Status | What it actually covers |
-|---|---|---|
-| `statement-v1` | Stable | Vanilla STARK proof of native ISA execution, plus enforced transformer/native semantic agreement checks |
-| `stwo-backend` | Experimental | Narrow `statement-v1` proving surface for shipped fixtures, lookup demos, transformer-shaped fixtures, and decoding artifacts |
-| `research-v2` | Artifact-only | Semantic agreement artifacts for transformer vs ONNX, not yet a full STARK claim |
-| `research-v3` | Artifact-only | Bounded multi-engine transformer/native/Burn/ONNX equivalence-kernel artifacts with transition relation hashes |
+| Surface        | Status        | What it actually covers                                                                                                       |
+| -------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `statement-v1` | Stable        | Vanilla STARK proof of native ISA execution, plus enforced transformer/native semantic agreement checks                       |
+| `stwo-backend` | Experimental  | Narrow `statement-v1` proving surface for shipped fixtures, lookup demos, transformer-shaped fixtures, and decoding artifacts |
+| `research-v2`  | Artifact-only | Semantic agreement artifacts for transformer vs ONNX, not yet a full STARK claim                                              |
+| `research-v3`  | Artifact-only | Bounded multi-engine transformer/native/Burn/ONNX equivalence-kernel artifacts with transition relation hashes                |
 
 The important boundary is explicit: this repo does **not** yet prove full
-standard-softmax transformer inference on `stwo`.
-The current proving boundary is native ISA execution with semantic agreement
-checks layered around the transformer runtime.
+standard-softmax transformer inference on `stwo`. The current proving boundary is native
+ISA execution with semantic agreement checks layered around the transformer runtime.
 
 Hardening and merge discipline for trusted-core work is formalized in:
 
@@ -72,34 +70,34 @@ Current public proof artifacts:
 - native-ISA `statement-v1` arithmetic proofs
 - shared-table lookup proofs
 - transformer-shaped fixed-shape block proofs
-- step-level proof envelopes and carried-state decode chains
+- step-level proof objects and carried-state decode chains
 - bounded multi-runtime semantic-agreement artifacts
 - pre-recursive aggregation bundles
 
 ## Start Here
 
-| Goal | Command | Notes |
-|---|---|---|
-| Run a program | `cargo run --bin tvm -- programs/fibonacci.tvm` | Fastest way to see the VM work |
-| Inspect a full trace | `cargo run --bin tvm -- run programs/fibonacci.tvm --trace` | Emits the full machine-state trace |
-| Prove with the vanilla STARK | `cargo run --bin tvm -- prove-stark programs/fibonacci.tvm -o fib.proof.json` | Stable proof path |
-| Verify a proof | `cargo run --bin tvm -- verify-stark fib.proof.json` | `statement-v1` includes lockstep semantic checks |
-| Try the experimental `stwo` path | `cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- prove-stark programs/addition.tvm -o add.proof.json --backend stwo` | Pinned nightly required |
-| Regenerate paper artifacts | `./scripts/generate_repro_bundle.sh` | Publication-facing bundle |
+| Goal                             | Command                                                                                                                                 | Notes                                            |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Run a program                    | `cargo run --bin tvm -- programs/fibonacci.tvm`                                                                                         | Fastest way to see the VM work                   |
+| Inspect a full trace             | `cargo run --bin tvm -- run programs/fibonacci.tvm --trace`                                                                             | Emits the full machine-state trace               |
+| Prove with the vanilla STARK     | `cargo run --bin tvm -- prove-stark programs/fibonacci.tvm -o fib.proof.json`                                                           | Stable proof path                                |
+| Verify a proof                   | `cargo run --bin tvm -- verify-stark fib.proof.json`                                                                                    | `statement-v1` includes lockstep semantic checks |
+| Try the experimental `stwo` path | `cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- prove-stark programs/addition.tvm -o add.proof.json --backend stwo` | Pinned nightly required                          |
+| Regenerate paper artifacts       | `./scripts/generate_repro_bundle.sh`                                                                                                    | Publication-facing bundle                        |
 
 ## Toolchains
 
-| Task | Requirement |
-|---|---|
-| Core runtime, vanilla STARK, default tests | Stable Rust |
-| `--features stwo-backend` compile and CLI paths | `cargo +nightly-2025-07-14` |
-| ONNX validation and paper figure scripts | Python venv + `pip install -r scripts/requirements.txt` |
+| Task                                            | Requirement                                             |
+| ----------------------------------------------- | ------------------------------------------------------- |
+| Core runtime, vanilla STARK, default tests      | Stable Rust                                             |
+| `--features stwo-backend` compile and CLI paths | `cargo +nightly-2025-07-14`                             |
+| ONNX validation and paper figure scripts        | Python venv + `pip install -r scripts/requirements.txt` |
 
-If you want the shortest successful path, start on stable Rust with the default
-runtime and vanilla STARK commands. Move to `stwo` only when you need the
-experimental backend surface.
+If you want the shortest successful path, start on stable Rust with the default runtime
+and vanilla STARK commands. Move to `stwo` only when you need the experimental backend
+surface.
 
----
+______________________________________________________________________
 
 ## Why This Works
 
@@ -107,40 +105,54 @@ Three ideas, stacked.
 
 ### 1. Attention Is Memory Access
 
-Each memory address maintains a write history as 2D points `(step, value)`. To read the latest write, query with direction `[1, 0]`:
+Each memory address maintains a write history as 2D points `(step, value)`. To read the
+latest write, query with direction `[1, 0]`:
 
 ```
 score(q, k) = 1 * step + 0 * value = step
 ```
 
-The argmax selects the most recent write. In 2D, the maximizer of any linear objective lies on the **convex hull** of the key set. So the runtime maintains a hull-backed KV cache and answers memory queries via binary search in **O(log n)** instead of scanning the full history.
+The argmax selects the most recent write. In 2D, the maximizer of any linear objective
+lies on the **convex hull** of the key set. So the runtime maintains a hull-backed KV
+cache and answers memory queries via binary search in **O(log n)** instead of scanning
+the full history.
 
 At step 1,000,000, each memory read still costs O(log n).
 
 ### 2. Feed-Forward Layers Are Instructions
 
-Each compiled instruction becomes a deterministic gate-and-transform operation in the FFN:
+Each compiled instruction becomes a deterministic gate-and-transform operation in the
+FFN:
 
 ```
 output = gate(state) * transition(state)
 ```
 
-The gate activates only for the correct opcode. The transition encodes the instruction semantics. Together they form a compiled, non-learned feed-forward layer that maps one machine state to the next.
+The gate activates only for the correct opcode. The transition encodes the instruction
+semantics. Together they form a compiled, non-learned feed-forward layer that maps one
+machine state to the next.
 
 ### 3. The Trace Is Already a STARK Witness
 
-A STARK proves that a sequence of states satisfies a set of polynomial constraints (an AIR). An execution trace --- a table of `(PC, ACC, SP, flags, memory)` rows where each row follows deterministically from the previous --- is exactly that object.
+A STARK proves that a sequence of states satisfies a set of polynomial constraints (an
+AIR). An execution trace --- a table of `(PC, ACC, SP, flags, memory)` rows where each
+row follows deterministically from the previous --- is exactly that object.
 
-The transition constraints **are** the instruction semantics. The boundary
-constraints **are** the initial and final states. You do not bolt provability
-onto the architecture after the fact; the execution trace is already the AIR
-object you need.
+The transition constraints **are** the instruction semantics. The boundary constraints
+**are** the initial and final states. You do not bolt provability onto the architecture
+after the fact; the execution trace is already the AIR object you need.
 
-The proof is **transparent** (no trusted setup) and **post-quantum** (hash-based, no elliptic curves). STARK verification itself is **O(log^2 n)**, while the current `statement-v1` verifier also performs transformer/native lockstep re-execution to enforce semantic equivalence.
+The proof is **transparent** (no trusted setup) and **post-quantum** (hash-based, no
+elliptic curves). STARK verification itself is **O(log^2 n)**, while the current
+`statement-v1` verifier also performs transformer/native lockstep re-execution to
+enforce semantic equivalence.
 
-Scope note: the current proof claim is a `statement-v1` claim over native ISA execution, with semantic agreement checks layered around it. This repository now exposes an experimental `stwo` backend and a frozen `stwo` artifact bundle, but it still does not provide a full standard-softmax transformer path on S-two.
+Scope note: the current proof claim is a `statement-v1` claim over native ISA execution,
+with semantic agreement checks layered around it. This repository now exposes an
+experimental `stwo` backend and a frozen `stwo` artifact bundle, but it still does not
+provide a full standard-softmax transformer path on S-two.
 
----
+______________________________________________________________________
 
 ## Common Commands
 
@@ -199,7 +211,7 @@ elapsed_ms: 9.760
 throughput_steps_per_sec: 10553.55
 ```
 
----
+______________________________________________________________________
 
 ## The Assembly Language
 
@@ -262,49 +274,50 @@ fact_base:
 <details>
 <summary><strong>Full instruction set</strong></summary>
 
-| Instruction | Effect |
-|---|---|
-| `NOP` | No operation |
-| `LOADI imm` | `ACC = imm` |
-| `LOAD addr` | `ACC = MEM[addr]` |
-| `STORE addr` | `MEM[addr] = ACC` |
-| `PUSH` | `SP -= 1; MEM[SP] = ACC` |
-| `POP` | `ACC = MEM[SP]; SP += 1` |
-| `ADD imm` | `ACC += imm` |
-| `ADDM addr` | `ACC += MEM[addr]` |
-| `SUB imm` | `ACC -= imm` |
-| `SUBM addr` | `ACC -= MEM[addr]` |
-| `MUL imm` | `ACC *= imm` |
-| `MULM addr` | `ACC *= MEM[addr]` |
-| `AND imm` | `ACC &= imm` |
-| `ANDM addr` | `ACC &= MEM[addr]` |
-| `OR imm` | `ACC \|= imm` |
-| `ORM addr` | `ACC \|= MEM[addr]` |
-| `XOR imm` | `ACC ^= imm` |
-| `XORM addr` | `ACC ^= MEM[addr]` |
-| `CMP imm` | `ACC = ACC - imm; carry_flag = ACC < imm` |
-| `CMPM addr` | `ACC = ACC - MEM[addr]; carry_flag = ACC < MEM[addr]` |
-| `CALL label` | Push return address, jump |
-| `RET` | Pop return address, jump |
-| `JMP label` | Unconditional jump |
-| `JZ label` | Jump if `zero_flag` |
-| `JNZ label` | Jump if not `zero_flag` |
-| `HALT` | Stop execution |
+| Instruction  | Effect                                                |
+| ------------ | ----------------------------------------------------- |
+| `NOP`        | No operation                                          |
+| `LOADI imm`  | `ACC = imm`                                           |
+| `LOAD addr`  | `ACC = MEM[addr]`                                     |
+| `STORE addr` | `MEM[addr] = ACC`                                     |
+| `PUSH`       | `SP -= 1; MEM[SP] = ACC`                              |
+| `POP`        | `ACC = MEM[SP]; SP += 1`                              |
+| `ADD imm`    | `ACC += imm`                                          |
+| `ADDM addr`  | `ACC += MEM[addr]`                                    |
+| `SUB imm`    | `ACC -= imm`                                          |
+| `SUBM addr`  | `ACC -= MEM[addr]`                                    |
+| `MUL imm`    | `ACC *= imm`                                          |
+| `MULM addr`  | `ACC *= MEM[addr]`                                    |
+| `AND imm`    | `ACC &= imm`                                          |
+| `ANDM addr`  | `ACC &= MEM[addr]`                                    |
+| `OR imm`     | `ACC \|= imm`                                         |
+| `ORM addr`   | `ACC \|= MEM[addr]`                                   |
+| `XOR imm`    | `ACC ^= imm`                                          |
+| `XORM addr`  | `ACC ^= MEM[addr]`                                    |
+| `CMP imm`    | `ACC = ACC - imm; carry_flag = ACC < imm`             |
+| `CMPM addr`  | `ACC = ACC - MEM[addr]; carry_flag = ACC < MEM[addr]` |
+| `CALL label` | Push return address, jump                             |
+| `RET`        | Pop return address, jump                              |
+| `JMP label`  | Unconditional jump                                    |
+| `JZ label`   | Jump if `zero_flag`                                   |
+| `JNZ label`  | Jump if not `zero_flag`                               |
+| `HALT`       | Stop execution                                        |
 
 </details>
 
----
+______________________________________________________________________
 
 ## Execution Engines
 
-The same compiled program runs through four independent backends. The verifier executes them in lockstep and fails on the first divergence.
+The same compiled program runs through four independent backends. The verifier executes
+them in lockstep and fails on the first divergence.
 
-| Engine | What it is | Purpose |
-|--------|-----------|---------|
-| **TransformerVm** | Encode-attend-FFN loop with hull-backed memory | The transformer runtime |
-| **NativeInterpreter** | Direct ISA semantics, no transformer structure | Semantic oracle |
-| **BurnRuntime** | Same compiled weights through [Burn](https://burn.dev) tensors | Tensor-level cross-check |
-| **OnnxRuntime** | Exported ONNX models through [Tract](https://github.com/sonos/tract) | Portable format proof |
+| Engine                | What it is                                                           | Purpose                  |
+| --------------------- | -------------------------------------------------------------------- | ------------------------ |
+| **TransformerVm**     | Encode-attend-FFN loop with hull-backed memory                       | The transformer runtime  |
+| **NativeInterpreter** | Direct ISA semantics, no transformer structure                       | Semantic oracle          |
+| **BurnRuntime**       | Same compiled weights through [Burn](https://burn.dev) tensors       | Tensor-level cross-check |
+| **OnnxRuntime**       | Exported ONNX models through [Tract](https://github.com/sonos/tract) | Portable format proof    |
 
 ```bash
 # Pick an engine
@@ -318,7 +331,9 @@ cargo run --bin tvm -- run programs/fibonacci.tvm --verify-native
 cargo run --features full --bin tvm -- run programs/fibonacci.tvm --verify-all
 ```
 
-If `--verify-all` passes and `scripts/validate_onnx.py` reproduces the result from exported ONNX files, the computation is not trapped inside custom Rust structs. It is a real, portable transformer computation with independent cross-checks.
+If `--verify-all` passes and `scripts/validate_onnx.py` reproduces the result from
+exported ONNX files, the computation is not trapped inside custom Rust structs. It is a
+real, portable transformer computation with independent cross-checks.
 
 ### ONNX Export + Python Validation
 
@@ -334,27 +349,30 @@ python3 scripts/validate_onnx.py compiled/fibonacci \
   --program-name fibonacci --expected-acc 21 --expected-halted true
 ```
 
-On PEP-668-managed Python installations, use the local venv above rather than
-system `pip`.
+On PEP-668-managed Python installations, use the local venv above rather than system
+`pip`.
 
----
+______________________________________________________________________
 
 ## Proof Stack
 
-The vanilla STARK prover operates over **F_p** where p = 1 + 407 &middot; 2^119 (a 128-bit prime with a large power-of-two subgroup for NTT). The in-repo implementation includes:
+The vanilla STARK prover operates over **F_p** where p = 1 + 407 · 2^119 (a 128-bit
+prime with a large power-of-two subgroup for NTT). The in-repo implementation includes:
 
-| Component | What it does |
-|-----------|-------------|
-| `field.rs` | Montgomery-form arithmetic via `ark-ff` |
-| `polynomial.rs` | Univariate polynomial ops, Lagrange interpolation |
-| `ntt.rs` | Number-theoretic transform for O(n log n) polynomial multiplication |
-| `multivariate.rs` | Multivariate polynomial representation for AIR constraints |
-| `merkle.rs` | Blake2b Merkle trees for commitment |
-| `fri.rs` | FRI protocol for low-degree testing |
-| `stark.rs` | STARK prover and verifier |
-| `proof.rs` | VM-specific AIR: transition constraints from instruction semantics |
+| Component         | What it does                                                        |
+| ----------------- | ------------------------------------------------------------------- |
+| `field.rs`        | Montgomery-form arithmetic via `ark-ff`                             |
+| `polynomial.rs`   | Univariate polynomial ops, Lagrange interpolation                   |
+| `ntt.rs`          | Number-theoretic transform for O(n log n) polynomial multiplication |
+| `multivariate.rs` | Multivariate polynomial representation for AIR constraints          |
+| `merkle.rs`       | Blake2b Merkle trees for commitment                                 |
+| `fri.rs`          | FRI protocol for low-degree testing                                 |
+| `stark.rs`        | STARK prover and verifier                                           |
+| `proof.rs`        | VM-specific AIR: transition constraints from instruction semantics  |
 
-The AIR encodes each supported instruction as polynomial transition constraints over the trace columns `(PC, ACC, SP, zero_flag, carry_flag, halted, MEM[0..n])`. The boundary constraints pin the initial and final machine states.
+The AIR encodes each supported instruction as polynomial transition constraints over the
+trace columns `(PC, ACC, SP, zero_flag, carry_flag, halted, MEM[0..n])`. The boundary
+constraints pin the initial and final machine states.
 
 ```bash
 # Prove
@@ -545,16 +563,20 @@ cargo run --bin tvm -- verify-stark fact.proof.json --min-conjectured-security 6
 cargo run --bin tvm -- verify-stark fact.proof.json --strict
 ```
 
-`prove-stark` first runs transformer/native lockstep verification and aborts on any divergence before emitting a proof.
-The STARK witness trace is then built from the transformer execution trace.
-Proof claims now include explicit statement metadata:
+`prove-stark` first runs transformer/native lockstep verification and aborts on any
+divergence before emitting a proof. The STARK witness trace is then built from the
+transformer execution trace. Proof claims now include explicit statement metadata:
 
 - `statement_version = statement-v1`
 - `semantic_scope = native_isa_execution_with_transformer_native_equivalence_check`
 
-Verifier checks enforce both fields exactly, so claim wording cannot drift from what is actually being verified.
-Proof claims also include transformer config, equivalence metadata (`equivalence_checked_steps`, transformer fingerprint, native fingerprint), and artifact commitments (program hash, config hash, deterministic-model hash, STARK-options hash, prover-build info/hash) in CLI output.
-Verifier policy checks are available via `--min-conjectured-security`; `--strict` enforces an 80-bit floor and turns on re-execution checks.
+Verifier checks enforce both fields exactly, so claim wording cannot drift from what is
+actually being verified. Proof claims also include transformer config, equivalence
+metadata (`equivalence_checked_steps`, transformer fingerprint, native fingerprint), and
+artifact commitments (program hash, config hash, deterministic-model hash, STARK-options
+hash, prover-build info/hash) in CLI output. Verifier policy checks are available via
+`--min-conjectured-security`; `--strict` enforces an 80-bit floor and turns on
+re-execution checks.
 
 ### Experimental `stwo` Surface
 
@@ -565,20 +587,18 @@ Verifier policy checks are available via `--min-conjectured-security`; `--strict
 
 #### Current Fixture Set
 
-The public `stwo` proving path currently proves and verifies these shipped
-fixtures under `statement-v1`:
+The public `stwo` proving path currently proves and verifies these shipped fixtures
+under `statement-v1`:
 
-- arithmetic fixtures:
-  `programs/addition.tvm`, `programs/counter.tvm`,
-  `programs/memory_roundtrip.tvm`, `programs/multiply.tvm`,
-  `programs/dot_product.tvm`, `programs/fibonacci.tvm`,
-  `programs/matmul_2x2.tvm`, `programs/single_neuron.tvm`
-- transformer-shaped fixtures:
-  `programs/gemma_block_v1.tvm`, `programs/gemma_block_v2.tvm`,
-  `programs/gemma_block_v3.tvm`, `programs/gemma_block_v4.tvm`
+- arithmetic fixtures: `programs/addition.tvm`, `programs/counter.tvm`,
+  `programs/memory_roundtrip.tvm`, `programs/multiply.tvm`, `programs/dot_product.tvm`,
+  `programs/fibonacci.tvm`, `programs/matmul_2x2.tvm`, `programs/single_neuron.tvm`
+- transformer-shaped fixtures: `programs/gemma_block_v1.tvm`,
+  `programs/gemma_block_v2.tvm`, `programs/gemma_block_v3.tvm`,
+  `programs/gemma_block_v4.tvm`
 
-Broader arithmetic-subset AIR coverage exists beyond those fixtures, but that
-surface is not yet exposed as a public end-to-end proving path.
+Broader arithmetic-subset AIR coverage exists beyond those fixtures, but that surface is
+not yet exposed as a public end-to-end proving path.
 
 #### Lookup Demos
 
@@ -587,8 +607,8 @@ The repo exposes dedicated serialized proof envelopes and CLI commands for:
 - single-row binary-step lookup and normalization demos
 - shared-table multi-claim lookup and normalization demos
 
-That means the lookup-backed components are part of the public proof workflow,
-not just internal metadata or library-only helpers.
+That means the lookup-backed components are part of the public proof workflow, not just
+internal metadata or library-only helpers.
 
 #### Decoding Families
 
@@ -597,38 +617,37 @@ The public decoding artifacts currently cover:
 - fixed-shape `decoding_step_v1`
 - parameterized `decoding_step_v2`
 
-Those power the proof-carrying decoding demos, including layout-bound carried
-state, rolling KV-cache windows, cumulative KV-history commitments, and the
-matrix/rollup-style packaging layers described in the next-paper track,
-including pre-recursive cross-step lookup accumulators (Phase 23) and full
-state-relation accumulators (Phase 24), honest intervalized carried-state
-artifacts (Phase 25), folded intervalized carried-state accumulators
-(Phase 26), chained fold-of-folds carried-state accumulators (Phase 27), and
-proof-carrying aggregation across chained carried-state artifacts (Phase 28).
+Those power the proof-carrying decoding demos, including layout-bound carried state,
+rolling KV-cache windows, cumulative KV-history commitments, and the matrix/rollup-style
+packaging layers described in the next-paper track, including pre-recursive cross-step
+lookup accumulators (Phase 23) and full state-relation accumulators (Phase 24), honest
+intervalized carried-state artifacts (Phase 25), folded intervalized carried-state
+accumulators (Phase 26), chained fold-of-folds carried-state accumulators (Phase 27),
+and proof-carrying aggregation across chained carried-state artifacts (Phase 28).
 
 #### Phase Highlights
 
 - Phase 6: canonical pre-aggregation batch manifests for future recursion work
-- Phase 8: `gemma_block_v2` binds canonical normalization inside the top-level
-  execution proof instead of only through `stwo_auxiliary`
-- Phase 9: `gemma_block_v3` binds normalization plus canonical binary-step
-  activation inside the same top-level execution proof
-- Phase 10: `gemma_block_v4` binds shared-table normalization and activation
-  rows inside the same top-level execution proof
+- Phase 8: `gemma_block_v2` binds canonical normalization inside the top-level execution
+  proof instead of only through `stwo_auxiliary`
+- Phase 9: `gemma_block_v3` binds normalization plus canonical binary-step activation
+  inside the same top-level execution proof
+- Phase 10: `gemma_block_v4` binds shared-table normalization and activation rows inside
+  the same top-level execution proof
 - Phase 11: fixed-shape proof-carrying decoding over `decoding_step_v1`
 - Phase 12: parameterized `decoding_step_v2` family with richer carried state,
-  proof-bound shared-lookup rows, and executed reads of both shared normalization
-  scale rows plus both shared activation output rows inside the decoding
-  transition itself, with the latest carried KV-cache pair now updated from
-  lookup-backed values rather than only forwarded incoming values, with three
-  carried lanes now driven by the bounded combined-output cell and one by the
-  lookup-backed primary output on the wider public layouts, with that
-  combined-output cell now also absorbing two additional bounded shared lookup
-  rows before it is carried forward, and with the primary and secondary outputs
-  both absorbing that combined-output cell so both shared activation rows
-  influence the carried output frontier and output commitment, plus exact
-  semantic tests and real-backend proving coverage over all default demo steps
-- Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend proving coverage across the default layout matrix
+  proof-bound shared-lookup rows, and executed reads of both shared normalization scale
+  rows plus both shared activation output rows inside the decoding transition itself,
+  with the latest carried KV-cache pair now updated from lookup-backed values rather
+  than only forwarded incoming values, with three carried lanes now driven by the
+  bounded combined-output cell and one by the lookup-backed primary output on the wider
+  public layouts, with that combined-output cell now also absorbing two additional
+  bounded shared lookup rows before it is carried forward, and with the primary and
+  secondary outputs both absorbing that combined-output cell so both shared activation
+  rows influence the carried output frontier and output commitment, plus exact semantic
+  tests and real-backend proving coverage over all default demo steps
+- Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend
+  proving coverage across the default layout matrix
 - Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
 - Phase 15: mergeable history segments with explicit global carried-state boundaries
 - Phase 16: rollups over verified Phase 15 segment bundles
@@ -636,18 +655,31 @@ proof-carrying aggregation across chained carried-state artifacts (Phase 28).
 - Phase 18: explicit KV-history frontier commitments tied to the live rolling cache
 - Phase 19: carried lookup transcripts over the same Phase 14-17 stack
 - Phase 20: explicit lookup frontier commitments over that same stack
-- Phase 21: template-bound accumulation over Phase 17 matrices with explicit template and accumulator commitments
-- Phase 22: lookup-side accumulation over a verified Phase 21 source accumulator with explicit source/template binding and derived frontier/count checks before recursion
-- Phase 23: pre-recursive cross-step lookup accumulation over cumulative Phase 22 prefixes with carried-state boundary commitments and derived counter checks
-- Phase 24: full carried-state relation accumulation over verified Phase 23 members with explicit relation-template and relation-accumulator commitments before recursive compression
-- Phase 25: honest intervalization of the Phase 24 carried-state relation into explicit contiguous carried-state intervals with derived interval-template and interval-accumulator commitments
-- Phase 26: folded accumulation over verified Phase 25 intervals with explicit fold-template binding and folded interval accumulator commitments over real carried-state intervals
-- Phase 27: chained fold-of-folds accumulation over verified Phase 26 members with explicit chain-template binding and chained accumulator commitments over honest carried-state intervals
-- Phase 28: proof-carrying aggregation over verified Phase 27 chained artifacts with explicit aggregation-template binding, length-framed aggregation transcripts, and aggregate carried-state boundary checks
+- Phase 21: template-bound accumulation over Phase 17 matrices with explicit template
+  and accumulator commitments
+- Phase 22: lookup-side accumulation over a verified Phase 21 source accumulator with
+  explicit source/template binding and derived frontier/count checks before recursion
+- Phase 23: pre-recursive cross-step lookup accumulation over cumulative Phase 22
+  prefixes with carried-state boundary commitments and derived counter checks
+- Phase 24: full carried-state relation accumulation over verified Phase 23 members with
+  explicit relation-template and relation-accumulator commitments before recursive
+  compression
+- Phase 25: honest intervalization of the Phase 24 carried-state relation into explicit
+  contiguous carried-state intervals with derived interval-template and
+  interval-accumulator commitments
+- Phase 26: folded accumulation over verified Phase 25 intervals with explicit
+  fold-template binding and folded interval accumulator commitments over real
+  carried-state intervals
+- Phase 27: chained fold-of-folds accumulation over verified Phase 26 members with
+  explicit chain-template binding and chained accumulator commitments over honest
+  carried-state intervals
+- Phase 28: proof-carrying aggregation over verified Phase 27 chained artifacts with
+  explicit aggregation-template binding, length-framed aggregation transcripts, and
+  aggregate carried-state boundary checks
 
-These phases define pre-recursive merge boundaries and carried-state bindings;
-they do not yet implement recursive cryptographic accumulation or compressed
-cross-member shared-table reuse.
+These phases define pre-recursive merge boundaries and carried-state bindings; they do
+not yet implement recursive cryptographic accumulation or compressed cross-member
+shared-table reuse.
 
 #### Explicit Non-Goals
 
@@ -658,8 +690,8 @@ cross-member shared-table reuse.
 Programs outside the current proven fixture set still fail cleanly on the
 execution-proof `stwo` path, which keeps the claim boundary honest.
 
-The canonical machine-readable statement contract is checked into `spec/statement-v1.json`.
-CI enforces sync between this file and verifier constants via:
+The canonical machine-readable statement contract is checked into
+`spec/statement-v1.json`. CI enforces sync between this file and verifier constants via:
 
 ```bash
 cargo test --quiet statement_spec_contract_is_synced_with_constants
@@ -673,10 +705,11 @@ cargo test --quiet statement_spec_contract_is_synced_with_constants
 - Verifier enforces `statement_version = statement-v1` and
   `semantic_scope = native_isa_execution_with_transformer_native_equivalence_check`.
 - Verification can re-execute transformer/native runtimes from claim data, and the
-  strict/default production verification path enforces agreement with claimed
-  outputs and equivalence fingerprints.
+  strict/default production verification path enforces agreement with claimed outputs
+  and equivalence fingerprints.
 
-`research-v2` (research artifacts, not yet a full STARK claim about transformer/ONNX semantics):
+`research-v2` (research artifacts, not yet a full STARK claim about transformer/ONNX
+semantics):
 
 - `research-v2-step`, `research-v2-trace`, and `research-v2-matrix` generate semantic
   equivalence certificates with cryptographic commitments.
@@ -685,21 +718,22 @@ cargo test --quiet statement_spec_contract_is_synced_with_constants
 
 `research-v3` (research artifacts, not yet a full implementation-equivalence proof):
 
-- `research-v3-equivalence` checks transformer, native, Burn, and ONNX/Tract
-  runtimes in lockstep and emits an equivalence-kernel artifact with rule
-  witnesses, bounded trace rows, semantic canonical event rows, per-engine
-  transition relation hashes, and commitment hashes.
+- `research-v3-equivalence` checks transformer, native, Burn, and ONNX/Tract runtimes in
+  lockstep and emits an equivalence-kernel artifact with rule witnesses, bounded trace
+  rows, semantic canonical event rows, per-engine transition relation hashes, and
+  commitment hashes.
 - `verify-research-v3-equivalence` verifies the artifact boundary by recomputing
-  internal commitments, bounded trace hashes, semantic canonical event-relation
-  hashes, cross-engine state-boundary consistency, final-state links, and
-  per-engine transition relation hashes.
+  internal commitments, bounded trace hashes, semantic canonical event-relation hashes,
+  cross-engine state-boundary consistency, final-state links, and per-engine transition
+  relation hashes.
 - The artifact is deliberately bounded: it is not an e-graph saturation result,
-  SMT-backed rewrite proof, randomized opaque-kernel test suite, or
-  cryptographic proof of implementation equivalence.
+  SMT-backed rewrite proof, randomized opaque-kernel test suite, or cryptographic proof
+  of implementation equivalence.
 
 ### Production Profile (v1)
 
-`production-v1` is a practical local proving profile intended for routine CI/integration checks:
+`production-v1` is a practical local proving profile intended for routine CI/integration
+checks:
 
 - `expansion_factor = 4`
 - `num_colinearity_checks = 16`
@@ -709,26 +743,32 @@ cargo test --quiet statement_spec_contract_is_synced_with_constants
 
 Measured reference (local release build):
 
-| Profile | Settings `(expansion, q, security)` | Conjectured bits | Prove time (`fibonacci`, 103 steps) |
-|---------|-------------------------------------|------------------|-------------------------------------|
-| default | `(4, 2, 2)` | 4 | ~7-12s |
-| production-v1 | `(4, 16, 32)` | 32 | ~29s |
-| heavier | `(8, 16, 32)` | 48 | ~61s |
+| Profile       | Settings `(expansion, q, security)` | Conjectured bits | Prove time (`fibonacci`, 103 steps) |
+| ------------- | ----------------------------------- | ---------------- | ----------------------------------- |
+| default       | `(4, 2, 2)`                         | 4                | ~7-12s                              |
+| production-v1 | `(4, 16, 32)`                       | 32               | ~29s                                |
+| heavier       | `(8, 16, 32)`                       | 48               | ~61s                                |
 
-Verification checks STARK validity and (for the current `statement-v1` semantic scope) re-executes transformer/native lockstep to enforce equivalence against claim outputs.
+Verification checks STARK validity and (for the current `statement-v1` semantic scope)
+re-executes transformer/native lockstep to enforce equivalence against claim outputs.
 
-The proof is transparent and public. The claim includes statement metadata (`statement_version`, `semantic_scope`), the program, attention mode/configuration, step count, final state, equivalence metadata, and claim commitments. Zero-knowledge hiding is out of scope.
+The proof is transparent and public. The claim includes statement metadata
+(`statement_version`, `semantic_scope`), the program, attention mode/configuration, step
+count, final state, equivalence metadata, and claim commitments. Zero-knowledge hiding
+is out of scope.
 
 ### Research V2 One-Step Semantic Artifact
 
-For research toward `statement-v2`, the CLI can generate a one-step transformer-vs-ONNX semantic equivalence artifact for a toy/target program:
+For research toward `statement-v2`, the CLI can generate a one-step transformer-vs-ONNX
+semantic equivalence artifact for a toy/target program:
 
 ```bash
 cargo run --features onnx-export --bin tvm -- research-v2-step programs/addition.tvm \
   -o compiled/research-v2-addition-step.json --max-steps 1
 ```
 
-This checks a single step across transformer and ONNX runtimes and emits a JSON artifact with:
+This checks a single step across transformer and ONNX runtimes and emits a JSON artifact
+with:
 
 - statement metadata (`statement-v2-research-draft`)
 - fixed-point profile and ONNX op subset version
@@ -744,16 +784,19 @@ Canonical research-v2 spec files:
 
 ### Research V2 Prefix-Trace Semantic Artifact
 
-For deeper research evidence, generate a prefix trace certificate across up to `N` steps:
+For deeper research evidence, generate a prefix trace certificate across up to `N`
+steps:
 
 ```bash
 cargo run --features onnx-export --bin tvm -- research-v2-trace programs/addition.tvm \
   -o compiled/research-v2-addition-trace.json --max-steps 8
 ```
 
-This checks transformer and ONNX step-by-step, emits mismatch localization (`first_mismatch_step`, `mismatch_reason`), and includes trace/final-state commitments.
-By default, the command still writes the artifact but exits non-zero when a mismatch is found.
-Use `--allow-mismatch` to keep the artifact and exit success for CI/reporting workflows.
+This checks transformer and ONNX step-by-step, emits mismatch localization
+(`first_mismatch_step`, `mismatch_reason`), and includes trace/final-state commitments.
+By default, the command still writes the artifact but exits non-zero when a mismatch is
+found. Use `--allow-mismatch` to keep the artifact and exit success for CI/reporting
+workflows.
 
 Additional trace spec files:
 
@@ -782,11 +825,11 @@ cargo run --features onnx-export --bin tvm -- research-v2-matrix \
   --max-steps 32
 ```
 
-The matrix artifact reports per-program match status, mismatch localization, aggregate counts
-(`total_programs`, `matched_programs`, `mismatched_programs`), and a top-level
-`matrix_entries_hash` commitment.
-By default, the command still writes the artifact but exits non-zero when
-`mismatched_programs > 0`; pass `--allow-mismatch` to keep success exits.
+The matrix artifact reports per-program match status, mismatch localization, aggregate
+counts (`total_programs`, `matched_programs`, `mismatched_programs`), and a top-level
+`matrix_entries_hash` commitment. By default, the command still writes the artifact but
+exits non-zero when `mismatched_programs > 0`; pass `--allow-mismatch` to keep success
+exits.
 
 Additional matrix spec files:
 
@@ -805,23 +848,22 @@ cargo run --features full --bin tvm -- verify-research-v3-equivalence \
   compiled/research-v3-addition-equivalence.json
 ```
 
-This checks transformer, native, Burn, and ONNX/Tract runtimes in lockstep,
-then emits a JSON artifact with engine summaries, deterministic rule witnesses,
-bounded trace rows, semantic canonical event rows, per-engine transition
-relation hashes, and commitment hashes. The transition hashes are the first
-narrow Emerge-style relation-kernel hardening step: they make each
-same-instruction state transition explicit without claiming equality saturation
-or synthesized rewrite validation. The verifier command recomputes the
-artifact's internal commitments, bounded trace hashes, semantic canonical
+This checks transformer, native, Burn, and ONNX/Tract runtimes in lockstep, then emits a
+JSON artifact with engine summaries, deterministic rule witnesses, bounded trace rows,
+semantic canonical event rows, per-engine transition relation hashes, and commitment
+hashes. The transition hashes are the first narrow Emerge-style relation-kernel
+hardening step: they make each same-instruction state transition explicit without
+claiming equality saturation or synthesized rewrite validation. The verifier command
+recomputes the artifact's internal commitments, bounded trace hashes, semantic canonical
 event-relation hashes, engine final-state hashes, cross-engine state-boundary
-consistency, and transition relation hashes; it is an artifact-integrity check,
-not a proof that independent model implementations are equivalent in general.
-The artifact also carries a frontend/runtime semantics
-registry that separates currently checked lanes from these research-watch lanes:
-`torch-export`, `executorch`, `stablehlo`, `iree`, `onnx-mlir`, `tvm-unity`,
-`vllm`, `sglang`, and `egg-emerge`. It intentionally does not claim support for
-those watch lanes, e-graph saturation, SMT-backed rewrite synthesis, randomized
-opaque-kernel testing, or a cryptographic implementation-equivalence proof.
+consistency, and transition relation hashes; it is an artifact-integrity check, not a
+proof that independent model implementations are equivalent in general. The artifact
+also carries a frontend/runtime semantics registry that separates currently checked
+lanes from these research-watch lanes: `torch-export`, `executorch`, `stablehlo`,
+`iree`, `onnx-mlir`, `tvm-unity`, `vllm`, `sglang`, and `egg-emerge`. It intentionally
+does not claim support for those watch lanes, e-graph saturation, SMT-backed rewrite
+synthesis, randomized opaque-kernel testing, or a cryptographic
+implementation-equivalence proof.
 
 Canonical research-v3 spec files:
 
@@ -846,15 +888,15 @@ cargo run --bin tvm -- prepare-hf-provenance-manifest \
 cargo run --bin tvm -- verify-hf-provenance-manifest compiled/hf-provenance.json
 ```
 
-This manifest is deliberately a provenance artifact, not a proving claim. It
-pins the Hub repo/revision, tokenizer identity/revision, optional tokenizer
-files and tokenization transcripts, local `safetensors` file hashes plus parsed
-metadata-header hashes/tensor counts, optional ONNX export file hashes, and
-optional model-card/DOI/dataset release metadata. The verifier rejects floating
-Hub revisions such as `main`, recomputes local file hashes, recomputes the
-manifest commitments, and rejects safetensors metadata drift. It does not prove
-tokenizer algorithm correctness, safetensors architectural semantics, Optimum
-export semantic equivalence, live Hub availability, or DOI validity.
+This manifest is deliberately a provenance artifact, not a proving claim. It pins the
+Hub repo/revision, tokenizer identity/revision, optional tokenizer files and
+tokenization transcripts, local `safetensors` file hashes plus parsed metadata-header
+hashes/tensor counts, optional ONNX export file hashes, and optional
+model-card/DOI/dataset release metadata. The verifier rejects floating Hub revisions
+such as `main`, recomputes local file hashes, recomputes the manifest commitments, and
+rejects safetensors metadata drift. It does not prove tokenizer algorithm correctness,
+safetensors architectural semantics, Optimum export semantic equivalence, live Hub
+availability, or DOI validity.
 
 Canonical HF provenance spec file:
 
@@ -862,8 +904,8 @@ Canonical HF provenance spec file:
 
 ### Reproducibility Bundle
 
-For publication-ready artifacts (benchmarks, proofs, semantic agreement artifacts, hashes),
-run:
+For publication-ready artifacts (benchmarks, proofs, semantic agreement artifacts,
+hashes), run:
 
 ```bash
 ./scripts/generate_repro_bundle.sh
@@ -874,7 +916,8 @@ Outputs are written to `compiled/repro-bundle/`:
 - `manifest.txt` (commit + toolchain + environment)
 - `benchmarks.tsv` (timings by command)
 - `sha256sums.txt` (hashes for generated artifacts)
-- STARK proof files and `research-v2` / `research-v3` certificates used for evidence sections
+- STARK proof files and `research-v2` / `research-v3` certificates used for evidence
+  sections
 
 Additional committed transformer-shaped semantic artifacts live under:
 
@@ -882,29 +925,30 @@ Additional committed transformer-shaped semantic artifacts live under:
 - `docs/paper/artifacts/transformer-soft-attention-v1/soft_attention_memory-step.json`
 - `docs/paper/artifacts/transformer-soft-attention-v1/soft_attention_memory-trace.json`
 
----
+______________________________________________________________________
 
 ## Attention Modes
 
-| Mode | Behavior | Flag |
-|------|----------|------|
-| `average-hard` | Deterministic argmax via convex hull | Default |
-| `softmax` | Weighted read over full write history | `--attention-mode softmax` |
-| `hard-softmax:T` | Temperature-interpolated | `--attention-mode hard-softmax:10` |
+| Mode             | Behavior                              | Flag                               |
+| ---------------- | ------------------------------------- | ---------------------------------- |
+| `average-hard`   | Deterministic argmax via convex hull  | Default                            |
+| `softmax`        | Weighted read over full write history | `--attention-mode softmax`         |
+| `hard-softmax:T` | Temperature-interpolated              | `--attention-mode hard-softmax:10` |
 
-The `average-hard` mode is the only one supported by the STARK proof path. `softmax` and `hard-softmax` are available for experimentation and comparison.
+The `average-hard` mode is the only one supported by the STARK proof path. `softmax` and
+`hard-softmax` are available for experimentation and comparison.
 
----
+______________________________________________________________________
 
 ## Feature Flags
 
-| Flag | Enables |
-|------|---------|
-| *(default)* | Transformer runtime, native interpreter, TUI, STARK prover |
-| `burn-model` | Burn tensor execution engine, `--verify-burn` |
-| `onnx-export` | ONNX export, Tract execution engine, `--verify-onnx` |
+| Flag           | Enables                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------------------ |
+| *(default)*    | Transformer runtime, native interpreter, TUI, STARK prover                                       |
+| `burn-model`   | Burn tensor execution engine, `--verify-burn`                                                    |
+| `onnx-export`  | ONNX export, Tract execution engine, `--verify-onnx`                                             |
 | `stwo-backend` | Experimental S-two backend seam for `prove-stark --backend stwo` / `verify-stark --backend stwo` |
-| `full` | `burn-model` + `onnx-export`, plus `--verify-all` convenience workflows |
+| `full`         | `burn-model` + `onnx-export`, plus `--verify-all` convenience workflows                          |
 
 ```bash
 cargo test                    # Core suite
@@ -912,9 +956,9 @@ cargo test --features full    # Everything
 cargo bench                   # Hull + STARK benchmarks
 ```
 
-`cargo test` is not a fast smoke check here: several suites generate and verify
-real STARK proofs, so full runs can take 10-30+ minutes depending on machine
-and enabled features.
+`cargo test` is not a fast smoke check here: several suites generate and verify real
+STARK proofs, so full runs can take 10-30+ minutes depending on machine and enabled
+features.
 
 ## Development Checks
 
@@ -931,7 +975,7 @@ cargo run --bin tvm -- --help
 cargo run --bin tvm -- run --help
 ```
 
----
+______________________________________________________________________
 
 ## Repository Structure
 
@@ -965,22 +1009,22 @@ scripts/                # Python ONNX validator
 
 ~10k lines of Rust. ~3k lines of tests. ~3k lines of STARK internals.
 
----
+______________________________________________________________________
 
 ## Scope and Status
 
 This repository is intentionally narrow. It is trying to make a difficult claim
 correctly, not to look broad.
 
-| Area | Status | Notes |
-|---|---|---|
-| Compact ISA + deterministic transformer runtime | Implemented | Arithmetic, memory, stack, and control flow |
-| Lockstep multi-engine execution | Implemented | Transformer, native, Burn, and ONNX surfaces |
-| Vanilla STARK proving | Implemented | Stable `statement-v1` path |
-| Experimental `stwo` proving | Implemented, narrow | Shipped fixtures, lookup demos, transformer-shaped fixtures, bounded decoding artifacts |
-| Full standard-softmax transformer proving on `stwo` | Not implemented | Still outside the current claim boundary |
-| Zero-knowledge hiding | Not implemented | Current proofs are transparent, not hiding |
-| Full-ISA STARK AIR for bitwise/compare | Not implemented | Broader subset exists, but not full public proof coverage |
+| Area                                                | Status              | Notes                                                                                   |
+| --------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------- |
+| Compact ISA + deterministic transformer runtime     | Implemented         | Arithmetic, memory, stack, and control flow                                             |
+| Lockstep multi-engine execution                     | Implemented         | Transformer, native, Burn, and ONNX surfaces                                            |
+| Vanilla STARK proving                               | Implemented         | Stable `statement-v1` path                                                              |
+| Experimental `stwo` proving                         | Implemented, narrow | Shipped fixtures, lookup demos, transformer-shaped fixtures, bounded decoding artifacts |
+| Full standard-softmax transformer proving on `stwo` | Not implemented     | Still outside the current claim boundary                                                |
+| Zero-knowledge hiding                               | Not implemented     | Current proofs are transparent, not hiding                                              |
+| Full-ISA STARK AIR for bitwise/compare              | Not implemented     | Broader subset exists, but not full public proof coverage                               |
 
 ### Experimental `stwo` Backend
 
@@ -991,24 +1035,21 @@ correctly, not to look broad.
 
 #### Current Fixture Set
 
-The public `stwo` proving path currently proves and verifies these shipped
-fixtures under `statement-v1`:
+The public `stwo` proving path currently proves and verifies these shipped fixtures
+under `statement-v1`:
 
-- arithmetic fixtures:
-  `programs/addition.tvm`, `programs/counter.tvm`,
-  `programs/memory_roundtrip.tvm`, `programs/multiply.tvm`,
-  `programs/dot_product.tvm`, `programs/fibonacci.tvm`,
-  `programs/matmul_2x2.tvm`, `programs/single_neuron.tvm`
-- transformer-shaped fixtures:
-  `programs/gemma_block_v1.tvm`, `programs/gemma_block_v2.tvm`,
-  `programs/gemma_block_v3.tvm`, `programs/gemma_block_v4.tvm`
-- decoding families:
-  fixed-shape `decoding_step_v1` and parameterized `decoding_step_v2`
+- arithmetic fixtures: `programs/addition.tvm`, `programs/counter.tvm`,
+  `programs/memory_roundtrip.tvm`, `programs/multiply.tvm`, `programs/dot_product.tvm`,
+  `programs/fibonacci.tvm`, `programs/matmul_2x2.tvm`, `programs/single_neuron.tvm`
+- transformer-shaped fixtures: `programs/gemma_block_v1.tvm`,
+  `programs/gemma_block_v2.tvm`, `programs/gemma_block_v3.tvm`,
+  `programs/gemma_block_v4.tvm`
+- decoding families: fixed-shape `decoding_step_v1` and parameterized `decoding_step_v2`
 
-The broader Phase 2 arithmetic subset (`NOP`, `LOADI`, `LOAD`, `STORE`, `ADD`,
-`ADDM`, `SUBM`, `MULM`, `JMP`, `JZ`, `HALT`) is implemented at the AIR/trace
-level and covered by internal constraint tests, but end-to-end `stwo` proving is
-only validated publicly for the shipped fixture set and decoding families.
+The broader Phase 2 arithmetic subset (`NOP`, `LOADI`, `LOAD`, `STORE`, `ADD`, `ADDM`,
+`SUBM`, `MULM`, `JMP`, `JZ`, `HALT`) is implemented at the AIR/trace level and covered
+by internal constraint tests, but end-to-end `stwo` proving is only validated publicly
+for the shipped fixture set and decoding families.
 
 #### Lookup Demos
 
@@ -1017,8 +1058,8 @@ The repo exposes dedicated serialized proof envelopes and CLI commands for:
 - single-row binary-step lookup and normalization demos
 - shared-table multi-claim lookup and normalization demos
 
-That means the lookup-backed components are part of the public proof workflow,
-not just internal metadata or library-only helpers.
+That means the lookup-backed components are part of the public proof workflow, not just
+internal metadata or library-only helpers.
 
 #### Decoding Families
 
@@ -1027,38 +1068,54 @@ The public decoding artifacts currently cover:
 - fixed-shape `decoding_step_v1`
 - parameterized `decoding_step_v2`
 
-Those power the proof-carrying decoding demos, including layout-bound carried
-state, rolling KV-cache windows, cumulative KV-history commitments, mergeable
-history segments, rollups, rollup matrices, and the newer KV / lookup frontier
-layers used by the next-paper track. The current Phase 12 transition now uses
-both shared normalization scale rows and both shared activation output rows in
-executed decoding semantics, not only as carried proof metadata, and feeds
-lookup-backed values into the latest carried KV-cache pair on the public demo
-layouts, with the current wider layout frontier now mostly output-derived
-rather than forwarded-input-derived, while the bounded combined-output cell
-itself now absorbs two additional shared lookup rows before both final output
-lanes carry it forward.
+Those power the proof-carrying decoding demos, including layout-bound carried state,
+rolling KV-cache windows, cumulative KV-history commitments, mergeable history segments,
+rollups, rollup matrices, and the newer KV / lookup frontier layers used by the
+next-paper track. The current Phase 12 transition now uses both shared normalization
+scale rows and both shared activation output rows in executed decoding semantics, not
+only as carried proof metadata, and feeds lookup-backed values into the latest carried
+KV-cache pair on the public demo layouts, with the current wider layout frontier now
+mostly output-derived rather than forwarded-input-derived, while the bounded
+combined-output cell itself now absorbs two additional shared lookup rows before both
+final output lanes carry it forward.
 
 #### Phase Highlights
 
 - Phase 3: narrow arithmetic pilot and bounded lookup-backed activation pilot
 - Phase 5: real arithmetic proof lifecycles plus normalization lookup demo
-- Phase 7-10: `gemma_block_v1` through `gemma_block_v4`, ending with shared-table lookup binding inside the top-level execution proof
-- Phase 11-14: fixed-shape decoding, parameterized decoding family, layout matrix, and chunked cumulative KV-history
-- Phase 15-17: mergeable history segments, rollups over segments, and multi-layout rollup matrices
-- Phase 18-20: explicit KV frontiers, carried lookup transcripts, and lookup frontier commitments
-- Phase 21: template-bound accumulation over Phase 17 matrices for a reusable pre-recursive merge boundary
-- Phase 22: lookup-side accumulation over a verified Phase 21 source accumulator with explicit source/template binding and derived frontier/count checks before recursion
-- Phase 23: pre-recursive cross-step lookup accumulation over cumulative Phase 22 prefixes with carried-state boundary commitments and derived counter checks
-- Phase 24: full carried-state relation accumulation over verified Phase 23 members with explicit relation-template and relation-accumulator commitments before recursive compression
-- Phase 25: honest intervalization of the Phase 24 carried-state relation into explicit contiguous carried-state intervals with derived interval-template and interval-accumulator commitments
-- Phase 26: folded accumulation over verified Phase 25 intervals with explicit fold-template binding and folded interval accumulator commitments over real carried-state intervals
-- Phase 27: chained fold-of-folds accumulation over verified Phase 26 members with explicit chain-template binding and chained accumulator commitments over honest carried-state intervals
-- Phase 28: proof-carrying aggregation over verified Phase 27 chained artifacts with explicit aggregation-template binding, length-framed aggregation transcripts, and aggregate carried-state boundary checks
+- Phase 7-10: `gemma_block_v1` through `gemma_block_v4`, ending with shared-table lookup
+  binding inside the top-level execution proof
+- Phase 11-14: fixed-shape decoding, parameterized decoding family, layout matrix, and
+  chunked cumulative KV-history
+- Phase 15-17: mergeable history segments, rollups over segments, and multi-layout
+  rollup matrices
+- Phase 18-20: explicit KV frontiers, carried lookup transcripts, and lookup frontier
+  commitments
+- Phase 21: template-bound accumulation over Phase 17 matrices for a reusable
+  pre-recursive merge boundary
+- Phase 22: lookup-side accumulation over a verified Phase 21 source accumulator with
+  explicit source/template binding and derived frontier/count checks before recursion
+- Phase 23: pre-recursive cross-step lookup accumulation over cumulative Phase 22
+  prefixes with carried-state boundary commitments and derived counter checks
+- Phase 24: full carried-state relation accumulation over verified Phase 23 members with
+  explicit relation-template and relation-accumulator commitments before recursive
+  compression
+- Phase 25: honest intervalization of the Phase 24 carried-state relation into explicit
+  contiguous carried-state intervals with derived interval-template and
+  interval-accumulator commitments
+- Phase 26: folded accumulation over verified Phase 25 intervals with explicit
+  fold-template binding and folded interval accumulator commitments over real
+  carried-state intervals
+- Phase 27: chained fold-of-folds accumulation over verified Phase 26 members with
+  explicit chain-template binding and chained accumulator commitments over honest
+  carried-state intervals
+- Phase 28: proof-carrying aggregation over verified Phase 27 chained artifacts with
+  explicit aggregation-template binding, length-framed aggregation transcripts, and
+  aggregate carried-state boundary checks
 
-These phases define pre-recursive merge boundaries and carried-state bindings;
-they do not yet implement recursive cryptographic accumulation or compressed
-cross-member shared-table reuse.
+These phases define pre-recursive merge boundaries and carried-state bindings; they do
+not yet implement recursive cryptographic accumulation or compressed cross-member
+shared-table reuse.
 
 #### Explicit Non-Goals
 
@@ -1066,8 +1123,8 @@ cross-member shared-table reuse.
 - not full public end-to-end proving for every arithmetic-subset program
 - not recursive proving yet
 
-This is still not a full `stwo` zkML backend for standard-softmax transformers,
-but it is well past the old “dependency seam only” stage.
+This is still not a full `stwo` zkML backend for standard-softmax transformers, but it
+is well past the old “dependency seam only” stage.
 
 ### Frozen Publication Artifacts
 
@@ -1076,16 +1133,15 @@ but it is well past the old “dependency seam only” stage.
   `docs/paper/artifacts/stwo-experimental-v1-2026-04-06/`
 - Frozen proof-carrying aggregation bundle:
   `docs/paper/artifacts/stwo-proof-carrying-aggregation-v1-2026-04-11/`
-- Publication-facing artifact index:
-  `docs/paper/artifacts/README.md`
+- Publication-facing artifact index: `docs/paper/artifacts/README.md`
 - Proof-carrying aggregation `stwo` bundle regeneration script:
   `scripts/paper/generate_stwo_proof_carrying_aggregation_bundle.sh`
 - `stwo` publication bundle regeneration script:
   `scripts/paper/generate_stwo_publication_bundle.sh`
 
-Older carried-state bundle generators remain available for archival provenance
-and engineering comparison, but the current paper package cites the frozen
-experimental `stwo` bundle and the frozen proof-carrying aggregation bundle.
+Older carried-state bundle generators remain available for archival provenance and
+engineering comparison, but the current paper package cites the frozen experimental
+`stwo` bundle and the frozen proof-carrying aggregation bundle.
 
 Archival provenance generators:
 
@@ -1095,22 +1151,27 @@ Archival provenance generators:
 
 ### Project Lineage
 
-The canonical launch repository is
-`omarespejel/provable-transformer-vm` (this repository). Earlier phases of the
-same research line were developed under the `llm-provable-computer` naming
-before consolidation here. This repository carries the maintained artifact
-bundles, research-oriented semantic agreement artifacts, transformer-shaped
-fixtures, shared-table lookup proofs, and proof-carrying decoding artifacts.
+The canonical launch repository is `omarespejel/provable-transformer-vm` (this
+repository). Earlier phases of the same research line were developed under the
+`llm-provable-computer` naming before consolidation here. This repository carries the
+maintained artifact bundles, research-oriented semantic agreement artifacts,
+transformer-shaped fixtures, shared-table lookup proofs, and proof-carrying decoding
+artifacts.
 
----
+______________________________________________________________________
 
 ## References
 
-- [Can LLMs Be Computers?](https://www.percepta.ai/blog/can-llms-be-computers) --- Percepta. The original idea.
-- [Scalable, Transparent, and Post-Quantum Secure Computational Integrity](https://eprint.iacr.org/2018/046) --- Ben-Sasson et al., 2018. The STARK protocol.
-- [Circle STARKs](https://eprint.iacr.org/2024/278) --- Haböck, Levit, Papini, 2024. STARKs over Mersenne prime fields.
-- [STWO Prover](https://github.com/starkware-libs/stwo) --- StarkWare's production Circle STARK prover.
-- [Anatomy of a STARK](https://aszepieniec.github.io/stark-anatomy/) --- Aszepieniec. The reference implementation this STARK is ported from.
+- [Can LLMs Be Computers?](https://www.percepta.ai/blog/can-llms-be-computers) ---
+  Percepta. The original idea.
+- [Scalable, Transparent, and Post-Quantum Secure Computational Integrity](https://eprint.iacr.org/2018/046)
+  --- Ben-Sasson et al., 2018. The STARK protocol.
+- [Circle STARKs](https://eprint.iacr.org/2024/278) --- Haböck, Levit, Papini, 2024.
+  STARKs over Mersenne prime fields.
+- [STWO Prover](https://github.com/starkware-libs/stwo) --- StarkWare's production
+  Circle STARK prover.
+- [Anatomy of a STARK](https://aszepieniec.github.io/stark-anatomy/) --- Aszepieniec.
+  The reference implementation this STARK is ported from.
 
 ## License
 

--- a/docs/paper/PUBLICATION_RELEASE.md
+++ b/docs/paper/PUBLICATION_RELEASE.md
@@ -2,16 +2,14 @@
 
 Snapshot date: **April 11, 2026**
 
-Planned publication tag after repository transfer:
-`paper-publication-v4-2026-04-11`
+Planned publication tag after repository transfer: `paper-publication-v4-2026-04-11`
 
-Canonical publication snapshot after transfer:
-The canonical v4 publication snapshot is the release tag
-`paper-publication-v4-2026-04-11` once cut in the final publication
-repository. Until that transfer and tag cut happen, the paper keeps Reference
-`[30]` pointed at the staging commit-pinned snapshot below. The final
-publication tag intentionally need not match the pinned carried-state evidence
-commit used by the aggregation bundle.
+Canonical publication snapshot after transfer: The canonical v4 publication snapshot is
+the release tag `paper-publication-v4-2026-04-11` once cut in the final publication
+repository. Until that transfer and tag cut happen, the paper keeps Reference `[30]`
+pointed at the staging commit-pinned snapshot below. The final publication tag
+intentionally need not match the pinned carried-state evidence commit used by the
+aggregation bundle.
 
 Pinned carried-state aggregation provenance checkpoint:
 `6ff972ddda4051d73dc65c92a88c0d00683ec8c7`
@@ -19,11 +17,9 @@ Pinned carried-state aggregation provenance checkpoint:
 Dedicated proof-carrying aggregation bundle index cited by Reference `[46]`:
 `6bb8cab99092203217d64951c3af61488aa2c58e`
 
-Current staging repository:
-`https://github.com/omarespejel/provable-transformer-vm`
-(earlier iterations of this research line used the `llm-provable-computer`
-project name). The final publication repository may move before the canonical
-tag is cut.
+Current staging repository: `https://github.com/omarespejel/provable-transformer-vm`
+(earlier iterations of this research line used the `llm-provable-computer` project
+name). The final publication repository may move before the canonical tag is cut.
 
 Formal paper author line in the draft:
 
@@ -31,8 +27,8 @@ Formal paper author line in the draft:
 - Omar Espejel - Starknet Foundation
 
 This repository state is the publication-facing package for the paper and its supporting
-artifacts. The package is intentionally split into evidence tiers rather than treated as one
-monolithic benchmark claim.
+artifacts. The package is intentionally split into evidence tiers rather than treated as
+one monolithic benchmark claim.
 
 ## Included materials
 
@@ -61,15 +57,17 @@ monolithic benchmark claim.
 ## Claim posture
 
 - `production-v1` is the primary frozen reproducibility bundle for the vanilla backend.
-- `stwo-experimental-v1` is the frozen narrow evidence tier for the experimental S-two path.
-- Post-freeze commit-pinned evidence now includes the merged pre-recursive
-  carried-state aggregation bundle, including proof-carrying outer aggregation over chained artifacts.
+- `stwo-experimental-v1` is the frozen narrow evidence tier for the experimental S-two
+  path.
+- Post-freeze commit-pinned evidence now includes the merged pre-recursive carried-state
+  aggregation bundle, including proof-carrying outer aggregation over chained artifacts.
 - Older carried-state artifact bundles are retained as archival provenance; see
   `docs/paper/artifacts/README.md`. The proof-carrying aggregation bundle is the
   publication-facing artifact bundle for the carried-state aggregation line.
-- The repo still does **not** claim full standard-softmax transformer inference on S-two,
-  recursive cross-step shared-table accumulation beyond the public lookup-accumulator artifact,
-  recursive cryptographic compression/verification closure, or production-scale zkML deployment.
+- The repo still does **not** claim full standard-softmax transformer inference on
+  S-two, recursive cross-step shared-table accumulation beyond the public
+  lookup-accumulator artifact, recursive cryptographic compression/verification closure,
+  or production-scale zkML deployment.
 
 ## Regeneration
 
@@ -90,16 +88,16 @@ monolithic benchmark claim.
 
 Before cutting a release tag, verify:
 
-1. the frozen bundle directories exist and their `sha256sums.txt` files validate,
-   and the aggregation bundle's `provenance_sha256sums.txt` also validates,
+1. the frozen bundle directories exist and their `sha256sums.txt` files validate, and
+   the aggregation bundle's `provenance_sha256sums.txt` also validates,
 2. the main paper and appendices refer to the same repo state and evidence tiers,
 3. the design note matches the current experimental `stwo` status,
 4. no stale top-level README language still describes S-two as merely prospective,
 5. Reference `[30]` remains commit-pinned until the repository transfer and v4
-   publication tag exist; after that tag is cut in the final publication
-   repository, update `[30]` to the v4 publication tag while keeping the
-   aggregation bundle directly pinned by Reference `[46]`,
+   publication tag exist; after that tag is cut in the final publication repository,
+   update `[30]` to the v4 publication tag while keeping the aggregation bundle directly
+   pinned by Reference `[46]`,
 6. the formal author line and affiliation text are confirmed before public release,
-7. `paper preflight` passes (citation integrity, immutable local repo links,
-   figure/link paths, appendix source note, and unresolved publication snapshot
-   placeholder detection).
+7. `paper preflight` passes (citation integrity, immutable local repo links, figure/link
+   paths, appendix source note, and unresolved publication snapshot placeholder
+   detection).

--- a/docs/paper/appendix-backend-artifact-comparison.md
+++ b/docs/paper/appendix-backend-artifact-comparison.md
@@ -1,42 +1,43 @@
 # Appendix: Frozen Backend Artifact Comparison
 
-Evidence snapshot: **April 6, 2026** bundle, with index material finalized April 7, 2026 UTC.
+Evidence snapshot: **April 6, 2026** bundle, with index material finalized April 7, 2026
+UTC.
 
-This appendix complements Appendix A and the main paper’s Section 5 by placing the two frozen
-artifact tiers side by side:
+This appendix complements Appendix A and the main paper’s Section 5 by placing the two
+frozen artifact tiers side by side:
 
 - the vanilla-backend `production-v1` reproducibility bundle, and
 - the narrow experimental `stwo-experimental-v1` bundle.
 
-These rows are **not** matched end-to-end benchmarks on identical workloads. They are frozen
-artifact facts drawn from the committed bundle indices under
+These rows are **not** matched end-to-end benchmarks on identical workloads. They are
+frozen artifact facts drawn from the committed bundle indices under
 `docs/paper/artifacts/production-v1-2026-04-04/` and
 `docs/paper/artifacts/stwo-experimental-v1-2026-04-06/`.
 
 The repository also contains
-`docs/paper/artifacts/stwo-proof-carrying-aggregation-v1-2026-04-11/`, a
-proof-carrying aggregation bundle. It is systems evidence for pre-recursive
-carried-state aggregation, not a normalized backend-performance row in Table C1.
+`docs/paper/artifacts/stwo-proof-carrying-aggregation-v1-2026-04-11/`, a proof-carrying
+aggregation bundle. It is systems evidence for pre-recursive carried-state aggregation,
+not a normalized backend-performance row in Table C1.
 
 ## Table C1. Frozen artifact comparison by backend and scope
 
-| Artifact | Backend | Bundle | Prove | Verify | Proof size | Semantic scope |
-|---|---|---|---:|---:|---:|---|
-| `addition` | vanilla | `production-v1` | `71s` | `2s` | `7,644,769` bytes | arithmetic `statement-v1` execution proof |
-| `addition` | `stwo` | `stwo-experimental-v1` | `2s` | `1s` | `54,563` bytes | arithmetic `statement-v1` execution proof |
-| `dot_product` | vanilla | `production-v1` | `430s` | `5s` | `12,835,175` bytes | neural-style arithmetic `statement-v1` execution proof |
-| `single_neuron` | vanilla | `production-v1` | `390s` | `4s` | `11,767,989` bytes | neural-style arithmetic `statement-v1` execution proof |
-| `shared-normalization-demo` | `stwo` | `stwo-experimental-v1` | `1s` | `1s` | `74,074` bytes | shared-table normalization lookup proof envelope |
-| `gemma_block_v4` | `stwo` | `stwo-experimental-v1` | `1s` | `1s` | `751,737` bytes | fixed-shape Gemma-inspired `statement-v1` proof with shared lookup bindings |
-| `decoding_demo` | `stwo` | `stwo-experimental-v1` | `1s` | `1s` | `4,032,182` bytes | three-step proof-carrying decoding chain |
+| Artifact                    | Backend | Bundle                 |  Prove | Verify |         Proof size | Semantic scope                                                              |
+| --------------------------- | ------- | ---------------------- | -----: | -----: | -----------------: | --------------------------------------------------------------------------- |
+| `addition`                  | vanilla | `production-v1`        |  `71s` |   `2s` |  `7,644,769` bytes | arithmetic `statement-v1` execution proof                                   |
+| `addition`                  | `stwo`  | `stwo-experimental-v1` |   `2s` |   `1s` |     `54,563` bytes | arithmetic `statement-v1` execution proof                                   |
+| `dot_product`               | vanilla | `production-v1`        | `430s` |   `5s` | `12,835,175` bytes | neural-style arithmetic `statement-v1` execution proof                      |
+| `single_neuron`             | vanilla | `production-v1`        | `390s` |   `4s` | `11,767,989` bytes | neural-style arithmetic `statement-v1` execution proof                      |
+| `shared-normalization-demo` | `stwo`  | `stwo-experimental-v1` |   `1s` |   `1s` |     `74,074` bytes | shared-table normalization lookup proof envelope                            |
+| `gemma_block_v4`            | `stwo`  | `stwo-experimental-v1` |   `1s` |   `1s` |    `751,737` bytes | fixed-shape Gemma-inspired `statement-v1` proof with shared lookup bindings |
+| `decoding_demo`             | `stwo`  | `stwo-experimental-v1` |   `1s` |   `1s` |  `4,032,182` bytes | three-step proof-carrying decoding chain                                    |
 
 ## How to read this appendix
 
-- `production-v1` remains the stronger vanilla reproducibility tier and the basis of the main
-  artifact discussion.
-- `stwo-experimental-v1` is intentionally narrower, but it freezes one arithmetic proof, one
-  lookup-backed proof envelope, one transformer-shaped fixed-shape proof, and one proof-carrying
-  decoding chain on the experimental S-two path.
-- The table is useful as artifact evidence, not as a normalized backend-performance study. In
-  particular, the `stwo-experimental-v1` timing rows come from warmed local bundle runs rather
-  than a cold-build or matched-hardware benchmark harness.
+- `production-v1` remains the stronger vanilla reproducibility tier and the basis of the
+  main artifact discussion.
+- `stwo-experimental-v1` is intentionally narrower, but it freezes one arithmetic proof,
+  one lookup-backed proof envelope, one transformer-shaped fixed-shape proof, and one
+  proof-carrying decoding chain on the experimental S-two path.
+- The table is useful as artifact evidence, not as a normalized backend-performance
+  study. In particular, the `stwo-experimental-v1` timing rows come from warmed local
+  bundle runs rather than a cold-build or matched-hardware benchmark harness.

--- a/docs/paper/appendix-influence-realization.md
+++ b/docs/paper/appendix-influence-realization.md
@@ -1,18 +1,18 @@
 # Appendix: External Influences and Current Repository Realization
 
 This supplementary appendix records how the current paper and repository draw on
-external work without overstating equivalence of scope. The table is meant to
-separate three questions that can otherwise blur together in review:
+external work without overstating equivalence of scope. The table is meant to separate
+three questions that can otherwise blur together in review:
 
 - which external line influenced the design,
 - where that influence is visible in the current paper and repository, and
 - which part remains future work rather than a present claim.
 
-| Work / line | What we took from it | Where it appears in the paper | Where it appears in the repo | What remains future work |
-|---|---|---|---|---|
-| Percepta transformer-computer line | Conceptual framing for transformer-shaped execution as a meaningful computational object | Introduction and conceptual framing | Transformer-shaped VM and execution-trace framing | This repository is not a learned-transformer proof system |
-| DeepProve / reusable lookup direction | Motivation for stateful decoding and reusable/shared lookup structure | Related work and near-term roadmap | Shared lookup-table identity binding and carried lookup state | Not yet recursive cross-step shared-table accumulation |
-| Emerge | Motivation for bounded multi-runtime semantic-agreement artifacts | Section 5.6 semantic-agreement boundary | `research-v3` bounded equivalence-kernel artifacts | Not a general e-graph / SMT equivalence prover |
-| Jolt Atlas | Motivation for lookup-centric operator-level proving and streaming-friendly proving surfaces | Related work and near-term roadmap | Lookup-heavy artifact direction and operator-surface roadmap | Not yet ONNX-operator proving in this repository |
-| NANOZK | Legibility of block/layer proof envelopes | Related work and near-term roadmap | Reusable block-shaped execution proofs and step-level proof envelopes | Not a constant-size layer-proof system |
-| HyperNova / NeutronNova / ProtoStar | Novelty boundary for what this paper is not claiming | Section 5 artifact-layer disclaimer | Pre-recursive artifact-layer packaging language | Recursive cryptographic accumulation remains future work |
+| Work / line                           | What we took from it                                                                         | Where it appears in the paper           | Where it appears in the repo                                        | What remains future work                                  |
+| ------------------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------- |
+| Percepta transformer-computer line    | Conceptual framing for transformer-shaped execution as a meaningful computational object     | Introduction and conceptual framing     | Transformer-shaped VM and execution-trace framing                   | This repository is not a learned-transformer proof system |
+| DeepProve / reusable lookup direction | Motivation for stateful decoding and reusable/shared lookup structure                        | Related work and near-term roadmap      | Shared lookup-table identity binding and carried lookup state       | Not yet recursive cross-step shared-table accumulation    |
+| Emerge                                | Motivation for bounded multi-runtime semantic-agreement artifacts                            | Section 5.6 semantic-agreement boundary | `research-v3` bounded equivalence-kernel artifacts                  | Not a general e-graph / SMT equivalence prover            |
+| Jolt Atlas                            | Motivation for lookup-centric operator-level proving and streaming-friendly proving surfaces | Related work and near-term roadmap      | Lookup-heavy artifact direction and operator-surface roadmap        | Not yet ONNX-operator proving in this repository          |
+| NANOZK                                | Legibility of block/layer proof envelopes                                                    | Related work and near-term roadmap      | Reusable block-shaped execution proofs and step-level proof objects | Not a constant-size layer-proof system                    |
+| HyperNova / NeutronNova / ProtoStar   | Novelty boundary for what this paper is not claiming                                         | Section 5 artifact-layer disclaimer     | Pre-recursive artifact-layer packaging language                     | Recursive cryptographic accumulation remains future work  |

--- a/docs/paper/appendix-scaling-companion.md
+++ b/docs/paper/appendix-scaling-companion.md
@@ -2,27 +2,35 @@
 
 Snapshot date: **April 5, 2026**
 
-This appendix is a compact companion to Figure 1 in the main paper. It gives exact ratios for the dense and sparse curves used in the figure and keeps the visual summary tied to explicit numeric values.
+This appendix is a compact companion to Figure 1 in the main paper. It gives exact
+ratios for the dense and sparse curves used in the figure and keeps the visual summary
+tied to explicit numeric values.
 
 The appendix should be read with the same scope boundary as Section 4:
 
 - the dense curve is the GPT-2-small symbolic model from Section 4.3,
-- the sparse curve is a representative `5:1` local/global sparse attention schedule, Gemma-style in spirit, with `W = 1024`,
-- both curves use the same stylized constants `C_exp = 300`, `C_norm = 30`, and `C_nonlin = 150`,
+- the sparse curve is a representative `5:1` local/global sparse attention schedule,
+  Gemma-style in spirit, with `W = 1024`,
+- both curves use the same stylized constants `C_exp = 300`, `C_norm = 30`, and
+  `C_nonlin = 150`,
 - the sparse curve is **not** claimed to be one exact released Gemma checkpoint.
 
 ## Table B1. Exact dense and sparse ratios used in Figure 1
 
 | Context `T` | Dense GPT-style ratio | Sparse `5:1` schedule ratio |
-|---|---:|---:|
-| `128` | `1.132040x` | `1.132040x` |
-| `1024` | `1.481751x` | `1.481751x` |
-| `2048` | `1.765578x` | `1.536050x` |
-| `8192` | `2.512512x` | `1.804566x` |
-| `32768` | `3.042486x` | `2.373694x` |
-| `131072` | `3.242027x` | `2.940835x` |
+| ----------- | --------------------: | --------------------------: |
+| `128`       |           `1.132040x` |                 `1.132040x` |
+| `1024`      |           `1.481751x` |                 `1.481751x` |
+| `2048`      |           `1.765578x` |                 `1.536050x` |
+| `8192`      |           `2.512512x` |                 `1.804566x` |
+| `32768`     |           `3.042486x` |                 `2.373694x` |
+| `131072`    |           `3.242027x` |                 `2.940835x` |
 
-At `T <= 1024`, the sparse and dense curves coincide because `W_eff(T) = min(T, 1024) = T`, so the representative sparse schedule has the same average attention span as the dense schedule. Beyond that point, the local-window term starts damping the quadratic attention component, which is why the sparse curve rises more slowly while still remaining above `1.0`.
+At `T <= 1024`, the sparse and dense curves coincide because
+`W_eff(T) = min(T, 1024) = T`, so the representative sparse schedule has the same
+average attention span as the dense schedule. Beyond that point, the local-window term
+starts damping the quadratic attention component, which is why the sparse curve rises
+more slowly while still remaining above `1.0`.
 
 For the dense GPT-style curve, the asymptotic ceiling from Section 4 is
 
@@ -30,7 +38,9 @@ For the dense GPT-style curve, the asymptotic ceiling from Section 4 is
 (2d + H C_exp) / (2d + H) = (2 * 768 + 12 * 300) / (2 * 768 + 12) = 3.317829x.
 ```
 
-Figure 1 now plots that ceiling explicitly as a horizontal dashed line so the “rises but saturates” behavior is visible in the figure itself rather than only in the surrounding prose.
+Figure 1 now plots that ceiling explicitly as a horizontal dashed line so the “rises but
+saturates” behavior is visible in the figure itself rather than only in the surrounding
+prose.
 
 ## Reproducibility
 
@@ -46,26 +56,33 @@ The machine-readable outputs used by this appendix are committed at:
 
 ## Table B1a. Sensitivity of the GPT-2-small ratio to stylized non-arithmetic constants
 
-This table moves the main-text sensitivity sweep into the appendix so that Section 4 can stay focused on the exact cost model and one worked example. It shows that the qualitative claim is materially more sensitive to the assumed softmax-like cost than to the normalization or activation constants.
+This table moves the main-text sensitivity sweep into the appendix so that Section 4 can
+stay focused on the exact cost model and one worked example. It shows that the
+qualitative claim is materially more sensitive to the assumed softmax-like cost than to
+the normalization or activation constants.
 
-| Constants varied | Setting | SNARK/STARK ratio |
-|---|---:|---:|
-| `C_exp` with `C_norm = 30`, `C_nonlin = 150` | `50` | `1.13x` |
-| `C_exp` with `C_norm = 30`, `C_nonlin = 150` | `100` | `1.20x` |
-| `C_exp` with `C_norm = 30`, `C_nonlin = 150` | `300` | `1.48x` |
-| `C_exp` with `C_norm = 30`, `C_nonlin = 150` | `500` | `1.77x` |
-| `C_norm` with `C_exp = 300`, `C_nonlin = 150` | `10` | `1.48x` |
-| `C_norm` with `C_exp = 300`, `C_nonlin = 150` | `30` | `1.48x` |
-| `C_norm` with `C_exp = 300`, `C_nonlin = 150` | `50` | `1.49x` |
-| `C_nonlin` with `C_exp = 300`, `C_norm = 30` | `50` | `1.45x` |
-| `C_nonlin` with `C_exp = 300`, `C_norm = 30` | `150` | `1.48x` |
-| `C_nonlin` with `C_exp = 300`, `C_norm = 30` | `250` | `1.52x` |
+| Constants varied                              | Setting | SNARK/STARK ratio |
+| --------------------------------------------- | ------: | ----------------: |
+| `C_exp` with `C_norm = 30`, `C_nonlin = 150`  |    `50` |           `1.13x` |
+| `C_exp` with `C_norm = 30`, `C_nonlin = 150`  |   `100` |           `1.20x` |
+| `C_exp` with `C_norm = 30`, `C_nonlin = 150`  |   `300` |           `1.48x` |
+| `C_exp` with `C_norm = 30`, `C_nonlin = 150`  |   `500` |           `1.77x` |
+| `C_norm` with `C_exp = 300`, `C_nonlin = 150` |    `10` |           `1.48x` |
+| `C_norm` with `C_exp = 300`, `C_nonlin = 150` |    `30` |           `1.48x` |
+| `C_norm` with `C_exp = 300`, `C_nonlin = 150` |    `50` |           `1.49x` |
+| `C_nonlin` with `C_exp = 300`, `C_norm = 30`  |    `50` |           `1.45x` |
+| `C_nonlin` with `C_exp = 300`, `C_norm = 30`  |   `150` |           `1.48x` |
+| `C_nonlin` with `C_exp = 300`, `C_norm = 30`  |   `250` |           `1.52x` |
 
 ## Table B2. Exact dense Llama-2-7B-style extension under the current model
 
-To show that the Section 4 model is not specific to GPT-2-small, this appendix also evaluates the **exact same dense symbolic formula** on a Llama-2-7B-style dense reference configuration. The point is not to claim that Llama 2 is the only relevant production architecture; it is to show how the exact model behaves on a substantially wider and more production-like decoder stack than GPT-2-small.
+To show that the Section 4 model is not specific to GPT-2-small, this appendix also
+evaluates the **exact same dense symbolic formula** on a Llama-2-7B-style dense
+reference configuration. The point is not to claim that Llama 2 is the only relevant
+production architecture; it is to show how the exact model behaves on a substantially
+wider and more production-like decoder stack than GPT-2-small.
 
-The configuration used here follows the released Llama 2 7B architecture family [37]:
+The configuration used here follows the released Llama 2 7B architecture family \[37\]:
 
 - `d = 4096`
 - `H = 32`
@@ -73,21 +90,33 @@ The configuration used here follows the released Llama 2 7B architecture family 
 - stylized constants `C_exp = 15, 50, 300`
 - `C_norm = 30`, `C_nonlin = 150`
 
-All values below use the **exact dense formula from Sections 4.1 and 4.2**, not the first-order `TH / d^2` heuristic. That distinction matters at long context because the `2T^2d` term in both the numerator and denominator materially tempers the growth rate.
+All values below use the **exact dense formula from Sections 4.1 and 4.2**, not the
+first-order `TH / d^2` heuristic. That distinction matters at long context because the
+`2T^2d` term in both the numerator and denominator materially tempers the growth rate.
 
 | Context `T` | Ratio at `C_exp = 15` | Ratio at `C_exp = 50` | Ratio at `C_exp = 300` | STARK lookup-plus-scaling share |
-|---|---:|---:|---:|---:|
-| `4,096` | `1.019204x` | `1.038722x` | `1.178133x` | `0.069706%` |
-| `32,768` | `1.036868x` | `1.114813x` | `1.671567x` | `0.229661%` |
-| `131,072` | `1.047994x` | `1.162746x` | `1.982397x` | `0.330422%` |
+| ----------- | --------------------: | --------------------: | ---------------------: | ------------------------------: |
+| `4,096`     |           `1.019204x` |           `1.038722x` |            `1.178133x` |                     `0.069706%` |
+| `32,768`    |           `1.036868x` |           `1.114813x` |            `1.671567x` |                     `0.229661%` |
+| `131,072`   |           `1.047994x` |           `1.162746x` |            `1.982397x` |                     `0.330422%` |
 
-Here `STARK lookup-plus-scaling share` is defined as `(T^2H + 8Td) / L_STARK`: the `T^2H` lookup term plus both the `6Td` linear baseline and the additional `2Td` linear scaling term carried by the exact dense denominator. The column is therefore intentionally broader than a literal “lookup-only” share.
+Here `STARK lookup-plus-scaling share` is defined as `(T^2H + 8Td) / L_STARK`: the
+`T^2H` lookup term plus both the `6Td` linear baseline and the additional `2Td` linear
+scaling term carried by the exact dense denominator. The column is therefore
+intentionally broader than a literal “lookup-only” share.
 
-This extension supports a narrower and more defensible statement than some earlier drafts: at wide-production hidden sizes, the symbolic ratio can be modest at shorter context and still increase substantially over longer windows. But under the exact dense model it does **not** explode linearly without bound; the `2T^2d` arithmetic term remains first-order and the ratio approaches a finite architecture-dependent ceiling.
+This extension supports a narrower and more defensible statement than some earlier
+drafts: at wide-production hidden sizes, the symbolic ratio can be modest at shorter
+context and still increase substantially over longer windows. But under the exact dense
+model it does **not** explode linearly without bound; the `2T^2d` arithmetic term
+remains first-order and the ratio approaches a finite architecture-dependent ceiling.
 
 ## Table B3. Exact autoregressive marginal ratio note
 
-For autoregressive generation, the more relevant object is often not one aggregate sequence-wide ratio but the **marginal proving ratio for the next token at generation step `t`**. Under the same dense symbolic model used in the main text, the per-step marginal ratio becomes
+For autoregressive generation, the more relevant object is often not one aggregate
+sequence-wide ratio but the **marginal proving ratio for the next token at generation
+step `t`**. Under the same dense symbolic model used in the main text, the per-step
+marginal ratio becomes
 
 ```text
 R_marginal(t) =
@@ -96,27 +125,41 @@ R_marginal(t) =
 (12d^2 + 2td + tH + 8d).
 ```
 
-This is the exact single-step analogue of the Section 4 dense model. It makes the production-relevant dynamic explicit: early tokens remain close to the arithmetic-dominated regime, while later tokens inherit a larger attention-span penalty.
+This is the exact single-step analogue of the Section 4 dense model. It makes the
+production-relevant dynamic explicit: early tokens remain close to the
+arithmetic-dominated regime, while later tokens inherit a larger attention-span penalty.
 
-By inspection, `R_marginal(t)` is algebraically identical to the dense per-layer ratio from Section 4 evaluated at context `T = t`. The autoregressive note is therefore not a different model; it is the same exact dense model viewed one generation step at a time.
+By inspection, `R_marginal(t)` is algebraically identical to the dense per-layer ratio
+from Section 4 evaluated at context `T = t`. The autoregressive note is therefore not a
+different model; it is the same exact dense model viewed one generation step at a time.
 
-| Configuration | Step `t` | Exact marginal ratio |
-|---|---:|---:|
-| GPT-2-small style (`d = 768`, `H = 12`) | `1` | `1.071393x` |
-| GPT-2-small style (`d = 768`, `H = 12`) | `128` | `1.132040x` |
-| GPT-2-small style (`d = 768`, `H = 12`) | `1,024` | `1.481751x` |
-| GPT-2-small style (`d = 768`, `H = 12`) | `4,096` | `2.132151x` |
-| Llama-2-7B style (`d = 4096`, `H = 32`) | `1` | `1.013350x` |
-| Llama-2-7B style (`d = 4096`, `H = 32`) | `512` | `1.036861x` |
-| Llama-2-7B style (`d = 4096`, `H = 32`) | `4,096` | `1.178133x` |
-| Llama-2-7B style (`d = 4096`, `H = 32`) | `32,768` | `1.671567x` |
-| Llama-2-7B style (`d = 4096`, `H = 32`) | `131,072` | `1.982397x` |
+| Configuration                           |  Step `t` | Exact marginal ratio |
+| --------------------------------------- | --------: | -------------------: |
+| GPT-2-small style (`d = 768`, `H = 12`) |       `1` |          `1.071393x` |
+| GPT-2-small style (`d = 768`, `H = 12`) |     `128` |          `1.132040x` |
+| GPT-2-small style (`d = 768`, `H = 12`) |   `1,024` |          `1.481751x` |
+| GPT-2-small style (`d = 768`, `H = 12`) |   `4,096` |          `2.132151x` |
+| Llama-2-7B style (`d = 4096`, `H = 32`) |       `1` |          `1.013350x` |
+| Llama-2-7B style (`d = 4096`, `H = 32`) |     `512` |          `1.036861x` |
+| Llama-2-7B style (`d = 4096`, `H = 32`) |   `4,096` |          `1.178133x` |
+| Llama-2-7B style (`d = 4096`, `H = 32`) |  `32,768` |          `1.671567x` |
+| Llama-2-7B style (`d = 4096`, `H = 32`) | `131,072` |          `1.982397x` |
 
-The right takeaway is therefore dynamic rather than aggregate: in autoregressive settings, the late-token regime is where the symbolic gap is largest. That observation is consistent with the main paper’s transformer-specific thesis while remaining within the exact formula rather than introducing a stronger unsupported runtime claim.
+The right takeaway is therefore dynamic rather than aggregate: in autoregressive
+settings, the late-token regime is where the symbolic gap is largest. That observation
+is consistent with the main paper’s transformer-specific thesis while remaining within
+the exact formula rather than introducing a stronger unsupported runtime claim.
 
 ## Table B4. Appendix-only Gemma 3 270M instantiation
 
-This table restores the more concrete Gemma-style numbers as an appendix-only supplement. The main text does **not** rely on these exact checkpoint parameters because the official Google Hugging Face raw config endpoints are gated. The values below are therefore derived from a public config mirror snapshot captured on or before April 5, 2026 and are kept out of the main argument for provenance reasons. To reduce dependence on a live mirror, the repository also stores the extracted fields actually used by this appendix at `docs/paper/evidence/gemma-config-snapshots/gemma_3_270m-extract.json`. The mirror used for this appendix-only instantiation is:
+This table restores the more concrete Gemma-style numbers as an appendix-only
+supplement. The main text does **not** rely on these exact checkpoint parameters because
+the official Google Hugging Face raw config endpoints are gated. The values below are
+therefore derived from a public config mirror snapshot captured on or before April 5,
+2026 and are kept out of the main argument for provenance reasons. To reduce dependence
+on a live mirror, the repository also stores the extracted fields actually used by this
+appendix at `docs/paper/evidence/gemma-config-snapshots/gemma_3_270m-extract.json`. The
+mirror used for this appendix-only instantiation is:
 
 - `https://huggingface.co/HedronCreeper/gemma-3-270m-custom-hedron/raw/ac458437b3053e9d1ef5ca71fed58f3bf84b513c/config.json`
 - SHA-256: `12371a6b5cfbe5849425093d1aace4c771ed6353a3fc8e3dc371ae6b307e0d8f`
@@ -133,16 +176,20 @@ Assumptions used here:
 - `W = 512`
 - `C_exp = 300`, `C_norm = 30`, `C_nonlin = 150`
 
-| Context `T` | SNARK symbolic work | STARK symbolic work | Ratio | Non-arithmetic share of SNARK | Softmax share of non-arithmetic |
-|---|---:|---:|---:|---:|---:|
-| `128` | `14,588,706,816` | `13,447,397,376` | `1.084872x` | `7.883885%` | `30.769231%` |
-| `2,048` | `310,049,243,136` | `263,571,111,936` | `1.176340x` | `15.066659%` | `72.727273%` |
-| `8,192` | `1,730,628,550,656` | `1,364,126,072,832` | `1.268672x` | `21.266850%` | `86.153846%` |
-| `32,768` | `14,769,419,452,416` | `10,413,970,292,736` | `1.418231x` | `29.596990%` | `95.336788%` |
+| Context `T` |  SNARK symbolic work |  STARK symbolic work |       Ratio | Non-arithmetic share of SNARK | Softmax share of non-arithmetic |
+| ----------- | -------------------: | -------------------: | ----------: | ----------------------------: | ------------------------------: |
+| `128`       |     `14,588,706,816` |     `13,447,397,376` | `1.084872x` |                   `7.883885%` |                    `30.769231%` |
+| `2,048`     |    `310,049,243,136` |    `263,571,111,936` | `1.176340x` |                  `15.066659%` |                    `72.727273%` |
+| `8,192`     |  `1,730,628,550,656` |  `1,364,126,072,832` | `1.268672x` |                  `21.266850%` |                    `86.153846%` |
+| `32,768`    | `14,769,419,452,416` | `10,413,970,292,736` | `1.418231x` |                  `29.596990%` |                    `95.336788%` |
 
 ## Table B5. Appendix-only Gemma 3 27B instantiation
 
-This larger appendix-only instantiation uses the same caveat. The official raw config endpoint for the released Google Hugging Face model is gated, so the exact parameters below are sourced from a public config mirror snapshot captured on or before April 5, 2026. The repository stores the extracted fields actually used by this appendix at `docs/paper/evidence/gemma-config-snapshots/gemma_3_27b-extract.json`:
+This larger appendix-only instantiation uses the same caveat. The official raw config
+endpoint for the released Google Hugging Face model is gated, so the exact parameters
+below are sourced from a public config mirror snapshot captured on or before April 5,
+2026\. The repository stores the extracted fields actually used by this appendix at
+`docs/paper/evidence/gemma-config-snapshots/gemma_3_27b-extract.json`:
 
 - `https://huggingface.co/Changgil/google-gemma-3-27b-it-text/raw/4e2fb1ce4d063d7877a056b82f0485f4b568563d/config.json`
 - SHA-256: `bd4724fd0098c1611881ceb958a0b294e870adfe21713b0a0cb0f47fff1c379e`
@@ -160,6 +207,6 @@ Assumptions used here:
 - `T = 131072`
 - `C_exp = 300`, `C_norm = 30`, `C_nonlin = 150`
 
-| Context `T` | SNARK symbolic work | STARK symbolic work | Ratio | Non-arithmetic share of SNARK | Softmax share of non-arithmetic |
-|---|---:|---:|---:|---:|---:|
-| `131,072` | `6,564,880,865,820,672` | `4,825,760,963,493,888` | `1.360383x` | `26.582401%` | `98.347720%` |
+| Context `T` |     SNARK symbolic work |     STARK symbolic work |       Ratio | Non-arithmetic share of SNARK | Softmax share of non-arithmetic |
+| ----------- | ----------------------: | ----------------------: | ----------: | ----------------------------: | ------------------------------: |
+| `131,072`   | `6,564,880,865,820,672` | `4,825,760,963,493,888` | `1.360383x` |                  `26.582401%` |                    `98.347720%` |

--- a/docs/paper/appendix-system-comparison.md
+++ b/docs/paper/appendix-system-comparison.md
@@ -2,32 +2,43 @@
 
 Snapshot date: **April 11, 2026**
 
-This appendix is a compact comparison table for the three systems most relevant to the argument in the main paper. It inherits its source posture from Sections 6 and 7: archival papers, official engineering/product materials, and commit-pinned repository artifacts are used for different claim types and should not be read as a single matched benchmark class.
+This appendix is a compact comparison table for the three systems most relevant to the
+argument in the main paper. It inherits its source posture from Sections 6 and 7:
+archival papers, official engineering/product materials, and commit-pinned repository
+artifacts are used for different claim types and should not be read as a single matched
+benchmark class.
 
-Sources: rows inherit the main paper’s source set from Sections 6 and 7, especially References 24-31 and 35-40.
+Sources: rows inherit the main paper’s source set from Sections 6 and 7, especially
+References 24-31 and 35-40.
 
-It should be read with one rule in mind: these are **not** matched end-to-end benchmarks on identical workloads. They are a structured comparison of public claims, committed artifacts, and implementation scope.
+It should be read with one rule in mind: these are **not** matched end-to-end benchmarks
+on identical workloads. They are a structured comparison of public claims, committed
+artifacts, and implementation scope.
 
 ## Table A1. DeepProve vs. BitSage obelyzk.rs (formerly stwo-ml) vs. `provable-transformer-vm`
 
-| Dimension | Lagrange DeepProve | BitSage obelyzk.rs (formerly stwo-ml) | `provable-transformer-vm` |
-|---|---|---|---|
-| Primary role | Production-oriented zkML system | Public STARK-native zkML stack | Semantics-and-proof research artifact |
-| Proof family | SNARK / SNARK-hybrid | STARK-native on S-two / STWO | Vanilla STARK by default; frozen narrow `stwo` artifact tier plus a pre-recursive carried-state aggregation line |
-| Public transformer scope | Public claims of full GPT-2 inference and later Gemma-class progress | Public repo/verifier claims transformer-block support, recursive verifier milestones, and aggressive single-block benchmarks | Deterministic transformer-shaped VM, not full learned transformer inference |
-| Strongest public evidence | Official Lagrange product/blog materials | Public repo, verifier docs, audit notes, Starknet verification path | Two frozen artifact bundles plus a proof-carrying aggregation bundle and statement-versioned repo outputs |
-| Non-arithmetic handling | Custom circuits and lookup-oriented techniques | LogUp-style lookup machinery on STWO | `average-hard` proof path only; `softmax` not yet in proved relation |
-| Backend maturity | Strongest public deployment maturity of the three | Strongest public STARK-native zkML signal | Strongest semantics-portability story among the three |
-| Public onchain posture | Production/prover maturity emphasized more than public Starknet verification demos | Starknet verification path and public demos emphasized | No onchain verifier integration yet |
-| Public onchain evidence | Public materials emphasize production deployment more than named Starknet proof-demo identifiers | Public verifier docs name `D8`, `D9`, `D10`, and `D11` as accepted on Starknet Sepolia, and later describe single-transaction recursive verification plus a six-step streaming path | No public onchain proof-verification artifact set |
-| Recursion posture | Present in system architecture, but details vary by release | Publicly aligned with S-two / STWO recursion path | Recursive cryptographic compression not implemented; repo stops at frozen narrow S-two execution proofs, proof-carrying decoding demos, and a pre-recursive aggregation ladder |
-| Paper relevance | Main counterexample to categorical anti-SNARK claims | Closest STARK-native comparator to the paper thesis | Concrete artifact that the paper can describe precisely |
-| Main caveat | Strong public claims, but not directly comparable to STARK systems on identical workloads | Public materials mix benchmark claims, verification demos, and roadmap claims; verifier docs still show uneven component maturity (`Attention` remains `Prover only`) | Narrow scope: vanilla backend remains primary, `average-hard` only in the main proved relation, no full learned-model proving |
+| Dimension                 | Lagrange DeepProve                                                                               | BitSage obelyzk.rs (formerly stwo-ml)                                                                                                                                               | `provable-transformer-vm`                                                                                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Primary role              | Production-oriented zkML system                                                                  | Public STARK-native zkML stack                                                                                                                                                      | Semantics-and-proof research artifact                                                                                                                                          |
+| Proof family              | SNARK / SNARK-hybrid                                                                             | STARK-native on S-two / STWO                                                                                                                                                        | Vanilla STARK by default; frozen narrow `stwo` artifact tier plus a pre-recursive carried-state aggregation line                                                               |
+| Public transformer scope  | Public claims of full GPT-2 inference and later Gemma-class progress                             | Public repo/verifier claims transformer-block support, recursive verifier milestones, and aggressive single-block benchmarks                                                        | Deterministic transformer-shaped VM, not full learned transformer inference                                                                                                    |
+| Strongest public evidence | Official Lagrange product/blog materials                                                         | Public repo, verifier docs, audit notes, Starknet verification path                                                                                                                 | Two frozen artifact bundles plus a proof-carrying aggregation bundle and statement-versioned repo outputs                                                                      |
+| Non-arithmetic handling   | Custom circuits and lookup-oriented techniques                                                   | LogUp-style lookup machinery on STWO                                                                                                                                                | `average-hard` proof path only; `softmax` not yet in proved relation                                                                                                           |
+| Backend maturity          | Strongest public deployment maturity of the three                                                | Strongest public STARK-native zkML signal                                                                                                                                           | Strongest semantics-portability story among the three                                                                                                                          |
+| Public onchain posture    | Production/prover maturity emphasized more than public Starknet verification demos               | Starknet verification path and public demos emphasized                                                                                                                              | No onchain verifier integration yet                                                                                                                                            |
+| Public onchain evidence   | Public materials emphasize production deployment more than named Starknet proof-demo identifiers | Public verifier docs name `D8`, `D9`, `D10`, and `D11` as accepted on Starknet Sepolia, and later describe single-transaction recursive verification plus a six-step streaming path | No public onchain proof-verification artifact set                                                                                                                              |
+| Recursion posture         | Present in system architecture, but details vary by release                                      | Publicly aligned with S-two / STWO recursion path                                                                                                                                   | Recursive cryptographic compression not implemented; repo stops at frozen narrow S-two execution proofs, proof-carrying decoding demos, and a pre-recursive aggregation ladder |
+| Paper relevance           | Main counterexample to categorical anti-SNARK claims                                             | Closest STARK-native comparator to the paper thesis                                                                                                                                 | Concrete artifact that the paper can describe precisely                                                                                                                        |
+| Main caveat               | Strong public claims, but not directly comparable to STARK systems on identical workloads        | Public materials mix benchmark claims, verification demos, and roadmap claims; verifier docs still show uneven component maturity (`Attention` remains `Prover only`)               | Narrow scope: vanilla backend remains primary, `average-hard` only in the main proved relation, no full learned-model proving                                                  |
 
 ## How to use this appendix
 
-Use this appendix when the main paper needs one concise comparison object, but keep the stronger qualifications in the main text:
+Use this appendix when the main paper needs one concise comparison object, but keep the
+stronger qualifications in the main text:
 
 - DeepProve is the strongest counterexample to categorical anti-SNARK claims.
-- BitSage is the strongest public STARK-native comparator, but public evidence should be separated into benchmark claims, onchain demos, and broader roadmap scope.
-- `provable-transformer-vm` is not a frontier zkML prover; it is a trace-semantics and proof-architecture artifact with reproducible evidence and an explicit pre-recursive aggregation boundary.
+- BitSage is the strongest public STARK-native comparator, but public evidence should be
+  separated into benchmark claims, onchain demos, and broader roadmap scope.
+- `provable-transformer-vm` is not a frontier zkML prover; it is a trace-semantics and
+  proof-architecture artifact with reproducible evidence and an explicit pre-recursive
+  aggregation boundary.

--- a/docs/paper/stark-transformer-alignment-2026.md
+++ b/docs/paper/stark-transformer-alignment-2026.md
@@ -1,72 +1,129 @@
 # On the Structural Fit of Transformer Workloads and STARK Proof Systems
 
-**Abdelhamid Bakhta**
-
+**Abdelhamid Bakhta**\
 StarkWare
 
-**Omar Espejel**
-
+**Omar Espejel**\
 Starknet Foundation
 
 *April 2026*
 
----
-
 ## Abstract
 
-This paper studies the structural fit between transformer workloads and STARK proof systems using a symbolic cost model together with a repository-backed proof artifact. Under a worked example with `C_exp = 300`, `C_norm = 30`, and `C_nonlin = 150`, GPT-2 small (`d = 768`, `T = 1024`, `H = 12`, `L = 12`) yields about `157.8B` symbolic SNARK constraints versus `106.5B` symbolic STARK rows across 12 layers (`1.48x`); over practical context ranges, the ratio rises and then approaches a finite architecture-dependent ceiling. These counts are symbolic proxies for prover-side work, not matched runtime measurements.
+This paper studies the structural fit between transformer workloads and STARK proof
+systems using a symbolic cost model together with a repository-backed proof artifact.
+Under a worked example with `C_exp = 300`, `C_norm = 30`, and `C_nonlin = 150`, GPT-2
+small (`d = 768`, `T = 1024`, `H = 12`, `L = 12`) yields about `157.8B` symbolic SNARK
+constraints versus `106.5B` symbolic STARK rows across 12 layers (`1.48x`); over
+practical context ranges, the ratio rises and then approaches a finite
+architecture-dependent ceiling. These counts are symbolic proxies for prover-side work,
+not matched runtime measurements.
 
-We pair that analysis with `provable-transformer-vm` [30], a supporting artifact that provides a frozen vanilla reproducibility tier, a frozen narrow experimental `stwo` tier, and a broader proof-carrying decoding path with explicit carried-state boundaries, shared lookup-table identity, reusable block/step proof surfaces, and a pre-recursive aggregation boundary. The repository does not yet provide full standard-softmax inference on S-two, recursive cryptographic compression/verification closure, recursive shared-table accumulation across decode steps as a compressed proof object, or production-scale zkML deployment. The narrower claim is that transformer workloads expose the design pressures under which STARK-native systems may compound advantages, while current artifacts already support a concrete bridge from execution traces to pre-recursive proof objects.
+We pair that analysis with `provable-transformer-vm` [30], a supporting artifact that
+provides a frozen vanilla reproducibility tier, a frozen narrow experimental `stwo`
+tier, and a broader proof-carrying decoding path with explicit carried-state boundaries,
+shared lookup-table identity, reusable block- and step-level proof objects, and a
+pre-recursive aggregation boundary. The repository does not yet provide full
+standard-softmax inference on S-two, recursive cryptographic compression/verification
+closure, recursive shared-table accumulation across decode steps as a compressed proof
+object, or production-scale zkML deployment. The narrower claim is that transformer
+workloads expose the design pressures under which STARK-native systems may compound
+advantages, while current artifacts already support a concrete bridge from execution
+traces to pre-recursive proof objects.
 
----
+______________________________________________________________________
 
 ## 1. Introduction
 
-Verifiable inference matters because model outputs are operational inputs. Where outputs trigger trades or onchain actions, computational integrity is the core requirement.
+Verifiable inference matters because model outputs are operational inputs. Where outputs
+trigger trades or onchain actions, computational integrity is the core requirement.
 
-The ecosystem already shows feasibility: modern systems can prove substantial inference workloads, and public materials report progress on both SNARK-heavy and STARK-native paths [24, 25, 26, 28, 29, 33]. Percepta's transformer-computer line provides a complementary conceptual motivation for treating transformer-shaped execution as a meaningful computational object [13].
+The ecosystem already shows feasibility: modern systems can prove substantial inference
+workloads, and public materials report progress on both SNARK-heavy and STARK-native
+paths [24, 25, 26, 28, 29, 33]. Percepta's transformer-computer line provides a
+complementary conceptual motivation for treating transformer-shaped execution as a
+meaningful computational object [13].
 
-The question addressed here is therefore narrower and more useful than “can transformers be proved?” The question is: **which proof architecture compounds most cleanly as transformer workloads scale in model size, sequence length, and deployment complexity?**
+The question addressed here is therefore narrower and more useful than “can transformers
+be proved?” The question is: **which proof architecture compounds most cleanly as
+transformer workloads scale in model size, sequence length, and deployment complexity?**
 
 This paper makes three claims:
 
-1. **Analytic claim.** Under a stated transformer cost model, non-arithmetic operations such as softmax, LayerNorm, and GELU can shift prover economics in favor of STARK-native systems.
-2. **Systems claim.** Deterministic execution of transformer-relevant programs can be compiled into traces that are directly consumable as AIR witnesses, and can be organized as a parameterized proof-carrying decoding relation with carried-state boundaries that survive statement-preserving chain, segment, interval, rollup, matrix, and pre-recursive aggregation layers.
-3. **Infrastructure claim.** The S-two / Starknet stack makes this direction increasingly practical, even though the reference repository used here still relies on the vanilla backend for its default artifact bundle and primary transformer proof relation while exposing `stwo` through a narrow experimental evidence tier.
+1. **Analytic claim.** Under a stated transformer cost model, non-arithmetic operations
+   such as softmax, LayerNorm, and GELU can shift prover economics in favor of
+   STARK-native systems.
+2. **Systems claim.** Deterministic execution of transformer-relevant programs can be
+   compiled into traces that are directly consumable as AIR witnesses, and can be
+   organized as a parameterized proof-carrying decoding relation with carried-state
+   boundaries that survive statement-preserving chain, segment, interval, rollup,
+   matrix, and pre-recursive aggregation layers.
+3. **Infrastructure claim.** The S-two / Starknet stack makes this direction
+   increasingly practical, even though the reference repository used here still relies
+   on the vanilla backend for its default artifact bundle and primary transformer proof
+   relation while exposing `stwo` through a narrow experimental evidence tier.
 
-Here a frozen tier means an immutable artifact snapshot with command logs, content hashes, and proof artifacts. The `production-v1` tier is the vanilla-backend reproducibility baseline, while `stwo-experimental-v1` is a narrow S-two evidence tier for representative fixtures; Section 5.4 gives the detailed artifact boundary.
+Here a frozen tier means an immutable artifact snapshot with command logs, content
+hashes, and proof artifacts. The `production-v1` tier is the vanilla-backend
+reproducibility baseline, while `stwo-experimental-v1` is a narrow S-two evidence tier
+for representative fixtures; Section 5.4 gives the detailed artifact boundary.
 
-The supporting artifact is the paper's systems hinge: it is where the symbolic pressure points of Section 4 are turned into explicit carried-state proof objects with frozen evidence tiers and pre-recursive aggregation boundaries. The systems claim is artifact-backed; the analytic claim remains model-based rather than a matched benchmark on identical hardware; and the infrastructure claim is supported by current public releases without implying full implementation closure in the repository. This is an architecture-and-systems thesis, not a final empirical verdict.
+The supporting artifact is the paper's systems hinge: it is where the symbolic pressure
+points of Section 4 are turned into explicit carried-state proof objects with frozen
+evidence tiers and pre-recursive aggregation boundaries. The systems claim is
+artifact-backed; the analytic claim remains model-based rather than a matched benchmark
+on identical hardware; and the infrastructure claim is supported by current public
+releases without implying full implementation closure in the repository. This is an
+architecture-and-systems thesis, not a final empirical verdict.
 
-The contributions are threefold: an exact symbolic model separating arithmetic from non-arithmetic work; a repository-backed artifact that materializes proof-carrying decoding with explicit carried-state boundaries and pre-recursive aggregation objects; and an infrastructure reading of S-two/Starknet that is current enough to matter without overstating implementation maturity.
+The contributions are threefold: an exact symbolic model separating arithmetic from
+non-arithmetic work; a repository-backed artifact that materializes proof-carrying
+decoding with explicit carried-state boundaries and pre-recursive aggregation objects;
+and an infrastructure reading of S-two/Starknet that is current enough to matter without
+overstating implementation maturity.
 
-The paper is organized accordingly. Section 4 develops the symbolic cost model and its worked examples. Section 5 then anchors the systems claim in a repository artifact that exposes two evidence tiers together with a broader proof-carrying decoding path and pre-recursive carried-state packaging ladder. Sections 6-8 place those results in the current S-two/Starknet landscape and identify the next cryptographic milestones beyond the present artifact boundary.
+The paper is organized accordingly. Section 4 develops the symbolic cost model and its
+worked examples. Section 5 then anchors the systems claim in a repository artifact that
+exposes two evidence tiers together with a broader proof-carrying decoding path and
+pre-recursive carried-state packaging ladder. Sections 6-8 place those results in the
+current S-two/Starknet landscape and identify the next cryptographic milestones beyond
+the present artifact boundary.
 
----
+______________________________________________________________________
 
 ## 2. Background
 
 ### 2.1 STARKs, AIR, and Circle STARKs
 
-STARKs arithmetize computation as execution traces with low-degree transition constraints and FRI-style proximity testing [1, 2, 3, 4].
+STARKs arithmetize computation as execution traces with low-degree transition
+constraints and FRI-style proximity testing [1, 2, 3, 4].
 
-Circle STARKs specialize this direction to Mersenne-31 (`2^31 - 1`). StarkWare positions S-two for recursion and Starknet integration [17, 18, 20], with a March 31, 2026 update reporting verification-path reduction from roughly one minute to roughly three seconds [19]. These are engineering/product claims, not archival benchmark results.
+Circle STARKs specialize this direction to Mersenne-31 (`2^31 - 1`). StarkWare positions
+S-two for recursion and Starknet integration [17, 18, 20], with a March 31, 2026 update
+reporting verification-path reduction from roughly one minute to roughly three seconds
+[19]. These are engineering/product claims, not archival benchmark results.
 
 ### 2.2 SNARKs, GKR, and modern zkML
 
-Modern zkML systems combine multiple techniques: GKR/sumcheck for large linear algebra, and lookups/custom circuits for non-polynomial functions [5, 6, 7, 10, 11]. The practical comparison is therefore whole-system architecture, not “R1CS vs AIR” in isolation.
+Modern zkML systems combine multiple techniques: GKR/sumcheck for large linear algebra,
+and lookups/custom circuits for non-polynomial functions [5, 6, 7, 10, 11]. The
+practical comparison is therefore whole-system architecture, not “R1CS vs AIR” in
+isolation.
 
-The model below does **not** claim all SNARK stacks pay one naive non-arithmetic cost; it uses representative constants to isolate sensitivity to non-arithmetic handling.
+The model below does **not** claim all SNARK stacks pay one naive non-arithmetic cost;
+it uses representative constants to isolate sensitivity to non-arithmetic handling.
 
 ### 2.3 LogUp and lookup-heavy workloads
 
-Lookup arguments are central because transformer bottlenecks include non-polynomial components (softmax, LayerNorm, GELU), not only matrix multiplies [8, 10, 38, 39].
+Lookup arguments are central because transformer bottlenecks include non-polynomial
+components (softmax, LayerNorm, GELU), not only matrix multiplies [8, 10, 38, 39].
 
----
+______________________________________________________________________
 
 ## 3. Transformer Operation Count
 
-We consider a standard transformer block with model dimension `d`, sequence length `T`, number of heads `H`, head dimension `d_k = d / H`, and feedforward expansion `4d` [12].
+We consider a standard transformer block with model dimension `d`, sequence length `T`,
+number of heads `H`, head dimension `d_k = d / H`, and feedforward expansion `4d` [12].
 
 ### 3.1 Arithmetic operations
 
@@ -99,13 +156,16 @@ Summing these terms gives:
 T^2H + 6Td
 ```
 
-The `8Td^2` feedforward term is the GPT-2-style dense-MLP case (`4d` expansion); Section 4.5 switches to the Gemma/GeGLU-style form `3Tdm`.
+The `8Td^2` feedforward term is the GPT-2-style dense-MLP case (`4d` expansion); Section
+4.5 switches to the Gemma/GeGLU-style form `3Tdm`.
 
----
+______________________________________________________________________
 
 ## 4. A Transformer-Specific Cost Model
 
-This section is a **model-based** comparison of symbolic proving work, not a controlled benchmark of complete production systems. SNARK constraints and STARK rows are treated as symbolic proxies, not equal runtime units.
+This section is a **model-based** comparison of symbolic proving work, not a controlled
+benchmark of complete production systems. SNARK constraints and STARK rows are treated
+as symbolic proxies, not equal runtime units.
 
 ### 4.1 SNARK-side symbolic cost
 
@@ -121,13 +181,21 @@ we model the per-layer SNARK-side cost as:
 C_SNARK = 12Td^2 + 2T^2d + 2Td + T^2H * C_exp + 2Td * C_norm + 4Td * C_nonlin
 ```
 
-This keeps the arithmetic term shared with the STARK side and makes explicit where the non-arithmetic amplification enters.
+This keeps the arithmetic term shared with the STARK side and makes explicit where the
+non-arithmetic amplification enters.
 
-The constants `C_exp`, `C_norm`, and `C_nonlin` are **stylized worked-example constants**, not normalized measurements from one prover/hardware stack. Their role is to expose sensitivity; Appendix B sweeps `C_exp` across `50, 100, 300, 500`.
+The constants `C_exp`, `C_norm`, and `C_nonlin` are **stylized worked-example
+constants**, not normalized measurements from one prover/hardware stack. Their role is
+to expose sensitivity; Appendix B sweeps `C_exp` across `50, 100, 300, 500`.
 
-The model isolates softmax-related non-arithmetic cost; backend-specific lowerings are not modeled separately.
+The model isolates softmax-related non-arithmetic cost; backend-specific lowerings are
+not modeled separately.
 
-Because softmax dominates the non-arithmetic budget in this model, `C_exp` is the highest-leverage constant. On the GPT-2-small instantiation, moving `C_exp` from `50` to `500` changes the overall ratio from about `1.13x` to `1.77x`, while comparable sweeps over `C_norm` and `C_nonlin` move it only modestly. Full sensitivities are in Appendix B; this is a model stress test, not a deployed benchmark.
+Because softmax dominates the non-arithmetic budget in this model, `C_exp` is the
+highest-leverage constant. On the GPT-2-small instantiation, moving `C_exp` from `50` to
+`500` changes the overall ratio from about `1.13x` to `1.77x`, while comparable sweeps
+over `C_norm` and `C_nonlin` move it only modestly. Full sensitivities are in Appendix
+B; this is a model stress test, not a deployed benchmark.
 
 ### 4.2 STARK-side symbolic cost
 
@@ -137,17 +205,23 @@ For the STARK side, we keep the exact expression:
 L_STARK = 12Td^2 + 2T^2d + T^2H + 8Td
 ```
 
-A naive approximation such as `12Td^2 + 3T^2d` is not justified for GPT-2 small because `H << d` (`H = 12`, `d = 768`), which would materially inflate the STARK side.
+A naive approximation such as `12Td^2 + 3T^2d` is not justified for GPT-2 small because
+`H << d` (`H = 12`, `d = 768`), which would materially inflate the STARK side.
 
-This lookup treatment is also optimistic: real lookup-backed implementations pay overhead in auxiliary columns, interaction phases, and commitments. The one-row-per-symbolic-lookup abstraction is a modeling choice; higher lookup overhead would narrow the symbolic gap.
+This lookup treatment is also optimistic: real lookup-backed implementations pay
+overhead in auxiliary columns, interaction phases, and commitments. The
+one-row-per-symbolic-lookup abstraction is a modeling choice; higher lookup overhead
+would narrow the symbolic gap.
 
-**Proposition 1.** Under the symbolic model of Sections 4.1 and 4.2, with `T, d, H > 0` and `C_exp, C_norm, C_nonlin >= 1`,
+**Proposition 1.** Under the symbolic model of Sections 4.1 and 4.2, with `T, d, H > 0`
+and `C_exp, C_norm, C_nonlin >= 1`,
 
 ```text
 C_SNARK - L_STARK = T^2H(C_exp - 1) + 2Td(C_norm - 1) + 4Td(C_nonlin - 1) >= 0.
 ```
 
-Equality holds only when `C_exp = C_norm = C_nonlin = 1`. For fixed `d`, `H`, and constants with at least one strict inequality, the gap grows monotonically in `T`.
+Equality holds only when `C_exp = C_norm = C_nonlin = 1`. For fixed `d`, `H`, and
+constants with at least one strict inequality, the gap grows monotonically in `T`.
 
 Rearranging the same expression gives the exact break-even surface:
 
@@ -161,9 +235,12 @@ For fixed `C_norm` and `C_nonlin`, this yields
 C_exp^* = 1 - (2d / TH)[(C_norm - 1) + 2(C_nonlin - 1)].
 ```
 
-If `C_norm = C_nonlin = 1`, the break-even reduces to `C_exp = 1`. On the GPT-2-small instantiation with `C_norm = 30` and `C_nonlin = 150`, the threshold is `C_exp^* = -39.875`, so no positive `C_exp` removes the modeled symbolic gap.
+If `C_norm = C_nonlin = 1`, the break-even reduces to `C_exp = 1`. On the GPT-2-small
+instantiation with `C_norm = 30` and `C_nonlin = 150`, the threshold is
+`C_exp^* = -39.875`, so no positive `C_exp` removes the modeled symbolic gap.
 
-For the dense GPT-style case, the ratio also has a finite large-context asymptote. Writing
+For the dense GPT-style case, the ratio also has a finite large-context asymptote.
+Writing
 
 ```text
 R(T) = C_SNARK / L_STARK,
@@ -175,52 +252,84 @@ and keeping `d`, `H`, and the non-arithmetic constants fixed gives
 lim_{T -> ∞} R(T) = (2d + H C_exp) / (2d + H) = (2d_h + C_exp) / (2d_h + 1).
 ```
 
-For GPT-2-small, `d_h = 64`, so under `C_exp = 300` the dense asymptote is approximately `3.32x`. The ratio rises over practical ranges and then saturates at a finite ceiling.
+For GPT-2-small, `d_h = 64`, so under `C_exp = 300` the dense asymptote is approximately
+`3.32x`. The ratio rises over practical ranges and then saturates at a finite ceiling.
 
 ### 4.3 Concrete analysis: GPT-2 small
 
-Instantiating the model with GPT-2 small parameters (`d = 768`, `T = 1024`, `H = 12`, `L = 12`) gives the following.
+Instantiating the model with GPT-2 small parameters (`d = 768`, `T = 1024`, `H = 12`,
+`L = 12`) gives the following.
 
 #### Table 2. GPT-2 small symbolic work under the stated cost model
 
-| Component | SNARK (constraints) | STARK (trace rows) | Ratio |
-|---|---:|---:|---:|
-| Arithmetic | 8,859,942,912 | 8,859,942,912 | 1.00x |
-| Softmax | 3,774,873,600 | 12,582,912 | 300x |
-| LayerNorm | 47,185,920 | 1,572,864 | 30x |
-| GELU | 471,859,200 | 3,145,728 | 150x |
-| Total per layer | 13,153,861,632 | 8,877,244,416 | 1.48x |
-| Total (12 layers) | 157,846,339,584 | 106,526,932,992 | 1.48x |
+| Component         | SNARK (constraints) | STARK (trace rows) | Ratio |
+| ----------------- | ------------------: | -----------------: | ----: |
+| Arithmetic        |       8,859,942,912 |      8,859,942,912 | 1.00x |
+| Softmax           |       3,774,873,600 |         12,582,912 |  300x |
+| LayerNorm         |          47,185,920 |          1,572,864 |   30x |
+| GELU              |         471,859,200 |          3,145,728 |  150x |
+| Total per layer   |      13,153,861,632 |      8,877,244,416 | 1.48x |
+| Total (12 layers) |     157,846,339,584 |    106,526,932,992 | 1.48x |
 
-Under this cost model, the non-arithmetic overhead adds about `4.29B` SNARK constraints versus about `17.3M` STARK rows per layer at `T = 1024`. Softmax alone contributes about `87.9%` of the SNARK non-arithmetic overhead. Scaling the same model to `T = 4096` yields an overall ratio of about `2.13x`, so the qualitative claim that the gap widens with context length remains intact.
+Under this cost model, the non-arithmetic overhead adds about `4.29B` SNARK constraints
+versus about `17.3M` STARK rows per layer at `T = 1024`. Softmax alone contributes about
+`87.9%` of the SNARK non-arithmetic overhead. Scaling the same model to `T = 4096`
+yields an overall ratio of about `2.13x`, so the qualitative claim that the gap widens
+with context length remains intact.
 
 ### 4.4 Interpretation
 
-This analysis does **not** prove that every STARK system is faster than every SNARK system. It supports a narrower claim: once both sides handle large linear algebra efficiently, differences are increasingly driven by lookup handling, recursion, field arithmetic, and commitments.
+This analysis does **not** prove that every STARK system is faster than every SNARK
+system. It supports a narrower claim: once both sides handle large linear algebra
+efficiently, differences are increasingly driven by lookup handling, recursion, field
+arithmetic, and commitments.
 
-The model also abstracts each activation/normalized value as one algebraic object; it does not model quantization layouts, packing strategies, or backend-specific decompositions.
+The model also abstracts each activation/normalized value as one algebraic object; it
+does not model quantization layouts, packing strategies, or backend-specific
+decompositions.
 
-Appendix B2 shows the same model on a wider Llama-2-7B-style dense reference [37]. Under the exact formula, a wider production-style dense model can remain near parity at shorter contexts under lower softmax constants while still widening materially at longer windows.
+Appendix B2 shows the same model on a wider Llama-2-7B-style dense reference [37]. Under
+the exact formula, a wider production-style dense model can remain near parity at
+shorter contexts under lower softmax constants while still widening materially at longer
+windows.
 
-Recent implementation-level comparisons reinforce that boundary. A December 2025 Groth16-vs-STARK comparison on consumer ARM hardware reports faster proving and smaller proofs for the Groth16 side, alongside faster verification and transparency/post-quantum advantages for the STARK side [34].
+Recent implementation-level comparisons reinforce that boundary. A December 2025
+Groth16-vs-STARK comparison on consumer ARM hardware reports faster proving and smaller
+proofs for the Groth16 side, alongside faster verification and transparency/post-quantum
+advantages for the STARK side [34].
 
-Threats to validity concentrate in four places: quantization/packing strategy, lookup-table reuse and non-arithmetic lowering, recursion/compression strategy, and hardware parallelism.
+Threats to validity concentrate in four places: quantization/packing strategy,
+lookup-table reuse and non-arithmetic lowering, recursion/compression strategy, and
+hardware parallelism.
 
-These caveats do not remove the structural result; they bound its interpretation. In this paper, symbolic counts are used to locate architectural pressure points, not to predict wall-clock performance for any one deployed prover stack.
+These caveats do not remove the structural result; they bound its interpretation. In
+this paper, symbolic counts are used to locate architectural pressure points, not to
+predict wall-clock performance for any one deployed prover stack.
 
-Figure 1 makes the symbolic-work decomposition behind that sensitivity visible for both the GPT-2-small worked example and a wider dense reference.
+Figure 1 makes the symbolic-work decomposition behind that sensitivity visible for both
+the GPT-2-small worked example and a wider dense reference.
 
 ![Figure 1. Symbolic-work decomposition versus context for GPT-2-small and a Llama-2-7B-style dense reference.](figures/section4-decomposition-vs-context.svg)
 
-**Figure 1.** Symbolic-work decomposition versus context. Each configuration is shown as paired SNARK and STARK stacked bars using the exact dense formulas from Sections 4.1 and 4.2. The GPT-2-small bars make the softmax-driven sensitivity of the model visually obvious, while the Llama-2-7B-style bars show the narrower short-context regime and the later widening discussed in Appendix B2.
+**Figure 1.** Symbolic-work decomposition versus context. Each configuration is shown as
+paired SNARK and STARK stacked bars using the exact dense formulas from Sections 4.1 and
+4.2. The GPT-2-small bars make the softmax-driven sensitivity of the model visually
+obvious, while the Llama-2-7B-style bars show the narrower short-context regime and the
+later widening discussed in Appendix B2.
 
 ### 4.5 Analytic extension to released Gemma 3 architectures
 
-GPT-2-small keeps the algebra transparent, but newer deployments motivate a sparse long-context extension. Public materials report Gemma-3-class requirements including GQA, alternating local/global attention, RMSNorm, and GeGLU [14, 15, 16, 25].
+GPT-2-small keeps the algebra transparent, but newer deployments motivate a sparse
+long-context extension. Public materials report Gemma-3-class requirements including
+GQA, alternating local/global attention, RMSNorm, and GeGLU [14, 15, 16, 25].
 
-This subsection asks whether the same symbolic logic still shows divergence under released sparse long-context patterns.
+This subsection asks whether the same symbolic logic still shows divergence under
+released sparse long-context patterns.
 
-For Gemma-style layers, let `n_q` be query heads, `n_kv` key/value heads, `d_h` head dimension, `q = n_q d_h`, `k = n_kv d_h`, `m` MLP intermediate size, `L_g` global-attention layers, `L_l` local-attention layers, and `W_eff(T) = min(T, W)`. Using the same constants, the model becomes:
+For Gemma-style layers, let `n_q` be query heads, `n_kv` key/value heads, `d_h` head
+dimension, `q = n_q d_h`, `k = n_kv d_h`, `m` MLP intermediate size, `L_g`
+global-attention layers, `L_l` local-attention layers, and `W_eff(T) = min(T, W)`. Using
+the same constants, the model becomes:
 
 ```text
 A_Gemma(T) = L[Td(q + 2k) + Tdq + 3Tdm] + 2q[L_g T^2 + L_l T W_eff(T)]
@@ -229,257 +338,532 @@ C_SNARK^Gemma(T) = A_Gemma(T) + S_Gemma(T) * C_exp + 2LTd * C_norm + LTm * C_non
 L_STARK^Gemma(T) = A_Gemma(T) + S_Gemma(T) + 2LTd + LTm
 ```
 
-Gemma-style sparsity is a harder test for this thesis than GPT-2-small because local/global attention suppresses long-context cost. It tempers the gap but does not erase the direction: as context grows, non-arithmetic share remains structurally important.
+Gemma-style sparsity is a harder test for this thesis than GPT-2-small because
+local/global attention suppresses long-context cost. It tempers the gap but does not
+erase the direction: as context grows, non-arithmetic share remains structurally
+important.
 
-With fixed local window `W` and nonzero global-layer fraction, the long-context ratio remains finite. In the representative `5:1` schedule used in Figure 2, the ratio still rises toward a finite ceiling.
+With fixed local window `W` and nonzero global-layer fraction, the long-context ratio
+remains finite. In the representative `5:1` schedule used in Figure 2, the ratio still
+rises toward a finite ceiling.
 
-**Corollary.** For a fixed positive global-attention fraction and fixed local window `W`, the representative sparse long-context ratio has the same large-context ceiling as the dense case:
+**Corollary.** For a fixed positive global-attention fraction and fixed local window
+`W`, the representative sparse long-context ratio has the same large-context ceiling as
+the dense case:
 
 ```text
 lim_{T -> ∞} R_sparse(T) = (2d_h + C_exp) / (2d_h + 1).
 ```
 
-The local `T W_eff(T)` terms are lower order than global `T^2` terms at large `T`, so sparsity delays the approach to the ceiling rather than lowering it.
+The local `T W_eff(T)` terms are lower order than global `T^2` terms at large `T`, so
+sparsity delays the approach to the ceiling rather than lowering it.
 
-Figure 2 visualizes that distinction. The dense curve uses the GPT-2-small model from Sections 4.1-4.3, and the sparse curve is a representative Gemma-style `5:1` local/global schedule with `W = 1024` under the same constants.
+Figure 2 visualizes that distinction. The dense curve uses the GPT-2-small model from
+Sections 4.1-4.3, and the sparse curve is a representative Gemma-style `5:1`
+local/global schedule with `W = 1024` under the same constants.
 
 ![Figure 2. SNARK/STARK symbolic ratio versus context length for a dense GPT-style model and a representative 5:1 local/global sparse schedule.](figures/section4-ratio-vs-context.svg)
 
-**Figure 2.** `SNARK/STARK` symbolic ratio versus context length. The sparse curve is representative, not tied to one exact checkpoint. The dashed line is the dense asymptotic ceiling from Section 4.2. Reproducibility metadata and exact point generation details are recorded in the supplementary scaling appendix and committed figure script/TSV.
+**Figure 2.** `SNARK/STARK` symbolic ratio versus context length. The sparse curve is
+representative, not tied to one exact checkpoint. The dashed line is the dense
+asymptotic ceiling from Section 4.2. Reproducibility metadata and exact point generation
+details are recorded in the supplementary scaling appendix and committed figure
+script/TSV.
 
-The symbolic analysis above identifies the architectural pressure points. The artifact below shows which parts of that structure already survive a real proof workflow as reproducible carried-state proof objects, and which parts still remain pre-recursive engineering boundaries rather than cryptographic compression layers.
+The symbolic analysis above identifies the architectural pressure points. The artifact
+below shows which parts of that structure already survive a real proof workflow as
+reproducible carried-state proof objects, and which parts still remain pre-recursive
+engineering boundaries rather than cryptographic compression layers.
 
----
+______________________________________________________________________
 
 ## 5. Repository Artifact: Evidence Boundary
 
-The supporting implementation is `omarespejel/provable-transformer-vm` [30]. In this paper it is treated as a **semantics-and-proof artifact**: deterministic transformer-relevant execution is compiled into AIR-consumable traces and then organized into proof-carrying decoding artifacts with explicit carried-state boundaries. Here, "proof-carrying" means that each artifact carries enough public boundary data and proof references for a verifier to replay continuity checks across the declared relation; it is **not** a claim of recursive proof-carrying data or compressed recursive verification. Likewise, terms such as `chain`, `segment`, `rollup`, `interval bundle`, and `pre-recursive aggregation boundary` are used in an **artifact-layer sense**. Unless explicitly stated otherwise, they do **not** denote recursive cryptographic accumulation schemes, compressed proof systems, or CCS-/IVC-style folding protocols in the sense of systems such as HyperNova, NeutronNova, or ProtoStar [43-45]. The point of this section is narrower: to show that a stable proof-carrying decoding relation with carried KV and lookup state can already be materialized as reproducible proof artifacts over the current repository surfaces.
+The supporting implementation is `omarespejel/provable-transformer-vm` [30]. In this
+paper it is treated as a **semantics-and-proof artifact**: deterministic
+transformer-relevant execution is compiled into AIR-consumable traces and then organized
+into proof-carrying decoding artifacts with explicit carried-state boundaries. Here,
+"proof-carrying" means that each artifact carries enough public boundary data and proof
+references for a verifier to replay continuity checks across the declared relation; it
+is **not** a claim of recursive proof-carrying data or compressed recursive
+verification. Likewise, terms such as `chain`, `segment`, `rollup`, `interval bundle`,
+and `pre-recursive aggregation boundary` are used in an **artifact-layer sense**. Unless
+explicitly stated otherwise, they do **not** denote recursive cryptographic accumulation
+schemes, compressed proof systems, or CCS-/IVC-style folding protocols in the sense of
+systems such as HyperNova, NeutronNova, or ProtoStar [43-45]. The point of this section
+is narrower: to show that a stable proof-carrying decoding relation with carried KV and
+lookup state can already be materialized as reproducible proof artifacts over the
+current repository surfaces.
 
 ### 5.1 Positive evidence
 
 The artifact provides:
 
 - a deterministic transformer-shaped VM with a statement-versioned proof claim,
-- two frozen evidence tiers: a vanilla reproducibility tier and a narrow experimental `stwo` tier,
-- a parameterized proof-carrying decoding relation over explicit carried-state boundaries,
+- two frozen evidence tiers: a vanilla reproducibility tier and a narrow experimental
+  `stwo` tier,
+- a parameterized proof-carrying decoding relation over explicit carried-state
+  boundaries,
 - statement-preserving pre-recursive packaging objects over that same decode relation,
-- a bounded multi-runtime semantic-agreement artifact together with hardened verifier kernels.
+- a bounded multi-runtime semantic-agreement artifact.
 
-The central systems property is stable statement structure: the same decode relation survives progressively richer manifest and packaging layers without changing the underlying public boundary semantics.
-In concrete terms, the repository now exposes reusable block-shaped execution proofs and, on its experimental `stwo` tooling surface, step-level proof envelopes whose public boundary shape and statement semantics remain stable across those richer artifact layers.
+The central systems property is stable statement structure: the same decode relation
+survives progressively richer manifest and packaging layers without changing the
+underlying public boundary semantics. In concrete terms, the repository already exposes
+reusable block-shaped execution proofs and, on its experimental `stwo` tooling surface,
+step-level proof objects whose public boundary schema and statement semantics remain
+stable across those richer artifact layers.
 
-For shared lookup evidence, the artifact binds normalization and activation table identity into a static lookup-table registry commitment inside the shared lookup artifact; this is table-identity and provenance binding, not recursive cross-step shared-table accumulation.
+For shared lookup evidence, the artifact binds normalization and activation table
+identity into a static lookup-table registry commitment inside the shared lookup
+artifact; this is table-identity and provenance binding, not recursive cross-step
+shared-table accumulation.
 
 ### 5.2 Carried-state relation
 
 The carried-state claim can be stated as a compact relation.
 
-**Definition 1 (Carried-state boundary).** A carried-state boundary at decode step `t` is the public tuple
+**Definition 1 (Carried-state boundary).** A carried-state boundary at decode step `t`
+is the public tuple
 
 ```text
 Σ_t = (ℓ_t, p_t, h_t^KV, f_t^KV, h_t^L, f_t^L, c_t^in, c_t^out)
 ```
 
-where `ℓ_t` identifies the layout/template, `p_t` records public step-position metadata, `h_t^KV` and `f_t^KV` are the KV cumulative and frontier commitments, `h_t^L` and `f_t^L` are the lookup cumulative and frontier commitments, and `c_t^in`, `c_t^out` are execution-boundary commitments.
+where `ℓ_t` identifies the layout/template, `p_t` records public step-position metadata,
+`h_t^KV` and `f_t^KV` are the KV cumulative and frontier commitments, `h_t^L` and
+`f_t^L` are the lookup cumulative and frontier commitments, and `c_t^in`, `c_t^out` are
+execution-boundary commitments.
 
-Let `R_decode` denote the repository's parameterized proof-carrying decoding relation over carried-state boundaries:
+Let `R_decode` denote the repository's parameterized proof-carrying decoding relation
+over carried-state boundaries:
 
 ```text
 R_decode(Σ_t, w_t, Σ_{t+1})
 ```
 
-where `w_t` contains the step witness and proof-bearing artifact material checked by the repository verifier.
+where `w_t` contains the step witness and proof-bearing artifact material checked by the
+repository verifier.
 
-In this terminology, an interval bundle packages contiguous decode prefixes between the segment and rollup layers. The pinned aggregation-bundle index records the concrete artifact mapping [46].
+In this terminology, an interval bundle packages contiguous decode prefixes between the
+segment and rollup layers. The pinned aggregation-bundle index records the concrete
+artifact mapping [46].
 
-**Definition 2 (Packaging-layer validity).** A chain, segment, interval bundle, rollup, matrix, or pre-recursive aggregation boundary is valid if its member order is declared, each nested proof artifact verifies under the stated backend and statement profile, and every adjacent pair of carried-state boundaries satisfies the continuity constraints required by the decode relation.
+**Definition 2 (Packaging-layer validity).** A chain, segment, interval bundle, rollup,
+matrix, or pre-recursive aggregation boundary is valid if its member order is declared,
+each nested proof artifact verifies under the stated backend and statement profile, and
+every adjacent pair of carried-state boundaries satisfies the continuity constraints
+required by the decode relation.
 
-The following proposition records the invariant that the repository artifact is intended to preserve across its pre-recursive packaging layers.
+The following proposition records the invariant that the repository artifact is intended
+to preserve across its pre-recursive packaging layers.
 
-**Proposition 2.** If each step proof in a chain verifies under `statement-v1`, and every adjacent pair satisfies `c_t^out = c_{t+1}^in` together with the corresponding KV and lookup frontier-continuity checks, then the resulting segment, interval bundle, rollup, matrix, or pre-recursive aggregation boundary preserves the same start-state to end-state relation as the underlying verified chain.
+**Proposition 2.** If each step proof in a chain verifies under `statement-v1`, and
+every adjacent pair satisfies `c_t^out = c_{t+1}^in` together with the corresponding KV
+and lookup frontier-continuity checks, then the resulting segment, interval bundle,
+rollup, matrix, or pre-recursive aggregation boundary preserves the same start-state to
+end-state relation as the underlying verified chain.
 
-**Proof sketch.** Each packaging layer records the first public state, last public state, member commitments, and declared member order. Its verifier replay-checks the nested members and rejects non-contiguous or template-incompatible boundaries. Induction over the ordered members gives the same start-to-end relation for the packaged object. This is a statement-preservation invariant, not a recursive proof-compression theorem.
+**Proof sketch.** Each packaging layer records the first public state, last public
+state, member commitments, and declared member order. Its verifier replay-checks the
+nested members and rejects non-contiguous or template-incompatible boundaries. Induction
+over the ordered members gives the same start-to-end relation for the packaged object.
+This is a statement-preservation invariant, not a recursive proof-compression theorem.
 
 Figure 3 summarizes the object flow and the two carried commitment lanes.
 
 ![Figure 3. Carried-state packaging ladder over the parameterized decoding relation.](figures/section5-carried-state-ladder.svg)
 
-**Figure 3.** Carried-state packaging ladder over the parameterized decoding relation. A verified `decoding_step_v2` chain is packaged into segments, interval bundles, rollups, a multi-layout matrix, and a pre-recursive aggregation boundary. The two carried lanes represent the KV-side cumulative/frontier commitments and the lookup-side cumulative/frontier commitments. The figure is architectural: it describes statement-preserving artifact layers in the repository, not a recursive cryptographic compression pipeline.
+**Figure 3.** Carried-state packaging ladder over the parameterized decoding relation. A
+verified `decoding_step_v2` chain is packaged into segments, interval bundles, rollups,
+a multi-layout matrix, and a pre-recursive aggregation boundary. The two carried lanes
+represent the KV-side cumulative/frontier commitments and the lookup-side
+cumulative/frontier commitments. The figure is architectural: it describes
+statement-preserving artifact layers in the repository, not a recursive cryptographic
+compression pipeline.
 
 ### 5.3 Negative evidence
 
-The repository remains deliberately narrow in four ways. First, the default reproducibility tier and primary transformer relation still live on the vanilla backend, while the `stwo` path remains a bounded experimental tier rather than a broad production zkML surface. Second, the main proved transformer relation still uses `average-hard` rather than full standard softmax. Third, the current repository already binds shared lookup-table identity inside public artifacts, but it does not yet expose recursive cross-step shared-table accumulation as a compressed proof object. Fourth, the decode overlays, semantic-agreement artifacts, and pre-recursive aggregation boundaries are statement-preserving packaging layers, not recursive cryptographic wrappers, SMT-backed implementation-equivalence proofs, or production-scale learned-model zkML claims.
+The repository remains deliberately narrow in four ways. First, the default
+reproducibility tier and primary transformer relation still live on the vanilla backend,
+while the `stwo` path remains a bounded experimental tier rather than a broad production
+zkML surface. Second, the main proved transformer relation still uses `average-hard`
+rather than full standard softmax. Third, the current repository already binds shared
+lookup-table identity inside public artifacts, but it does not yet expose recursive
+cross-step shared-table accumulation as a compressed proof object. Fourth, the decode
+overlays, semantic-agreement artifacts, and pre-recursive aggregation boundaries are
+statement-preserving packaging layers, not recursive cryptographic wrappers, SMT-backed
+implementation-equivalence proofs, or production-scale learned-model zkML claims.
 
-These limits are intentional scope discipline: the artifact supports structural systems evidence, pre-recursive carried-state claims, and narrow experimental packaging artifacts, but not full softmax-plus-recursion closure.
+These limits are intentional scope discipline: the artifact supports structural systems
+evidence, pre-recursive carried-state claims, and narrow experimental packaging
+artifacts, but not full softmax-plus-recursion closure.
 
 ### 5.4 Reproducibility tiers
 
-The vanilla `production-v1` tier is the primary reproducibility baseline. It is documented in an immutable artifact snapshot with command logs, hashes, and proof artifacts [31]. Timings and sizes are treated as reproducibility evidence, not performance evidence.
+The vanilla `production-v1` tier is the primary reproducibility baseline. It is
+documented in an immutable artifact snapshot with command logs, hashes, and proof
+artifacts [31]. Timings and sizes are treated as reproducibility evidence, not
+performance evidence.
 
-The `stwo-experimental-v1` tier is the narrow S-two evidence tier. It contains command logs, wall-clock timings, SHA-256 hashes, and proof artifacts for four representative outputs: an arithmetic `statement-v1` proof (`addition`), a shared-table normalization lookup proof envelope, a Gemma-inspired fixed-shape proof (`gemma_block_v4`) with shared lookup bindings, and a three-step proof-carrying decoding chain [40]. Taken together, these four artifacts illustrate representative proof outputs across the repository's current public artifact inventory: a `statement-v1` arithmetic proof, a shared-table lookup proof envelope, a block-shaped execution proof, and a carried-state decode chain. The broader repository artifact inventory also includes bounded multi-runtime semantic-agreement artifacts and pre-recursive aggregation bundles. Appendix C1 compares the two backend-facing tiers.
+The `stwo-experimental-v1` tier is the narrow S-two evidence tier. It contains command
+logs, wall-clock timings, SHA-256 hashes, and proof artifacts for four representative
+outputs: an arithmetic `statement-v1` proof (`addition`), a shared-table normalization
+lookup proof envelope, a Gemma-inspired fixed-shape proof (`gemma_block_v4`) with shared
+lookup bindings, and a three-step proof-carrying decoding chain [40]. Taken together,
+these four artifacts illustrate representative proof outputs across the repository's
+current public artifact inventory: a `statement-v1` arithmetic proof, a shared-table
+lookup proof envelope, a block-shaped execution proof, and a carried-state decode chain.
+The broader repository artifact inventory also includes bounded multi-runtime
+semantic-agreement artifacts and pre-recursive aggregation bundles. Appendix C1 compares
+the two backend-facing tiers.
 
 ### 5.5 Pre-recursive aggregation boundary
 
-The present aggregation layer is statement-preserving and pre-recursive: it packages verified carried-state artifacts into merge-compatible boundaries, but it is not yet a recursive cryptographic accumulator or verifier-closed compression layer. This is a bridge artifact, not a backend benchmark row. The dedicated aggregation-bundle index is cited directly as systems evidence for this layer [46]. It does not support a recursive compression claim or recursive cross-step shared-table accumulation beyond the public lookup-accumulator artifact [30, 40, 46]. The broader carried-state ladder is documented in the repository's supplementary design and README materials and is cited here as commit-pinned systems evidence rather than as a recursive compression result.
+The present aggregation layer is statement-preserving and pre-recursive: it packages
+verified carried-state artifacts into merge-compatible boundaries, but it is not yet a
+recursive cryptographic accumulator or verifier-closed compression layer. This is a
+bridge artifact, not a backend benchmark row. The dedicated aggregation-bundle index is
+cited directly as systems evidence for this layer [46]. It does not support a recursive
+compression claim or recursive cross-step shared-table accumulation beyond the public
+lookup-accumulator artifact [30, 40, 46]. The broader carried-state ladder is documented
+in the repository's supplementary design and README materials and is cited here as
+commit-pinned systems evidence rather than as a recursive compression result.
 
 ### 5.6 Semantic-agreement and provenance boundaries
 
-The repository also contains a bounded multi-runtime semantic-agreement artifact motivated by implementation-equivalence work on large-model graphs [47]. It lockstep-executes a fixed program across transformer/native/Burn/ONNX paths, records relation witnesses, and binds observed transitions by per-runtime hashes plus a canonical transition hash. This is deterministic bounded relation evidence, not a general e-graph/SMT equivalence prover. It addresses a practical systems risk: proof artifacts should not silently rely on informal claims that distinct frontend/runtime paths are semantically identical. For reproducibility rather than proof semantics, the artifact set also includes a release-provenance manifest that can bind model and tokenizer identifiers, local tokenizer/transcript files, safetensors file and metadata-header hashes, optional ONNX export hashes, and model-card/DOI/dataset metadata when supplied. This is a packaging guardrail, not part of the proof relation.
+The repository also contains a bounded multi-runtime semantic-agreement artifact
+motivated by implementation-equivalence work on large-model graphs [47]. It
+lockstep-executes a fixed program across transformer/native/Burn/ONNX paths, records
+relation witnesses, and binds observed transitions by per-runtime hashes plus a
+canonical transition hash. This is deterministic bounded relation evidence, not a
+general e-graph/SMT equivalence prover. It addresses a practical systems risk: proof
+artifacts should not silently rely on informal claims that distinct frontend/runtime
+paths are semantically identical. Separately, a release-provenance manifest can bind
+model and tokenizer identifiers, local tokenizer/transcript files, safetensors hashes,
+optional ONNX export hashes, and model-card/DOI/dataset metadata. That manifest is a
+reproducibility guardrail, not part of the proof relation.
 
 ### 5.7 Why this artifact matters
 
 This artifact narrows the gap between analytic and systems claims by showing:
 
 1. transformer-relevant traces can be proved directly,
-2. semantic equivalence can be checked across runtimes before proving and exposed as transition-relation hashes rather than prose-only assertions,
-3. one parameterized decode relation preserves carried state across layouts and packaging layers,
-4. carried-state packages can be aggregated as pre-recursive statements without changing the underlying decode relation,
+2. semantic equivalence can be checked across runtimes before proving and exposed as
+   transition-relation hashes rather than prose-only assertions,
+3. one parameterized decode relation preserves carried state across layouts and
+   packaging layers,
+4. carried-state packages can be aggregated as pre-recursive statements without changing
+   the underlying decode relation,
 5. reproducibility can be anchored in immutable bundles and commit-pinned artifacts.
 
-The central systems fact is that one parameterized decode relation now survives richer artifact boundaries without changing the public commitments that later recursive or accumulation work would need to preserve.
+The central systems fact is that one parameterized decode relation now survives richer
+artifact boundaries without changing the public commitments that later recursive or
+accumulation work would need to preserve.
 
-In other words, the artifact does not merely show that transformer-relevant traces can be proved; it shows that one parameterized decode relation can be lifted into reusable carried-state proof objects that later recursive or accumulation layers can consume without changing the underlying boundary semantics.
+In other words, the artifact does not merely show that transformer-relevant traces can
+be proved; it shows that one parameterized decode relation can be lifted into reusable
+carried-state proof objects that later recursive or accumulation layers can consume
+without changing the underlying boundary semantics.
 
----
+______________________________________________________________________
 
 ## 6. Infrastructure Context: S-two and Starknet
 
-The infrastructure context matters because recursion and onchain verification determine whether trace-level artifacts can become practical verifiable inference systems.
+The infrastructure context matters because recursion and onchain verification determine
+whether trace-level artifacts can become practical verifiable inference systems.
 
 ### 6.1 S-two, recursion, and Starknet integration
 
-StarkWare’s public materials position S-two as a next-generation open-source prover around Circle STARKs over M31. The March 31, 2026 recursion update matters because aggregation is required once workloads become large or modular [19].
+StarkWare’s public materials position S-two as a next-generation open-source prover
+around Circle STARKs over M31. The March 31, 2026 recursion update matters because
+aggregation is required once workloads become large or modular [19].
 
-For this paper, the key distinction is: **S-two progress strengthens the roadmap, while the repository still keeps its default artifact bundle and primary transformer relation on the vanilla backend.**
+For this paper, the key distinction is: **S-two progress strengthens the roadmap, while
+the repository still keeps its default artifact bundle and primary transformer relation
+on the vanilla backend.**
 
-Verifier cost and proof size remain part of that roadmap. The frozen vanilla tier still produces multi-megabyte proofs for tiny fixtures, so aggregation/compression remains necessary for practical onchain use [19, 34].
+Verifier cost and proof size remain part of that roadmap. The frozen vanilla tier still
+produces multi-megabyte proofs for tiny fixtures, so aggregation/compression remains
+necessary for practical onchain use [19, 34].
 
-The supporting artifact nevertheless exposes meaningful S-two evidence through a narrow experimental tier and a carried-state aggregation path, which is why the paper frames the repository evidence as a bridge rather than a finished recursion system.
+The supporting artifact nevertheless exposes meaningful S-two evidence through a narrow
+experimental tier and a carried-state aggregation path, which is why the paper frames
+the repository evidence as a bridge rather than a finished recursion system.
 
 ### 6.2 Starknet proof verification and privacy
 
-Starknet `0.14.2` public materials list in-protocol S-two verification, and `SNIP-36` describes proof-carrying transaction structure (`proof_facts`) [22, 23]. Starknet’s account model remains relevant to this integration boundary [32]. Starknet’s March 10, 2026 STRK20 announcement adds privacy relevance by stating any ERC-20 on Starknet can now be private [21].
+Starknet `0.14.2` public materials list in-protocol S-two verification, and `SNIP-36`
+describes proof-carrying transaction structure (`proof_facts`) [22, 23]. Starknet’s
+account model remains relevant to this integration boundary [32]. Starknet’s March 10,
+2026 STRK20 announcement adds privacy relevance by stating any ERC-20 on Starknet can
+now be private [21].
 
----
+______________________________________________________________________
 
 ## 7. Related Systems and Competitive Landscape
 
 ### 7.1 DeepProve as a strong SNARK counterexample
 
-DeepProve is a direct counterexample to sweeping anti-SNARK claims: public Lagrange materials report full GPT-2 inference and later Gemma-class progress with specialized non-arithmetic handling [24, 25]. The relevant conclusion is narrower: SNARK systems can prove transformer workloads, but with different prover-side economics.
+DeepProve is a direct counterexample to sweeping anti-SNARK claims: public Lagrange
+materials report full GPT-2 inference and later Gemma-class progress with specialized
+non-arithmetic handling [24, 25]. The relevant conclusion is narrower: SNARK systems can
+prove transformer workloads, but with different prover-side economics.
 
 ### 7.2 Jolt Atlas and lookup-native SNARK convergence
 
-Jolt Atlas reaches a lookup-centric architecture from the SNARK side, extending Jolt to ONNX tensor operations and emphasizing non-linear workload handling [38]. The main relevance is convergence around lookup-heavy non-arithmetic handling.
-Related SNARK-side lines such as zkCNN and compiler-driven proving systems reinforce that non-arithmetic handling remains a central systems concern even when benchmark setups differ [9, 35, 36].
+Jolt Atlas reaches a lookup-centric architecture from the SNARK side, extending Jolt to
+ONNX tensor operations and emphasizing non-linear workload handling [38]. The main
+relevance is convergence around lookup-heavy non-arithmetic handling. Related SNARK-side
+lines such as zkCNN and compiler-driven proving systems reinforce that non-arithmetic
+handling remains a central systems concern even when benchmark setups differ [9, 35,
+36].
 
 ### 7.3 NANOZK and zkLLM on layerwise and attention-specific specialization
 
-NANOZK and zkLLM reinforce the same trend: layerwise decomposition and attention/nonlinearity specialization with lookup-heavy machinery [10, 39]. Here they are architectural evidence, not matched benchmarks.
+NANOZK and zkLLM reinforce the same trend: layerwise decomposition and
+attention/nonlinearity specialization with lookup-heavy machinery [10, 39]. Here they
+are architectural evidence, not matched benchmarks.
 
 ### 7.4 BitSage obelyzk.rs (formerly stwo-ml) as the closest public STARK-native comparator
 
-BitSage obelyzk.rs (formerly stwo-ml) is the closest public STARK-native comparator. According to current project-reported public materials, it combines GKR/sumcheck/LogUp-style machinery on an S-two/STWO path with Starknet verification paths, including a single-transaction recursive STARK verification claim for a 30-layer SmolLM2-135M proof and a six-step streaming verification path for a Qwen2-0.5B one-layer model [26, 27]. These remain project-reported evidence, not normalized benchmarks, and the same public materials still show uneven component maturity (`Attention` remains listed as `Prover only`).
+BitSage obelyzk.rs (formerly stwo-ml) is the closest public STARK-native comparator.
+According to current project-reported public materials, it combines
+GKR/sumcheck/LogUp-style machinery on an S-two/STWO path with Starknet verification
+paths, including a single-transaction recursive STARK verification claim for a 30-layer
+SmolLM2-135M proof and a six-step streaming verification path for a Qwen2-0.5B one-layer
+model [26, 27]. These remain project-reported evidence, not normalized benchmarks, and
+the same public materials still show uneven component maturity (`Attention` remains
+listed as `Prover only`).
 
 ### 7.5 LuminAIR and the custom-AIR path
 
-LuminAIR shows a different STARK-native path: custom AIR compilation for computational graphs rather than a transformer-VM-first substrate [28, 29]. The contest is therefore also between STARK-native architectures.
+LuminAIR shows a different STARK-native path: custom AIR compilation for computational
+graphs rather than a transformer-VM-first substrate [28, 29]. The contest is therefore
+also between STARK-native architectures.
 
 ### 7.6 A more defensible comparative claim
 
 The most defensible comparative claim is therefore:
 
-> Once large linear algebra is handled efficiently on both sides, the remaining contest is dominated by lookup handling, transparent recursion, field arithmetic, and commitment backend. On those axes, STARK-native stacks remain highly compelling.
+> Once large linear algebra is handled efficiently on both sides, the remaining contest
+> is dominated by lookup handling, transparent recursion, field arithmetic, and
+> commitment backend. On those axes, STARK-native stacks remain highly compelling.
 
-This is stronger than “STARKs have already won” because it is narrower and better evidenced. A supplementary appendix summarizes comparison details.
+This is stronger than “STARKs have already won” because it is narrower and better
+evidenced. A supplementary appendix summarizes comparison details.
 
-Against that external landscape, the remaining question is practical sequencing: which engineering steps most directly strengthen the next paper without diluting scope discipline.
+Against that external landscape, the remaining question is practical sequencing: which
+engineering steps most directly strengthen the next paper without diluting scope
+discipline.
 
----
+______________________________________________________________________
 
 ## 8. Discussion
 
 ### 8.1 What the paper supports, and what it does not
 
-Taken together, the paper supports: a transformer-specific symbolic argument, a concrete semantics-and-proof artifact with parameterized carried-state decoding, and a live infrastructure roadmap.
+Taken together, the paper supports: a transformer-specific symbolic argument, a concrete
+semantics-and-proof artifact with parameterized carried-state decoding, and a live
+infrastructure roadmap.
 
-It does **not** support stronger claims such as “STARKs have conclusively beaten SNARKs,” full standard-softmax end-to-end inference in this repository, or production-scale LLM proving evidence.
+It does **not** support stronger claims such as “STARKs have conclusively beaten
+SNARKs,” full standard-softmax end-to-end inference in this repository, or
+production-scale LLM proving evidence.
 
 ### 8.2 Highest-leverage next step
 
-Given the parameterized decoding bridge and the pre-recursive carried-state aggregation ladder, the highest-leverage next result is **recursive cryptographic carried-state compression and accumulation** over the existing decode relation.
+Given the parameterized decoding bridge and the pre-recursive carried-state aggregation
+ladder, the highest-leverage next result is **recursive cryptographic carried-state
+compression and accumulation** over the existing decode relation.
 
-The methodological reason is simple: the statement boundary is already explicit. The cleanest next paper is therefore one that keeps the same decode relation and carried-state commitments while improving proof-size and verifier-cost behavior through accumulation/compression, rather than changing the execution relation and the aggregation mechanism at the same time.
+The methodological reason is simple: the statement boundary is already explicit. The
+cleanest next paper is therefore one that keeps the same decode relation and
+carried-state commitments while improving proof-size and verifier-cost behavior through
+accumulation/compression, rather than changing the execution relation and the
+aggregation mechanism at the same time.
 
-More generic folding and recursive-argument frameworks already cover much of the broad abstraction space [41, 43, 44, 45]. The sharper contribution available here is transformer-specific carried-state accumulation over a fixed decode relation. Within that boundary, the most credible near-term strengthening is to keep the public decode relation unchanged while making the carried-state kernels more reusable: stable shared lookup-table identity and reuse across decode artifacts, explicit block and step proof envelopes with machine-readable carried-state and lookup boundaries, bounded multi-runtime semantic-agreement kernels over fixed operator surfaces, and continued verifier hardening on the experimental `stwo` route all sharpen the same fixed relation rather than replacing it [38, 39, 42, 47, 48]. A supplementary appendix maps those external influences to the current repository realization and the explicit future-work boundary they motivate.
+More generic folding and recursive-argument frameworks already cover much of the broad
+abstraction space [41, 43, 44, 45]. The sharper contribution available here is
+transformer-specific carried-state accumulation over a fixed decode relation. Within
+that boundary, the most credible near-term strengthening is to keep the public decode
+relation unchanged while making the carried-state kernels more reusable: stable shared
+lookup-table identity and reuse across decode artifacts, explicit block and step proof
+envelopes with machine-readable carried-state and lookup boundaries, bounded
+multi-runtime semantic-agreement kernels over fixed operator surfaces, and continued
+verifier hardening on the experimental `stwo` route all sharpen the same fixed relation
+rather than replacing it [38, 39, 42, 47, 48]. A supplementary appendix maps those
+external influences to the current repository realization and the explicit future-work
+boundary they motivate.
 
-That direction keeps the next contribution transformer-specific and technically attributable: gains can be read as accumulation/compression gains over a fixed public boundary, not as a consequence of moving the underlying claim.
+That direction keeps the next contribution transformer-specific and technically
+attributable: gains can be read as accumulation/compression gains over a fixed public
+boundary, not as a consequence of moving the underlying claim.
 
----
+______________________________________________________________________
 
 ## 9. Conclusion
 
-This paper does not argue that SNARKs cannot prove transformers or that STARKs have already won. It argues a narrower point: transformer workloads emphasize lookup-heavy nonlinearities, recursion, and field/commitment design choices where STARK-native systems may compound advantages.
+This paper does not argue that SNARKs cannot prove transformers or that STARKs have
+already won. It argues a narrower point: transformer workloads emphasize lookup-heavy
+nonlinearities, recursion, and field/commitment design choices where STARK-native
+systems may compound advantages.
 
-The repository contributes evidence at two layers: trace semantics and pre-recursive carried state. It shows direct proving of transformer-relevant traces, semantic checks across runtimes, and a parameterized decode relation that preserves commitments across chains, segments, interval bundles, rollups, layout matrices, and pre-recursive aggregation boundaries.
+The repository contributes evidence at two layers: trace semantics and pre-recursive
+carried state. It shows direct proving of transformer-relevant traces, semantic checks
+across runtimes, and a parameterized decode relation that preserves commitments across
+chains, segments, interval bundles, rollups, layout matrices, and pre-recursive
+aggregation boundaries.
 
-The frontier is no longer “can transformers be proved?” It is: **which architecture scales most cleanly to long-context, production verifiable inference while preserving transparency/post-quantum properties and compressing repeated transformer structure without losing semantic discipline?**
+The frontier is no longer “can transformers be proved?” It is: **which architecture
+scales most cleanly to long-context, production verifiable inference while preserving
+transparency/post-quantum properties and compressing repeated transformer structure
+without losing semantic discipline?**
 
----
+______________________________________________________________________
 
 ## Acknowledgments
 
-This paper uses the maintained repository `omarespejel/provable-transformer-vm`, which consolidates the current artifact bundles and the earlier `llm-provable-computer` line.
+This paper uses the maintained repository `omarespejel/provable-transformer-vm`, which
+consolidates the current artifact bundles and the earlier `llm-provable-computer` line.
 
----
+______________________________________________________________________
 
 ## References
 
-1. Eli Ben-Sasson, Iddo Bentov, Yinon Horesh, and Michael Riabzev. “Scalable, Transparent, and Post-Quantum Secure Computational Integrity.” *IACR Cryptology ePrint Archive*, Paper 2018/046, 2018. <https://eprint.iacr.org/2018/046>
-2. Eli Ben-Sasson, Iddo Bentov, Yinon Horesh, and Michael Riabzev. “Fast Reed-Solomon Interactive Oracle Proofs of Proximity.” In *Proceedings of the 45th International Colloquium on Automata, Languages, and Programming (ICALP)*, 2018.
-3. Eli Ben-Sasson, Lior Goldberg, Swastik Kopparty, and Shubhangi Saraf. “DEEP-FRI: Sampling Outside the Box Improves Soundness.” In *Proceedings of the 11th Innovations in Theoretical Computer Science Conference (ITCS)*, 2020.
-4. Ulrich Haböck, David Levit, and Shahar Papini. “Circle STARKs.” *IACR Cryptology ePrint Archive*, Paper 2024/278, 2024. <https://eprint.iacr.org/2024/278>
-5. Jens Groth. “On the Size of Pairing-Based Non-interactive Arguments.” In *Advances in Cryptology - EUROCRYPT 2016*, 2016.
-6. Ariel Gabizon, Zachary J. Williamson, and Oana Ciobotaru. “PLONK: Permutations over Lagrange-bases for Oecumenical Noninteractive Arguments of Knowledge.” *IACR Cryptology ePrint Archive*, Paper 2019/953, 2019. <https://eprint.iacr.org/2019/953>
-7. Shafi Goldwasser, Yael Tauman Kalai, and Guy N. Rothblum. “Delegating Computation: Interactive Proofs for Muggles.” *Journal of the ACM* 62(4), 2015.
-8. Ulrich Haböck. “Multivariate Lookups Based on Logarithmic Derivatives.” *IACR Cryptology ePrint Archive*, Paper 2022/1530, 2022. <https://eprint.iacr.org/2022/1530>
-9. Tianxiang Liu, Xiang Xie, and Yupeng Zhang. “zkCNN: Zero Knowledge Proofs for Convolutional Neural Network Predictions and Accuracy.” In *Proceedings of the 2021 ACM SIGSAC Conference on Computer and Communications Security (CCS)*, 2021.
-10. Haochen Sun, Jason Li, and Hongyang Zhang. “zkLLM: Zero Knowledge Proofs for Large Language Models.” *arXiv preprint* arXiv:2404.16109, 2024. <https://arxiv.org/abs/2404.16109>
-11. Daniel Balbás, Dario Fiore, et al. “Modular Sumcheck Proofs with Applications to Machine Learning and Image Processing.” In *Proceedings of the 2023 ACM SIGSAC Conference on Computer and Communications Security (CCS)*, 2023.
-12. Ashish Vaswani, Noam Shazeer, Niki Parmar, et al. “Attention Is All You Need.” In *Advances in Neural Information Processing Systems 30 (NeurIPS)*, 2017.
-13. Percepta Labs. “Can LLMs Be Computers?” *Percepta Blog*, March 2026. <https://percepta.ai/blog/can-llms-be-computers>
-14. Gemma Team. “Gemma 3 Technical Report.” Technical report, March 25, 2025. <https://storage.googleapis.com/deepmind-media/gemma/Gemma3Report.pdf>
-15. Google AI for Developers. “Gemma 3 Model Card.” Official model documentation. Accessed April 6, 2026. <https://ai.google.dev/gemma/docs/core/model_card_3>
-16. Google Developers Blog. “Gemma explained: An overview of Gemma model family architectures.” August 15, 2024. <https://developers.googleblog.com/en/gemma-explained-overview-gemma-model-family-architectures/>
-17. StarkWare. “Introducing S-two: The Fastest Prover for Real-world ZK Applications.” *StarkWare Blog*, May 26, 2025. <https://starkware.co/blog/s-two-prover/>
-18. StarkWare. “S-two 2.0.0 Is a Developer-Friendly, Fully Open-Source Toolkit.” *StarkWare Blog*, January 27, 2026. <https://starkware.co/blog/s-two-2-0-0-prover-for-developers/>
-19. StarkWare. “Minutes to Seconds: Efficiency Gains with Recursive Circuit Proving.” *StarkWare Blog*, March 31, 2026. <https://starkware.co/blog/minutes-to-seconds-efficiency-gains-with-recursive-circuit-proving/>
-20. Starknet Docs. “S-two Book: Introduction.” *Starknet Documentation*. Accessed April 5, 2026. <https://docs.starknet.io/learn/S-two-book/introduction>
-21. Starknet. “Make All ERC-20 Tokens Private with STRK20.” *Starknet Blog*, March 10, 2026. <https://www.starknet.io/blog/make-all-erc-20-tokens-private-with-strk20/>
-22. Starknet. “Version Releases.” *Starknet Documentation*. Accessed April 5, 2026. <https://www.starknet.io/developers/version-releases/>
-23. Starknet Community Forum. “SNIP-36: In-protocol Proof Verification.” Specification discussion. Accessed April 5, 2026. <https://community.starknet.io/t/snip-36-in-protocol-proof-verification/116123>
-24. Lagrange. “DeepProve-1.” *Lagrange Blog*, August 18, 2025. <https://www.lagrange.dev/blog/deepprove-1>
-25. Lagrange. “Engineering Update: September 2025.” *Lagrange Engineering Update*, published October 20, 2025. <https://www.lagrange.dev/engineering-updates/september-2025>
-26. BitSage Network. *obelyzk.rs* (formerly *stwo-ml*). GitHub repository. Accessed April 9, 2026. <https://github.com/Bitsage-Network/obelyzk.rs>
-27. BitSage Network. “elo-cairo-verifier/README.md.” GitHub documentation file in *obelyzk.rs*. Accessed April 9, 2026. <https://github.com/Bitsage-Network/obelyzk.rs/blob/main/elo-cairo-verifier/README.md>
-28. Giza. *LuminAIR*. GitHub repository. Accessed April 5, 2026. <https://github.com/gizatechxyz/LuminAIR>
-29. StarkWare. “Giza x S-two: Powering Verifiable ML with LuminAIR.” *StarkWare Blog*. Accessed April 5, 2026. <https://starkware.co/blog/giza-x-s-two-powering-verifiable-ml-with-luminair/>
-30. `omarespejel/provable-transformer-vm`. “Staging Repository Snapshot Discussed in Sections 5 and 8.” GitHub repository snapshot (pinned carried-state evidence commit), commit `6ff972ddda4051d73dc65c92a88c0d00683ec8c7`. This commit remains the citation target until the final publication repository and release tag are cut. <https://github.com/omarespejel/provable-transformer-vm/tree/6ff972ddda4051d73dc65c92a88c0d00683ec8c7>
-31. `omarespejel/provable-transformer-vm`. “Appendix Artifact Index (Production V1).” GitHub artifact snapshot, commit `8d435d540b8e3cf33ec4381bb820a00b6fe7aae6`, with command logs, hashes, and proof artifacts for the vanilla reproducibility tier. <https://github.com/omarespejel/provable-transformer-vm/blob/8d435d540b8e3cf33ec4381bb820a00b6fe7aae6/docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md>
-32. Starknet Docs. “Accounts.” *Starknet Documentation*. Accessed April 5, 2026. <https://docs.starknet.io/architecture/accounts>
-33. Zhizhi Peng, Chonghe Zhao, Taotao Wang, Guofu Liao, Zibin Lin, Yifeng Liu, Bin Cao, Long Shi, Qing Yang, and Shengli Zhang. “A Survey of Zero-Knowledge Proof-Based Verifiable Machine Learning.” *Artificial Intelligence Review* (accepted manuscript), arXiv:2502.18535v2, 2026. <https://arxiv.org/abs/2502.18535>
-34. Ayush Nainwal, Atharva Kamble, and Nitin Awathare. “A Comparative Analysis of zk-SNARKs and zk-STARKs: Theory and Practice.” *arXiv preprint* arXiv:2512.10020, 2025. <https://arxiv.org/abs/2512.10020>
-35. Jiajun Wang, Xiaowen Wang, Zekun Wen, Linyan Lyu, Wei Wang, Yuxin Wang, Yanjiang Yang, Jian Liu, Jiaheng Zhang, Chao Li, and Qianhui Wang. “zkPyTorch: Verifiable Training and Inference with Zero-Knowledge Proofs.” *IACR Cryptology ePrint Archive*, Paper 2025/535, 2025. <https://eprint.iacr.org/2025/535>
-36. Polyhedra Network. “zkPyTorch.” *Polyhedra Product Page*. Accessed April 6, 2026. <https://polyhedra.network/zkPyTorch>
-37. Hugo Touvron, Louis Martin, Kevin Stone, et al. “Llama 2: Open Foundation and Fine-Tuned Chat Models.” *arXiv preprint* arXiv:2307.09288, 2023. <https://arxiv.org/abs/2307.09288>
-38. Wyatt Benno, Alberto Centelles, Antoine Douchet, and Khalil Gibran. “Jolt Atlas: Verifiable Inference via Lookup Arguments in Zero Knowledge.” *arXiv preprint* arXiv:2602.17452, 2026. <https://arxiv.org/abs/2602.17452>
-39. Zhaohui Geoffrey Wang. “NANOZK: Layerwise Zero-Knowledge Proofs for Verifiable Large Language Model Inference.” *arXiv preprint* arXiv:2603.18046, 2026. <https://arxiv.org/abs/2603.18046>
-40. `omarespejel/provable-transformer-vm`. “Appendix Artifact Index (S-two Experimental V1).” GitHub artifact snapshot, commit `3970277d964a0a9a5326b0db364cf16822c1ccd4`, at `docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md`. <https://github.com/omarespejel/provable-transformer-vm/blob/3970277d964a0a9a5326b0db364cf16822c1ccd4/docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md>
-41. Wilson Nguyen and Srinath Setty. “Neo: Lattice-based folding scheme for CCS over small fields and pay-per-bit commitments.” *IACR Cryptology ePrint Archive*, Paper 2025/294, 2025. <https://eprint.iacr.org/2025/294>
-42. StarkWare. “How StarkWare Uses Formal Verification to Prove Tech Soundness.” *StarkWare Blog*, March 5, 2026. <https://starkware.co/blog/starkwares-gold-standard-of-soundness-with-formal-verification/>
-43. Abhiram Kothapalli and Srinath Setty. “HyperNova: Recursive Arguments for Customizable Constraint Systems.” *IACR Cryptology ePrint Archive*, Paper 2023/573, 2023. <https://eprint.iacr.org/2023/573>
-44. Abhiram Kothapalli and Srinath Setty. “NeutronNova: Folding Everything that Reduces to Zero-Check.” *IACR Cryptology ePrint Archive*, Paper 2024/1606, 2024. <https://eprint.iacr.org/2024/1606>
-45. Abhiram Kothapalli and Srinath Setty. “ProtoStar: Generic Efficient Accumulation/Folding for Special Sound Protocols.” *IACR Cryptology ePrint Archive*, Paper 2023/620, 2023. <https://eprint.iacr.org/2023/620>
-46. `omarespejel/provable-transformer-vm`. “Appendix Artifact Index (S-two Proof-Carrying Aggregation V1).” GitHub artifact snapshot, commit `6bb8cab99092203217d64951c3af61488aa2c58e`, at `docs/paper/artifacts/stwo-proof-carrying-aggregation-v1-2026-04-11/APPENDIX_ARTIFACT_INDEX.md`. <https://github.com/omarespejel/provable-transformer-vm/blob/6bb8cab99092203217d64951c3af61488aa2c58e/docs/paper/artifacts/stwo-proof-carrying-aggregation-v1-2026-04-11/APPENDIX_ARTIFACT_INDEX.md>
-47. Qi Zhan, Xing Hu, Xin Xia, and Shanping Li. “Verify Implementation Equivalence of Large Models.” *arXiv preprint* arXiv:2603.21851, 2026. <https://arxiv.org/abs/2603.21851>
-48. Lagrange. “Engineering Update: July 2025.” *Lagrange Engineering Update*, published July 24, 2025. <https://www.lagrange.dev/engineering-updates/july-2025>
+01. Eli Ben-Sasson, Iddo Bentov, Yinon Horesh, and Michael Riabzev. “Scalable,
+    Transparent, and Post-Quantum Secure Computational Integrity.” *IACR Cryptology
+    ePrint Archive*, Paper 2018/046, 2018. <https://eprint.iacr.org/2018/046>
+02. Eli Ben-Sasson, Iddo Bentov, Yinon Horesh, and Michael Riabzev. “Fast Reed-Solomon
+    Interactive Oracle Proofs of Proximity.” In *Proceedings of the 45th International
+    Colloquium on Automata, Languages, and Programming (ICALP)*, 2018.
+03. Eli Ben-Sasson, Lior Goldberg, Swastik Kopparty, and Shubhangi Saraf. “DEEP-FRI:
+    Sampling Outside the Box Improves Soundness.” In *Proceedings of the 11th
+    Innovations in Theoretical Computer Science Conference (ITCS)*, 2020.
+04. Ulrich Haböck, David Levit, and Shahar Papini. “Circle STARKs.” *IACR Cryptology
+    ePrint Archive*, Paper 2024/278, 2024. <https://eprint.iacr.org/2024/278>
+05. Jens Groth. “On the Size of Pairing-Based Non-interactive Arguments.” In *Advances
+    in Cryptology - EUROCRYPT 2016*, 2016.
+06. Ariel Gabizon, Zachary J. Williamson, and Oana Ciobotaru. “PLONK: Permutations over
+    Lagrange-bases for Oecumenical Noninteractive Arguments of Knowledge.” *IACR
+    Cryptology ePrint Archive*, Paper 2019/953, 2019. <https://eprint.iacr.org/2019/953>
+07. Shafi Goldwasser, Yael Tauman Kalai, and Guy N. Rothblum. “Delegating Computation:
+    Interactive Proofs for Muggles.” *Journal of the ACM* 62(4), 2015.
+08. Ulrich Haböck. “Multivariate Lookups Based on Logarithmic Derivatives.” *IACR
+    Cryptology ePrint Archive*, Paper 2022/1530, 2022.
+    <https://eprint.iacr.org/2022/1530>
+09. Tianxiang Liu, Xiang Xie, and Yupeng Zhang. “zkCNN: Zero Knowledge Proofs for
+    Convolutional Neural Network Predictions and Accuracy.” In *Proceedings of the 2021
+    ACM SIGSAC Conference on Computer and Communications Security (CCS)*, 2021.
+10. Haochen Sun, Jason Li, and Hongyang Zhang. “zkLLM: Zero Knowledge Proofs for Large
+    Language Models.” *arXiv preprint* arXiv:2404.16109, 2024.
+    <https://arxiv.org/abs/2404.16109>
+11. Daniel Balbás, Dario Fiore, et al. “Modular Sumcheck Proofs with Applications to
+    Machine Learning and Image Processing.” In *Proceedings of the 2023 ACM SIGSAC
+    Conference on Computer and Communications Security (CCS)*, 2023.
+12. Ashish Vaswani, Noam Shazeer, Niki Parmar, et al. “Attention Is All You Need.” In
+    *Advances in Neural Information Processing Systems 30 (NeurIPS)*, 2017.
+13. Percepta Labs. “Can LLMs Be Computers?” *Percepta Blog*, March 2026.
+    <https://percepta.ai/blog/can-llms-be-computers>
+14. Gemma Team. “Gemma 3 Technical Report.” Technical report, March 25, 2025.
+    <https://storage.googleapis.com/deepmind-media/gemma/Gemma3Report.pdf>
+15. Google AI for Developers. “Gemma 3 Model Card.” Official model documentation.
+    Accessed April 6, 2026. <https://ai.google.dev/gemma/docs/core/model_card_3>
+16. Google Developers Blog. “Gemma explained: An overview of Gemma model family
+    architectures.” August 15, 2024.
+    <https://developers.googleblog.com/en/gemma-explained-overview-gemma-model-family-architectures/>
+17. StarkWare. “Introducing S-two: The Fastest Prover for Real-world ZK Applications.”
+    *StarkWare Blog*, May 26, 2025. <https://starkware.co/blog/s-two-prover/>
+18. StarkWare. “S-two 2.0.0 Is a Developer-Friendly, Fully Open-Source Toolkit.”
+    *StarkWare Blog*, January 27, 2026.
+    <https://starkware.co/blog/s-two-2-0-0-prover-for-developers/>
+19. StarkWare. “Minutes to Seconds: Efficiency Gains with Recursive Circuit Proving.”
+    *StarkWare Blog*, March 31, 2026.
+    <https://starkware.co/blog/minutes-to-seconds-efficiency-gains-with-recursive-circuit-proving/>
+20. Starknet Docs. “S-two Book: Introduction.” *Starknet Documentation*. Accessed April
+    5, 2026. <https://docs.starknet.io/learn/S-two-book/introduction>
+21. Starknet. “Make All ERC-20 Tokens Private with STRK20.” *Starknet Blog*, March 10,
+    2026\. <https://www.starknet.io/blog/make-all-erc-20-tokens-private-with-strk20/>
+22. Starknet. “Version Releases.” *Starknet Documentation*. Accessed April 5, 2026.
+    <https://www.starknet.io/developers/version-releases/>
+23. Starknet Community Forum. “SNIP-36: In-protocol Proof Verification.” Specification
+    discussion. Accessed April 5, 2026.
+    <https://community.starknet.io/t/snip-36-in-protocol-proof-verification/116123>
+24. Lagrange. “DeepProve-1.” *Lagrange Blog*, August 18, 2025.
+    <https://www.lagrange.dev/blog/deepprove-1>
+25. Lagrange. “Engineering Update: September 2025.” *Lagrange Engineering Update*,
+    published October 20, 2025.
+    <https://www.lagrange.dev/engineering-updates/september-2025>
+26. BitSage Network. *obelyzk.rs* (formerly *stwo-ml*). GitHub repository. Accessed
+    April 9, 2026. <https://github.com/Bitsage-Network/obelyzk.rs>
+27. BitSage Network. “elo-cairo-verifier/README.md.” GitHub documentation file in
+    *obelyzk.rs*. Accessed April 9, 2026.
+    <https://github.com/Bitsage-Network/obelyzk.rs/blob/main/elo-cairo-verifier/README.md>
+28. Giza. *LuminAIR*. GitHub repository. Accessed April 5, 2026.
+    <https://github.com/gizatechxyz/LuminAIR>
+29. StarkWare. “Giza x S-two: Powering Verifiable ML with LuminAIR.” *StarkWare Blog*.
+    Accessed April 5, 2026.
+    <https://starkware.co/blog/giza-x-s-two-powering-verifiable-ml-with-luminair/>
+30. `omarespejel/provable-transformer-vm`. “Staging Repository Snapshot Discussed in
+    Sections 5 and 8.” GitHub repository snapshot (pinned carried-state evidence
+    commit), commit `6ff972ddda4051d73dc65c92a88c0d00683ec8c7`. This commit remains the
+    citation target until the final publication repository and release tag are cut.
+    <https://github.com/omarespejel/provable-transformer-vm/tree/6ff972ddda4051d73dc65c92a88c0d00683ec8c7>
+31. `omarespejel/provable-transformer-vm`. “Appendix Artifact Index (Production V1).”
+    GitHub artifact snapshot, commit `8d435d540b8e3cf33ec4381bb820a00b6fe7aae6`, with
+    command logs, hashes, and proof artifacts for the vanilla reproducibility tier.
+    <https://github.com/omarespejel/provable-transformer-vm/blob/8d435d540b8e3cf33ec4381bb820a00b6fe7aae6/docs/paper/artifacts/production-v1-2026-04-04/APPENDIX_ARTIFACT_INDEX.md>
+32. Starknet Docs. “Accounts.” *Starknet Documentation*. Accessed April 5, 2026.
+    <https://docs.starknet.io/architecture/accounts>
+33. Zhizhi Peng, Chonghe Zhao, Taotao Wang, Guofu Liao, Zibin Lin, Yifeng Liu, Bin Cao,
+    Long Shi, Qing Yang, and Shengli Zhang. “A Survey of Zero-Knowledge Proof-Based
+    Verifiable Machine Learning.” *Artificial Intelligence Review* (accepted
+    manuscript), arXiv:2502.18535v2, 2026. <https://arxiv.org/abs/2502.18535>
+34. Ayush Nainwal, Atharva Kamble, and Nitin Awathare. “A Comparative Analysis of
+    zk-SNARKs and zk-STARKs: Theory and Practice.” *arXiv preprint* arXiv:2512.10020,
+    2025\. <https://arxiv.org/abs/2512.10020>
+35. Jiajun Wang, Xiaowen Wang, Zekun Wen, Linyan Lyu, Wei Wang, Yuxin Wang, Yanjiang
+    Yang, Jian Liu, Jiaheng Zhang, Chao Li, and Qianhui Wang. “zkPyTorch: Verifiable
+    Training and Inference with Zero-Knowledge Proofs.” *IACR Cryptology ePrint
+    Archive*, Paper 2025/535, 2025. <https://eprint.iacr.org/2025/535>
+36. Polyhedra Network. “zkPyTorch.” *Polyhedra Product Page*. Accessed April 6, 2026.
+    <https://polyhedra.network/zkPyTorch>
+37. Hugo Touvron, Louis Martin, Kevin Stone, et al. “Llama 2: Open Foundation and
+    Fine-Tuned Chat Models.” *arXiv preprint* arXiv:2307.09288, 2023.
+    <https://arxiv.org/abs/2307.09288>
+38. Wyatt Benno, Alberto Centelles, Antoine Douchet, and Khalil Gibran. “Jolt Atlas:
+    Verifiable Inference via Lookup Arguments in Zero Knowledge.” *arXiv preprint*
+    arXiv:2602.17452, 2026. <https://arxiv.org/abs/2602.17452>
+39. Zhaohui Geoffrey Wang. “NANOZK: Layerwise Zero-Knowledge Proofs for Verifiable Large
+    Language Model Inference.” *arXiv preprint* arXiv:2603.18046, 2026.
+    <https://arxiv.org/abs/2603.18046>
+40. `omarespejel/provable-transformer-vm`. “Appendix Artifact Index (S-two Experimental
+    V1).” GitHub artifact snapshot, commit `3970277d964a0a9a5326b0db364cf16822c1ccd4`,
+    at
+    `docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md`.
+    <https://github.com/omarespejel/provable-transformer-vm/blob/3970277d964a0a9a5326b0db364cf16822c1ccd4/docs/paper/artifacts/stwo-experimental-v1-2026-04-06/APPENDIX_ARTIFACT_INDEX.md>
+41. Wilson Nguyen and Srinath Setty. “Neo: Lattice-based folding scheme for CCS over
+    small fields and pay-per-bit commitments.” *IACR Cryptology ePrint Archive*, Paper
+    2025/294, 2025. <https://eprint.iacr.org/2025/294>
+42. StarkWare. “How StarkWare Uses Formal Verification to Prove Tech Soundness.”
+    *StarkWare Blog*, March 5, 2026.
+    <https://starkware.co/blog/starkwares-gold-standard-of-soundness-with-formal-verification/>
+43. Abhiram Kothapalli and Srinath Setty. “HyperNova: Recursive Arguments for
+    Customizable Constraint Systems.” *IACR Cryptology ePrint Archive*, Paper 2023/573,
+    2023\. <https://eprint.iacr.org/2023/573>
+44. Abhiram Kothapalli and Srinath Setty. “NeutronNova: Folding Everything that Reduces
+    to Zero-Check.” *IACR Cryptology ePrint Archive*, Paper 2024/1606, 2024.
+    <https://eprint.iacr.org/2024/1606>
+45. Abhiram Kothapalli and Srinath Setty. “ProtoStar: Generic Efficient
+    Accumulation/Folding for Special Sound Protocols.” *IACR Cryptology ePrint Archive*,
+    Paper 2023/620, 2023. <https://eprint.iacr.org/2023/620>
+46. `omarespejel/provable-transformer-vm`. “Appendix Artifact Index (S-two
+    Proof-Carrying Aggregation V1).” GitHub artifact snapshot, commit
+    `6bb8cab99092203217d64951c3af61488aa2c58e`, at
+    `docs/paper/artifacts/stwo-proof-carrying-aggregation-v1-2026-04-11/APPENDIX_ARTIFACT_INDEX.md`.
+    <https://github.com/omarespejel/provable-transformer-vm/blob/6bb8cab99092203217d64951c3af61488aa2c58e/docs/paper/artifacts/stwo-proof-carrying-aggregation-v1-2026-04-11/APPENDIX_ARTIFACT_INDEX.md>
+47. Qi Zhan, Xing Hu, Xin Xia, and Shanping Li. “Verify Implementation Equivalence of
+    Large Models.” *arXiv preprint* arXiv:2603.21851, 2026.
+    <https://arxiv.org/abs/2603.21851>
+48. Lagrange. “Engineering Update: July 2025.” *Lagrange Engineering Update*, published
+    July 24, 2025. <https://www.lagrange.dev/engineering-updates/july-2025>

--- a/docs/paper/submission-v4-2026-04-11/BUNDLE_INDEX.md
+++ b/docs/paper/submission-v4-2026-04-11/BUNDLE_INDEX.md
@@ -1,21 +1,26 @@
 # Submission Bundle Index (v4, 2026-04-11)
 
 Planned publication tag after repository transfer:
+
 - `paper-publication-v4-2026-04-11`
 
 Canonical repository snapshot after transfer:
-- `paper-publication-v4-2026-04-11` once cut in the final publication
-  repository. Until that happens, the paper cites the staging commit-pinned
-  snapshot for Reference `[30]`.
+
+- `paper-publication-v4-2026-04-11` once cut in the final publication repository. Until
+  that happens, the paper cites the staging commit-pinned snapshot for Reference `[30]`.
 
 Carried-state aggregation provenance checkpoint:
-- `6ff972ddda4051d73dc65c92a88c0d00683ec8c7` (publication-facing proof-carrying aggregation provenance)
+
+- `6ff972ddda4051d73dc65c92a88c0d00683ec8c7` (publication-facing proof-carrying
+  aggregation provenance)
 
 Draft author line:
+
 - Abdelhamid Bakhta - StarkWare
 - Omar Espejel - Starknet Foundation
 
 Paper title:
+
 - `On the Structural Fit of Transformer Workloads and STARK Proof Systems`
 
 ## Core Paper Files
@@ -41,8 +46,8 @@ Paper title:
   - Citation commit: `6bb8cab99092203217d64951c3af61488aa2c58e`
 
 Older carried-state artifact directories remain archival provenance; see
-`docs/paper/artifacts/README.md`. The bundle above is the publication-facing
-artifact bundle for the carried-state aggregation line.
+`docs/paper/artifacts/README.md`. The bundle above is the publication-facing artifact
+bundle for the carried-state aggregation line.
 
 ## Evidence Pointer
 

--- a/docs/paper/submission-v4-2026-04-11/REPRODUCIBILITY_NOTE.md
+++ b/docs/paper/submission-v4-2026-04-11/REPRODUCIBILITY_NOTE.md
@@ -1,13 +1,12 @@
 # Reproducibility Note (One Page)
 
-This note describes how to reproduce the publication-facing paper artifacts for
-**On the Structural Fit of Transformer Workloads and STARK Proof Systems**
-under the rolling base tag `paper-publication-v4-2026-04-11` once cut.
-The tag should resolve to a commit that contains this v4 paper metadata. The
-carried-state aggregation evidence remains pinned to the proof-carrying
-aggregation checkpoint commit `6ff972ddda4051d73dc65c92a88c0d00683ec8c7`, with
-the dedicated bundle index cited at commit
-`6bb8cab99092203217d64951c3af61488aa2c58e`.
+This note describes how to reproduce the publication-facing paper artifacts for **On the
+Structural Fit of Transformer Workloads and STARK Proof Systems** under the rolling base
+tag `paper-publication-v4-2026-04-11` once cut. The tag should resolve to a commit that
+contains this v4 paper metadata. The carried-state aggregation evidence remains pinned
+to the proof-carrying aggregation checkpoint commit
+`6ff972ddda4051d73dc65c92a88c0d00683ec8c7`, with the dedicated bundle index cited at
+commit `6bb8cab99092203217d64951c3af61488aa2c58e`.
 
 ## 1) Scope and Intended Reproduction Target
 
@@ -16,7 +15,8 @@ The target is reproducibility of:
 - paper text and references,
 - appendix artifacts and evidence pointers,
 - figure-generating scripts and TSV outputs,
-- frozen artifact index manifests for the evidence tiers, including the proof-carrying aggregation bundle.
+- frozen artifact index manifests for the evidence tiers, including the proof-carrying
+  aggregation bundle.
 
 This package is intentionally a **research artifact snapshot**, not a claim of
 production-scale zkML deployment.
@@ -104,8 +104,8 @@ Primary evidence manifest:
 - `docs/paper/evidence/web-2026-04-06/manifest.tsv`
 - `docs/paper/evidence/web-2026-04-06/manifest.json`
 
-This records the source set used for infrastructure/system-state claims at the
-time of packaging.
+This records the source set used for infrastructure/system-state claims at the time of
+packaging.
 
 ## 7) Consistency Sweep Before Sharing
 
@@ -116,8 +116,9 @@ Before sharing a draft externally, verify:
    - `docs/paper/stark-transformer-alignment-2026.md`
    - `docs/paper/PUBLICATION_RELEASE.md`
 3. paper preflight passes,
-4. the aggregation bundle checksum files validate locally or in a clean reproduction environment,
+4. the aggregation bundle checksum files validate locally or in a clean reproduction
+   environment,
 5. release tag and commit references are consistent with the single main paper.
 
-If additional reviewer feedback lands, patch on top and cut a follow-up
-publication tag rather than mutating existing evidence claims.
+If additional reviewer feedback lands, patch on top and cut a follow-up publication tag
+rather than mutating existing evidence claims.


### PR DESCRIPTION
## What Changed

This PR applies the final package-level polish from the latest editorial review across the paper-facing materials.

Key changes:
- reflowed the paper, README, release note, submission notes, and appendices so the raw markdown is reviewable and arXiv-facing source is less compressed
- cleaned the paper title/author block in source form
- tightened the abstract and Section 5 wording so the paper reads less like a repo inventory and more like a paper
- tightened Section 5.6 so the semantic-agreement/provenance boundary reads as a precise scope boundary rather than a defensive aside
- kept the strong Section 5 disclaimer intact
- made proof-object terminology more consistent across the paper package
- kept the release-tag / canonical-citation step deferred until the final publication repository decision is made

## Why

The paper package was already substantively strong, but the remaining issues were mostly presentation and package mechanics:
- overly compressed raw markdown
- title block/source readability
- slightly repo-lexical phrasing in a few high-visibility places
- minor paper/package consistency cleanup

## Validation

- `git diff --check`
- `python3 scripts/paper/paper_preflight.py --repo-root .`

## Notes

- Reference `[30]` remains commit-pinned intentionally until the final canonical publication repository and release tag are settled.
- No new claims were added; this is a polish and packaging pass over the existing paper/package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted documentation for improved readability, including adjusted line wrapping, enhanced table layouts, and consistent visual presentation across README and technical papers. No content or functional changes made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->