### PR TITLE
[codex] Harden research-v3 artifact ingestion

### DIFF
--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -30,6 +30,19 @@ hardening_onnx_test_filters=(
   "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
 )
 
+# Keep the `research-v3` equivalence artifact loader and witness checks on the
+# smoke/UB path. These live in the `tvm` binary test harness rather than the
+# library test harness because the strict loader is part of the CLI-facing
+# verifier surface.
+hardening_research_v3_test_filters=(
+  "tests::research_v3_rule_witnesses_rejects_event_length_mismatch"
+  "tests::load_research_v3_equivalence_artifact_rejects_unknown_top_level_field"
+  "tests::load_research_v3_equivalence_artifact_rejects_unknown_nested_rule_witness_field"
+  "tests::load_research_v3_equivalence_artifact_rejects_oversized_file"
+  "tests::load_research_v3_equivalence_artifact_reports_malformed_json_as_serialization"
+  "tests::load_research_v3_equivalence_artifact_rejects_non_regular_file"
+)
+
 # Keep the heavier `stwo-backend` verifier gates on the sanitizer path. They are
 # intentionally excluded from the Miri loop because feature-enabled Miri builds
 # are too expensive for the fast hardening cycle on this repo.

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -363,13 +363,21 @@ onnx_smoke_targets=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_instruction_table_instruction_drift"
   "onnx_export::tests::load_onnx_program_metadata_rejects_model_path_escape"
   "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_top_level_field"
-    "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
-    "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
-    "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
-    "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_direct_memory_read_field"
-    "onnx_export::tests::load_onnx_program_metadata_rejects_missing_direct_memory_read_address"
-    "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
-  )
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_config_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_program_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_nested_memory_read_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_unknown_direct_memory_read_field"
+  "onnx_export::tests::load_onnx_program_metadata_rejects_missing_direct_memory_read_address"
+  "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
+)
+research_v3_smoke_targets=(
+  "tests::research_v3_rule_witnesses_rejects_event_length_mismatch"
+  "tests::load_research_v3_equivalence_artifact_rejects_unknown_top_level_field"
+  "tests::load_research_v3_equivalence_artifact_rejects_unknown_nested_rule_witness_field"
+  "tests::load_research_v3_equivalence_artifact_rejects_oversized_file"
+  "tests::load_research_v3_equivalence_artifact_reports_malformed_json_as_serialization"
+  "tests::load_research_v3_equivalence_artifact_rejects_non_regular_file"
+)
 stwo_cli_smoke_targets=(
   "cli_can_verify_stwo_recursive_compression_input_contract"
   "cli_verify_stwo_recursive_compression_input_contract_rejects_tampered_commitment"
@@ -407,6 +415,15 @@ changed_path_is_onnx_surface() {
     changed_path_has_prefix "src/model.rs" ||
     changed_path_has_prefix "tests/onnx_export.rs" ||
     changed_path_has_prefix "spec/onnx"
+}
+
+changed_path_is_research_v3_surface() {
+  changed_path_has_prefix "src/bin/tvm.rs" ||
+    changed_path_has_prefix "tests/cli.rs" ||
+    changed_path_has_prefix "spec/statement-v3-equivalence-kernel" ||
+    changed_path_has_prefix "spec/frontend-runtime-semantics-registry-v1.json" ||
+    changed_path_has_prefix "spec/fixed-point-semantics-v2.json" ||
+    changed_path_has_prefix "spec/onnx-op-subset-v2.json"
 }
 
 changed_path_is_dependency_audit_input() {
@@ -475,6 +492,16 @@ run_stwo_cli_smoke_targets() {
 }
 
 run_research_v3_smoke_targets() {
+  local research_v3_smoke label
+  for research_v3_smoke in "${research_v3_smoke_targets[@]}"; do
+    label="${research_v3_smoke##*::}"
+    run_logged "research-v3-smoke-${label}" cargo test -q \
+      --features burn-model,onnx-export \
+      --bin tvm "$research_v3_smoke" \
+      -- \
+      --exact
+  done
+
   run_logged research-v3-equivalence-cli cargo test -q \
     --features full \
     --test cli cli_supports_research_v3_equivalence_command \
@@ -533,6 +560,9 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
   fi
+  if changed_path_is_research_v3_surface; then
+    run_research_v3_smoke_targets
+  fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   completed_local_mode="$RUN_MODE"
@@ -546,9 +576,11 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
   fi
+  if changed_path_is_research_v3_surface; then
+    run_research_v3_smoke_targets
+  fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
-  run_research_v3_smoke_targets
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -560,9 +592,11 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
   fi
+  if changed_path_is_research_v3_surface; then
+    run_research_v3_smoke_targets
+  fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
-  run_research_v3_smoke_targets
   run_conditional_mutation_check
   run_logged fuzz-smoke env FUZZ_TIME_PER_TARGET=20 scripts/run_fuzz_smoke_suite.sh
   run_logged ub-checks env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -417,15 +417,6 @@ changed_path_is_onnx_surface() {
     changed_path_has_prefix "spec/onnx"
 }
 
-changed_path_is_research_v3_surface() {
-  changed_path_has_prefix "src/bin/tvm.rs" ||
-    changed_path_has_prefix "tests/cli.rs" ||
-    changed_path_has_prefix "spec/statement-v3-equivalence-kernel" ||
-    changed_path_has_prefix "spec/frontend-runtime-semantics-registry-v1.json" ||
-    changed_path_has_prefix "spec/fixed-point-semantics-v2.json" ||
-    changed_path_has_prefix "spec/onnx-op-subset-v2.json"
-}
-
 changed_path_is_dependency_audit_input() {
   local path
 
@@ -560,9 +551,7 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
   fi
-  if changed_path_is_research_v3_surface; then
-    run_research_v3_smoke_targets
-  fi
+  run_research_v3_smoke_targets
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   completed_local_mode="$RUN_MODE"
@@ -576,9 +565,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
   fi
-  if changed_path_is_research_v3_surface; then
-    run_research_v3_smoke_targets
-  fi
+  run_research_v3_smoke_targets
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   completed_local_mode="$RUN_MODE"
@@ -592,9 +579,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
   fi
-  if changed_path_is_research_v3_surface; then
-    run_research_v3_smoke_targets
-  fi
+  run_research_v3_smoke_targets
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   run_conditional_mutation_check

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -417,6 +417,18 @@ changed_path_is_onnx_surface() {
     changed_path_has_prefix "spec/onnx"
 }
 
+changed_path_is_research_v3_surface() {
+  changed_path_has_prefix "src/bin/tvm.rs" ||
+    changed_path_has_prefix "tests/cli.rs" ||
+    changed_path_has_prefix "spec/statement-v3-equivalence-kernel" ||
+    changed_path_has_prefix "spec/frontend-runtime-semantics-registry-v1.json" ||
+    changed_path_has_prefix "spec/fixed-point-semantics-v2.json" ||
+    changed_path_has_prefix "spec/onnx-op-subset-v2.json" ||
+    changed_path_has_prefix "scripts/local_merge_gate.sh" ||
+    changed_path_has_prefix "scripts/hardening_test_names.sh" ||
+    changed_path_has_prefix "scripts/run_ub_checks_suite.sh"
+}
+
 changed_path_is_dependency_audit_input() {
   local path
 
@@ -493,6 +505,9 @@ run_research_v3_smoke_targets() {
       --exact
   done
 
+}
+
+run_research_v3_cli_smoke_target() {
   run_logged research-v3-equivalence-cli cargo test -q \
     --features full \
     --test cli cli_supports_research_v3_equivalence_command \
@@ -551,7 +566,9 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
   fi
-  run_research_v3_smoke_targets
+  if changed_path_is_research_v3_surface; then
+    run_research_v3_smoke_targets
+  fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   completed_local_mode="$RUN_MODE"
@@ -565,7 +582,10 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
   fi
-  run_research_v3_smoke_targets
+  if changed_path_is_research_v3_surface; then
+    run_research_v3_smoke_targets
+    run_research_v3_cli_smoke_target
+  fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   completed_local_mode="$RUN_MODE"
@@ -579,7 +599,10 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
   fi
-  run_research_v3_smoke_targets
+  if changed_path_is_research_v3_surface; then
+    run_research_v3_smoke_targets
+    run_research_v3_cli_smoke_target
+  fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
   run_conditional_mutation_check

--- a/scripts/run_ub_checks_suite.sh
+++ b/scripts/run_ub_checks_suite.sh
@@ -8,7 +8,7 @@ HARDENING_TOOLCHAIN="${HARDENING_TOOLCHAIN:-nightly-2025-07-14}"
 
 source "$ROOT_DIR/scripts/hardening_test_names.sh"
 
-if ((${#hardening_base_test_filters[@]} == 0 && ${#hardening_onnx_test_filters[@]} == 0 && ${#hardening_stwo_test_filters[@]} == 0)); then
+if ((${#hardening_base_test_filters[@]} == 0 && ${#hardening_onnx_test_filters[@]} == 0 && ${#hardening_research_v3_test_filters[@]} == 0 && ${#hardening_stwo_test_filters[@]} == 0)); then
   echo "hardening test filter lists are empty; refusing to run an empty UB-checks suite" >&2
   exit 1
 fi
@@ -24,6 +24,14 @@ for test_filter in "${hardening_onnx_test_filters[@]}"; do
   cargo +"${HARDENING_TOOLCHAIN}" test \
     --features onnx-export \
     --lib "${test_filter}" \
+    -- \
+    --exact
+done
+
+for test_filter in "${hardening_research_v3_test_filters[@]}"; do
+  cargo +"${HARDENING_TOOLCHAIN}" test \
+    --features burn-model,onnx-export \
+    --bin tvm "${test_filter}" \
     -- \
     --exact
 done

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -5283,23 +5283,54 @@ fn research_v3_limitations() -> Vec<String> {
 fn load_research_v3_equivalence_artifact(
     artifact_path: &Path,
 ) -> llm_provable_computer::Result<ResearchV3EquivalenceArtifact> {
+    let metadata = fs::symlink_metadata(artifact_path).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to read research-v3 artifact {}: {err}",
+            artifact_path.display()
+        ))
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(VmError::InvalidConfig(format!(
+            "research-v3 artifact {} is not a regular file",
+            artifact_path.display()
+        )));
+    }
+    if metadata.len() > MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES as u64 {
+        return Err(VmError::InvalidConfig(format!(
+            "research-v3 artifact {} is {} bytes, exceeding the limit of {} bytes",
+            artifact_path.display(),
+            metadata.len(),
+            MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES
+        )));
+    }
     let file = fs::File::open(artifact_path).map_err(|err| {
         VmError::InvalidConfig(format!(
             "failed to read research-v3 artifact {}: {err}",
             artifact_path.display()
         ))
     })?;
-    let metadata = file.metadata().map_err(|err| {
+    let opened_metadata = file.metadata().map_err(|err| {
         VmError::InvalidConfig(format!(
             "failed to read research-v3 artifact {}: {err}",
             artifact_path.display()
         ))
     })?;
-    if !metadata.is_file() {
+    if !opened_metadata.is_file() {
         return Err(VmError::InvalidConfig(format!(
-            "research-v3 artifact {} is not a regular file",
+            "research-v3 artifact {} is not a regular file after opening",
             artifact_path.display()
         )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        if metadata.dev() != opened_metadata.dev() || metadata.ino() != opened_metadata.ino() {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 artifact {} changed between metadata inspection and open",
+                artifact_path.display()
+            )));
+        }
     }
     let mut artifact_bytes = Vec::new();
     let mut limited_reader = file.take(MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES as u64 + 1);

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -5332,6 +5332,19 @@ fn load_research_v3_equivalence_artifact(
             )));
         }
     }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+
+        if metadata.volume_serial_number() != opened_metadata.volume_serial_number()
+            || metadata.file_index() != opened_metadata.file_index()
+        {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 artifact {} changed between metadata inspection and open",
+                artifact_path.display()
+            )));
+        }
+    }
     let mut artifact_bytes = Vec::new();
     let mut limited_reader = file.take(MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES as u64 + 1);
     limited_reader

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsString;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
@@ -5282,7 +5283,13 @@ fn research_v3_limitations() -> Vec<String> {
 fn load_research_v3_equivalence_artifact(
     artifact_path: &Path,
 ) -> llm_provable_computer::Result<ResearchV3EquivalenceArtifact> {
-    let metadata = fs::metadata(artifact_path).map_err(|err| {
+    let file = fs::File::open(artifact_path).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to read research-v3 artifact {}: {err}",
+            artifact_path.display()
+        ))
+    })?;
+    let metadata = file.metadata().map_err(|err| {
         VmError::InvalidConfig(format!(
             "failed to read research-v3 artifact {}: {err}",
             artifact_path.display()
@@ -5294,21 +5301,16 @@ fn load_research_v3_equivalence_artifact(
             artifact_path.display()
         )));
     }
-    if metadata.len() > MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES as u64 {
-        return Err(VmError::InvalidConfig(format!(
-            "research-v3 artifact {} is {} bytes, exceeding the limit of {} bytes",
-            artifact_path.display(),
-            metadata.len(),
-            MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES
-        )));
-    }
-
-    let artifact_bytes = fs::read(artifact_path).map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read research-v3 artifact {}: {err}",
-            artifact_path.display()
-        ))
-    })?;
+    let mut artifact_bytes = Vec::new();
+    let mut limited_reader = file.take(MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES as u64 + 1);
+    limited_reader
+        .read_to_end(&mut artifact_bytes)
+        .map_err(|err| {
+            VmError::InvalidConfig(format!(
+                "failed to read research-v3 artifact {}: {err}",
+                artifact_path.display()
+            ))
+        })?;
     if artifact_bytes.len() > MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES {
         return Err(VmError::InvalidConfig(format!(
             "research-v3 artifact {} is {} bytes after read, exceeding the limit of {} bytes",
@@ -6678,12 +6680,12 @@ mod tests {
     }
 
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
-    fn research_v3_test_artifact_path(label: &str) -> PathBuf {
-        let suffix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("llm-provable-computer-{label}-{suffix}.json"))
+    fn research_v3_test_artifact_file(label: &str) -> tempfile::NamedTempFile {
+        tempfile::Builder::new()
+            .prefix(&format!("llm-provable-computer-{label}-"))
+            .suffix(".json")
+            .tempfile()
+            .expect("create temp file")
     }
 
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
@@ -6786,69 +6788,61 @@ mod tests {
     #[test]
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
     fn load_research_v3_equivalence_artifact_rejects_unknown_top_level_field() {
-        let path = research_v3_test_artifact_path("research-v3-extra-top");
+        let file = research_v3_test_artifact_file("research-v3-extra-top");
         let mut value =
             serde_json::to_value(sample_research_v3_equivalence_artifact()).expect("artifact json");
         value
             .as_object_mut()
             .expect("artifact object")
             .insert("unexpected_field".to_string(), serde_json::json!(true));
-        write_research_v3_test_artifact(&path, &value);
+        write_research_v3_test_artifact(file.path(), &value);
 
-        let err =
-            load_research_v3_equivalence_artifact(&path).expect_err("unknown field should fail");
+        let err = load_research_v3_equivalence_artifact(file.path())
+            .expect_err("unknown field should fail");
         assert!(err.to_string().contains("unknown field"));
-
-        let _ = fs::remove_file(path);
     }
 
     #[test]
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
     fn load_research_v3_equivalence_artifact_rejects_unknown_nested_rule_witness_field() {
-        let path = research_v3_test_artifact_path("research-v3-extra-witness");
+        let file = research_v3_test_artifact_file("research-v3-extra-witness");
         let mut value =
             serde_json::to_value(sample_research_v3_equivalence_artifact()).expect("artifact json");
         value["rule_witnesses"][0]["unexpected_field"] = serde_json::json!(7);
-        write_research_v3_test_artifact(&path, &value);
+        write_research_v3_test_artifact(file.path(), &value);
 
-        let err = load_research_v3_equivalence_artifact(&path)
+        let err = load_research_v3_equivalence_artifact(file.path())
             .expect_err("unknown nested rule witness field should fail");
         assert!(err.to_string().contains("unknown field"));
-
-        let _ = fs::remove_file(path);
     }
 
     #[test]
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
     fn load_research_v3_equivalence_artifact_rejects_oversized_file() {
-        let path = research_v3_test_artifact_path("research-v3-oversized");
+        let file = research_v3_test_artifact_file("research-v3-oversized");
         fs::write(
-            &path,
+            file.path(),
             vec![b'x'; MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES + 1],
         )
         .expect("write oversized artifact");
 
-        let err = load_research_v3_equivalence_artifact(&path)
+        let err = load_research_v3_equivalence_artifact(file.path())
             .expect_err("oversized artifact should fail");
         assert!(err.to_string().contains("exceeding the limit"));
-
-        let _ = fs::remove_file(path);
     }
 
     #[test]
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
     fn load_research_v3_equivalence_artifact_reports_malformed_json_as_serialization() {
-        let path = research_v3_test_artifact_path("research-v3-malformed");
-        fs::write(&path, b"{").expect("write malformed artifact");
+        let file = research_v3_test_artifact_file("research-v3-malformed");
+        fs::write(file.path(), b"{").expect("write malformed artifact");
 
-        let err = load_research_v3_equivalence_artifact(&path)
+        let err = load_research_v3_equivalence_artifact(file.path())
             .expect_err("malformed artifact should fail");
         assert!(matches!(err, VmError::Serialization(_)));
         assert!(err
             .to_string()
             .contains("failed to parse research-v3 artifact"));
-
-        let _ = fs::remove_file(path);
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -860,6 +860,8 @@ const STATEMENT_V3_EQUIVALENCE_ARTIFACT_SCHEMA_PATH: &str =
 const RESEARCH_V2_HASH_FUNCTION: &str = "blake2b-256";
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const RESEARCH_V3_RELATION_FORMAT: &str = "multi-engine-trace-relation-v1-no-egraph-no-smt";
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+const MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES: usize = 32 * 1024 * 1024;
 const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v1";
 const HF_PROVENANCE_SEMANTIC_SCOPE: &str = "hf-release-provenance-boundary-v1";
 const HF_PROVENANCE_HASH_FUNCTION: &str = "blake2b-256";
@@ -1097,6 +1099,7 @@ struct ResearchV2MatrixArtifact {
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ResearchV3CanonicalEvent {
     step: usize,
     instruction: String,
@@ -1106,6 +1109,7 @@ struct ResearchV3CanonicalEvent {
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ResearchV3TransitionRelationRow {
     relation_format: String,
     step: usize,
@@ -1116,6 +1120,7 @@ struct ResearchV3TransitionRelationRow {
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ResearchV3EngineSummary {
     name: String,
     steps: usize,
@@ -1132,6 +1137,7 @@ struct ResearchV3EngineSummary {
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ResearchV3RuleValidation {
     differential_lockstep: bool,
     egraph_status: String,
@@ -1141,6 +1147,7 @@ struct ResearchV3RuleValidation {
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ResearchV3RuleWitness {
     step: usize,
     rule_id: String,
@@ -1156,6 +1163,7 @@ struct ResearchV3RuleWitness {
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ResearchV3EquivalenceCommitments {
     hash_function: String,
     statement_spec_hash: String,
@@ -1174,6 +1182,7 @@ struct ResearchV3EquivalenceCommitments {
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ResearchV3EquivalenceArtifact {
     statement_version: String,
     semantic_scope: String,
@@ -5270,22 +5279,58 @@ fn research_v3_limitations() -> Vec<String> {
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
-fn verify_research_v3_equivalence_command_impl(
+fn load_research_v3_equivalence_artifact(
     artifact_path: &Path,
-) -> llm_provable_computer::Result<()> {
+) -> llm_provable_computer::Result<ResearchV3EquivalenceArtifact> {
+    let metadata = fs::metadata(artifact_path).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to read research-v3 artifact {}: {err}",
+            artifact_path.display()
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(VmError::InvalidConfig(format!(
+            "research-v3 artifact {} is not a regular file",
+            artifact_path.display()
+        )));
+    }
+    if metadata.len() > MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES as u64 {
+        return Err(VmError::InvalidConfig(format!(
+            "research-v3 artifact {} is {} bytes, exceeding the limit of {} bytes",
+            artifact_path.display(),
+            metadata.len(),
+            MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES
+        )));
+    }
+
     let artifact_bytes = fs::read(artifact_path).map_err(|err| {
         VmError::InvalidConfig(format!(
             "failed to read research-v3 artifact {}: {err}",
             artifact_path.display()
         ))
     })?;
-    let artifact: ResearchV3EquivalenceArtifact =
-        serde_json::from_slice(&artifact_bytes).map_err(|err| {
-            VmError::Serialization(format!(
-                "failed to parse research-v3 artifact {}: {err}",
-                artifact_path.display()
-            ))
-        })?;
+    if artifact_bytes.len() > MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES {
+        return Err(VmError::InvalidConfig(format!(
+            "research-v3 artifact {} is {} bytes after read, exceeding the limit of {} bytes",
+            artifact_path.display(),
+            artifact_bytes.len(),
+            MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES
+        )));
+    }
+
+    serde_json::from_slice(&artifact_bytes).map_err(|err| {
+        VmError::Serialization(format!(
+            "failed to parse research-v3 artifact {}: {err}",
+            artifact_path.display()
+        ))
+    })
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn verify_research_v3_equivalence_command_impl(
+    artifact_path: &Path,
+) -> llm_provable_computer::Result<()> {
+    let artifact = load_research_v3_equivalence_artifact(artifact_path)?;
 
     verify_research_v3_equivalence_artifact(&artifact)?;
 
@@ -6630,6 +6675,190 @@ mod tests {
         assert!(err
             .to_string()
             .contains("research-v3-equivalence event length mismatch"));
+    }
+
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn research_v3_test_artifact_path(label: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir().join(format!("llm-provable-computer-{label}-{suffix}.json"))
+    }
+
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn research_v3_test_hash() -> String {
+        "0".repeat(64)
+    }
+
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn sample_research_v3_equivalence_artifact() -> ResearchV3EquivalenceArtifact {
+        let state_before = MachineState::with_memory(vec![0, 1, 2]);
+        let mut state_after = state_before.clone();
+        state_after.pc = 1;
+        state_after.acc = 7;
+
+        let registry =
+            read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH).expect("registry json");
+        let engine_name = "transformer-vm".to_string();
+
+        ResearchV3EquivalenceArtifact {
+            statement_version: "statement-v3-equivalence-kernel".to_string(),
+            semantic_scope: "native_isa_execution_with_transformer_native_equivalence_check"
+                .to_string(),
+            relation_format: RESEARCH_V3_RELATION_FORMAT.to_string(),
+            fixed_point_profile: "fixed-point-semantics-v2".to_string(),
+            onnx_op_subset_version: "onnx-op-subset-v2".to_string(),
+            onnx_op_subset_size: 1,
+            program_path: "programs/addition.tvm".to_string(),
+            requested_max_steps: 1,
+            checked_steps: 1,
+            engines: vec![ResearchV3EngineSummary {
+                name: engine_name.clone(),
+                steps: 1,
+                halted: false,
+                trace_len: 1,
+                events_len: 1,
+                trace: vec![state_before.clone()],
+                canonical_events: vec![ResearchV3CanonicalEvent {
+                    step: 1,
+                    instruction: "NOP".to_string(),
+                    state_before_hash: research_v3_test_hash(),
+                    state_after_hash: research_v3_test_hash(),
+                }],
+                final_state: state_after,
+                trace_hash: research_v3_test_hash(),
+                event_relation_hash: research_v3_test_hash(),
+                final_state_hash: research_v3_test_hash(),
+            }],
+            rule_witnesses: vec![ResearchV3RuleWitness {
+                step: 1,
+                rule_id: "nop".to_string(),
+                relation: "identity".to_string(),
+                instruction: "NOP".to_string(),
+                participating_engines: vec![engine_name.clone()],
+                state_before_hashes: std::collections::BTreeMap::from([(
+                    engine_name.clone(),
+                    research_v3_test_hash(),
+                )]),
+                state_after_hashes: std::collections::BTreeMap::from([(
+                    engine_name.clone(),
+                    research_v3_test_hash(),
+                )]),
+                engine_transition_hashes: std::collections::BTreeMap::from([(
+                    engine_name,
+                    research_v3_test_hash(),
+                )]),
+                canonical_transition_hash: research_v3_test_hash(),
+                validation: ResearchV3RuleValidation {
+                    differential_lockstep: true,
+                    egraph_status: "not-run".to_string(),
+                    smt_status: "not-run".to_string(),
+                    randomized_testing_status: "not-run".to_string(),
+                },
+            }],
+            frontend_runtime_semantics_registry: registry,
+            limitations: research_v3_limitations(),
+            commitments: ResearchV3EquivalenceCommitments {
+                hash_function: RESEARCH_V2_HASH_FUNCTION.to_string(),
+                statement_spec_hash: research_v3_test_hash(),
+                fixed_point_spec_hash: research_v3_test_hash(),
+                onnx_op_subset_hash: research_v3_test_hash(),
+                artifact_schema_hash: research_v3_test_hash(),
+                frontend_runtime_semantics_registry_hash: research_v3_test_hash(),
+                relation_format_hash: research_v3_test_hash(),
+                limitations_hash: research_v3_test_hash(),
+                program_hash: research_v3_test_hash(),
+                transformer_config_hash: research_v3_test_hash(),
+                onnx_metadata_hash: research_v3_test_hash(),
+                engine_summaries_hash: research_v3_test_hash(),
+                rule_witnesses_hash: research_v3_test_hash(),
+            },
+        }
+    }
+
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn write_research_v3_test_artifact(path: &Path, value: &serde_json::Value) {
+        let bytes = serde_json::to_vec_pretty(value).expect("serialize artifact");
+        fs::write(path, bytes).expect("write artifact");
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn load_research_v3_equivalence_artifact_rejects_unknown_top_level_field() {
+        let path = research_v3_test_artifact_path("research-v3-extra-top");
+        let mut value =
+            serde_json::to_value(sample_research_v3_equivalence_artifact()).expect("artifact json");
+        value
+            .as_object_mut()
+            .expect("artifact object")
+            .insert("unexpected_field".to_string(), serde_json::json!(true));
+        write_research_v3_test_artifact(&path, &value);
+
+        let err =
+            load_research_v3_equivalence_artifact(&path).expect_err("unknown field should fail");
+        assert!(err.to_string().contains("unknown field"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn load_research_v3_equivalence_artifact_rejects_unknown_nested_rule_witness_field() {
+        let path = research_v3_test_artifact_path("research-v3-extra-witness");
+        let mut value =
+            serde_json::to_value(sample_research_v3_equivalence_artifact()).expect("artifact json");
+        value["rule_witnesses"][0]["unexpected_field"] = serde_json::json!(7);
+        write_research_v3_test_artifact(&path, &value);
+
+        let err = load_research_v3_equivalence_artifact(&path)
+            .expect_err("unknown nested rule witness field should fail");
+        assert!(err.to_string().contains("unknown field"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn load_research_v3_equivalence_artifact_rejects_oversized_file() {
+        let path = research_v3_test_artifact_path("research-v3-oversized");
+        fs::write(
+            &path,
+            vec![b'x'; MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES + 1],
+        )
+        .expect("write oversized artifact");
+
+        let err = load_research_v3_equivalence_artifact(&path)
+            .expect_err("oversized artifact should fail");
+        assert!(err.to_string().contains("exceeding the limit"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn load_research_v3_equivalence_artifact_reports_malformed_json_as_serialization() {
+        let path = research_v3_test_artifact_path("research-v3-malformed");
+        fs::write(&path, b"{").expect("write malformed artifact");
+
+        let err = load_research_v3_equivalence_artifact(&path)
+            .expect_err("malformed artifact should fail");
+        assert!(matches!(err, VmError::Serialization(_)));
+        assert!(err
+            .to_string()
+            .contains("failed to parse research-v3 artifact"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn load_research_v3_equivalence_artifact_rejects_non_regular_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+
+        let err = load_research_v3_equivalence_artifact(dir.path())
+            .expect_err("directory artifact path should fail");
+        assert!(err.to_string().contains("not a regular file"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- harden the research-v3 equivalence artifact loader with a regular-file check, a 32 MiB byte budget, and strict `deny_unknown_fields` deserialization across the artifact schema
- add direct regressions for malformed JSON, oversized files, non-regular paths, and unknown top-level or nested witness fields
- wire research-v3 loader and witness-ingestion checks into the hardening filter registry, the local smoke gate, and the UB-check suite
- fix the ONNX smoke-target indentation while touching the shared merge gate

## Validation
- [x] `cargo +nightly-2025-07-14 check --quiet --features burn-model,onnx-export --bin tvm`
- [x] targeted tests listed below

Commands run:

```text
cargo fmt --all
cargo test --features burn-model,onnx-export --bin tvm tests::load_research_v3_equivalence_artifact_rejects_unknown_top_level_field -- --exact --nocapture
cargo test --features burn-model,onnx-export --bin tvm tests::load_research_v3_equivalence_artifact_rejects_unknown_nested_rule_witness_field -- --exact --nocapture
cargo test --features burn-model,onnx-export --bin tvm tests::load_research_v3_equivalence_artifact_rejects_oversized_file -- --exact --nocapture
cargo test --features burn-model,onnx-export --bin tvm tests::load_research_v3_equivalence_artifact_reports_malformed_json_as_serialization -- --exact --nocapture
cargo test --features burn-model,onnx-export --bin tvm tests::load_research_v3_equivalence_artifact_rejects_non_regular_file -- --exact --nocapture
cargo test --features burn-model,onnx-export --bin tvm tests::research_v3_rule_witnesses_rejects_event_length_mismatch -- --exact --nocapture
bash scripts/run_shellcheck_suite.sh
scripts/run_ub_checks_suite.sh
git diff --check
```

## Hardening

- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Not applicable notes:

```text
Oracle/differential: updated. The slice keeps the existing research-v3 witness mismatch regression and adds strict-loader regressions for malformed or oversized artifacts before semantic verification.
Resource-bound/untrusted-input: reviewed. The loader now rejects non-regular paths, rejects oversized inputs before parse, and rejects unknown fields across the artifact schema.
Kani/formal-kernel: not applicable. This slice does not change proof-kernel arithmetic or a formalized contract function.
```

## Notes
- This slice is aimed at the paper-2 boundary: proof-carrying decode surfaces with carried-state validity and bounded semantic-agreement evidence.
- The strict loader now fails malformed research-v3 artifact inputs before they reach witness verification.
- The merge gate now exercises research-v3 artifact-ingestion checks only when research-v3 surfaces change, instead of running them opportunistically.
- This change hardens ingestion of the existing research-v3 schema; it does not widen the statement surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger Research V3 artifact validation: enforces regular-file requirement, byte-size limits, and clearer error classification for invalid or malformed artifacts.

* **Tests**
  * Expanded smoke and hardening tests for Research V3 to detect unknown fields (top-level and nested), oversized files, malformed JSON, non-regular paths, and related failure modes.

* **Behavior**
  * Test-run logic now triggers Research V3 smoke checks when relevant changes are detected and includes Research V3 filters in hardening-suite emptiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->