### PR TITLE
[codex] Publication polish and README timeline cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Hardening and merge discipline for trusted-core work is formalized in:
 - [`docs/engineering/hardening-policy.md`](docs/engineering/hardening-policy.md)
 - [`docs/engineering/hardening-strategy.md`](docs/engineering/hardening-strategy.md)
 
-Current public proof artifacts:
+Current public proof surfaces:
 
 - native-ISA `statement-v1` arithmetic proofs
 - shared-table lookup proofs
-- transformer-shaped fixed-shape block proofs
-- step-level proof objects and carried-state decode chains
+- reusable block-shaped execution proofs
+- step-level proof-carrying decode artifacts
 - bounded multi-runtime semantic-agreement artifacts
 - pre-recursive aggregation bundles
 
@@ -602,7 +602,7 @@ not yet exposed as a public end-to-end proving path.
 
 #### Lookup Demos
 
-The repo exposes dedicated serialized proof envelopes and CLI commands for:
+The repo exposes dedicated serialized proof artifacts and CLI commands for:
 
 - single-row binary-step lookup and normalization demos
 - shared-table multi-claim lookup and normalization demos
@@ -618,68 +618,12 @@ The public decoding artifacts currently cover:
 - parameterized `decoding_step_v2`
 
 Those power the proof-carrying decoding demos, including layout-bound carried state,
-rolling KV-cache windows, cumulative KV-history commitments, and the matrix/rollup-style
-packaging layers described in the next-paper track, including pre-recursive cross-step
-lookup accumulators (Phase 23) and full state-relation accumulators (Phase 24), honest
-intervalized carried-state artifacts (Phase 25), folded intervalized carried-state
-accumulators (Phase 26), chained fold-of-folds carried-state accumulators (Phase 27),
-and proof-carrying aggregation across chained carried-state artifacts (Phase 28).
-
-#### Phase Highlights
-
-- Phase 6: canonical pre-aggregation batch manifests for future recursion work
-- Phase 8: `gemma_block_v2` binds canonical normalization inside the top-level execution
-  proof instead of only through `stwo_auxiliary`
-- Phase 9: `gemma_block_v3` binds normalization plus canonical binary-step activation
-  inside the same top-level execution proof
-- Phase 10: `gemma_block_v4` binds shared-table normalization and activation rows inside
-  the same top-level execution proof
-- Phase 11: fixed-shape proof-carrying decoding over `decoding_step_v1`
-- Phase 12: parameterized `decoding_step_v2` family with richer carried state,
-  proof-bound shared-lookup rows, and executed reads of both shared normalization scale
-  rows plus both shared activation output rows inside the decoding transition itself,
-  with the latest carried KV-cache pair now updated from lookup-backed values rather
-  than only forwarded incoming values, with three carried lanes now driven by the
-  bounded combined-output cell and one by the lookup-backed primary output on the wider
-  public layouts, with that combined-output cell now also absorbing two additional
-  bounded shared lookup rows before it is carried forward, and with the primary and
-  secondary outputs both absorbing that combined-output cell so both shared activation
-  rows influence the carried output frontier and output commitment, plus exact semantic
-  tests and real-backend proving coverage over all default demo steps
-- Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend
-  proving coverage across the default layout matrix
-- Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
-- Phase 15: mergeable history segments with explicit global carried-state boundaries
-- Phase 16: rollups over verified Phase 15 segment bundles
-- Phase 17: multi-layout rollup matrices over the same carried-state family
-- Phase 18: explicit KV-history frontier commitments tied to the live rolling cache
-- Phase 19: carried lookup transcripts over the same Phase 14-17 stack
-- Phase 20: explicit lookup frontier commitments over that same stack
-- Phase 21: template-bound accumulation over Phase 17 matrices with explicit template
-  and accumulator commitments
-- Phase 22: lookup-side accumulation over a verified Phase 21 source accumulator with
-  explicit source/template binding and derived frontier/count checks before recursion
-- Phase 23: pre-recursive cross-step lookup accumulation over cumulative Phase 22
-  prefixes with carried-state boundary commitments and derived counter checks
-- Phase 24: full carried-state relation accumulation over verified Phase 23 members with
-  explicit relation-template and relation-accumulator commitments before recursive
-  compression
-- Phase 25: honest intervalization of the Phase 24 carried-state relation into explicit
-  contiguous carried-state intervals with derived interval-template and
-  interval-accumulator commitments
-- Phase 26: folded accumulation over verified Phase 25 intervals with explicit
-  fold-template binding and folded interval accumulator commitments over real
-  carried-state intervals
-- Phase 27: chained fold-of-folds accumulation over verified Phase 26 members with
-  explicit chain-template binding and chained accumulator commitments over honest
-  carried-state intervals
-- Phase 28: proof-carrying aggregation over verified Phase 27 chained artifacts with
-  explicit aggregation-template binding, length-framed aggregation transcripts, and
-  aggregate carried-state boundary checks
-
-These phases define pre-recursive merge boundaries and carried-state bindings; they do
-not yet implement recursive cryptographic accumulation or compressed cross-member
-shared-table reuse.
+rolling KV-cache windows, cumulative KV-history commitments, and the pre-recursive
+packaging objects discussed in the paper. The detailed phase chronology for this line
+now lives in
+[`docs/engineering/design/engineering-timeline.md`](docs/engineering/design/engineering-timeline.md),
+so the public README can stay focused on current proof surfaces rather than internal
+implementation sequencing.
 
 #### Explicit Non-Goals
 
@@ -1053,7 +997,7 @@ for the shipped fixture set and decoding families.
 
 #### Lookup Demos
 
-The repo exposes dedicated serialized proof envelopes and CLI commands for:
+The repo exposes dedicated serialized proof artifacts and CLI commands for:
 
 - single-row binary-step lookup and normalization demos
 - shared-table multi-claim lookup and normalization demos
@@ -1070,52 +1014,10 @@ The public decoding artifacts currently cover:
 
 Those power the proof-carrying decoding demos, including layout-bound carried state,
 rolling KV-cache windows, cumulative KV-history commitments, mergeable history segments,
-rollups, rollup matrices, and the newer KV / lookup frontier layers used by the
-next-paper track. The current Phase 12 transition now uses both shared normalization
-scale rows and both shared activation output rows in executed decoding semantics, not
-only as carried proof metadata, and feeds lookup-backed values into the latest carried
-KV-cache pair on the public demo layouts, with the current wider layout frontier now
-mostly output-derived rather than forwarded-input-derived, while the bounded
-combined-output cell itself now absorbs two additional shared lookup rows before both
-final output lanes carry it forward.
-
-#### Phase Highlights
-
-- Phase 3: narrow arithmetic pilot and bounded lookup-backed activation pilot
-- Phase 5: real arithmetic proof lifecycles plus normalization lookup demo
-- Phase 7-10: `gemma_block_v1` through `gemma_block_v4`, ending with shared-table lookup
-  binding inside the top-level execution proof
-- Phase 11-14: fixed-shape decoding, parameterized decoding family, layout matrix, and
-  chunked cumulative KV-history
-- Phase 15-17: mergeable history segments, rollups over segments, and multi-layout
-  rollup matrices
-- Phase 18-20: explicit KV frontiers, carried lookup transcripts, and lookup frontier
-  commitments
-- Phase 21: template-bound accumulation over Phase 17 matrices for a reusable
-  pre-recursive merge boundary
-- Phase 22: lookup-side accumulation over a verified Phase 21 source accumulator with
-  explicit source/template binding and derived frontier/count checks before recursion
-- Phase 23: pre-recursive cross-step lookup accumulation over cumulative Phase 22
-  prefixes with carried-state boundary commitments and derived counter checks
-- Phase 24: full carried-state relation accumulation over verified Phase 23 members with
-  explicit relation-template and relation-accumulator commitments before recursive
-  compression
-- Phase 25: honest intervalization of the Phase 24 carried-state relation into explicit
-  contiguous carried-state intervals with derived interval-template and
-  interval-accumulator commitments
-- Phase 26: folded accumulation over verified Phase 25 intervals with explicit
-  fold-template binding and folded interval accumulator commitments over real
-  carried-state intervals
-- Phase 27: chained fold-of-folds accumulation over verified Phase 26 members with
-  explicit chain-template binding and chained accumulator commitments over honest
-  carried-state intervals
-- Phase 28: proof-carrying aggregation over verified Phase 27 chained artifacts with
-  explicit aggregation-template binding, length-framed aggregation transcripts, and
-  aggregate carried-state boundary checks
-
-These phases define pre-recursive merge boundaries and carried-state bindings; they do
-not yet implement recursive cryptographic accumulation or compressed cross-member
-shared-table reuse.
+rollups, rollup matrices, and pre-recursive aggregation bundles. The detailed internal
+phase chronology and transition notes now live in
+[`docs/engineering/design/engineering-timeline.md`](docs/engineering/design/engineering-timeline.md),
+so the public README stays publication-facing.
 
 #### Explicit Non-Goals
 

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -5,6 +5,7 @@ This directory contains engineering-facing material that supports implementation
 Contents:
 
 - `design/`: implementation and artifact-line design notes
+- `design/engineering-timeline.md`: detailed internal phase chronology moved out of the public README
 - `hardening-policy.md`: local CI, hardening, and merge-gate policy
 - `reproducibility.md`: broader engineering reproducibility guidance, including non-paper artifact flows
 

--- a/docs/engineering/design/README.md
+++ b/docs/engineering/design/README.md
@@ -7,3 +7,6 @@ They are implementation documents, not publication-facing claims.
 Repository-wide hardening and test policy lives in
 [`docs/engineering/hardening-policy.md`](../hardening-policy.md) and
 [`docs/engineering/hardening-strategy.md`](../hardening-strategy.md).
+
+The detailed phase chronology moved out of the public README lives in
+[`engineering-timeline.md`](engineering-timeline.md).

--- a/docs/engineering/design/engineering-timeline.md
+++ b/docs/engineering/design/engineering-timeline.md
@@ -1,0 +1,122 @@
+# Engineering Timeline
+
+This note preserves the detailed internal phase chronology that was removed from the
+top-level README during the publication-facing cleanup pass.
+
+It is engineering provenance, not publication-facing claim language.
+
+## Experimental `stwo` Execution And Decoding Line
+
+The public README now summarizes current proof surfaces and explicit non-goals. This
+note keeps the more detailed sequencing for maintainers who need the implementation
+history behind the experimental `stwo` line.
+
+### Phase 6-28 Highlights
+
+- Phase 6: canonical pre-aggregation batch manifests for future recursion work
+- Phase 8: `gemma_block_v2` binds canonical normalization inside the top-level execution
+  proof instead of only through `stwo_auxiliary`
+- Phase 9: `gemma_block_v3` binds normalization plus canonical binary-step activation
+  inside the same top-level execution proof
+- Phase 10: `gemma_block_v4` binds shared-table normalization and activation rows inside
+  the same top-level execution proof
+- Phase 11: fixed-shape proof-carrying decoding over `decoding_step_v1`
+- Phase 12: parameterized `decoding_step_v2` family with richer carried state,
+  proof-bound shared-lookup rows, and executed reads of both shared normalization scale
+  rows plus both shared activation output rows inside the decoding transition itself,
+  with the latest carried KV-cache pair now updated from lookup-backed values rather
+  than only forwarded incoming values, with three carried lanes now driven by the
+  bounded combined-output cell and one by the lookup-backed primary output on the wider
+  public layouts, with that combined-output cell now also absorbing two additional
+  bounded shared lookup rows before it is carried forward, and with the primary and
+  secondary outputs both absorbing that combined-output cell so both shared activation
+  rows influence the carried output frontier and output commitment, plus exact semantic
+  tests and real-backend proving coverage over all default demo steps
+- Phase 13: validated layout matrix for `decoding_step_v2`, now with real-backend
+  proving coverage across the default layout matrix
+- Phase 14: chunked cumulative KV-history with sealed/open segment boundaries
+- Phase 15: mergeable history segments with explicit global carried-state boundaries
+- Phase 16: rollups over verified Phase 15 segment bundles
+- Phase 17: multi-layout rollup matrices over the same carried-state family
+- Phase 18: explicit KV-history frontier commitments tied to the live rolling cache
+- Phase 19: carried lookup transcripts over the same Phase 14-17 stack
+- Phase 20: explicit lookup frontier commitments over that same stack
+- Phase 21: template-bound accumulation over Phase 17 matrices with explicit template
+  and accumulator commitments
+- Phase 22: lookup-side accumulation over a verified Phase 21 source accumulator with
+  explicit source/template binding and derived frontier/count checks before recursion
+- Phase 23: pre-recursive cross-step lookup accumulation over cumulative Phase 22
+  prefixes with carried-state boundary commitments and derived counter checks
+- Phase 24: full carried-state relation accumulation over verified Phase 23 members with
+  explicit relation-template and relation-accumulator commitments before recursive
+  compression
+- Phase 25: honest intervalization of the Phase 24 carried-state relation into explicit
+  contiguous carried-state intervals with derived interval-template and
+  interval-accumulator commitments
+- Phase 26: folded accumulation over verified Phase 25 intervals with explicit
+  fold-template binding and folded interval accumulator commitments over real
+  carried-state intervals
+- Phase 27: chained fold-of-folds accumulation over verified Phase 26 members with
+  explicit chain-template binding and chained accumulator commitments over honest
+  carried-state intervals
+- Phase 28: proof-carrying aggregation over verified Phase 27 chained artifacts with
+  explicit aggregation-template binding, length-framed aggregation transcripts, and
+  aggregate carried-state boundary checks
+
+These phases define pre-recursive merge boundaries and carried-state bindings; they do
+not yet implement recursive cryptographic accumulation or compressed cross-member
+shared-table reuse.
+
+## Carried-State Aggregation Line
+
+The broader carried-state aggregation line overlaps with the experimental `stwo`
+decoding path but also has its own internal sequencing milestones. The README now keeps
+only the publication-facing surface summary; this note keeps the chronology.
+
+### Detailed Transition Note
+
+The current Phase 12 transition now uses both shared normalization scale rows and both
+shared activation output rows in executed decoding semantics, not only as carried proof
+metadata, and feeds lookup-backed values into the latest carried KV-cache pair on the
+public demo layouts, with the current wider layout frontier now mostly
+output-derived rather than forwarded-input-derived, while the bounded combined-output
+cell itself now absorbs two additional shared lookup rows before both final output lanes
+carry it forward.
+
+### Phase 3-28 Highlights
+
+- Phase 3: narrow arithmetic pilot and bounded lookup-backed activation pilot
+- Phase 5: real arithmetic proof lifecycles plus normalization lookup demo
+- Phase 7-10: `gemma_block_v1` through `gemma_block_v4`, ending with shared-table lookup
+  binding inside the top-level execution proof
+- Phase 11-14: fixed-shape decoding, parameterized decoding family, layout matrix, and
+  chunked cumulative KV-history
+- Phase 15-17: mergeable history segments, rollups over segments, and multi-layout
+  rollup matrices
+- Phase 18-20: explicit KV frontiers, carried lookup transcripts, and lookup frontier
+  commitments
+- Phase 21: template-bound accumulation over Phase 17 matrices for a reusable
+  pre-recursive merge boundary
+- Phase 22: lookup-side accumulation over a verified Phase 21 source accumulator with
+  explicit source/template binding and derived frontier/count checks before recursion
+- Phase 23: pre-recursive cross-step lookup accumulation over cumulative Phase 22
+  prefixes with carried-state boundary commitments and derived counter checks
+- Phase 24: full carried-state relation accumulation over verified Phase 23 members with
+  explicit relation-template and relation-accumulator commitments before recursive
+  compression
+- Phase 25: honest intervalization of the Phase 24 carried-state relation into explicit
+  contiguous carried-state intervals with derived interval-template and
+  interval-accumulator commitments
+- Phase 26: folded accumulation over verified Phase 25 intervals with explicit
+  fold-template binding and folded interval accumulator commitments over real
+  carried-state intervals
+- Phase 27: chained fold-of-folds accumulation over verified Phase 26 members with
+  explicit chain-template binding and chained accumulator commitments over honest
+  carried-state intervals
+- Phase 28: proof-carrying aggregation over verified Phase 27 chained artifacts with
+  explicit aggregation-template binding, length-framed aggregation transcripts, and
+  aggregate carried-state boundary checks
+
+These phases define pre-recursive merge boundaries and carried-state bindings; they do
+not yet implement recursive cryptographic accumulation or compressed cross-member
+shared-table reuse.

--- a/docs/paper/PUBLICATION_RELEASE.md
+++ b/docs/paper/PUBLICATION_RELEASE.md
@@ -9,7 +9,8 @@ the release tag `paper-publication-v4-2026-04-11` once cut in the final publicat
 repository. Until that transfer and tag cut happen, the paper keeps Reference `[30]`
 pointed at the staging commit-pinned snapshot below. The final publication tag
 intentionally need not match the pinned carried-state evidence commit used by the
-aggregation bundle.
+aggregation bundle. Before upload, that tag still needs to be cut in the final
+publication repository and Reference `[30]` needs to be retargeted to it.
 
 Pinned carried-state aggregation provenance checkpoint:
 `6ff972ddda4051d73dc65c92a88c0d00683ec8c7`

--- a/docs/paper/stark-transformer-alignment-2026.md
+++ b/docs/paper/stark-transformer-alignment-2026.md
@@ -1,9 +1,9 @@
 # On the Structural Fit of Transformer Workloads and STARK Proof Systems
 
-**Abdelhamid Bakhta**\
+**Abdelhamid Bakhta**<br>
 StarkWare
 
-**Omar Espejel**\
+**Omar Espejel**<br>
 Starknet Foundation
 
 *April 2026*
@@ -22,7 +22,7 @@ not matched runtime measurements.
 We pair that analysis with `provable-transformer-vm` [30], a supporting artifact that
 provides a frozen vanilla reproducibility tier, a frozen narrow experimental `stwo`
 tier, and a broader proof-carrying decoding path with explicit carried-state boundaries,
-shared lookup-table identity, reusable block- and step-level proof objects, and a
+shared lookup-table identity, reusable block- and step-level proof surfaces, and a
 pre-recursive aggregation boundary. The repository does not yet provide full
 standard-softmax inference on S-two, recursive cryptographic compression/verification
 closure, recursive shared-table accumulation across decode steps as a compressed proof
@@ -405,13 +405,14 @@ The artifact provides:
 - a parameterized proof-carrying decoding relation over explicit carried-state
   boundaries,
 - statement-preserving pre-recursive packaging objects over that same decode relation,
-- a bounded multi-runtime semantic-agreement artifact.
+- a bounded multi-runtime semantic-agreement artifact together with hardened verifier
+  kernels.
 
 The central systems property is stable statement structure: the same decode relation
 survives progressively richer manifest and packaging layers without changing the
 underlying public boundary semantics. In concrete terms, the repository already exposes
 reusable block-shaped execution proofs and, on its experimental `stwo` tooling surface,
-step-level proof objects whose public boundary schema and statement semantics remain
+step-level proof surfaces whose public boundary schema and statement semantics remain
 stable across those richer artifact layers.
 
 For shared lookup evidence, the artifact binds normalization and activation table
@@ -539,10 +540,10 @@ relation witnesses, and binds observed transitions by per-runtime hashes plus a
 canonical transition hash. This is deterministic bounded relation evidence, not a
 general e-graph/SMT equivalence prover. It addresses a practical systems risk: proof
 artifacts should not silently rely on informal claims that distinct frontend/runtime
-paths are semantically identical. Separately, a release-provenance manifest can bind
-model and tokenizer identifiers, local tokenizer/transcript files, safetensors hashes,
-optional ONNX export hashes, and model-card/DOI/dataset metadata. That manifest is a
-reproducibility guardrail, not part of the proof relation.
+paths are semantically identical. For reproducibility rather than proof semantics, the
+artifact set also includes a release-provenance manifest for model, tokenizer, ONNX,
+and safetensors identity data. This is a packaging guardrail, not part of the proof
+relation.
 
 ### 5.7 Why this artifact matters
 


### PR DESCRIPTION
## What Changed

This PR applies the remaining still-relevant publication polish from the latest editorial review.

Key changes:
- smoothed the abstract and Section 5 wording in the main paper without changing the claim boundary
- made the title block source cleaner using explicit HTML line breaks rather than compressed raw markdown or trailing-space hacks
- moved the heavy internal phase chronology out of the public README into a dedicated engineering note
- replaced the README's internal phase blocks with shorter publication-facing summaries and links to the engineering timeline
- clarified in the publication release note that the final tag cut and Reference `[30]` retarget are still the remaining provenance step before upload

## Why

The package was already substantively strong after the previous paper polish pass, but a few publication-facing issues were still real on `main`:
- the abstract could still read less like repo inventory
- Section 5.1 and 5.6 could still be slightly tighter
- the top-level README still carried too much internal phase chronology for a first public read
- the release note needed a clearer statement that the final tag/Reference `[30]` switch remains pending

## Validation

- `git diff --check`
- `python3 scripts/paper/paper_preflight.py --repo-root .`

## Notes

- This PR intentionally does **not** cut the final publication tag or retarget Reference `[30]`, because that is still blocked on the final canonical-publication repository decision.
- The detailed phase chronology is preserved in `docs/engineering/design/engineering-timeline.md`; it is removed only from the public README surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated public-facing documentation with refined terminology for proof artifacts and decoding surfaces.
  * Reorganized internal engineering documentation by moving detailed phase chronology to a dedicated engineering timeline document.
  * Enhanced publication materials with clarified release procedures and improved author formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->