### PR TITLE
Harden research-v3 witness boundary checks

### DIFF
--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -43,6 +43,7 @@ hardening_research_v3_test_filters=(
   "tests::load_research_v3_equivalence_artifact_rejects_non_regular_file"
   "tests::verify_research_v3_equivalence_artifact_rejects_unknown_engine_binding"
   "tests::verify_research_v3_equivalence_artifact_rejects_missing_pinned_engine"
+  "tests::verify_research_v3_equivalence_artifact_rejects_extra_engine_events_beyond_checked_steps"
 )
 
 # Keep the heavier `stwo-backend` verifier gates on the sanitizer path. They are

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -379,6 +379,7 @@ research_v3_smoke_targets=(
   "tests::load_research_v3_equivalence_artifact_rejects_non_regular_file"
   "tests::verify_research_v3_equivalence_artifact_rejects_unknown_engine_binding"
   "tests::verify_research_v3_equivalence_artifact_rejects_missing_pinned_engine"
+  "tests::verify_research_v3_equivalence_artifact_rejects_extra_engine_events_beyond_checked_steps"
 )
 stwo_cli_smoke_targets=(
   "cli_can_verify_stwo_recursive_compression_input_contract"

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -6988,11 +6988,7 @@ mod tests {
         for engine in &mut artifact.engines {
             let next_step = engine.canonical_events.len() + 1;
             let final_state_hash = hash_json_hex(&engine.final_state).expect("final state hash");
-            let instruction = engine
-                .canonical_events
-                .last()
-                .map(|event| event.instruction.clone())
-                .unwrap_or_else(|| "NOP".to_string());
+            let instruction = "NOP".to_string();
             engine.trace.push(engine.final_state.clone());
             engine.canonical_events.push(ResearchV3CanonicalEvent {
                 step: next_step,
@@ -7121,14 +7117,17 @@ mod tests {
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
     fn verify_research_v3_equivalence_artifact_rejects_extra_engine_events_beyond_checked_steps() {
         let mut artifact = sample_research_v3_equivalence_artifact();
+        let expected_steps = artifact.checked_steps;
         append_research_v3_test_terminal_noop_event(&mut artifact);
         refresh_research_v3_test_artifact_commitments(&mut artifact);
 
         let err = verify_research_v3_equivalence_artifact(&artifact)
             .expect_err("extra engine events beyond checked_steps should fail");
-        assert!(err
-            .to_string()
-            .contains("events_len 2 does not match checked_steps 1"));
+        assert!(err.to_string().contains(&format!(
+            "events_len {} does not match checked_steps {}",
+            expected_steps + 1,
+            expected_steps
+        )));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -5597,6 +5597,9 @@ fn verify_research_v3_engine_lane_binding(
 fn verify_research_v3_engine_summaries(
     artifact: &ResearchV3EquivalenceArtifact,
 ) -> llm_provable_computer::Result<()> {
+    let expected_trace_len = artifact.checked_steps.checked_add(1).ok_or_else(|| {
+        VmError::InvalidConfig("research-v3 checked_steps overflowed trace_len".to_string())
+    })?;
     let mut seen = std::collections::BTreeSet::new();
     for engine in &artifact.engines {
         if !seen.insert(engine.name.as_str()) {
@@ -5623,18 +5626,6 @@ fn verify_research_v3_engine_summaries(
                 engine.name, engine.events_len, artifact.checked_steps
             )));
         }
-        let expected_trace_len = engine.events_len.checked_add(1).ok_or_else(|| {
-            VmError::InvalidConfig(format!(
-                "research-v3 engine {} events_len overflow while checking trace_len",
-                engine.name
-            ))
-        })?;
-        if engine.trace_len != expected_trace_len {
-            return Err(VmError::InvalidConfig(format!(
-                "research-v3 engine {} trace_len {} does not match events_len + 1 ({})",
-                engine.name, engine.trace_len, expected_trace_len
-            )));
-        }
         if engine.trace.len() != engine.trace_len {
             return Err(VmError::InvalidConfig(format!(
                 "research-v3 engine {} trace array length {} does not match trace_len {}",
@@ -5649,6 +5640,12 @@ fn verify_research_v3_engine_summaries(
                 engine.name,
                 engine.canonical_events.len(),
                 engine.events_len
+            )));
+        }
+        if engine.trace_len != expected_trace_len {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 engine {} trace_len {} does not match checked_steps+1 {}",
+                engine.name, engine.trace_len, expected_trace_len
             )));
         }
         if engine.trace.last() != Some(&engine.final_state) {
@@ -6908,12 +6905,30 @@ mod tests {
     }
 
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn refresh_research_v3_test_engine_summary(engine: &mut ResearchV3EngineSummary) {
+        engine.trace_len = engine.trace.len();
+        engine.events_len = engine.canonical_events.len();
+        engine.final_state = engine
+            .trace
+            .last()
+            .cloned()
+            .expect("research-v3 engine trace must be non-empty");
+        engine.trace_hash = hash_json_hex(&engine.trace).expect("trace hash");
+        engine.event_relation_hash =
+            hash_json_hex(&engine.canonical_events).expect("event relation hash");
+        engine.final_state_hash = hash_json_hex(&engine.final_state).expect("final state hash");
+    }
+
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
     fn refresh_research_v3_test_artifact_commitments(artifact: &mut ResearchV3EquivalenceArtifact) {
         let bundle = load_research_v2_spec_bundle(
             STATEMENT_V3_EQUIVALENCE_SPEC_PATH,
             STATEMENT_V3_EQUIVALENCE_ARTIFACT_SCHEMA_PATH,
         )
         .expect("statement-v3 bundle");
+        for engine in &mut artifact.engines {
+            refresh_research_v3_test_engine_summary(engine);
+        }
         artifact.statement_version = bundle.statement_version.clone();
         artifact.semantic_scope = bundle.semantic_scope.clone();
         artifact.fixed_point_profile = bundle.fixed_point_profile.clone();
@@ -6965,6 +6980,26 @@ mod tests {
                     hashes.insert(to.to_string(), value);
                 }
             }
+        }
+    }
+
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn append_research_v3_test_terminal_noop_event(artifact: &mut ResearchV3EquivalenceArtifact) {
+        for engine in &mut artifact.engines {
+            let next_step = engine.canonical_events.len() + 1;
+            let final_state_hash = hash_json_hex(&engine.final_state).expect("final state hash");
+            let instruction = engine
+                .canonical_events
+                .last()
+                .map(|event| event.instruction.clone())
+                .unwrap_or_else(|| "NOP".to_string());
+            engine.trace.push(engine.final_state.clone());
+            engine.canonical_events.push(ResearchV3CanonicalEvent {
+                step: next_step,
+                instruction,
+                state_before_hash: final_state_hash.clone(),
+                state_after_hash: final_state_hash,
+            });
         }
     }
 
@@ -7080,6 +7115,20 @@ mod tests {
         assert!(err
             .to_string()
             .contains("engine set does not match the pinned artifact boundary"));
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn verify_research_v3_equivalence_artifact_rejects_extra_engine_events_beyond_checked_steps() {
+        let mut artifact = sample_research_v3_equivalence_artifact();
+        append_research_v3_test_terminal_noop_event(&mut artifact);
+        refresh_research_v3_test_artifact_commitments(&mut artifact);
+
+        let err = verify_research_v3_equivalence_artifact(&artifact)
+            .expect_err("extra engine events beyond checked_steps should fail");
+        assert!(err
+            .to_string()
+            .contains("events_len 2 does not match checked_steps 1"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5168,6 +5168,8 @@ fn cli_supports_research_v3_equivalence_command() {
         unique_temp_dir("cli-research-v3-equivalence-missing-engine").with_extension("json");
     let extra_event_path =
         unique_temp_dir("cli-research-v3-equivalence-extra-event").with_extension("json");
+    let extra_trace_path =
+        unique_temp_dir("cli-research-v3-equivalence-extra-trace").with_extension("json");
     let mut command = tvm_command();
     command
         .arg("research-v3-equivalence")
@@ -5617,12 +5619,6 @@ fn cli_supports_research_v3_equivalence_command() {
             .as_array()
             .map(|events| events.len() as u64 + 1)
             .expect("canonical events");
-        let last_instruction = engine["canonical_events"]
-            .as_array()
-            .and_then(|events| events.last())
-            .and_then(|event| event.get("instruction"))
-            .cloned()
-            .expect("last instruction");
         engine["trace"]
             .as_array_mut()
             .expect("engine trace")
@@ -5632,7 +5628,7 @@ fn cli_supports_research_v3_equivalence_command() {
             .expect("canonical events")
             .push(serde_json::json!({
                 "step": next_step,
-                "instruction": last_instruction,
+                "instruction": "NOP",
                 "state_before_hash": final_state_hash.clone(),
                 "state_after_hash": final_state_hash,
             }));
@@ -5675,6 +5671,48 @@ fn cli_supports_research_v3_equivalence_command() {
             extra_event_expected_steps
         )));
 
+    let mut extra_trace = artifact_json.clone();
+    let extra_trace_expected_steps = extra_trace
+        .get("checked_steps")
+        .and_then(serde_json::Value::as_u64)
+        .expect("checked_steps");
+    for engine in extra_trace["engines"].as_array_mut().expect("engines") {
+        let final_state = engine
+            .get("final_state")
+            .cloned()
+            .expect("engine final state");
+        engine["trace"]
+            .as_array_mut()
+            .expect("engine trace")
+            .push(final_state);
+        let trace_len = engine["trace"]
+            .as_array()
+            .map(|trace| trace.len() as u64)
+            .expect("trace");
+        engine["trace_len"] = serde_json::Value::from(trace_len);
+        engine["trace_hash"] =
+            serde_json::Value::String(hash_json_value(engine.get("trace").expect("engine trace")));
+    }
+    extra_trace["commitments"]["engine_summaries_hash"] = serde_json::Value::String(
+        hash_json_value(extra_trace.get("engines").expect("extra-trace engines")),
+    );
+    std::fs::write(
+        &extra_trace_path,
+        serde_json::to_vec(&extra_trace).expect("extra trace artifact json"),
+    )
+    .expect("write extra trace artifact");
+    let mut verify_extra_trace = tvm_command();
+    verify_extra_trace
+        .arg("verify-research-v3-equivalence")
+        .arg(&extra_trace_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(format!(
+            "trace_len {} does not match checked_steps+1 {}",
+            extra_trace_expected_steps + 2,
+            extra_trace_expected_steps + 1
+        )));
+
     let mut malformed_hash = artifact_json.clone();
     malformed_hash["commitments"]["relation_format_hash"] =
         serde_json::Value::String("not-a-blake2b-hash".to_string());
@@ -5711,6 +5749,7 @@ fn cli_supports_research_v3_equivalence_command() {
     let _ = std::fs::remove_file(unexpected_engine_path);
     let _ = std::fs::remove_file(missing_engine_path);
     let _ = std::fs::remove_file(extra_event_path);
+    let _ = std::fs::remove_file(extra_trace_path);
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5166,6 +5166,8 @@ fn cli_supports_research_v3_equivalence_command() {
         unique_temp_dir("cli-research-v3-equivalence-unexpected-engine").with_extension("json");
     let missing_engine_path =
         unique_temp_dir("cli-research-v3-equivalence-missing-engine").with_extension("json");
+    let extra_event_path =
+        unique_temp_dir("cli-research-v3-equivalence-extra-event").with_extension("json");
     let mut command = tvm_command();
     command
         .arg("research-v3-equivalence")
@@ -5600,6 +5602,79 @@ fn cli_supports_research_v3_equivalence_command() {
             "engine set does not match the pinned artifact boundary",
         ));
 
+    let mut extra_event = artifact_json.clone();
+    let extra_event_expected_steps = extra_event
+        .get("checked_steps")
+        .and_then(serde_json::Value::as_u64)
+        .expect("checked_steps");
+    for engine in extra_event["engines"].as_array_mut().expect("engines") {
+        let final_state = engine
+            .get("final_state")
+            .cloned()
+            .expect("engine final state");
+        let final_state_hash = hash_json_value(&final_state);
+        let next_step = engine["canonical_events"]
+            .as_array()
+            .map(|events| events.len() as u64 + 1)
+            .expect("canonical events");
+        let last_instruction = engine["canonical_events"]
+            .as_array()
+            .and_then(|events| events.last())
+            .and_then(|event| event.get("instruction"))
+            .cloned()
+            .expect("last instruction");
+        engine["trace"]
+            .as_array_mut()
+            .expect("engine trace")
+            .push(final_state);
+        engine["canonical_events"]
+            .as_array_mut()
+            .expect("canonical events")
+            .push(serde_json::json!({
+                "step": next_step,
+                "instruction": last_instruction,
+                "state_before_hash": final_state_hash.clone(),
+                "state_after_hash": final_state_hash,
+            }));
+        let trace_len = engine["trace"]
+            .as_array()
+            .map(|trace| trace.len() as u64)
+            .expect("trace");
+        let events_len = engine["canonical_events"]
+            .as_array()
+            .map(|events| events.len() as u64)
+            .expect("canonical events");
+        engine["trace_len"] = serde_json::Value::from(trace_len);
+        engine["events_len"] = serde_json::Value::from(events_len);
+        engine["trace_hash"] =
+            serde_json::Value::String(hash_json_value(engine.get("trace").expect("engine trace")));
+        engine["event_relation_hash"] = serde_json::Value::String(hash_json_value(
+            engine.get("canonical_events").expect("canonical events"),
+        ));
+        engine["final_state_hash"] = serde_json::Value::String(hash_json_value(
+            engine.get("final_state").expect("final state"),
+        ));
+    }
+    extra_event["commitments"]["engine_summaries_hash"] = serde_json::Value::String(
+        hash_json_value(extra_event.get("engines").expect("extra-event engines")),
+    );
+    std::fs::write(
+        &extra_event_path,
+        serde_json::to_vec(&extra_event).expect("extra event artifact json"),
+    )
+    .expect("write extra event artifact");
+    let mut verify_extra_event = tvm_command();
+    verify_extra_event
+        .arg("verify-research-v3-equivalence")
+        .arg(&extra_event_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(format!(
+            "events_len {} does not match checked_steps {}",
+            extra_event_expected_steps + 1,
+            extra_event_expected_steps
+        )));
+
     let mut malformed_hash = artifact_json.clone();
     malformed_hash["commitments"]["relation_format_hash"] =
         serde_json::Value::String("not-a-blake2b-hash".to_string());
@@ -5635,6 +5710,7 @@ fn cli_supports_research_v3_equivalence_command() {
     let _ = std::fs::remove_file(canonical_event_path);
     let _ = std::fs::remove_file(unexpected_engine_path);
     let _ = std::fs::remove_file(missing_engine_path);
+    let _ = std::fs::remove_file(extra_event_path);
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]


### PR DESCRIPTION
## Summary
- bind research-v3 engine summary lengths to the artifact checked_steps boundary
- add verifier and CLI tamper regressions for extra engine events beyond the claimed witness set
- wire the new research-v3 boundary regression into the local smoke gate and hardening filters

## Validation
- cargo fmt --all
- cargo +nightly-2025-07-14 test --features burn-model,onnx-export --bin tvm tests::verify_research_v3_equivalence_artifact_rejects_extra_engine_events_beyond_checked_steps -- --exact --nocapture
- cargo +nightly-2025-07-14 test --features burn-model,onnx-export --bin tvm tests::verify_research_v3_equivalence_artifact_rejects_unknown_engine_binding -- --exact --nocapture
- cargo +nightly-2025-07-14 test --features burn-model,onnx-export --bin tvm tests::verify_research_v3_equivalence_artifact_rejects_missing_pinned_engine -- --exact --nocapture
- cargo +nightly-2025-07-14 test --features full --test cli cli_supports_research_v3_equivalence_command -- --exact --nocapture
- bash scripts/run_shellcheck_suite.sh
- git diff --check

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

### Notes
- Oracle / differential checks: the CLI end-to-end verifier path now rejects engine-summary over-ingestion beyond the artifact checked_steps boundary.
- Resource-bound / untrusted-input impact: reviewed. The new checks reject extra untrusted engine events and trace growth before they can widen the claimed witness surface.
- Kani / formal-kernel impact: reviewed as not requiring a Kani/formal-kernel change because this slice only tightens runtime artifact-boundary validation in the research-v3 verifier and tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to detect and reject artifacts with extra engine events beyond verified steps.
  * Enhanced trace-length validation with improved overflow detection.

* **Tests**
  * Added regression tests verifying artifact rejection of extra engine events and trace entries.
  * Extended research v3 smoke test suite with additional equivalence validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->