### PR TITLE
Harden HF provenance manifest loading

### DIFF
--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -31,6 +31,12 @@ hardening_onnx_test_filters=(
 )
 
 # Keep the other CLI-facing artifact loaders in the `tvm` binary smoke/UB path.
+# These tests are intentionally run on the default `tvm` surface so the
+# hardened HF provenance loader is exercised even when `onnx-export` is off.
+hardening_tvm_bin_cargo_args=(
+  --bin tvm
+)
+
 hardening_tvm_bin_test_filters=(
   "hf_provenance_manifest_tests::load_hf_provenance_manifest_rejects_unknown_top_level_field"
   "hf_provenance_manifest_tests::load_hf_provenance_manifest_rejects_unknown_nested_onnx_export_field"

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -32,11 +32,12 @@ hardening_onnx_test_filters=(
 
 # Keep the other CLI-facing artifact loaders in the `tvm` binary smoke/UB path.
 hardening_tvm_bin_test_filters=(
-  "tests::load_hf_provenance_manifest_rejects_unknown_top_level_field"
-  "tests::load_hf_provenance_manifest_rejects_unknown_nested_onnx_export_field"
-  "tests::load_hf_provenance_manifest_reports_malformed_json_as_serialization"
-  "tests::load_hf_provenance_manifest_rejects_oversized_file"
-  "tests::load_hf_provenance_manifest_rejects_non_regular_file"
+  "hf_provenance_manifest_tests::load_hf_provenance_manifest_rejects_unknown_top_level_field"
+  "hf_provenance_manifest_tests::load_hf_provenance_manifest_rejects_unknown_nested_onnx_export_field"
+  "hf_provenance_manifest_tests::load_hf_provenance_manifest_reports_malformed_json_as_serialization"
+  "hf_provenance_manifest_tests::load_hf_provenance_manifest_rejects_oversized_file"
+  "hf_provenance_manifest_tests::load_hf_provenance_manifest_rejects_non_regular_file"
+  "hf_provenance_manifest_tests::prepare_hf_provenance_manifest_rejects_oversized_output"
 )
 
 # Keep the `research-v3` equivalence artifact loader and witness checks on the

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -44,6 +44,7 @@ hardening_tvm_bin_test_filters=(
   "hf_provenance_manifest_tests::load_hf_provenance_manifest_rejects_oversized_file"
   "hf_provenance_manifest_tests::load_hf_provenance_manifest_rejects_non_regular_file"
   "hf_provenance_manifest_tests::prepare_hf_provenance_manifest_rejects_oversized_output"
+  "hf_provenance_manifest_tests::verify_hf_provenance_manifest_rejects_non_regular_bound_file"
 )
 
 # Keep the `research-v3` equivalence artifact loader and witness checks on the

--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -30,6 +30,15 @@ hardening_onnx_test_filters=(
   "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
 )
 
+# Keep the other CLI-facing artifact loaders in the `tvm` binary smoke/UB path.
+hardening_tvm_bin_test_filters=(
+  "tests::load_hf_provenance_manifest_rejects_unknown_top_level_field"
+  "tests::load_hf_provenance_manifest_rejects_unknown_nested_onnx_export_field"
+  "tests::load_hf_provenance_manifest_reports_malformed_json_as_serialization"
+  "tests::load_hf_provenance_manifest_rejects_oversized_file"
+  "tests::load_hf_provenance_manifest_rejects_non_regular_file"
+)
+
 # Keep the `research-v3` equivalence artifact loader and witness checks on the
 # smoke/UB path. These live in the `tvm` binary test harness rather than the
 # library test harness because the strict loader is part of the CLI-facing

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -58,6 +58,11 @@ fail() {
   exit 1
 }
 
+# shellcheck source=scripts/hardening_test_names.sh
+source "$ROOT_DIR/scripts/hardening_test_names.sh"
+declare -p hardening_tvm_bin_test_filters >/dev/null 2>&1 ||
+  fail "scripts/hardening_test_names.sh must define hardening_tvm_bin_test_filters"
+
 sleep_with_wait_budget() {
   local duration="$1"
   local reason="$2"
@@ -370,13 +375,7 @@ onnx_smoke_targets=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_missing_direct_memory_read_address"
   "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
 )
-tvm_bin_smoke_targets=(
-  "tests::load_hf_provenance_manifest_rejects_unknown_top_level_field"
-  "tests::load_hf_provenance_manifest_rejects_unknown_nested_onnx_export_field"
-  "tests::load_hf_provenance_manifest_reports_malformed_json_as_serialization"
-  "tests::load_hf_provenance_manifest_rejects_oversized_file"
-  "tests::load_hf_provenance_manifest_rejects_non_regular_file"
-)
+tvm_bin_smoke_targets=("${hardening_tvm_bin_test_filters[@]}")
 research_v3_smoke_targets=(
   "tests::research_v3_rule_witnesses_rejects_event_length_mismatch"
   "tests::load_research_v3_equivalence_artifact_rejects_unknown_top_level_field"
@@ -498,7 +497,6 @@ run_tvm_bin_smoke_targets() {
   for tvm_bin_smoke in "${tvm_bin_smoke_targets[@]}"; do
     label="${tvm_bin_smoke##*::}"
     run_logged "tvm-bin-smoke-${label}" cargo test -q \
-      --features onnx-export \
       --bin tvm "$tvm_bin_smoke" \
       -- \
       --exact

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -370,6 +370,13 @@ onnx_smoke_targets=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_missing_direct_memory_read_address"
   "onnx_export::tests::load_onnx_program_metadata_maps_runtime_conversion_failures_to_serialization"
 )
+tvm_bin_smoke_targets=(
+  "tests::load_hf_provenance_manifest_rejects_unknown_top_level_field"
+  "tests::load_hf_provenance_manifest_rejects_unknown_nested_onnx_export_field"
+  "tests::load_hf_provenance_manifest_reports_malformed_json_as_serialization"
+  "tests::load_hf_provenance_manifest_rejects_oversized_file"
+  "tests::load_hf_provenance_manifest_rejects_non_regular_file"
+)
 research_v3_smoke_targets=(
   "tests::research_v3_rule_witnesses_rejects_event_length_mismatch"
   "tests::load_research_v3_equivalence_artifact_rejects_unknown_top_level_field"
@@ -486,6 +493,18 @@ run_onnx_smoke_targets() {
   done
 }
 
+run_tvm_bin_smoke_targets() {
+  local tvm_bin_smoke label
+  for tvm_bin_smoke in "${tvm_bin_smoke_targets[@]}"; do
+    label="${tvm_bin_smoke##*::}"
+    run_logged "tvm-bin-smoke-${label}" cargo test -q \
+      --features onnx-export \
+      --bin tvm "$tvm_bin_smoke" \
+      -- \
+      --exact
+  done
+}
+
 run_stwo_cli_smoke_targets() {
   local stwo_cli_smoke
   for stwo_cli_smoke in "${stwo_cli_smoke_targets[@]}"; do
@@ -570,6 +589,7 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
     run_onnx_smoke_targets
   fi
   if changed_path_is_research_v3_surface; then
+    run_tvm_bin_smoke_targets
     run_research_v3_smoke_targets
     run_research_v3_cli_smoke_target
   fi
@@ -587,6 +607,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
     run_onnx_smoke_targets
   fi
   if changed_path_is_research_v3_surface; then
+    run_tvm_bin_smoke_targets
     run_research_v3_smoke_targets
     run_research_v3_cli_smoke_target
   fi
@@ -604,6 +625,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
     run_onnx_smoke_targets
   fi
   if changed_path_is_research_v3_surface; then
+    run_tvm_bin_smoke_targets
     run_research_v3_smoke_targets
     run_research_v3_cli_smoke_target
   fi

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -62,6 +62,8 @@ fail() {
 source "$ROOT_DIR/scripts/hardening_test_names.sh"
 declare -p hardening_tvm_bin_test_filters >/dev/null 2>&1 ||
   fail "scripts/hardening_test_names.sh must define hardening_tvm_bin_test_filters"
+declare -p hardening_tvm_bin_cargo_args >/dev/null 2>&1 ||
+  fail "scripts/hardening_test_names.sh must define hardening_tvm_bin_cargo_args"
 
 sleep_with_wait_budget() {
   local duration="$1"
@@ -497,7 +499,7 @@ run_tvm_bin_smoke_targets() {
   for tvm_bin_smoke in "${tvm_bin_smoke_targets[@]}"; do
     label="${tvm_bin_smoke##*::}"
     run_logged "tvm-bin-smoke-${label}" cargo test -q \
-      --bin tvm "$tvm_bin_smoke" \
+      "${hardening_tvm_bin_cargo_args[@]}" "$tvm_bin_smoke" \
       -- \
       --exact
   done

--- a/scripts/run_ub_checks_suite.sh
+++ b/scripts/run_ub_checks_suite.sh
@@ -8,7 +8,7 @@ HARDENING_TOOLCHAIN="${HARDENING_TOOLCHAIN:-nightly-2025-07-14}"
 
 source "$ROOT_DIR/scripts/hardening_test_names.sh"
 
-if ((${#hardening_base_test_filters[@]} == 0 && ${#hardening_onnx_test_filters[@]} == 0 && ${#hardening_research_v3_test_filters[@]} == 0 && ${#hardening_stwo_test_filters[@]} == 0)); then
+if ((${#hardening_base_test_filters[@]} == 0 && ${#hardening_onnx_test_filters[@]} == 0 && ${#hardening_tvm_bin_test_filters[@]} == 0 && ${#hardening_research_v3_test_filters[@]} == 0 && ${#hardening_stwo_test_filters[@]} == 0)); then
   echo "hardening test filter lists are empty; refusing to run an empty UB-checks suite" >&2
   exit 1
 fi
@@ -24,6 +24,14 @@ for test_filter in "${hardening_onnx_test_filters[@]}"; do
   cargo +"${HARDENING_TOOLCHAIN}" test \
     --features onnx-export \
     --lib "${test_filter}" \
+    -- \
+    --exact
+done
+
+for test_filter in "${hardening_tvm_bin_test_filters[@]}"; do
+  cargo +"${HARDENING_TOOLCHAIN}" test \
+    --features onnx-export \
+    --bin tvm "${test_filter}" \
     -- \
     --exact
 done

--- a/scripts/run_ub_checks_suite.sh
+++ b/scripts/run_ub_checks_suite.sh
@@ -30,7 +30,7 @@ done
 
 for test_filter in "${hardening_tvm_bin_test_filters[@]}"; do
   cargo +"${HARDENING_TOOLCHAIN}" test \
-    --bin tvm "${test_filter}" \
+    "${hardening_tvm_bin_cargo_args[@]}" "${test_filter}" \
     -- \
     --exact
 done

--- a/scripts/run_ub_checks_suite.sh
+++ b/scripts/run_ub_checks_suite.sh
@@ -30,7 +30,6 @@ done
 
 for test_filter in "${hardening_tvm_bin_test_filters[@]}"; do
   cargo +"${HARDENING_TOOLCHAIN}" test \
-    --features onnx-export \
     --bin tvm "${test_filter}" \
     -- \
     --exact

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4734,7 +4734,7 @@ fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, S
     let mut output = [0u8; 32];
     let mut hasher = Blake2bVar::new(output.len()).expect("blake2b-256 hasher");
     let mut observed_size = 0u64;
-    let mut buffer = [0u8; HF_PROVENANCE_FILE_READ_CHUNK_BYTES];
+    let mut buffer = vec![0u8; HF_PROVENANCE_FILE_READ_CHUNK_BYTES];
     loop {
         let read_bytes = file.read(&mut buffer).map_err(|err| {
             VmError::InvalidConfig(format!(
@@ -4836,7 +4836,7 @@ fn inspect_hf_safetensors_file(
         hf_safetensors_metadata_commitment_from_header(path, &header_bytes)?;
 
     let mut observed_size = header_end;
-    let mut buffer = [0u8; HF_PROVENANCE_FILE_READ_CHUNK_BYTES];
+    let mut buffer = vec![0u8; HF_PROVENANCE_FILE_READ_CHUNK_BYTES];
     loop {
         let read_bytes = file.read(&mut buffer).map_err(|err| {
             VmError::InvalidConfig(format!(

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4734,16 +4734,22 @@ fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, S
     let mut output = [0u8; 32];
     let mut hasher = Blake2bVar::new(output.len()).expect("blake2b-256 hasher");
     let mut observed_size = 0u64;
+    let mut remaining = size_bytes;
     let mut buffer = vec![0u8; HF_PROVENANCE_FILE_READ_CHUNK_BYTES];
-    loop {
-        let read_bytes = file.read(&mut buffer).map_err(|err| {
+    while remaining > 0 {
+        let chunk_len = remaining.min(buffer.len() as u64) as usize;
+        let read_bytes = file.read(&mut buffer[..chunk_len]).map_err(|err| {
             VmError::InvalidConfig(format!(
                 "failed to read HF provenance file {}: {err}",
                 path.display()
             ))
         })?;
         if read_bytes == 0 {
-            break;
+            return Err(VmError::InvalidConfig(format!(
+                "HF provenance file {} ended before the expected {} bytes were read",
+                path.display(),
+                size_bytes
+            )));
         }
         observed_size = observed_size
             .checked_add(read_bytes as u64)
@@ -4753,14 +4759,21 @@ fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, S
                     path.display()
                 ))
             })?;
+        remaining -= read_bytes as u64;
         hasher.update(&buffer[..read_bytes]);
     }
-    if observed_size != size_bytes {
+    let mut extra_byte = [0u8; 1];
+    if file.read(&mut extra_byte).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to read HF provenance file {}: {err}",
+            path.display()
+        ))
+    })? != 0
+    {
         return Err(VmError::InvalidConfig(format!(
-            "HF provenance file {} changed during read: expected {} bytes, got {}",
+            "HF provenance file {} grew while being hashed after {} bytes were expected",
             path.display(),
-            size_bytes,
-            observed_size
+            size_bytes
         )));
     }
     hasher
@@ -4836,16 +4849,22 @@ fn inspect_hf_safetensors_file(
         hf_safetensors_metadata_commitment_from_header(path, &header_bytes)?;
 
     let mut observed_size = header_end;
+    let mut remaining = size_bytes - header_end;
     let mut buffer = vec![0u8; HF_PROVENANCE_FILE_READ_CHUNK_BYTES];
-    loop {
-        let read_bytes = file.read(&mut buffer).map_err(|err| {
+    while remaining > 0 {
+        let chunk_len = remaining.min(buffer.len() as u64) as usize;
+        let read_bytes = file.read(&mut buffer[..chunk_len]).map_err(|err| {
             VmError::InvalidConfig(format!(
                 "failed to read HF provenance file {}: {err}",
                 path.display()
             ))
         })?;
         if read_bytes == 0 {
-            break;
+            return Err(VmError::InvalidConfig(format!(
+                "HF provenance file {} ended before the expected {} bytes were read",
+                path.display(),
+                size_bytes
+            )));
         }
         observed_size = observed_size
             .checked_add(read_bytes as u64)
@@ -4855,14 +4874,21 @@ fn inspect_hf_safetensors_file(
                     path.display()
                 ))
             })?;
+        remaining -= read_bytes as u64;
         hasher.update(&buffer[..read_bytes]);
     }
-    if observed_size != size_bytes {
+    let mut extra_byte = [0u8; 1];
+    if file.read(&mut extra_byte).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to read HF provenance file {}: {err}",
+            path.display()
+        ))
+    })? != 0
+    {
         return Err(VmError::InvalidConfig(format!(
-            "HF provenance file {} changed during read: expected {} bytes, got {}",
+            "HF provenance file {} grew while being hashed after {} bytes were expected",
             path.display(),
-            size_bytes,
-            observed_size
+            size_bytes
         )));
     }
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 use std::fs;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
@@ -4246,17 +4246,7 @@ fn prepare_hf_provenance_manifest_command(
         limitations,
     };
     verify_hf_provenance_manifest(&manifest)?;
-    let bytes = serde_json::to_vec_pretty(&manifest).map_err(|err| {
-        VmError::Serialization(format!("failed to serialize HF provenance manifest: {err}"))
-    })?;
-    if bytes.len() > MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES {
-        return Err(VmError::InvalidConfig(format!(
-            "HF provenance manifest {} would be {} bytes, exceeding the limit of {} bytes",
-            command.output.display(),
-            bytes.len(),
-            MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES
-        )));
-    }
+    let bytes = serialize_hf_provenance_manifest_bytes(&manifest, &command.output)?;
     write_bytes_atomically(&command.output, &bytes)?;
 
     println!("hf_provenance_manifest: {}", command.output.display());
@@ -4272,6 +4262,73 @@ fn prepare_hf_provenance_manifest_command(
     );
 
     Ok(())
+}
+
+struct BoundedManifestWriter {
+    bytes: Vec<u8>,
+    max_len: usize,
+    attempted_len: usize,
+}
+
+impl BoundedManifestWriter {
+    fn new(max_len: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            max_len,
+            attempted_len: 0,
+        }
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+impl Write for BoundedManifestWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let attempted_len = self
+            .bytes
+            .len()
+            .checked_add(buf.len())
+            .ok_or_else(|| std::io::Error::other("HF provenance manifest size overflow"))?;
+        if attempted_len > self.max_len {
+            self.attempted_len = attempted_len;
+            return Err(std::io::Error::other(
+                "HF provenance manifest exceeds byte limit",
+            ));
+        }
+        self.attempted_len = attempted_len;
+        self.bytes.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn serialize_hf_provenance_manifest_bytes(
+    manifest: &HfProvenanceManifest,
+    output_path: &Path,
+) -> llm_provable_computer::Result<Vec<u8>> {
+    let mut writer = BoundedManifestWriter::new(MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES);
+    match serde_json::to_writer_pretty(&mut writer, manifest) {
+        Ok(()) => Ok(writer.into_bytes()),
+        Err(err) if writer.attempted_len > MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES || err.is_io() => {
+            let observed_len = writer
+                .attempted_len
+                .max(MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES + 1);
+            Err(VmError::InvalidConfig(format!(
+                "HF provenance manifest {} would be at least {} bytes, exceeding the limit of {} bytes",
+                output_path.display(),
+                observed_len,
+                MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES
+            )))
+        }
+        Err(err) => Err(VmError::Serialization(format!(
+            "failed to serialize HF provenance manifest: {err}"
+        ))),
+    }
 }
 
 fn verify_hf_provenance_manifest_command(

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4249,6 +4249,14 @@ fn prepare_hf_provenance_manifest_command(
     let bytes = serde_json::to_vec_pretty(&manifest).map_err(|err| {
         VmError::Serialization(format!("failed to serialize HF provenance manifest: {err}"))
     })?;
+    if bytes.len() > MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance manifest {} would be {} bytes, exceeding the limit of {} bytes",
+            command.output.display(),
+            bytes.len(),
+            MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES
+        )));
+    }
     write_bytes_atomically(&command.output, &bytes)?;
 
     println!("hf_provenance_manifest: {}", command.output.display());
@@ -6675,6 +6683,160 @@ fn write_bytes_atomically(path: &Path, bytes: &[u8]) -> llm_provable_computer::R
     )))
 }
 
+#[cfg(test)]
+mod hf_provenance_manifest_tests {
+    use super::*;
+
+    fn hf_provenance_test_manifest_file(label: &str) -> tempfile::NamedTempFile {
+        tempfile::Builder::new()
+            .prefix(&format!("hf-provenance-{label}-"))
+            .suffix(".json")
+            .tempfile()
+            .expect("create HF provenance manifest fixture")
+    }
+
+    fn sample_hf_provenance_manifest_value() -> serde_json::Value {
+        serde_json::json!({
+            "manifest_version": HF_PROVENANCE_MANIFEST_VERSION,
+            "semantic_scope": HF_PROVENANCE_SEMANTIC_SCOPE,
+            "hash_function": HF_PROVENANCE_HASH_FUNCTION,
+            "hub_repo": "example/test-model",
+            "hub_revision": "0123456789abcdef",
+            "tokenizer": {
+                "tokenizer_id": "example/test-model",
+                "tokenizer_revision": "0123456789abcdef",
+                "tokenizer_json": null,
+                "tokenizer_config": null,
+                "tokenization_transcript": null
+            },
+            "safetensors": [],
+            "onnx_export": null,
+            "release": {
+                "model_card": null,
+                "doi": null,
+                "datasets": [],
+                "notes": []
+            },
+            "limitations": hf_provenance_limitations(),
+            "commitments": {
+                "tokenizer_hash": "0".repeat(64),
+                "safetensors_manifest_hash": "1".repeat(64),
+                "onnx_export_hash": "2".repeat(64),
+                "release_metadata_hash": "3".repeat(64),
+                "limitations_hash": "4".repeat(64)
+            }
+        })
+    }
+
+    fn write_hf_provenance_test_manifest(path: &Path, value: &serde_json::Value) {
+        let bytes = serde_json::to_vec_pretty(value).expect("serialize HF provenance manifest");
+        fs::write(path, bytes).expect("write HF provenance manifest");
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_unknown_top_level_field() {
+        let file = hf_provenance_test_manifest_file("extra-top");
+        let mut value = sample_hf_provenance_manifest_value();
+        value
+            .as_object_mut()
+            .expect("manifest object")
+            .insert("unexpected_field".to_string(), serde_json::json!(true));
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("unknown top-level field should fail");
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_unknown_nested_onnx_export_field() {
+        let file = hf_provenance_test_manifest_file("extra-onnx");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["onnx_export"] = serde_json::json!({
+            "exporter": "optimum",
+            "exporter_version": "1.0.0",
+            "graph": {
+                "path": "model.onnx",
+                "size_bytes": 16,
+                "blake2b_256": "5".repeat(64)
+            },
+            "unexpected_field": 7
+        });
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("unknown nested ONNX field should fail");
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_reports_malformed_json_as_serialization() {
+        let file = hf_provenance_test_manifest_file("malformed");
+        fs::write(file.path(), b"{").expect("write malformed manifest");
+
+        let err =
+            load_hf_provenance_manifest(file.path()).expect_err("malformed manifest should fail");
+        assert!(matches!(err, VmError::Serialization(_)));
+        assert!(err
+            .to_string()
+            .contains("failed to parse HF provenance manifest"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_oversized_file() {
+        let file = hf_provenance_test_manifest_file("oversized");
+        fs::write(
+            file.path(),
+            vec![b'x'; MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES + 1],
+        )
+        .expect("write oversized HF provenance manifest");
+
+        let err =
+            load_hf_provenance_manifest(file.path()).expect_err("oversized manifest should fail");
+        assert!(err.to_string().contains("exceeding the limit"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_non_regular_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+
+        let err = load_hf_provenance_manifest(dir.path())
+            .expect_err("directory manifest path should fail");
+        assert!(err.to_string().contains("not a regular file"));
+    }
+
+    #[test]
+    fn prepare_hf_provenance_manifest_rejects_oversized_output() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let output = dir.path().join("manifest.json");
+        let model_card = dir.path().join("README.md");
+        fs::write(&model_card, b"model card").expect("write model card");
+
+        let err = prepare_hf_provenance_manifest_command(HfProvenanceManifestCommand {
+            output: output.clone(),
+            hub_repo: "example/test-model".to_string(),
+            hub_revision: "0123456789abcdef".to_string(),
+            tokenizer_id: "example/test-model".to_string(),
+            tokenizer_revision: None,
+            tokenizer_json: None,
+            tokenizer_config: None,
+            tokenization_transcript: None,
+            safetensors_files: Vec::new(),
+            onnx_model: None,
+            onnx_exporter: "optimum-onnx".to_string(),
+            onnx_exporter_version: None,
+            model_card: Some(model_card),
+            doi: None,
+            datasets: Vec::new(),
+            notes: vec!["x".repeat(MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES)],
+        })
+        .expect_err("oversized manifest output should fail");
+
+        assert!(err.to_string().contains("exceeding the limit"));
+        assert!(!output.exists());
+    }
+}
+
 #[cfg(all(test, feature = "onnx-export"))]
 mod tests {
     use super::*;
@@ -7091,124 +7253,6 @@ mod tests {
     fn write_research_v3_test_artifact(path: &Path, value: &serde_json::Value) {
         let bytes = serde_json::to_vec_pretty(value).expect("serialize artifact");
         fs::write(path, bytes).expect("write artifact");
-    }
-
-    fn hf_provenance_test_manifest_file(label: &str) -> tempfile::NamedTempFile {
-        tempfile::Builder::new()
-            .prefix(&format!("hf-provenance-{label}-"))
-            .suffix(".json")
-            .tempfile()
-            .expect("create HF provenance manifest fixture")
-    }
-
-    fn sample_hf_provenance_manifest_value() -> serde_json::Value {
-        serde_json::json!({
-            "manifest_version": HF_PROVENANCE_MANIFEST_VERSION,
-            "semantic_scope": HF_PROVENANCE_SEMANTIC_SCOPE,
-            "hash_function": HF_PROVENANCE_HASH_FUNCTION,
-            "hub_repo": "example/test-model",
-            "hub_revision": "0123456789abcdef",
-            "tokenizer": {
-                "tokenizer_id": "example/test-model",
-                "tokenizer_revision": "0123456789abcdef",
-                "tokenizer_json": null,
-                "tokenizer_config": null,
-                "tokenization_transcript": null
-            },
-            "safetensors": [],
-            "onnx_export": null,
-            "release": {
-                "model_card": null,
-                "doi": null,
-                "datasets": [],
-                "notes": []
-            },
-            "limitations": hf_provenance_limitations(),
-            "commitments": {
-                "tokenizer_hash": "0".repeat(64),
-                "safetensors_manifest_hash": "1".repeat(64),
-                "onnx_export_hash": "2".repeat(64),
-                "release_metadata_hash": "3".repeat(64),
-                "limitations_hash": "4".repeat(64)
-            }
-        })
-    }
-
-    fn write_hf_provenance_test_manifest(path: &Path, value: &serde_json::Value) {
-        let bytes = serde_json::to_vec_pretty(value).expect("serialize HF provenance manifest");
-        fs::write(path, bytes).expect("write HF provenance manifest");
-    }
-
-    #[test]
-    fn load_hf_provenance_manifest_rejects_unknown_top_level_field() {
-        let file = hf_provenance_test_manifest_file("extra-top");
-        let mut value = sample_hf_provenance_manifest_value();
-        value
-            .as_object_mut()
-            .expect("manifest object")
-            .insert("unexpected_field".to_string(), serde_json::json!(true));
-        write_hf_provenance_test_manifest(file.path(), &value);
-
-        let err = load_hf_provenance_manifest(file.path())
-            .expect_err("unknown top-level field should fail");
-        assert!(err.to_string().contains("unknown field"));
-    }
-
-    #[test]
-    fn load_hf_provenance_manifest_rejects_unknown_nested_onnx_export_field() {
-        let file = hf_provenance_test_manifest_file("extra-onnx");
-        let mut value = sample_hf_provenance_manifest_value();
-        value["onnx_export"] = serde_json::json!({
-            "exporter": "optimum",
-            "exporter_version": "1.0.0",
-            "graph": {
-                "path": "model.onnx",
-                "size_bytes": 16,
-                "blake2b_256": "5".repeat(64)
-            },
-            "unexpected_field": 7
-        });
-        write_hf_provenance_test_manifest(file.path(), &value);
-
-        let err = load_hf_provenance_manifest(file.path())
-            .expect_err("unknown nested ONNX field should fail");
-        assert!(err.to_string().contains("unknown field"));
-    }
-
-    #[test]
-    fn load_hf_provenance_manifest_reports_malformed_json_as_serialization() {
-        let file = hf_provenance_test_manifest_file("malformed");
-        fs::write(file.path(), b"{").expect("write malformed manifest");
-
-        let err =
-            load_hf_provenance_manifest(file.path()).expect_err("malformed manifest should fail");
-        assert!(matches!(err, VmError::Serialization(_)));
-        assert!(err
-            .to_string()
-            .contains("failed to parse HF provenance manifest"));
-    }
-
-    #[test]
-    fn load_hf_provenance_manifest_rejects_oversized_file() {
-        let file = hf_provenance_test_manifest_file("oversized");
-        fs::write(
-            file.path(),
-            vec![b'x'; MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES + 1],
-        )
-        .expect("write oversized HF provenance manifest");
-
-        let err =
-            load_hf_provenance_manifest(file.path()).expect_err("oversized manifest should fail");
-        assert!(err.to_string().contains("exceeding the limit"));
-    }
-
-    #[test]
-    fn load_hf_provenance_manifest_rejects_non_regular_file() {
-        let dir = tempfile::tempdir().expect("create temp dir");
-
-        let err = load_hf_provenance_manifest(dir.path())
-            .expect_err("directory manifest path should fail");
-        assert!(err.to_string().contains("not a regular file"));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -861,6 +861,7 @@ const STATEMENT_V3_EQUIVALENCE_ARTIFACT_SCHEMA_PATH: &str =
 const RESEARCH_V2_HASH_FUNCTION: &str = "blake2b-256";
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const RESEARCH_V3_RELATION_FORMAT: &str = "multi-engine-trace-relation-v1-no-egraph-no-smt";
+const MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES: usize = 8 * 1024 * 1024;
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES: usize = 32 * 1024 * 1024;
 #[cfg(feature = "onnx-export")]
@@ -906,6 +907,7 @@ struct HfProvenanceManifestCommand {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct HfFileCommitment {
     path: String,
     size_bytes: u64,
@@ -913,6 +915,7 @@ struct HfFileCommitment {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct HfSafetensorsFileCommitment {
     path: String,
     size_bytes: u64,
@@ -922,6 +925,7 @@ struct HfSafetensorsFileCommitment {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct HfTokenizerProvenance {
     tokenizer_id: String,
     tokenizer_revision: String,
@@ -931,6 +935,7 @@ struct HfTokenizerProvenance {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct HfOnnxExportProvenance {
     exporter: String,
     exporter_version: Option<String>,
@@ -938,6 +943,7 @@ struct HfOnnxExportProvenance {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct HfReleaseMetadata {
     model_card: Option<HfFileCommitment>,
     doi: Option<String>,
@@ -946,6 +952,7 @@ struct HfReleaseMetadata {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct HfProvenanceCommitments {
     tokenizer_hash: String,
     safetensors_manifest_hash: String,
@@ -955,6 +962,7 @@ struct HfProvenanceCommitments {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct HfProvenanceManifest {
     manifest_version: String,
     semantic_scope: String,
@@ -4261,19 +4269,7 @@ fn prepare_hf_provenance_manifest_command(
 fn verify_hf_provenance_manifest_command(
     manifest_path: &Path,
 ) -> llm_provable_computer::Result<()> {
-    let manifest_bytes = fs::read(manifest_path).map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read HF provenance manifest {}: {err}",
-            manifest_path.display()
-        ))
-    })?;
-    let manifest: HfProvenanceManifest =
-        serde_json::from_slice(&manifest_bytes).map_err(|err| {
-            VmError::Serialization(format!(
-                "failed to parse HF provenance manifest {}: {err}",
-                manifest_path.display()
-            ))
-        })?;
+    let manifest = load_hf_provenance_manifest(manifest_path)?;
     verify_hf_provenance_manifest(&manifest)?;
 
     println!("verified_hf_provenance_manifest: true");
@@ -4285,6 +4281,98 @@ fn verify_hf_provenance_manifest_command(
     println!("safetensors_files: {}", manifest.safetensors.len());
 
     Ok(())
+}
+
+fn load_hf_provenance_manifest(
+    manifest_path: &Path,
+) -> llm_provable_computer::Result<HfProvenanceManifest> {
+    let metadata = fs::symlink_metadata(manifest_path).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to read HF provenance manifest {}: {err}",
+            manifest_path.display()
+        ))
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance manifest {} is not a regular file",
+            manifest_path.display()
+        )));
+    }
+    if metadata.len() > MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES as u64 {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance manifest {} is {} bytes, exceeding the limit of {} bytes",
+            manifest_path.display(),
+            metadata.len(),
+            MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES
+        )));
+    }
+    let file = fs::File::open(manifest_path).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to read HF provenance manifest {}: {err}",
+            manifest_path.display()
+        ))
+    })?;
+    let opened_metadata = file.metadata().map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to read HF provenance manifest {}: {err}",
+            manifest_path.display()
+        ))
+    })?;
+    if !opened_metadata.is_file() {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance manifest {} is not a regular file after opening",
+            manifest_path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        if metadata.dev() != opened_metadata.dev() || metadata.ino() != opened_metadata.ino() {
+            return Err(VmError::InvalidConfig(format!(
+                "HF provenance manifest {} changed between metadata inspection and open",
+                manifest_path.display()
+            )));
+        }
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+
+        if metadata.volume_serial_number() != opened_metadata.volume_serial_number()
+            || metadata.file_index() != opened_metadata.file_index()
+        {
+            return Err(VmError::InvalidConfig(format!(
+                "HF provenance manifest {} changed between metadata inspection and open",
+                manifest_path.display()
+            )));
+        }
+    }
+    let mut manifest_bytes = Vec::new();
+    let mut limited_reader = file.take(MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES as u64 + 1);
+    limited_reader
+        .read_to_end(&mut manifest_bytes)
+        .map_err(|err| {
+            VmError::InvalidConfig(format!(
+                "failed to read HF provenance manifest {}: {err}",
+                manifest_path.display()
+            ))
+        })?;
+    if manifest_bytes.len() > MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance manifest {} is {} bytes after read, exceeding the limit of {} bytes",
+            manifest_path.display(),
+            manifest_bytes.len(),
+            MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES
+        )));
+    }
+
+    serde_json::from_slice(&manifest_bytes).map_err(|err| {
+        VmError::Serialization(format!(
+            "failed to parse HF provenance manifest {}: {err}",
+            manifest_path.display()
+        ))
+    })
 }
 
 fn verify_hf_provenance_manifest(
@@ -7003,6 +7091,124 @@ mod tests {
     fn write_research_v3_test_artifact(path: &Path, value: &serde_json::Value) {
         let bytes = serde_json::to_vec_pretty(value).expect("serialize artifact");
         fs::write(path, bytes).expect("write artifact");
+    }
+
+    fn hf_provenance_test_manifest_file(label: &str) -> tempfile::NamedTempFile {
+        tempfile::Builder::new()
+            .prefix(&format!("hf-provenance-{label}-"))
+            .suffix(".json")
+            .tempfile()
+            .expect("create HF provenance manifest fixture")
+    }
+
+    fn sample_hf_provenance_manifest_value() -> serde_json::Value {
+        serde_json::json!({
+            "manifest_version": HF_PROVENANCE_MANIFEST_VERSION,
+            "semantic_scope": HF_PROVENANCE_SEMANTIC_SCOPE,
+            "hash_function": HF_PROVENANCE_HASH_FUNCTION,
+            "hub_repo": "example/test-model",
+            "hub_revision": "0123456789abcdef",
+            "tokenizer": {
+                "tokenizer_id": "example/test-model",
+                "tokenizer_revision": "0123456789abcdef",
+                "tokenizer_json": null,
+                "tokenizer_config": null,
+                "tokenization_transcript": null
+            },
+            "safetensors": [],
+            "onnx_export": null,
+            "release": {
+                "model_card": null,
+                "doi": null,
+                "datasets": [],
+                "notes": []
+            },
+            "limitations": hf_provenance_limitations(),
+            "commitments": {
+                "tokenizer_hash": "0".repeat(64),
+                "safetensors_manifest_hash": "1".repeat(64),
+                "onnx_export_hash": "2".repeat(64),
+                "release_metadata_hash": "3".repeat(64),
+                "limitations_hash": "4".repeat(64)
+            }
+        })
+    }
+
+    fn write_hf_provenance_test_manifest(path: &Path, value: &serde_json::Value) {
+        let bytes = serde_json::to_vec_pretty(value).expect("serialize HF provenance manifest");
+        fs::write(path, bytes).expect("write HF provenance manifest");
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_unknown_top_level_field() {
+        let file = hf_provenance_test_manifest_file("extra-top");
+        let mut value = sample_hf_provenance_manifest_value();
+        value
+            .as_object_mut()
+            .expect("manifest object")
+            .insert("unexpected_field".to_string(), serde_json::json!(true));
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("unknown top-level field should fail");
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_unknown_nested_onnx_export_field() {
+        let file = hf_provenance_test_manifest_file("extra-onnx");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["onnx_export"] = serde_json::json!({
+            "exporter": "optimum",
+            "exporter_version": "1.0.0",
+            "graph": {
+                "path": "model.onnx",
+                "size_bytes": 16,
+                "blake2b_256": "5".repeat(64)
+            },
+            "unexpected_field": 7
+        });
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("unknown nested ONNX field should fail");
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_reports_malformed_json_as_serialization() {
+        let file = hf_provenance_test_manifest_file("malformed");
+        fs::write(file.path(), b"{").expect("write malformed manifest");
+
+        let err =
+            load_hf_provenance_manifest(file.path()).expect_err("malformed manifest should fail");
+        assert!(matches!(err, VmError::Serialization(_)));
+        assert!(err
+            .to_string()
+            .contains("failed to parse HF provenance manifest"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_oversized_file() {
+        let file = hf_provenance_test_manifest_file("oversized");
+        fs::write(
+            file.path(),
+            vec![b'x'; MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES + 1],
+        )
+        .expect("write oversized HF provenance manifest");
+
+        let err =
+            load_hf_provenance_manifest(file.path()).expect_err("oversized manifest should fail");
+        assert!(err.to_string().contains("exceeding the limit"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_non_regular_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+
+        let err = load_hf_provenance_manifest(dir.path())
+            .expect_err("directory manifest path should fail");
+        assert!(err.to_string().contains("not a regular file"));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4331,6 +4331,27 @@ fn serialize_hf_provenance_manifest_bytes(
     }
 }
 
+fn require_windows_manifest_file_identity(
+    manifest_path: &Path,
+    volume_serial_number: Option<u32>,
+    file_index: Option<u64>,
+    phase: &str,
+) -> llm_provable_computer::Result<(u32, u64)> {
+    let volume_serial_number = volume_serial_number.ok_or_else(|| {
+        VmError::InvalidConfig(format!(
+            "HF provenance manifest {}: cannot read volume serial number {phase}",
+            manifest_path.display()
+        ))
+    })?;
+    let file_index = file_index.ok_or_else(|| {
+        VmError::InvalidConfig(format!(
+            "HF provenance manifest {}: cannot read file index {phase}",
+            manifest_path.display()
+        ))
+    })?;
+    Ok((volume_serial_number, file_index))
+}
+
 fn verify_hf_provenance_manifest_command(
     manifest_path: &Path,
 ) -> llm_provable_computer::Result<()> {
@@ -4404,8 +4425,21 @@ fn load_hf_provenance_manifest(
     {
         use std::os::windows::fs::MetadataExt;
 
-        if metadata.volume_serial_number() != opened_metadata.volume_serial_number()
-            || metadata.file_index() != opened_metadata.file_index()
+        let (pre_volume_serial_number, pre_file_index) = require_windows_manifest_file_identity(
+            manifest_path,
+            metadata.volume_serial_number(),
+            metadata.file_index(),
+            "before open",
+        )?;
+        let (post_volume_serial_number, post_file_index) = require_windows_manifest_file_identity(
+            manifest_path,
+            opened_metadata.volume_serial_number(),
+            opened_metadata.file_index(),
+            "after open",
+        )?;
+
+        if pre_volume_serial_number != post_volume_serial_number
+            || pre_file_index != post_file_index
         {
             return Err(VmError::InvalidConfig(format!(
                 "HF provenance manifest {} changed between metadata inspection and open",
@@ -6891,6 +6925,36 @@ mod hf_provenance_manifest_tests {
 
         assert!(err.to_string().contains("exceeding the limit"));
         assert!(!output.exists());
+    }
+
+    #[test]
+    fn windows_manifest_identity_requires_volume_serial_number() {
+        let err = require_windows_manifest_file_identity(
+            Path::new("manifest.json"),
+            None,
+            Some(7),
+            "before open",
+        )
+        .expect_err("missing volume serial number should fail");
+
+        assert!(err
+            .to_string()
+            .contains("cannot read volume serial number before open"));
+    }
+
+    #[test]
+    fn windows_manifest_identity_requires_file_index() {
+        let err = require_windows_manifest_file_identity(
+            Path::new("manifest.json"),
+            Some(11),
+            None,
+            "after open",
+        )
+        .expect_err("missing file index should fail");
+
+        assert!(err
+            .to_string()
+            .contains("cannot read file index after open"));
     }
 }
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -862,6 +862,7 @@ const RESEARCH_V2_HASH_FUNCTION: &str = "blake2b-256";
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const RESEARCH_V3_RELATION_FORMAT: &str = "multi-engine-trace-relation-v1-no-egraph-no-smt";
 const MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES: usize = 8 * 1024 * 1024;
+const HF_PROVENANCE_FILE_READ_CHUNK_BYTES: usize = 1024 * 1024;
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES: usize = 32 * 1024 * 1024;
 #[cfg(feature = "onnx-export")]
@@ -4331,25 +4332,115 @@ fn serialize_hf_provenance_manifest_bytes(
     }
 }
 
-fn require_windows_manifest_file_identity(
-    manifest_path: &Path,
+#[cfg_attr(not(windows), allow(dead_code))]
+fn require_windows_regular_file_identity(
+    path: &Path,
+    label: &str,
     volume_serial_number: Option<u32>,
     file_index: Option<u64>,
     phase: &str,
 ) -> llm_provable_computer::Result<(u32, u64)> {
     let volume_serial_number = volume_serial_number.ok_or_else(|| {
         VmError::InvalidConfig(format!(
-            "HF provenance manifest {}: cannot read volume serial number {phase}",
-            manifest_path.display()
+            "{label} {}: cannot read volume serial number {phase}",
+            path.display()
         ))
     })?;
     let file_index = file_index.ok_or_else(|| {
         VmError::InvalidConfig(format!(
-            "HF provenance manifest {}: cannot read file index {phase}",
-            manifest_path.display()
+            "{label} {}: cannot read file index {phase}",
+            path.display()
         ))
     })?;
     Ok((volume_serial_number, file_index))
+}
+
+fn open_checked_regular_file(
+    path: &Path,
+    label: &str,
+    max_bytes: Option<u64>,
+) -> llm_provable_computer::Result<(fs::File, u64)> {
+    let metadata = fs::symlink_metadata(path).map_err(|err| {
+        VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} {} is not a regular file",
+            path.display()
+        )));
+    }
+    if let Some(max_bytes) = max_bytes {
+        if metadata.len() > max_bytes {
+            return Err(VmError::InvalidConfig(format!(
+                "{label} {} is {} bytes, exceeding the limit of {} bytes",
+                path.display(),
+                metadata.len(),
+                max_bytes
+            )));
+        }
+    }
+    let file = fs::File::open(path).map_err(|err| {
+        VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
+    })?;
+    let opened_metadata = file.metadata().map_err(|err| {
+        VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
+    })?;
+    if !opened_metadata.is_file() {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} {} is not a regular file after opening",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        if metadata.dev() != opened_metadata.dev() || metadata.ino() != opened_metadata.ino() {
+            return Err(VmError::InvalidConfig(format!(
+                "{label} {} changed between metadata inspection and open",
+                path.display()
+            )));
+        }
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+
+        let (pre_volume_serial_number, pre_file_index) = require_windows_regular_file_identity(
+            path,
+            label,
+            metadata.volume_serial_number(),
+            metadata.file_index(),
+            "before open",
+        )?;
+        let (post_volume_serial_number, post_file_index) = require_windows_regular_file_identity(
+            path,
+            label,
+            opened_metadata.volume_serial_number(),
+            opened_metadata.file_index(),
+            "after open",
+        )?;
+
+        if pre_volume_serial_number != post_volume_serial_number
+            || pre_file_index != post_file_index
+        {
+            return Err(VmError::InvalidConfig(format!(
+                "{label} {} changed between metadata inspection and open",
+                path.display()
+            )));
+        }
+    }
+    if let Some(max_bytes) = max_bytes {
+        if opened_metadata.len() > max_bytes {
+            return Err(VmError::InvalidConfig(format!(
+                "{label} {} is {} bytes after opening, exceeding the limit of {} bytes",
+                path.display(),
+                opened_metadata.len(),
+                max_bytes
+            )));
+        }
+    }
+    Ok((file, opened_metadata.len()))
 }
 
 fn verify_hf_provenance_manifest_command(
@@ -4372,81 +4463,11 @@ fn verify_hf_provenance_manifest_command(
 fn load_hf_provenance_manifest(
     manifest_path: &Path,
 ) -> llm_provable_computer::Result<HfProvenanceManifest> {
-    let metadata = fs::symlink_metadata(manifest_path).map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read HF provenance manifest {}: {err}",
-            manifest_path.display()
-        ))
-    })?;
-    if !metadata.file_type().is_file() {
-        return Err(VmError::InvalidConfig(format!(
-            "HF provenance manifest {} is not a regular file",
-            manifest_path.display()
-        )));
-    }
-    if metadata.len() > MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES as u64 {
-        return Err(VmError::InvalidConfig(format!(
-            "HF provenance manifest {} is {} bytes, exceeding the limit of {} bytes",
-            manifest_path.display(),
-            metadata.len(),
-            MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES
-        )));
-    }
-    let file = fs::File::open(manifest_path).map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read HF provenance manifest {}: {err}",
-            manifest_path.display()
-        ))
-    })?;
-    let opened_metadata = file.metadata().map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read HF provenance manifest {}: {err}",
-            manifest_path.display()
-        ))
-    })?;
-    if !opened_metadata.is_file() {
-        return Err(VmError::InvalidConfig(format!(
-            "HF provenance manifest {} is not a regular file after opening",
-            manifest_path.display()
-        )));
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-
-        if metadata.dev() != opened_metadata.dev() || metadata.ino() != opened_metadata.ino() {
-            return Err(VmError::InvalidConfig(format!(
-                "HF provenance manifest {} changed between metadata inspection and open",
-                manifest_path.display()
-            )));
-        }
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::MetadataExt;
-
-        let (pre_volume_serial_number, pre_file_index) = require_windows_manifest_file_identity(
-            manifest_path,
-            metadata.volume_serial_number(),
-            metadata.file_index(),
-            "before open",
-        )?;
-        let (post_volume_serial_number, post_file_index) = require_windows_manifest_file_identity(
-            manifest_path,
-            opened_metadata.volume_serial_number(),
-            opened_metadata.file_index(),
-            "after open",
-        )?;
-
-        if pre_volume_serial_number != post_volume_serial_number
-            || pre_file_index != post_file_index
-        {
-            return Err(VmError::InvalidConfig(format!(
-                "HF provenance manifest {} changed between metadata inspection and open",
-                manifest_path.display()
-            )));
-        }
-    }
+    let (file, _) = open_checked_regular_file(
+        manifest_path,
+        "HF provenance manifest",
+        Some(MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES as u64),
+    )?;
     let mut manifest_bytes = Vec::new();
     let mut limited_reader = file.take(MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES as u64 + 1);
     limited_reader
@@ -4626,23 +4647,22 @@ fn hf_optional_file_commitment(
 }
 
 fn hf_file_commitment(path: &Path) -> llm_provable_computer::Result<HfFileCommitment> {
-    let (bytes, size_bytes) = read_file_for_hf_commitment(path)?;
+    let (size_bytes, blake2b_256) = hash_hf_commitment_file(path)?;
     Ok(HfFileCommitment {
         path: path.display().to_string(),
         size_bytes,
-        blake2b_256: hash_bytes_hex(&bytes),
+        blake2b_256,
     })
 }
 
 fn hf_safetensors_file_commitment(
     path: &Path,
 ) -> llm_provable_computer::Result<HfSafetensorsFileCommitment> {
-    let (bytes, size_bytes) = read_file_for_hf_commitment(path)?;
-    let (metadata_hash, tensor_count) = hf_safetensors_metadata_commitment(path, &bytes)?;
+    let (size_bytes, blake2b_256, metadata_hash, tensor_count) = inspect_hf_safetensors_file(path)?;
     Ok(HfSafetensorsFileCommitment {
         path: path.display().to_string(),
         size_bytes,
-        blake2b_256: hash_bytes_hex(&bytes),
+        blake2b_256,
         metadata_hash,
         tensor_count,
     })
@@ -4662,7 +4682,7 @@ fn verify_hf_file_commitment(
     label: &str,
     commitment: &HfFileCommitment,
 ) -> llm_provable_computer::Result<()> {
-    let (bytes, size_bytes) = read_file_for_hf_commitment(Path::new(&commitment.path))?;
+    let (size_bytes, blake2b_256) = hash_hf_commitment_file(Path::new(&commitment.path))?;
     if commitment.size_bytes != size_bytes {
         return Err(VmError::InvalidConfig(format!(
             "HF provenance {label} size_bytes mismatch: expected {}, got {}",
@@ -4672,14 +4692,15 @@ fn verify_hf_file_commitment(
     verify_hash_commitment(
         &format!("HF provenance {label} blake2b_256"),
         &commitment.blake2b_256,
-        &hash_bytes_hex(&bytes),
+        &blake2b_256,
     )
 }
 
 fn verify_hf_safetensors_file_commitment(
     commitment: &HfSafetensorsFileCommitment,
 ) -> llm_provable_computer::Result<()> {
-    let (bytes, size_bytes) = read_file_for_hf_commitment(Path::new(&commitment.path))?;
+    let (size_bytes, blake2b_256, metadata_hash, tensor_count) =
+        inspect_hf_safetensors_file(Path::new(&commitment.path))?;
     if commitment.size_bytes != size_bytes {
         return Err(VmError::InvalidConfig(format!(
             "HF provenance safetensors {} size_bytes mismatch: expected {}, got {}",
@@ -4689,10 +4710,8 @@ fn verify_hf_safetensors_file_commitment(
     verify_hash_commitment(
         &format!("HF provenance safetensors {} blake2b_256", commitment.path),
         &commitment.blake2b_256,
-        &hash_bytes_hex(&bytes),
+        &blake2b_256,
     )?;
-    let (metadata_hash, tensor_count) =
-        hf_safetensors_metadata_commitment(Path::new(&commitment.path), &bytes)?;
     verify_hash_commitment(
         &format!(
             "HF provenance safetensors {} metadata_hash",
@@ -4710,35 +4729,74 @@ fn verify_hf_safetensors_file_commitment(
     Ok(())
 }
 
-fn read_file_for_hf_commitment(path: &Path) -> llm_provable_computer::Result<(Vec<u8>, u64)> {
-    let bytes = fs::read(path).map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read HF provenance file {}: {err}",
-            path.display()
-        ))
-    })?;
-    let size_bytes = u64::try_from(bytes.len()).map_err(|_| {
-        VmError::InvalidConfig(format!(
-            "HF provenance file {} is too large to commit",
-            path.display()
-        ))
-    })?;
-    Ok((bytes, size_bytes))
+fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, String)> {
+    let (mut file, size_bytes) = open_checked_regular_file(path, "HF provenance file", None)?;
+    let mut output = [0u8; 32];
+    let mut hasher = Blake2bVar::new(output.len()).expect("blake2b-256 hasher");
+    let mut observed_size = 0u64;
+    let mut buffer = [0u8; HF_PROVENANCE_FILE_READ_CHUNK_BYTES];
+    loop {
+        let read_bytes = file.read(&mut buffer).map_err(|err| {
+            VmError::InvalidConfig(format!(
+                "failed to read HF provenance file {}: {err}",
+                path.display()
+            ))
+        })?;
+        if read_bytes == 0 {
+            break;
+        }
+        observed_size = observed_size
+            .checked_add(read_bytes as u64)
+            .ok_or_else(|| {
+                VmError::InvalidConfig(format!(
+                    "HF provenance file {} exceeded supported size accounting during read",
+                    path.display()
+                ))
+            })?;
+        hasher.update(&buffer[..read_bytes]);
+    }
+    if observed_size != size_bytes {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance file {} changed during read: expected {} bytes, got {}",
+            path.display(),
+            size_bytes,
+            observed_size
+        )));
+    }
+    hasher
+        .finalize_variable(&mut output)
+        .expect("blake2b-256 finalization");
+    Ok((
+        size_bytes,
+        output.iter().map(|byte| format!("{byte:02x}")).collect(),
+    ))
 }
 
-fn hf_safetensors_metadata_commitment(
+fn inspect_hf_safetensors_file(
     path: &Path,
-    bytes: &[u8],
-) -> llm_provable_computer::Result<(String, usize)> {
+) -> llm_provable_computer::Result<(u64, String, String, usize)> {
     const MAX_SAFETENSORS_HEADER_BYTES: u64 = 16 * 1024 * 1024;
-    if bytes.len() < 8 {
+
+    let (mut file, size_bytes) = open_checked_regular_file(path, "HF provenance file", None)?;
+    if size_bytes < 8 {
         return Err(VmError::InvalidConfig(format!(
             "HF provenance safetensors {} is shorter than the 8-byte metadata length header",
             path.display()
         )));
     }
+
+    let mut output = [0u8; 32];
+    let mut hasher = Blake2bVar::new(output.len()).expect("blake2b-256 hasher");
+
     let mut header_len_bytes = [0u8; 8];
-    header_len_bytes.copy_from_slice(&bytes[..8]);
+    file.read_exact(&mut header_len_bytes).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to read HF provenance file {}: {err}",
+            path.display()
+        ))
+    })?;
+    hasher.update(&header_len_bytes);
+
     let header_len = u64::from_le_bytes(header_len_bytes);
     if header_len > MAX_SAFETENSORS_HEADER_BYTES {
         return Err(VmError::InvalidConfig(format!(
@@ -4747,25 +4805,82 @@ fn hf_safetensors_metadata_commitment(
             header_len
         )));
     }
+    let header_end = 8u64.checked_add(header_len).ok_or_else(|| {
+        VmError::InvalidConfig(format!(
+            "HF provenance safetensors {} metadata header end overflows u64",
+            path.display()
+        ))
+    })?;
+    if size_bytes < header_end {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance safetensors {} metadata header length exceeds file size",
+            path.display()
+        )));
+    }
+
     let header_len = usize::try_from(header_len).map_err(|_| {
         VmError::InvalidConfig(format!(
             "HF provenance safetensors {} metadata header length overflows usize",
             path.display()
         ))
     })?;
-    let header_end = 8usize.checked_add(header_len).ok_or_else(|| {
+    let mut header_bytes = vec![0u8; header_len];
+    file.read_exact(&mut header_bytes).map_err(|err| {
         VmError::InvalidConfig(format!(
-            "HF provenance safetensors {} metadata header end overflows usize",
+            "failed to read HF provenance file {}: {err}",
             path.display()
         ))
     })?;
-    if bytes.len() < header_end {
+    hasher.update(&header_bytes);
+    let (metadata_hash, tensor_count) =
+        hf_safetensors_metadata_commitment_from_header(path, &header_bytes)?;
+
+    let mut observed_size = header_end;
+    let mut buffer = [0u8; HF_PROVENANCE_FILE_READ_CHUNK_BYTES];
+    loop {
+        let read_bytes = file.read(&mut buffer).map_err(|err| {
+            VmError::InvalidConfig(format!(
+                "failed to read HF provenance file {}: {err}",
+                path.display()
+            ))
+        })?;
+        if read_bytes == 0 {
+            break;
+        }
+        observed_size = observed_size
+            .checked_add(read_bytes as u64)
+            .ok_or_else(|| {
+                VmError::InvalidConfig(format!(
+                    "HF provenance file {} exceeded supported size accounting during read",
+                    path.display()
+                ))
+            })?;
+        hasher.update(&buffer[..read_bytes]);
+    }
+    if observed_size != size_bytes {
         return Err(VmError::InvalidConfig(format!(
-            "HF provenance safetensors {} metadata header length exceeds file size",
-            path.display()
+            "HF provenance file {} changed during read: expected {} bytes, got {}",
+            path.display(),
+            size_bytes,
+            observed_size
         )));
     }
-    let header_bytes = &bytes[8..header_end];
+
+    hasher
+        .finalize_variable(&mut output)
+        .expect("blake2b-256 finalization");
+    Ok((
+        size_bytes,
+        output.iter().map(|byte| format!("{byte:02x}")).collect(),
+        metadata_hash,
+        tensor_count,
+    ))
+}
+
+fn hf_safetensors_metadata_commitment_from_header(
+    path: &Path,
+    header_bytes: &[u8],
+) -> llm_provable_computer::Result<(String, usize)> {
     let header_json: serde_json::Value = serde_json::from_slice(header_bytes).map_err(|err| {
         VmError::Serialization(format!(
             "failed to parse HF provenance safetensors metadata {}: {err}",
@@ -6929,8 +7044,9 @@ mod hf_provenance_manifest_tests {
 
     #[test]
     fn windows_manifest_identity_requires_volume_serial_number() {
-        let err = require_windows_manifest_file_identity(
+        let err = require_windows_regular_file_identity(
             Path::new("manifest.json"),
+            "HF provenance manifest",
             None,
             Some(7),
             "before open",
@@ -6944,8 +7060,9 @@ mod hf_provenance_manifest_tests {
 
     #[test]
     fn windows_manifest_identity_requires_file_index() {
-        let err = require_windows_manifest_file_identity(
+        let err = require_windows_regular_file_identity(
             Path::new("manifest.json"),
+            "HF provenance manifest",
             Some(11),
             None,
             "after open",
@@ -6955,6 +7072,79 @@ mod hf_provenance_manifest_tests {
         assert!(err
             .to_string()
             .contains("cannot read file index after open"));
+    }
+
+    #[test]
+    fn verify_hf_provenance_manifest_rejects_non_regular_bound_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let bound_dir = dir.path().join("bound-dir");
+        fs::create_dir(&bound_dir).expect("create bound dir");
+
+        let tokenizer = HfTokenizerProvenance {
+            tokenizer_id: "example/test-model".to_string(),
+            tokenizer_revision: "0123456789abcdef".to_string(),
+            tokenizer_json: None,
+            tokenizer_config: None,
+            tokenization_transcript: None,
+        };
+        let safetensors = Vec::new();
+        let onnx_export = None;
+        let release = HfReleaseMetadata {
+            model_card: Some(HfFileCommitment {
+                path: bound_dir.display().to_string(),
+                size_bytes: 0,
+                blake2b_256: "0".repeat(64),
+            }),
+            doi: None,
+            datasets: Vec::new(),
+            notes: Vec::new(),
+        };
+        let limitations = hf_provenance_limitations();
+        let manifest = HfProvenanceManifest {
+            manifest_version: HF_PROVENANCE_MANIFEST_VERSION.to_string(),
+            semantic_scope: HF_PROVENANCE_SEMANTIC_SCOPE.to_string(),
+            hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
+            hub_repo: "example/test-model".to_string(),
+            hub_revision: "0123456789abcdef".to_string(),
+            tokenizer,
+            safetensors,
+            onnx_export,
+            release,
+            limitations,
+            commitments: HfProvenanceCommitments {
+                tokenizer_hash: hash_json_projection_hex(&HfTokenizerProvenance {
+                    tokenizer_id: "example/test-model".to_string(),
+                    tokenizer_revision: "0123456789abcdef".to_string(),
+                    tokenizer_json: None,
+                    tokenizer_config: None,
+                    tokenization_transcript: None,
+                })
+                .expect("tokenizer hash"),
+                safetensors_manifest_hash: hash_json_projection_hex(&Vec::<
+                    HfSafetensorsFileCommitment,
+                >::new())
+                .expect("safetensors hash"),
+                onnx_export_hash: hash_json_projection_hex(&Option::<HfOnnxExportProvenance>::None)
+                    .expect("onnx hash"),
+                release_metadata_hash: hash_json_projection_hex(&HfReleaseMetadata {
+                    model_card: Some(HfFileCommitment {
+                        path: bound_dir.display().to_string(),
+                        size_bytes: 0,
+                        blake2b_256: "0".repeat(64),
+                    }),
+                    doi: None,
+                    datasets: Vec::new(),
+                    notes: Vec::new(),
+                })
+                .expect("release hash"),
+                limitations_hash: hash_json_projection_hex(&hf_provenance_limitations())
+                    .expect("limitations hash"),
+            },
+        };
+
+        let err = verify_hf_provenance_manifest(&manifest)
+            .expect_err("non-regular bound file should fail verification");
+        assert!(err.to_string().contains("not a regular file"));
     }
 }
 


### PR DESCRIPTION
## Summary
- harden HF provenance manifest loading with bounded regular-file reads and unknown-field rejection
- keep HF manifest prepare and verify on the same byte budget with bounded streaming serialization
- move HF provenance loader regressions onto the default `tvm` test surface and share the `tvm` smoke selector/cargo-args source of truth across the gate scripts

## Validation
- `cargo fmt --all`
- `cargo test --bin tvm hf_provenance_manifest_tests::load_hf_provenance_manifest_rejects_unknown_top_level_field -- --exact --nocapture`
- `cargo test --bin tvm hf_provenance_manifest_tests::prepare_hf_provenance_manifest_rejects_oversized_output -- --exact --nocapture`
- `cargo test --test cli cli_can_prepare_and_verify_hf_provenance_manifest -- --exact --nocapture`
- `cargo test --features burn-model,onnx-export --bin tvm tests::load_research_v3_equivalence_artifact_rejects_unknown_top_level_field -- --exact --nocapture`
- `bash -lc 'source scripts/hardening_test_names.sh && cargo test "${hardening_tvm_bin_cargo_args[@]}" hf_provenance_manifest_tests::prepare_hf_provenance_manifest_rejects_oversized_output -- --exact --nocapture'`
- `bash scripts/run_shellcheck_suite.sh`
- `git diff --check`

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Oracle / differential checks are not applicable here because this slice hardens loader/parser rejection behavior rather than semantic cross-engine equivalence.

Resource-bound / untrusted-input impact reviewed: the verifier now bounds HF manifest size, rejects non-regular files and unknown fields before semantic verification, and the prepare path now enforces the same manifest budget without materializing oversized JSON first.

Kani / formal-kernel impact reviewed as not requiring Kani or formal-kernel changes because this slice tightens CLI artifact parsing, manifest I/O, and bounded serialization only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened HF provenance manifest handling: stricter validation (reject unknown top-level and nested fields, map malformed JSON to serialization errors), enforce an 8 MiB size cap, and detect non-regular or tampered files to prevent TOCTOU issues.
* **Tests**
  * Added smoke/unit tests covering unknown fields, malformed JSON, oversized inputs, non-regular files, and oversized output handling.
* **Chores**
  * Updated local and CI test flows to run the new TVM-related smoke tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->