### PR TITLE
[codex] Harden ONNX metadata parser contract

### DIFF
--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -18,6 +18,7 @@ hardening_base_test_filters=(
 hardening_onnx_test_filters=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_wrong_format_version"
   "onnx_export::tests::load_onnx_program_metadata_rejects_input_contract_drift"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_output_contract_drift"
   "onnx_export::tests::load_onnx_program_metadata_rejects_instruction_table_instruction_drift"
   "onnx_export::tests::load_onnx_program_metadata_rejects_model_path_escape"
 )

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -21,6 +21,9 @@ hardening_onnx_test_filters=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_output_contract_drift"
   "onnx_export::tests::load_onnx_program_metadata_rejects_instruction_table_instruction_drift"
   "onnx_export::tests::load_onnx_program_metadata_rejects_model_path_escape"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_top_level_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
 )
 
 # Keep the heavier `stwo-backend` verifier gates on the sanitizer path. They are

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -11,6 +11,17 @@ hardening_base_test_filters=(
   "vanillastark::proof_stream::tests::test_deserialize_rejects_truncated_stream"
 )
 
+# Keep the `onnx-export` metadata parser gates on the smoke/UB path. They are
+# intentionally excluded from the Miri loop, and from the ASAN suite on the
+# current Apple toolchain, because feature-enabled tract/ONNX sanitizer builds
+# are not reliable enough for the fast hardening cycle on this repo.
+hardening_onnx_test_filters=(
+  "onnx_export::tests::load_onnx_program_metadata_rejects_wrong_format_version"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_input_contract_drift"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_instruction_table_instruction_drift"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_model_path_escape"
+)
+
 # Keep the heavier `stwo-backend` verifier gates on the sanitizer path. They are
 # intentionally excluded from the Miri loop because feature-enabled Miri builds
 # are too expensive for the fast hardening cycle on this repo.

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -24,6 +24,7 @@ hardening_onnx_test_filters=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_top_level_field"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
 )
 
 # Keep the heavier `stwo-backend` verifier gates on the sanitizer path. They are

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -25,7 +25,8 @@ hardening_onnx_test_filters=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
-  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_direct_memory_read_field_without_address"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_direct_memory_read_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_missing_direct_memory_read_address"
   "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
 )
 

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -25,6 +25,7 @@ hardening_onnx_test_filters=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_direct_memory_read_field_without_address"
   "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
 )
 

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -25,6 +25,7 @@ hardening_onnx_test_filters=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
+  "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
 )
 
 # Keep the heavier `stwo-backend` verifier gates on the sanitizer path. They are

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -356,6 +356,11 @@ stwo_smoke_targets=(
   "stwo_backend::decoding::tests::phase30_step_envelope_manifest_rejects_step_index_drift"
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_tampered_commitment"
 )
+onnx_smoke_targets=(
+  "onnx_export::tests::load_onnx_program_metadata_rejects_wrong_format_version"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_instruction_table_instruction_drift"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_model_path_escape"
+)
 stwo_cli_smoke_targets=(
   "cli_can_verify_stwo_recursive_compression_input_contract"
   "cli_verify_stwo_recursive_compression_input_contract_rejects_tampered_commitment"
@@ -384,6 +389,12 @@ changed_path_is_shell_script() {
     fi
   done
   return 1
+}
+
+changed_path_is_onnx_surface() {
+  changed_path_has_prefix "src/onnx_" ||
+    changed_path_has_prefix "tests/onnx_export.rs" ||
+    changed_path_has_prefix "spec/onnx"
 }
 
 changed_path_is_dependency_audit_input() {
@@ -423,6 +434,18 @@ run_stwo_smoke_targets() {
     run_logged "stwo-backend-smoke-${label}" cargo +nightly-2025-07-14 test -q \
       --features stwo-backend \
       --lib "$stwo_smoke" \
+      -- \
+      --exact
+  done
+}
+
+run_onnx_smoke_targets() {
+  local onnx_smoke label
+  for onnx_smoke in "${onnx_smoke_targets[@]}"; do
+    label="${onnx_smoke##*::}"
+    run_logged "onnx-smoke-${label}" cargo test -q \
+      --features onnx-export \
+      --lib "$onnx_smoke" \
       -- \
       --exact
   done
@@ -495,6 +518,9 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   for test_target in "${smoke_targets[@]}"; do
     run_logged "integration-${test_target}" cargo test -q --test "$test_target"
   done
+  if changed_path_is_onnx_surface; then
+    run_onnx_smoke_targets
+  fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   completed_local_mode="$RUN_MODE"
@@ -505,6 +531,9 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged cargo-lib-tests cargo test -q --lib
   run_logged cargo-lib-and-integration-tests cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
+  if changed_path_is_onnx_surface; then
+    run_onnx_smoke_targets
+  fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   run_research_v3_smoke_targets
@@ -516,6 +545,9 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged cargo-lib-tests cargo test -q --lib
   run_logged cargo-lib-and-integration-tests cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
+  if changed_path_is_onnx_surface; then
+    run_onnx_smoke_targets
+  fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   run_research_v3_smoke_targets

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -366,6 +366,7 @@ onnx_smoke_targets=(
     "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
     "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
     "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
+    "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_direct_memory_read_field_without_address"
     "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
   )
 stwo_cli_smoke_targets=(

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -358,6 +358,8 @@ stwo_smoke_targets=(
 )
 onnx_smoke_targets=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_wrong_format_version"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_input_contract_drift"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_output_contract_drift"
   "onnx_export::tests::load_onnx_program_metadata_rejects_instruction_table_instruction_drift"
   "onnx_export::tests::load_onnx_program_metadata_rejects_model_path_escape"
 )

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -366,7 +366,8 @@ onnx_smoke_targets=(
     "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
     "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
     "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
-    "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_direct_memory_read_field_without_address"
+    "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_direct_memory_read_field"
+    "onnx_export::tests::load_onnx_program_metadata_rejects_missing_direct_memory_read_address"
     "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
   )
 stwo_cli_smoke_targets=(

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -362,6 +362,9 @@ onnx_smoke_targets=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_output_contract_drift"
   "onnx_export::tests::load_onnx_program_metadata_rejects_instruction_table_instruction_drift"
   "onnx_export::tests::load_onnx_program_metadata_rejects_model_path_escape"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_top_level_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
 )
 stwo_cli_smoke_targets=(
   "cli_can_verify_stwo_recursive_compression_input_contract"
@@ -395,6 +398,9 @@ changed_path_is_shell_script() {
 
 changed_path_is_onnx_surface() {
   changed_path_has_prefix "src/onnx_" ||
+    changed_path_has_prefix "src/config.rs" ||
+    changed_path_has_prefix "src/instruction.rs" ||
+    changed_path_has_prefix "src/model.rs" ||
     changed_path_has_prefix "tests/onnx_export.rs" ||
     changed_path_has_prefix "spec/onnx"
 }

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -363,10 +363,11 @@ onnx_smoke_targets=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_instruction_table_instruction_drift"
   "onnx_export::tests::load_onnx_program_metadata_rejects_model_path_escape"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_top_level_field"
-  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
-  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
-  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
-)
+    "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
+    "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
+    "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
+    "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
+  )
 stwo_cli_smoke_targets=(
   "cli_can_verify_stwo_recursive_compression_input_contract"
   "cli_verify_stwo_recursive_compression_input_contract_rejects_tampered_commitment"

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -365,6 +365,7 @@ onnx_smoke_targets=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_top_level_field"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
 )
 stwo_cli_smoke_targets=(
   "cli_can_verify_stwo_recursive_compression_input_contract"

--- a/scripts/run_ub_checks_suite.sh
+++ b/scripts/run_ub_checks_suite.sh
@@ -8,7 +8,7 @@ HARDENING_TOOLCHAIN="${HARDENING_TOOLCHAIN:-nightly-2025-07-14}"
 
 source "$ROOT_DIR/scripts/hardening_test_names.sh"
 
-if ((${#hardening_base_test_filters[@]} == 0 && ${#hardening_stwo_test_filters[@]} == 0)); then
+if ((${#hardening_base_test_filters[@]} == 0 && ${#hardening_onnx_test_filters[@]} == 0 && ${#hardening_stwo_test_filters[@]} == 0)); then
   echo "hardening test filter lists are empty; refusing to run an empty UB-checks suite" >&2
   exit 1
 fi
@@ -18,6 +18,14 @@ export RUSTDOCFLAGS="${RUSTDOCFLAGS:-} -Zub-checks=yes"
 
 for test_filter in "${hardening_base_test_filters[@]}"; do
   cargo +"${HARDENING_TOOLCHAIN}" test --lib "${test_filter}" -- --exact
+done
+
+for test_filter in "${hardening_onnx_test_filters[@]}"; do
+  cargo +"${HARDENING_TOOLCHAIN}" test \
+    --features onnx-export \
+    --lib "${test_filter}" \
+    -- \
+    --exact
 done
 
 for test_filter in "${hardening_stwo_test_filters[@]}"; do

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,7 @@ impl FromStr for Attention2DMode {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TransformerVmConfig {
     pub d_model: usize,
     pub num_heads: usize,

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,6 @@ impl FromStr for Attention2DMode {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct TransformerVmConfig {
     pub d_model: usize,
     pub num_heads: usize,

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -103,7 +103,6 @@ impl fmt::Display for Instruction {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Program {
     instructions: Vec<Instruction>,
     initial_memory: Vec<i16>,

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -109,6 +109,17 @@ pub struct Program {
 }
 
 impl Program {
+    fn validate_memory_size(memory_size: usize) -> Result<()> {
+        if memory_size > usize::from(u8::MAX) {
+            return Err(VmError::InvalidConfig(format!(
+                "memory size {} exceeds the encoded stack/address limit of {} cells",
+                memory_size,
+                u8::MAX
+            )));
+        }
+        Ok(())
+    }
+
     pub fn new(instructions: Vec<Instruction>, memory_size: usize) -> Self {
         Self {
             instructions,
@@ -116,14 +127,16 @@ impl Program {
         }
     }
 
+    pub fn from_parts(instructions: Vec<Instruction>, initial_memory: Vec<i16>) -> Result<Self> {
+        Self::validate_memory_size(initial_memory.len())?;
+        Ok(Self {
+            instructions,
+            initial_memory,
+        })
+    }
+
     pub fn with_initial_memory(mut self, initial_memory: Vec<i16>) -> Result<Self> {
-        if initial_memory.len() > usize::from(u8::MAX) {
-            return Err(VmError::InvalidConfig(format!(
-                "memory size {} exceeds the encoded stack/address limit of {} cells",
-                initial_memory.len(),
-                u8::MAX
-            )));
-        }
+        Self::validate_memory_size(initial_memory.len())?;
         if initial_memory.len() != self.initial_memory.len() {
             return Err(VmError::InvalidConfig(format!(
                 "initial memory length {} does not match configured memory size {}",
@@ -232,6 +245,18 @@ mod tests {
         let err = Program::new(vec![Instruction::Halt], 256)
             .with_initial_memory(vec![0; 256])
             .unwrap_err();
+        assert!(err.to_string().contains("encoded stack/address limit"));
+    }
+
+    #[test]
+    fn from_parts_sets_values() {
+        let program = Program::from_parts(vec![Instruction::Halt], vec![10, 20, 30]).unwrap();
+        assert_eq!(program.initial_memory(), &[10, 20, 30]);
+    }
+
+    #[test]
+    fn from_parts_rejects_exceeding_u8_max() {
+        let err = Program::from_parts(vec![Instruction::Halt], vec![0; 256]).unwrap_err();
         assert!(err.to_string().contains("encoded stack/address limit"));
     }
 

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -103,6 +103,7 @@ impl fmt::Display for Instruction {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Program {
     instructions: Vec<Instruction>,
     initial_memory: Vec<i16>,

--- a/src/onnx_export.rs
+++ b/src/onnx_export.rs
@@ -132,7 +132,106 @@ pub fn load_onnx_program_metadata(path: &Path) -> Result<OnnxProgramMetadata> {
         path.to_path_buf()
     };
     let bytes = fs::read(metadata_path)?;
-    serde_json::from_slice(&bytes).map_err(|err| VmError::Serialization(err.to_string()))
+    let metadata: OnnxProgramMetadata =
+        serde_json::from_slice(&bytes).map_err(|err| VmError::Serialization(err.to_string()))?;
+    validate_onnx_program_metadata(&metadata)?;
+    Ok(metadata)
+}
+
+fn validate_onnx_program_metadata(metadata: &OnnxProgramMetadata) -> Result<()> {
+    if metadata.format_version != FORMAT_VERSION {
+        return Err(VmError::InvalidConfig(format!(
+            "ONNX metadata format_version {} does not match expected {}",
+            metadata.format_version, FORMAT_VERSION
+        )));
+    }
+    if metadata.ir_version != ONNX_IR_VERSION {
+        return Err(VmError::InvalidConfig(format!(
+            "ONNX metadata ir_version {} does not match expected {}",
+            metadata.ir_version, ONNX_IR_VERSION
+        )));
+    }
+    if metadata.opset_version != ONNX_OPSET_VERSION {
+        return Err(VmError::InvalidConfig(format!(
+            "ONNX metadata opset_version {} does not match expected {}",
+            metadata.opset_version, ONNX_OPSET_VERSION
+        )));
+    }
+    if metadata.input_dim != INPUT_DIM {
+        return Err(VmError::InvalidConfig(format!(
+            "ONNX metadata input_dim {} does not match expected {}",
+            metadata.input_dim, INPUT_DIM
+        )));
+    }
+    if metadata.output_dim != ONNX_OUTPUT_DIM {
+        return Err(VmError::InvalidConfig(format!(
+            "ONNX metadata output_dim {} does not match expected {}",
+            metadata.output_dim, ONNX_OUTPUT_DIM
+        )));
+    }
+    if metadata.input_encoding != "machine_input_v1" {
+        return Err(VmError::InvalidConfig(format!(
+            "ONNX metadata input_encoding {} does not match machine_input_v1",
+            metadata.input_encoding
+        )));
+    }
+    if metadata.output_encoding != "transition_with_flags_v1" {
+        return Err(VmError::InvalidConfig(format!(
+            "ONNX metadata output_encoding {} does not match transition_with_flags_v1",
+            metadata.output_encoding
+        )));
+    }
+    if metadata.input_layout != input_layout() {
+        return Err(VmError::InvalidConfig(
+            "ONNX metadata input_layout does not match the machine_input_v1 contract".to_string(),
+        ));
+    }
+    if metadata.output_layout != output_layout() {
+        return Err(VmError::InvalidConfig(
+            "ONNX metadata output_layout does not match the transition_with_flags_v1 contract"
+                .to_string(),
+        ));
+    }
+    if metadata.instructions.len() != metadata.program.len() {
+        return Err(VmError::InvalidConfig(format!(
+            "ONNX metadata instruction table length {} does not match program length {}",
+            metadata.instructions.len(),
+            metadata.program.len()
+        )));
+    }
+
+    for (index, instruction) in metadata.instructions.iter().enumerate() {
+        let expected_pc = u8::try_from(index).map_err(|_| {
+            VmError::InvalidConfig(format!(
+                "ONNX metadata instruction table exceeds u8 pc space at index {}",
+                index
+            ))
+        })?;
+        if instruction.pc != expected_pc {
+            return Err(VmError::InvalidConfig(format!(
+                "ONNX metadata instruction table is misaligned at index {}: found pc {}",
+                index, instruction.pc
+            )));
+        }
+
+        let expected_instruction = metadata.program.instruction_at(expected_pc)?;
+        if instruction.instruction != expected_instruction {
+            return Err(VmError::InvalidConfig(format!(
+                "ONNX metadata instruction table does not match embedded program at pc {}",
+                expected_pc
+            )));
+        }
+
+        let expected_model_file = instruction_model_file(index);
+        if instruction.model_file != expected_model_file {
+            return Err(VmError::InvalidConfig(format!(
+                "ONNX metadata model_file {} does not match expected {} for pc {}",
+                instruction.model_file, expected_model_file, expected_pc
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 pub(crate) fn export_compiled_instruction_onnx(
@@ -806,6 +905,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::compiler::ProgramCompiler;
     use crate::config::TransformerVmConfig;
     use crate::memory::AddressedMemory;
     use crate::model::{
@@ -852,6 +952,21 @@ mod tests {
             Instruction::JumpIfNotZero(6),
             Instruction::Halt,
         ]
+    }
+
+    fn sample_exported_program_metadata(name: &str) -> (PathBuf, OnnxProgramMetadata) {
+        let source = fs::read_to_string("programs/addition.tvm").expect("fixture");
+        let model = ProgramCompiler
+            .compile_source(&source, TransformerVmConfig::default())
+            .expect("compile model");
+        let export_dir = unique_temp_dir(name);
+        let metadata = export_program_onnx(&model, &export_dir).expect("export program");
+        (export_dir, metadata)
+    }
+
+    fn overwrite_metadata(export_dir: &Path, metadata: &OnnxProgramMetadata) {
+        let bytes = serde_json::to_vec_pretty(metadata).expect("serialize metadata");
+        fs::write(metadata_path(export_dir), bytes).expect("write metadata");
     }
 
     fn load_plan(path: &Path) -> Arc<TypedRunnableModel> {
@@ -971,5 +1086,78 @@ mod tests {
         }
 
         let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_rejects_wrong_format_version() {
+        let (export_dir, mut metadata) = sample_exported_program_metadata("onnx-metadata-format");
+        metadata.format_version = metadata.format_version.saturating_add(1);
+        overwrite_metadata(&export_dir, &metadata);
+
+        let err = load_onnx_program_metadata(&export_dir)
+            .expect_err("wrong metadata format version should fail");
+        assert!(
+            err.to_string().contains("format_version"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_rejects_input_contract_drift() {
+        let (export_dir, mut metadata) =
+            sample_exported_program_metadata("onnx-metadata-input-contract");
+        metadata.input_layout[0].name = "tampered-input".to_string();
+        overwrite_metadata(&export_dir, &metadata);
+
+        let err =
+            load_onnx_program_metadata(&export_dir).expect_err("input contract drift should fail");
+        assert!(
+            err.to_string().contains("input_layout"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_rejects_instruction_table_instruction_drift() {
+        let (export_dir, mut metadata) =
+            sample_exported_program_metadata("onnx-metadata-instruction-drift");
+        let original = metadata.instructions[0].instruction;
+        metadata.instructions[0].instruction = if original == Instruction::Halt {
+            Instruction::Nop
+        } else {
+            Instruction::Halt
+        };
+        overwrite_metadata(&export_dir, &metadata);
+
+        let err = load_onnx_program_metadata(&export_dir)
+            .expect_err("instruction-table drift should fail");
+        assert!(
+            err.to_string()
+                .contains("instruction table does not match embedded program"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_rejects_model_path_escape() {
+        let (export_dir, mut metadata) =
+            sample_exported_program_metadata("onnx-metadata-model-path");
+        metadata.instructions[0].model_file = "../escape.onnx".to_string();
+        overwrite_metadata(&export_dir, &metadata);
+
+        let err =
+            load_onnx_program_metadata(&export_dir).expect_err("path escape should fail to load");
+        assert!(
+            err.to_string().contains("model_file"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
     }
 }

--- a/src/onnx_export.rs
+++ b/src/onnx_export.rs
@@ -227,7 +227,7 @@ fn parse_strict_memory_read(value: serde_json::Value) -> Result<OnnxInstructionR
             Ok(OnnxInstructionRead::StackTop)
         }
         "direct" => {
-            if object.len() != 2 {
+            if object.keys().any(|key| key != "kind" && key != "address") {
                 return Err(VmError::Serialization(
                     "unknown field in memory_read direct variant".to_string(),
                 ));
@@ -1437,6 +1437,28 @@ mod tests {
             .expect_err("unknown nested memory_read field should fail");
         assert!(
             err.to_string().contains("unknown field"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_rejects_unknown_direct_memory_read_field_without_address() {
+        let (export_dir, metadata) =
+            sample_exported_program_metadata("onnx-metadata-direct-memory-read-extra-field");
+        let mut metadata_json = serde_json::to_value(metadata).expect("metadata to json");
+        metadata_json["instructions"][0]["memory_read"] = serde_json::json!({
+            "kind": "direct",
+            "unexpected_field": 7
+        });
+        overwrite_metadata_json(&export_dir, &metadata_json);
+
+        let err = load_onnx_program_metadata(&export_dir)
+            .expect_err("unknown direct memory_read field should fail");
+        assert!(
+            err.to_string()
+                .contains("unknown field in memory_read direct variant"),
             "unexpected error: {err}"
         );
 

--- a/src/onnx_export.rs
+++ b/src/onnx_export.rs
@@ -76,6 +76,183 @@ pub struct OnnxProgramMetadata {
     pub instructions: Vec<OnnxInstructionMetadata>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictOnnxInputLayoutEntry {
+    index: usize,
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictOnnxInstructionMetadata {
+    pc: u8,
+    layer_idx: usize,
+    instruction: Instruction,
+    model_file: String,
+    memory_read: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictTransformerVmConfig {
+    d_model: usize,
+    num_heads: usize,
+    num_layers: usize,
+    vocab_size: usize,
+    max_seq_len: usize,
+    ff_dim: usize,
+    attention_mode: crate::config::Attention2DMode,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictProgram {
+    instructions: Vec<Instruction>,
+    initial_memory: Vec<i16>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictOnnxProgramMetadata {
+    format_version: u32,
+    ir_version: i64,
+    opset_version: i64,
+    input_dim: usize,
+    output_dim: usize,
+    input_encoding: String,
+    output_encoding: String,
+    input_layout: Vec<StrictOnnxInputLayoutEntry>,
+    output_layout: Vec<String>,
+    config: StrictTransformerVmConfig,
+    program: StrictProgram,
+    instructions: Vec<StrictOnnxInstructionMetadata>,
+}
+
+impl From<StrictOnnxInputLayoutEntry> for OnnxInputLayoutEntry {
+    fn from(value: StrictOnnxInputLayoutEntry) -> Self {
+        Self {
+            index: value.index,
+            name: value.name,
+        }
+    }
+}
+
+impl TryFrom<StrictOnnxInstructionMetadata> for OnnxInstructionMetadata {
+    type Error = VmError;
+
+    fn try_from(value: StrictOnnxInstructionMetadata) -> Result<Self> {
+        Ok(Self {
+            pc: value.pc,
+            layer_idx: value.layer_idx,
+            instruction: value.instruction,
+            model_file: value.model_file,
+            memory_read: parse_strict_memory_read(value.memory_read)?,
+        })
+    }
+}
+
+impl From<StrictTransformerVmConfig> for TransformerVmConfig {
+    fn from(value: StrictTransformerVmConfig) -> Self {
+        Self {
+            d_model: value.d_model,
+            num_heads: value.num_heads,
+            num_layers: value.num_layers,
+            vocab_size: value.vocab_size,
+            max_seq_len: value.max_seq_len,
+            ff_dim: value.ff_dim,
+            attention_mode: value.attention_mode,
+        }
+    }
+}
+
+impl StrictProgram {
+    fn into_program(self) -> Result<Program> {
+        Program::new(self.instructions, self.initial_memory.len())
+            .with_initial_memory(self.initial_memory)
+    }
+}
+
+impl StrictOnnxProgramMetadata {
+    fn into_runtime_metadata(self) -> Result<OnnxProgramMetadata> {
+        Ok(OnnxProgramMetadata {
+            format_version: self.format_version,
+            ir_version: self.ir_version,
+            opset_version: self.opset_version,
+            input_dim: self.input_dim,
+            output_dim: self.output_dim,
+            input_encoding: self.input_encoding,
+            output_encoding: self.output_encoding,
+            input_layout: self
+                .input_layout
+                .into_iter()
+                .map(OnnxInputLayoutEntry::from)
+                .collect(),
+            output_layout: self.output_layout,
+            config: self.config.into(),
+            program: self.program.into_program()?,
+            instructions: self
+                .instructions
+                .into_iter()
+                .map(OnnxInstructionMetadata::try_from)
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+}
+
+fn parse_strict_memory_read(value: serde_json::Value) -> Result<OnnxInstructionRead> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| VmError::Serialization("memory_read must be a JSON object".to_string()))?;
+    let kind = object
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| VmError::Serialization("memory_read.kind must be a string".to_string()))?;
+
+    match kind {
+        "none" => {
+            if object.len() != 1 {
+                return Err(VmError::Serialization(
+                    "unknown field in memory_read none variant".to_string(),
+                ));
+            }
+            Ok(OnnxInstructionRead::None)
+        }
+        "stack_top" => {
+            if object.len() != 1 {
+                return Err(VmError::Serialization(
+                    "unknown field in memory_read stack_top variant".to_string(),
+                ));
+            }
+            Ok(OnnxInstructionRead::StackTop)
+        }
+        "direct" => {
+            if object.len() != 2 {
+                return Err(VmError::Serialization(
+                    "unknown field in memory_read direct variant".to_string(),
+                ));
+            }
+            let address = object
+                .get("address")
+                .and_then(serde_json::Value::as_u64)
+                .ok_or_else(|| {
+                    VmError::Serialization(
+                        "memory_read direct variant requires numeric address".to_string(),
+                    )
+                })?;
+            let address = u8::try_from(address).map_err(|_| {
+                VmError::Serialization(
+                    "memory_read direct variant address exceeds u8 range".to_string(),
+                )
+            })?;
+            Ok(OnnxInstructionRead::Direct { address })
+        }
+        _ => Err(VmError::Serialization(format!(
+            "unknown memory_read kind `{kind}`"
+        ))),
+    }
+}
+
 pub fn export_program_onnx(
     model: &TransformerVm,
     output_dir: &Path,
@@ -135,8 +312,9 @@ pub fn load_onnx_program_metadata(path: &Path) -> Result<OnnxProgramMetadata> {
         path.to_path_buf()
     };
     let bytes = fs::read(metadata_path)?;
-    let metadata: OnnxProgramMetadata =
+    let metadata: StrictOnnxProgramMetadata =
         serde_json::from_slice(&bytes).map_err(|err| VmError::Serialization(err.to_string()))?;
+    let metadata = metadata.into_runtime_metadata()?;
     validate_onnx_program_metadata(&metadata)?;
     Ok(metadata)
 }
@@ -1237,6 +1415,24 @@ mod tests {
 
         let err = load_onnx_program_metadata(&export_dir)
             .expect_err("unknown nested program field should fail");
+        assert!(
+            err.to_string().contains("unknown field"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_rejects_unknown_nested_memory_read_field() {
+        let (export_dir, metadata) =
+            sample_exported_program_metadata("onnx-metadata-extra-memory-read-field");
+        let mut metadata_json = serde_json::to_value(metadata).expect("metadata to json");
+        metadata_json["instructions"][0]["memory_read"]["unexpected_field"] = serde_json::json!(7);
+        overwrite_metadata_json(&export_dir, &metadata_json);
+
+        let err = load_onnx_program_metadata(&export_dir)
+            .expect_err("unknown nested memory_read field should fail");
         assert!(
             err.to_string().contains("unknown field"),
             "unexpected error: {err}"

--- a/src/onnx_export.rs
+++ b/src/onnx_export.rs
@@ -314,7 +314,9 @@ pub fn load_onnx_program_metadata(path: &Path) -> Result<OnnxProgramMetadata> {
     let bytes = fs::read(metadata_path)?;
     let metadata: StrictOnnxProgramMetadata =
         serde_json::from_slice(&bytes).map_err(|err| VmError::Serialization(err.to_string()))?;
-    let metadata = metadata.into_runtime_metadata()?;
+    let metadata = metadata
+        .into_runtime_metadata()
+        .map_err(|err| VmError::Serialization(err.to_string()))?;
     validate_onnx_program_metadata(&metadata)?;
     Ok(metadata)
 }
@@ -1435,6 +1437,29 @@ mod tests {
             .expect_err("unknown nested memory_read field should fail");
         assert!(
             err.to_string().contains("unknown field"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization() {
+        let (export_dir, metadata) =
+            sample_exported_program_metadata("onnx-metadata-oversized-memory");
+        let mut metadata_json = serde_json::to_value(metadata).expect("metadata to json");
+        metadata_json["program"]["initial_memory"] =
+            serde_json::Value::Array((0..256).map(|_| serde_json::json!(0)).collect());
+        overwrite_metadata_json(&export_dir, &metadata_json);
+
+        let err = load_onnx_program_metadata(&export_dir)
+            .expect_err("oversized initial memory should fail");
+        assert!(
+            matches!(err, VmError::Serialization(_)),
+            "unexpected error variant: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("encoded stack/address limit"),
             "unexpected error: {err}"
         );
 

--- a/src/onnx_export.rs
+++ b/src/onnx_export.rs
@@ -43,12 +43,14 @@ pub enum OnnxInstructionRead {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OnnxInputLayoutEntry {
     pub index: usize,
     pub name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OnnxInstructionMetadata {
     pub pc: u8,
     pub layer_idx: usize,
@@ -58,6 +60,7 @@ pub struct OnnxInstructionMetadata {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OnnxProgramMetadata {
     pub format_version: u32,
     pub ir_version: i64,
@@ -969,6 +972,11 @@ mod tests {
         fs::write(metadata_path(export_dir), bytes).expect("write metadata");
     }
 
+    fn overwrite_metadata_json(export_dir: &Path, metadata: &serde_json::Value) {
+        let bytes = serde_json::to_vec_pretty(metadata).expect("serialize metadata json");
+        fs::write(metadata_path(export_dir), bytes).expect("write metadata");
+    }
+
     fn load_plan(path: &Path) -> Arc<TypedRunnableModel> {
         tract_onnx::onnx()
             .model_for_path(path)
@@ -1172,6 +1180,65 @@ mod tests {
             load_onnx_program_metadata(&export_dir).expect_err("path escape should fail to load");
         assert!(
             err.to_string().contains("model_file"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_rejects_unknown_top_level_field() {
+        let (export_dir, metadata) = sample_exported_program_metadata("onnx-metadata-extra-top");
+        let mut metadata_json = serde_json::to_value(metadata).expect("metadata to json");
+        metadata_json
+            .as_object_mut()
+            .expect("metadata object")
+            .insert(
+                "unexpected_field".to_string(),
+                serde_json::Value::Bool(true),
+            );
+        overwrite_metadata_json(&export_dir, &metadata_json);
+
+        let err = load_onnx_program_metadata(&export_dir)
+            .expect_err("unknown top-level metadata field should fail");
+        assert!(
+            err.to_string().contains("unknown field"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_rejects_unknown_nested_config_field() {
+        let (export_dir, metadata) =
+            sample_exported_program_metadata("onnx-metadata-extra-config-field");
+        let mut metadata_json = serde_json::to_value(metadata).expect("metadata to json");
+        metadata_json["config"]["unexpected_field"] = serde_json::json!(7);
+        overwrite_metadata_json(&export_dir, &metadata_json);
+
+        let err = load_onnx_program_metadata(&export_dir)
+            .expect_err("unknown nested config field should fail");
+        assert!(
+            err.to_string().contains("unknown field"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_rejects_unknown_nested_program_field() {
+        let (export_dir, metadata) =
+            sample_exported_program_metadata("onnx-metadata-extra-program-field");
+        let mut metadata_json = serde_json::to_value(metadata).expect("metadata to json");
+        metadata_json["program"]["unexpected_field"] = serde_json::json!(7);
+        overwrite_metadata_json(&export_dir, &metadata_json);
+
+        let err = load_onnx_program_metadata(&export_dir)
+            .expect_err("unknown nested program field should fail");
+        assert!(
+            err.to_string().contains("unknown field"),
             "unexpected error: {err}"
         );
 

--- a/src/onnx_export.rs
+++ b/src/onnx_export.rs
@@ -1122,6 +1122,23 @@ mod tests {
     }
 
     #[test]
+    fn load_onnx_program_metadata_rejects_output_contract_drift() {
+        let (export_dir, mut metadata) =
+            sample_exported_program_metadata("onnx-metadata-output-contract");
+        metadata.output_layout[0] = "tampered-output".to_string();
+        overwrite_metadata(&export_dir, &metadata);
+
+        let err =
+            load_onnx_program_metadata(&export_dir).expect_err("output contract drift should fail");
+        assert!(
+            err.to_string().contains("output_layout"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
     fn load_onnx_program_metadata_rejects_instruction_table_instruction_drift() {
         let (export_dir, mut metadata) =
             sample_exported_program_metadata("onnx-metadata-instruction-drift");

--- a/src/onnx_export.rs
+++ b/src/onnx_export.rs
@@ -168,8 +168,8 @@ impl From<StrictTransformerVmConfig> for TransformerVmConfig {
 
 impl StrictProgram {
     fn into_program(self) -> Result<Program> {
-        Program::new(self.instructions, self.initial_memory.len())
-            .with_initial_memory(self.initial_memory)
+        Program::from_parts(self.instructions, self.initial_memory)
+            .map_err(|err| VmError::Serialization(err.to_string()))
     }
 }
 
@@ -314,9 +314,7 @@ pub fn load_onnx_program_metadata(path: &Path) -> Result<OnnxProgramMetadata> {
     let bytes = fs::read(metadata_path)?;
     let metadata: StrictOnnxProgramMetadata =
         serde_json::from_slice(&bytes).map_err(|err| VmError::Serialization(err.to_string()))?;
-    let metadata = metadata
-        .into_runtime_metadata()
-        .map_err(|err| VmError::Serialization(err.to_string()))?;
+    let metadata = metadata.into_runtime_metadata()?;
     validate_onnx_program_metadata(&metadata)?;
     Ok(metadata)
 }
@@ -1444,12 +1442,13 @@ mod tests {
     }
 
     #[test]
-    fn load_onnx_program_metadata_rejects_unknown_direct_memory_read_field_without_address() {
+    fn load_onnx_program_metadata_rejects_unknown_direct_memory_read_field() {
         let (export_dir, metadata) =
             sample_exported_program_metadata("onnx-metadata-direct-memory-read-extra-field");
         let mut metadata_json = serde_json::to_value(metadata).expect("metadata to json");
         metadata_json["instructions"][0]["memory_read"] = serde_json::json!({
             "kind": "direct",
+            "address": 0,
             "unexpected_field": 7
         });
         overwrite_metadata_json(&export_dir, &metadata_json);
@@ -1459,6 +1458,27 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("unknown field in memory_read direct variant"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(export_dir);
+    }
+
+    #[test]
+    fn load_onnx_program_metadata_rejects_missing_direct_memory_read_address() {
+        let (export_dir, metadata) =
+            sample_exported_program_metadata("onnx-metadata-direct-memory-read-missing-address");
+        let mut metadata_json = serde_json::to_value(metadata).expect("metadata to json");
+        metadata_json["instructions"][0]["memory_read"] = serde_json::json!({
+            "kind": "direct"
+        });
+        overwrite_metadata_json(&export_dir, &metadata_json);
+
+        let err = load_onnx_program_metadata(&export_dir)
+            .expect_err("missing direct memory_read address should fail");
+        assert!(
+            err.to_string()
+                .contains("memory_read direct variant requires numeric address"),
             "unexpected error: {err}"
         );
 
@@ -1479,10 +1499,6 @@ mod tests {
         assert!(
             matches!(err, VmError::Serialization(_)),
             "unexpected error variant: {err:?}"
-        );
-        assert!(
-            err.to_string().contains("encoded stack/address limit"),
-            "unexpected error: {err}"
         );
 
         let _ = fs::remove_dir_all(export_dir);


### PR DESCRIPTION
## Summary
- validate ONNX metadata against the frozen export contract on load instead of accepting arbitrary deserialized JSON
- reject instruction-table drift and model-file path escape before runtime model loading
- wire the new ONNX parser regressions into smoke and UB hardening coverage

## Validation
- rustfmt src/onnx_export.rs
- cargo test --features onnx-export --lib load_onnx_program_metadata_rejects_ -- --nocapture
- env RUSTFLAGS='-Zub-checks=yes' cargo +nightly-2025-07-14 test --features onnx-export --lib load_onnx_program_metadata_rejects_ -- --nocapture
- cargo test -q --features onnx-export --lib onnx_export::tests::load_onnx_program_metadata_rejects_wrong_format_version -- --exact
- cargo test -q --features onnx-export --lib onnx_export::tests::load_onnx_program_metadata_rejects_instruction_table_instruction_drift -- --exact
- cargo test -q --features onnx-export --lib onnx_export::tests::load_onnx_program_metadata_rejects_model_path_escape -- --exact
- bash scripts/run_shellcheck_suite.sh
- git diff --check

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

## Notes
- ONNX metadata load now rejects format drift, input/output contract drift, embedded-program drift, and model-file path drift before runtime loading.
- Smoke gate now exercises targeted ONNX parser checks when ONNX surfaces change.
- UB hardening coverage now includes the ONNX metadata parser checks.
- Oracle/differential: not applicable for this slice because it hardens metadata parser invariants, not model semantics.
- Resource-bound/untrusted-input: reviewed; this keeps the parser on a fixed contract and rejects mismatched instruction tables before file traversal or model load.
- Kani/formal-kernel: not applicable in this slice; no proof-kernel arithmetic or formal contract function changed.
- ASAN note: attempted locally, but feature-enabled tract/ONNX ASAN linking fails on the current Apple toolchain, so this slice keeps ONNX parser coverage on smoke plus UB paths rather than pretending ASAN is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened ONNX metadata validation to reject tampered or inconsistent metadata (format, layout, instruction/model mismatches, and malformed fields).

* **Tests**
  * Added extensive rejection tests for ONNX metadata parsing and serialization edge cases.
  * Introduced ONNX-targeted smoke tests to catch regressions earlier.

* **Chores**
  * Enhanced local and hardening test runners to include ONNX-focused test selection and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->