### PR TITLE
[codex] Draft paper 2 and harden ONNX provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,10 @@ algorithm correctness, safetensors architectural semantics, ONNX exporter semant
 equivalence, ONNX metadata semantic correctness, live Hub availability, or DOI
 validity.
 
+The current manifest wire format is `hf-provenance-manifest-v2`. Older
+`hf-provenance-manifest-v1` files must be regenerated before verification
+because the ONNX sidecar surface now has an explicit versioned format boundary.
+
 Canonical HF provenance spec file:
 
 - `spec/hf-provenance-manifest.schema.json`

--- a/README.md
+++ b/README.md
@@ -828,6 +828,8 @@ cargo run --bin tvm -- prepare-hf-provenance-manifest \
   --tokenizer-json path/to/tokenizer.json \
   --safetensors path/to/model.safetensors \
   --onnx-model path/to/model.onnx \
+  --onnx-metadata path/to/metadata.json \
+  --onnx-external-data path/to/model.onnx_data \
   --model-card path/to/README.md
 cargo run --bin tvm -- verify-hf-provenance-manifest compiled/hf-provenance.json
 ```
@@ -835,12 +837,13 @@ cargo run --bin tvm -- verify-hf-provenance-manifest compiled/hf-provenance.json
 This manifest is deliberately a provenance artifact, not a proving claim. It pins the
 Hub repo/revision, tokenizer identity/revision, optional tokenizer files and
 tokenization transcripts, local `safetensors` file hashes plus parsed metadata-header
-hashes/tensor counts, optional ONNX export file hashes, and optional
-model-card/DOI/dataset release metadata. The verifier rejects floating Hub revisions
-such as `main`, recomputes local file hashes, recomputes the manifest commitments, and
-rejects safetensors metadata drift. It does not prove tokenizer algorithm correctness,
-safetensors architectural semantics, Optimum export semantic equivalence, live Hub
-availability, or DOI validity.
+hashes/tensor counts, optional ONNX graph/metadata/external-data file hashes, and
+optional model-card/DOI/dataset release metadata. The verifier rejects floating Hub
+revisions such as `main`, recomputes local file hashes, recomputes the manifest
+commitments, and rejects safetensors metadata drift. It does not prove tokenizer
+algorithm correctness, safetensors architectural semantics, ONNX exporter semantic
+equivalence, ONNX metadata semantic correctness, live Hub availability, or DOI
+validity.
 
 Canonical HF provenance spec file:
 

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -7,6 +7,7 @@ Contents:
 - `design/`: implementation and artifact-line design notes
 - `design/engineering-timeline.md`: detailed internal phase chronology moved out of the public README
 - `hardening-policy.md`: local CI, hardening, and merge-gate policy
+- `paper2-roadmap.md`: engineering roadmap for the bounded proof-carrying decode paper
 - `reproducibility.md`: broader engineering reproducibility guidance, including non-paper artifact flows
 
 These files may use repository-internal terminology and phase labels because they document implementation sequencing rather than publication claims.

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -7,7 +7,7 @@ Contents:
 - `design/`: implementation and artifact-line design notes
 - `design/engineering-timeline.md`: detailed internal phase chronology moved out of the public README
 - `hardening-policy.md`: local CI, hardening, and merge-gate policy
-- `paper2-roadmap.md`: engineering roadmap for the bounded proof-carrying decode paper
+- `paper2-roadmap.md`: engineering roadmap for bounded paper-2 implementation hardening and provenance/reproducibility work
 - `reproducibility.md`: broader engineering reproducibility guidance, including non-paper artifact flows
 
 These files may use repository-internal terminology and phase labels because they document implementation sequencing rather than publication claims.

--- a/docs/engineering/paper2-roadmap.md
+++ b/docs/engineering/paper2-roadmap.md
@@ -1,0 +1,90 @@
+# Paper 2 Engineering Roadmap
+
+This note turns the second-paper draft boundary into concrete implementation
+work.
+
+The target paper claim is:
+
+- proof-carrying decode surfaces,
+- carried-state validity,
+- statement-preserving pre-recursive aggregation boundaries.
+
+The roadmap below is intentionally scoped to that claim. It does not assume that
+recursive compression is already available.
+
+## Current status
+
+The repository is already strong enough for the bounded paper-2 claim:
+
+- carried-state packaging layers are implemented through the current
+  pre-recursive aggregation boundary,
+- recursive-adjacent Phase 29 and Phase 30 boundary artifacts exist,
+- bounded multi-runtime semantic-agreement artifacts exist,
+- Hugging Face provenance manifests exist as reproducibility artifacts,
+- ONNX-facing provenance now binds exported graph, metadata companion, and
+  declared external-data side files,
+- parser/verifier hardening has materially improved the trust boundary around
+  those surfaces.
+
+## Remaining engineering priorities
+
+### 1. Keep hardening the exact paper-facing verifier boundaries
+
+Focus on:
+
+- carried-state package verification,
+- recursive-compression input contract verification,
+- step-envelope manifest verification,
+- `research-v3` artifact verification,
+- HF provenance manifest verification.
+
+This work remains highest leverage because the paper’s main claim is about
+public statement stability at those boundaries.
+
+### 2. Extend provenance binding toward attestation-friendly release metadata
+
+The next substantive gap is no longer basic ONNX sidecar binding. It is richer
+attestation-friendly provenance over the same release surface.
+
+Concrete targets:
+
+- bind exporter identity more explicitly,
+- bind graph-constraint identity where exporter metadata exposes it,
+- preserve external-file identity where ONNX layout requires it,
+- add richer release/build metadata without letting the claim drift into proof
+  semantics,
+- keep the claim phrased as provenance/reproducibility, not proof semantics.
+
+### 3. Keep semantic-agreement artifacts bounded
+
+Do not let the runtime-consistency line drift into a false general-equivalence
+claim.
+
+Concrete rule:
+
+- every public description must keep `research-v3` in the bounded
+  semantic-agreement bucket,
+- hardening should continue to focus on manifest, trace, event, and commitment
+  mismatch rejection.
+
+### 4. Only then move to recursive compression
+
+Recursive work should come after the public decode statement is stable enough
+that recursion preserves a claim the repository already exposes cleanly.
+
+That means the next recursive milestone should be phrased as:
+
+- recursion over the existing decode boundary,
+
+not:
+
+- a new statement surface invented by the recursive layer itself.
+
+## Practical next step
+
+The next concrete engineering slice should be:
+
+1. one more targeted verifier/tamper pass over the expanded HF provenance
+   manifest surface,
+2. then attestation-friendly release-metadata hardening over the same bounded
+   provenance claim.

--- a/docs/engineering/paper2-roadmap.md
+++ b/docs/engineering/paper2-roadmap.md
@@ -1,16 +1,18 @@
 # Paper 2 Engineering Roadmap
 
-This note turns the second-paper draft boundary into concrete implementation
-work.
+This note maps the current bounded paper-2 scope into concrete implementation
+sequencing and hardening work.
 
-The target paper claim is:
+## Roadmap scope
+
+Implementation goals this roadmap supports:
 
 - proof-carrying decode surfaces,
 - carried-state validity,
 - statement-preserving pre-recursive aggregation boundaries.
 
-The roadmap below is intentionally scoped to that claim. It does not assume that
-recursive compression is already available.
+The roadmap below is intentionally scoped to those verifier boundaries and does
+not assume that recursive compression is already available.
 
 ## Current status
 
@@ -39,7 +41,8 @@ Focus on:
 - HF provenance manifest verification.
 
 This work remains highest leverage because the paper’s main claim is about
-public statement stability at those boundaries.
+these verifier boundaries define the repository’s current reproducibility and
+statement-stability envelope.
 
 ### 2. Extend provenance binding toward attestation-friendly release metadata
 
@@ -79,6 +82,13 @@ That means the next recursive milestone should be phrased as:
 not:
 
 - a new statement surface invented by the recursive layer itself.
+
+## Claim boundary reminder
+
+The associated paper draft phrases the bounded publication claim as
+proof-carrying decode surfaces, carried-state validity, and
+statement-preserving pre-recursive aggregation boundaries. This engineering note
+exists to sequence the implementation work that keeps those boundaries honest.
 
 ## Practical next step
 

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -20,6 +20,15 @@ Supporting publication assets:
 - `submission-v4-2026-04-11/`
 - `artifacts/`
 
+Draft next-paper package:
+
+- `paper2/README.md`
+- `paper2/proof-carrying-decode-surfaces-2026.md`
+- `paper2/appendix-claim-boundary.md`
+- `paper2/appendix-ivc-positioning.md`
+- `paper2/appendix-engineering-gaps.md`
+- `paper2/appendix-artifact-map.md`
+
 For artifact-bundle scope, cited bundles, and archival provenance bundles, see:
 
 - `artifacts/README.md`

--- a/docs/paper/paper2/README.md
+++ b/docs/paper/paper2/README.md
@@ -1,0 +1,29 @@
+# Paper 2 Draft Package
+
+This directory contains the draft package for:
+
+`Proof-Carrying Decode Surfaces with Carried-State Validity and Pre-Recursive Aggregation Boundaries`
+
+Primary files:
+
+- `proof-carrying-decode-surfaces-2026.md`
+- `appendix-claim-boundary.md`
+- `appendix-ivc-positioning.md`
+- `appendix-engineering-gaps.md`
+- `appendix-artifact-map.md`
+
+Supporting inputs reused from the main paper package:
+
+- `../figures/section5-carried-state-ladder.svg`
+- `../artifacts/stwo-proof-carrying-aggregation-v1-2026-04-11/`
+- `../artifacts/stwo-experimental-v1-2026-04-06/`
+- `../../engineering/hardening-policy.md`
+- `../../engineering/hardening-strategy.md`
+
+Current scope:
+
+- crypto-audience draft centered on statement semantics and verifier boundaries
+- bounded claim only: proof-carrying decode surfaces, carried-state validity, and
+  pre-recursive aggregation boundaries
+- explicit non-claim: no recursive cryptographic accumulation, no general
+  implementation-equivalence proof, no supply-chain attestation theorem

--- a/docs/paper/paper2/appendix-artifact-map.md
+++ b/docs/paper/paper2/appendix-artifact-map.md
@@ -1,0 +1,37 @@
+# Appendix D. Artifact-To-Claim Map
+
+This appendix maps the main paper’s language to concrete repository artifact
+surfaces.
+
+## D1. Carried-state and packaging line
+
+| Repository surface | Publication-facing description | Claim status |
+| --- | --- | --- |
+| Phase 24 state-relation accumulator | carried-state relation accumulator over cumulative prefixes | inside proof-carrying decode surface |
+| Phase 25 intervalized state relation | honest interval bundle over rebased carried-state prefixes | inside proof-carrying decode surface |
+| Phase 26 folded intervalized state relation | bounded folded packaging over interval artifacts | inside proof-carrying decode surface; still pre-recursive |
+| Phase 27 chained folded intervalized state relation | chained fold-of-folds packaging over real intervals | inside proof-carrying decode surface; still pre-recursive |
+| Phase 28 aggregated chained folded intervalized state relation | proof-carrying pre-recursive aggregation boundary | inside proof-carrying decode surface; still pre-recursive |
+| Phase 29 recursive-compression input contract | recursive-adjacent input boundary derived from a verified Phase 28 aggregate | boundary artifact only; not recursive proof closure |
+| Phase 30 decoding step proof envelope manifest | ordered manifest binding step proofs, boundaries, and package commitments | statement-preserving manifest layer; not recursive proof closure |
+
+## D2. Adjacent evidence surfaces
+
+| Repository surface | Publication-facing description | Claim status |
+| --- | --- | --- |
+| `research-v3-equivalence` | bounded multi-runtime semantic-agreement artifact | operational evidence; not part of the proof relation |
+| HF provenance manifest | release-provenance manifest for model and artifact identity | reproducibility guardrail; not part of the proof relation |
+| `stwo-experimental-v1` frozen bundle | narrow experimental S-two evidence tier | evidence tier, not a broad production claim |
+| vanilla `production-v1` bundle | frozen reproducibility baseline | primary reproducibility tier |
+
+## D3. Why this map matters
+
+The paper becomes much clearer once each artifact family is assigned one of only
+three roles:
+
+- inside the proof-carrying decode relation,
+- adjacent operational evidence,
+- release/reproducibility provenance.
+
+That separation prevents accidental escalation from “artifact exists” to “the
+artifact proves more than it actually proves.”

--- a/docs/paper/paper2/appendix-claim-boundary.md
+++ b/docs/paper/paper2/appendix-claim-boundary.md
@@ -1,0 +1,34 @@
+# Appendix A. Claim Boundary
+
+This appendix makes the positive and negative claim surfaces explicit.
+
+## A1. Positive claim surface
+
+The paper claims only the following:
+
+| Surface | Honest claim |
+| --- | --- |
+| Step and chain artifacts | Verified step-bearing artifacts expose a fixed public statement surface and compose into ordered decode chains. |
+| Carried-state boundaries | Public carried-state tuples bind execution, KV, and lookup continuity across ordered members. |
+| Packaging layers | Chain, segment, interval, rollup, matrix, and pre-recursive aggregation layers preserve the same decode semantics when their validity conditions hold. |
+| Semantic-agreement artifacts | Bounded multi-runtime relation evidence reduces the risk of silently assuming frontend/runtime semantic identity. |
+| Provenance manifests | Release manifests bind local file identities and pinned release coordinates for reproducibility. |
+
+## A2. Negative claim surface
+
+The paper does not claim:
+
+| Surface | Explicit non-claim |
+| --- | --- |
+| Recursive proof systems | No recursive proof-carrying data, no verifier-closed recursion, no folding theorem. |
+| IVC/PCD semantics | No formal IVC or PCD construction in the sense of the recursive literature. |
+| Shared-table recursion | No recursive shared-table accumulation as a compressed proof object. |
+| General equivalence proving | No general SMT/e-graph/compiler equivalence theorem. |
+| Supply-chain theorems | No complete provenance-attestation theorem for exporter or build systems. |
+| Full `stwo` transformer proving | No claim of full standard-softmax transformer inference proving on the current `stwo` path. |
+
+## A3. Why this boundary is sufficient
+
+The paper is worthwhile because the repository already stabilizes the public
+statement that later recursive work would need to preserve. That is a meaningful
+intermediate result even though the recursive layer is not yet implemented.

--- a/docs/paper/paper2/appendix-engineering-gaps.md
+++ b/docs/paper/paper2/appendix-engineering-gaps.md
@@ -1,0 +1,62 @@
+# Appendix C. Remaining Engineering Gaps
+
+This appendix records what is still missing before the repository can honestly
+support a stronger follow-on claim than the current paper.
+
+## C1. Gaps that matter most
+
+### Recursive closure
+
+The repository still stops before recursive cryptographic accumulation. The
+current aggregation line preserves statements across ordered artifacts, but it
+does not produce a recursively verifiable compressed proof.
+
+### Shared-table recursive reuse
+
+The repository binds shared lookup-table identity inside public artifacts, but
+it does not yet expose recursive cross-step shared-table accumulation as a
+compressed proof object.
+
+### Exporter and provenance binding
+
+The Hugging Face provenance line is strong as a bounded reproducibility surface,
+but it is not yet a complete supply-chain attestation story. In particular,
+stronger binding of exporter-side ONNX provenance and attestation-compatible
+release metadata remains a live engineering gap. Today the repository binds the
+produced ONNX-facing graph, metadata, and external-file identities together with
+local file hashes, but it does not yet expose a broader attestation-compatible
+layer for exporter graph identity, shape/range constraints, or richer build
+provenance.
+
+### Runtime-consistency scope
+
+The `research-v3` line is good bounded evidence, but it is not a general proof
+of implementation equivalence across all compilers, frontends, or graph
+rewrites.
+
+### `stwo` scope
+
+The current `stwo` line is still deliberately narrow. It is enough for a paper
+about artifact boundaries, not for a claim of full production transformer
+proving.
+
+## C2. Recommended next engineering order
+
+1. keep hardening parser, verifier, and manifest boundaries that sit directly on
+   the paper-2 claim surface,
+2. extend the current ONNX graph/metadata/external-file provenance binding
+   toward exporter identity, graph-constraint identity, and
+   attestation-compatible release metadata,
+3. keep semantic-agreement artifacts bounded and explicit rather than pretending
+   they are full equivalence proofs,
+4. move to recursive compression only after the public decode statement is
+   stable enough that recursion preserves an already well-defined claim.
+
+## C3. Why this does not block the current paper
+
+These gaps block a stronger paper, not the current one. The current paper is
+about the strongest honest boundary already implemented:
+
+- proof-carrying decode surfaces,
+- carried-state validity,
+- statement-preserving pre-recursive packaging.

--- a/docs/paper/paper2/appendix-ivc-positioning.md
+++ b/docs/paper/paper2/appendix-ivc-positioning.md
@@ -1,0 +1,54 @@
+# Appendix B. Positioning Against IVC, Folding, and PCD
+
+This appendix is written for readers who want the recursive-systems distinction
+stated plainly.
+
+## B1. What the repository does
+
+The repository currently provides:
+
+- proof-bearing step and chain artifacts,
+- explicit carried-state boundary tuples,
+- verifier-recomputed package commitments,
+- ordered packaging layers over verified members,
+- a pre-recursive aggregation boundary,
+- a recursive-compression input contract that remains an input-boundary artifact,
+  not a recursive proof system.
+
+## B2. What recursive systems additionally provide
+
+Recursive proof-carrying data, IVC, and folding systems aim to provide one or
+more of the following:
+
+- a verifier whose output becomes the next proof input,
+- asymptotic or practical proof-size compression across many steps,
+- recursive soundness over composed instances,
+- formal accumulation or folding theorems over committed instances.
+
+Those properties are outside the present repository claim.
+
+## B3. Correct comparison language
+
+The right comparison language is:
+
+- “recursive-adjacent artifact boundary”
+- “pre-recursive aggregation”
+- “statement-preserving packaging over a fixed decode relation”
+- “future recursive consumer of the same public statement”
+
+The wrong comparison language is:
+
+- “already an IVC system”
+- “already recursive proof-carrying data”
+- “already a folding construction”
+- “already compressed recursive verification”
+
+## B4. Why this distinction matters
+
+For a crypto audience, overclaiming here would be fatal. The paper becomes
+stronger, not weaker, by separating:
+
+- what the artifact already proves,
+- what it only packages,
+- what later recursive systems could consume,
+- what remains unimplemented.

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -1,10 +1,10 @@
 # Proof-Carrying Decode Surfaces with Carried-State Validity and Pre-Recursive Aggregation Boundaries
 
-**Abdelhamid Bakhta**  
-StarkWare  
+**Abdelhamid Bakhta**<br>
+StarkWare
 
-**Omar Espejel**  
-Starknet Foundation  
+**Omar Espejel**<br>
+Starknet Foundation
 
 *April 2026 draft*
 

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -45,7 +45,7 @@ ______________________________________________________________________
 There is a persistent failure mode in zkML systems writing: artifacts are often
 described in language that sounds stronger than the actual verified statement.
 This is especially easy once a repository accumulates chains, bundles, rollups,
-aggregation objects, semantic-equivalence artifacts, and provenance manifests.
+aggregation objects, semantic-agreement artifacts, and provenance manifests.
 Without a precise statement boundary, those objects can be mistaken for
 recursive proof-carrying data, compressed recursive verification, or even
 general implementation-equivalence proofs.

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -1,0 +1,449 @@
+# Proof-Carrying Decode Surfaces with Carried-State Validity and Pre-Recursive Aggregation Boundaries
+
+**Abdelhamid Bakhta**  
+StarkWare  
+
+**Omar Espejel**  
+Starknet Foundation  
+
+*April 2026 draft*
+
+## Abstract
+
+This paper studies a narrower systems question than end-to-end zkML deployment:
+what cryptographically meaningful public statement can already be supported by a
+repository-backed proof artifact before recursive compression closure exists. We
+answer that question for `provable-transformer-vm` by isolating a
+proof-carrying decode relation over explicit carried-state boundaries and by
+formalizing the statement-preserving packaging layers that the repository
+already realizes.
+
+The artifact surface is bounded but nontrivial. Verified step artifacts compose
+into chains, segments, interval bundles, rollups, matrices, and a
+pre-recursive aggregation boundary while preserving the same start-state to
+end-state decode semantics. We formalize carried-state boundary tuples,
+packaging-layer validity, and a preservation proposition for these ordered
+artifacts. We also separate two adjacent but distinct engineering surfaces:
+bounded multi-runtime semantic-agreement artifacts and release-provenance
+manifests. Both matter operationally, but neither is part of the proof
+relation.
+
+The result is not recursive proof-carrying data, incrementally verifiable
+computation, or compressed recursive verification in the sense of HyperNova,
+NeutronNova, ProtoStar, or related folding systems. The contribution is a
+statement-stable bridge: a decode relation with explicit public boundary
+semantics that future recursive work could consume without redefining the
+underlying claim. Appendix A states the claim boundary directly, Appendix B
+positions the artifact against IVC and folding systems, Appendix C records the
+remaining engineering gaps, and Appendix D maps the paper’s language onto the
+concrete repository surfaces.
+
+______________________________________________________________________
+
+## 1. Introduction
+
+There is a persistent failure mode in zkML systems writing: artifacts are often
+described in language that sounds stronger than the actual verified statement.
+This is especially easy once a repository accumulates chains, bundles, rollups,
+aggregation objects, semantic-equivalence artifacts, and provenance manifests.
+Without a precise statement boundary, those objects can be mistaken for
+recursive proof-carrying data, compressed recursive verification, or even
+general implementation-equivalence proofs.
+
+This paper takes the opposite approach. It asks for the strongest honest claim
+that the current repository can defend to a cryptography audience. The answer
+is a bounded one:
+
+- there is a stable proof-carrying decode relation over explicit carried-state
+  boundaries,
+- the repository already realizes statement-preserving packaging layers over
+  that relation,
+- those layers stop at a pre-recursive aggregation boundary,
+- adjacent semantic-agreement and provenance artifacts strengthen engineering
+  trust but do not enlarge the proof statement.
+
+That claim is narrower than full recursive accumulation, but it is also more
+useful than a vague “artifact supports future recursion” sentence. It specifies
+what later recursive machinery would need to preserve, namely the same public
+decode boundary semantics already exposed by the current implementation.
+
+The paper makes four contributions.
+
+1. It isolates a repository-backed public statement surface for proof-carrying
+   decode artifacts.
+2. It formalizes carried-state boundary tuples and packaging-layer validity.
+3. It states a preservation proposition for ordered packaging layers over
+   verified step artifacts.
+4. It separates proof semantics from semantic-agreement and provenance
+   guardrails, making the negative claim surface explicit.
+
+For this paper, “proof-carrying” means only that each artifact carries enough
+public boundary data, nested commitments, and proof references for the
+repository verifier to replay continuity checks across the declared relation. It
+does not mean recursive proof-carrying data or compressed verifier recursion.
+
+______________________________________________________________________
+
+## 2. Public Statement Surface
+
+The starting point is not a benchmark row. It is a public statement boundary.
+
+The repository already exposes:
+
+- deterministic transformer-shaped execution with statement-versioned proof
+  claims,
+- reusable step and block proof artifacts,
+- carried-state decode chains with explicit continuity fields,
+- higher-order packaging objects that preserve member ordering and public
+  boundaries,
+- bounded multi-runtime semantic-agreement artifacts,
+- release-provenance manifests for model and artifact identity.
+
+The cryptographically relevant question is which of those surfaces belong to the
+same proof statement.
+
+Our answer is:
+
+- the decode relation and its packaging layers are inside the proof-facing
+  statement surface,
+- semantic-agreement artifacts are adjacent evidence about runtime consistency,
+- provenance manifests are release guardrails,
+- neither semantic-agreement nor provenance artifacts enlarge the proof
+  relation.
+
+This yields a clean separation between proof semantics and operational
+trust-hardening.
+
+### 2.1 Step statement
+
+Let `statement-v1` denote the repository’s public execution-claim surface for a
+single proof-bearing step or fixed execution unit. A valid step artifact binds:
+
+- the public execution boundary,
+- the applicable backend and statement profile,
+- the carried commitments required by the decode layer,
+- the nested proof or proof reference checked by the verifier.
+
+The decode line then lifts those per-step statements into an ordered relation
+over carried-state boundaries.
+
+### 2.2 Stable statement structure
+
+The main systems fact is stable statement structure: richer artifact layers do
+not change the underlying public decode semantics. They only package,
+re-index, and commitment-bind already verified members.
+
+That is the right center of gravity for a crypto audience. The interesting point
+is not that the repository has many JSON artifacts. It is that the same public
+boundary semantics survive across those artifacts without being redefined at
+each layer.
+
+______________________________________________________________________
+
+## 3. Carried-State Decode Relation
+
+We now isolate the proof-facing object.
+
+**Definition 1 (Carried-state boundary).** At decode step `t`, the public
+boundary is the tuple
+
+```text
+Σ_t = (ℓ_t, p_t, h_t^KV, f_t^KV, h_t^L, f_t^L, c_t^in, c_t^out)
+```
+
+where:
+
+- `ℓ_t` is the layout or template identifier,
+- `p_t` is the public step-position metadata,
+- `h_t^KV` and `f_t^KV` are the cumulative and frontier KV commitments,
+- `h_t^L` and `f_t^L` are the cumulative and frontier lookup commitments,
+- `c_t^in` and `c_t^out` are the execution-boundary commitments.
+
+**Definition 2 (Proof-carrying decode relation).** Let
+
+```text
+R_decode(Σ_t, w_t, Σ_{t+1})
+```
+
+denote the repository’s parameterized decode relation, where `w_t` is the
+step-level witness and proof-bearing artifact material checked by the verifier.
+
+The relation is parameterized because the repository admits multiple templates
+and packaging layouts, but the public boundary vocabulary remains fixed. This is
+exactly the structure later recursive work would need: one relation whose
+statement semantics do not drift as artifact packaging grows richer.
+
+### 3.1 Continuity conditions
+
+The decode relation is carried by explicit continuity conditions, not by prose.
+At minimum, adjacent members must agree on:
+
+- output-to-input execution continuity,
+- KV frontier continuity,
+- lookup frontier continuity,
+- declared member order and layout compatibility.
+
+This is why the repository’s chain, segment, interval, rollup, matrix, and
+pre-recursive aggregation objects are interesting. They are not arbitrary
+bundles; they are ordered packaging layers over the same continuity-checked
+relation.
+
+### 3.2 Why this is not yet recursive PCD or IVC
+
+Nothing in the current artifact line compresses verification into a new proof
+whose verifier asymptotically replaces the nested proofs. The packaging objects
+carry commitments, ordering data, and continuity metadata, but they do not
+realize a recursive verifier or folding theorem. The current contribution is
+therefore semantic stabilization, not recursive compression.
+
+______________________________________________________________________
+
+## 4. Packaging-Layer Validity
+
+The packaging layers matter only if their validity condition is explicit.
+
+**Definition 3 (Packaging-layer validity).** A chain, segment, interval bundle,
+rollup, matrix, or pre-recursive aggregation object is valid if:
+
+1. its member order is declared,
+2. each nested member verifies under the stated backend and statement profile,
+3. each adjacent pair satisfies the continuity constraints required by
+   `R_decode`,
+4. the package-level commitments recompute from the declared ordered members,
+5. the package start and end boundaries agree with the first and last member
+   boundaries.
+
+This definition matches the actual repository discipline more closely than a
+generic “aggregate of proofs” phrase. The important fact is not just that there
+are nested proofs; it is that the package verifier recomputes the public
+structure from those ordered members and rejects drift.
+
+### 4.1 Preservation proposition
+
+**Proposition 1.** Suppose each member of an ordered step chain verifies under
+the same public statement surface and every adjacent member satisfies the decode
+continuity checks. Then any valid chain, segment, interval bundle, rollup,
+matrix, or pre-recursive aggregation package over those ordered members
+preserves the same start-state to end-state decode relation as the underlying
+verified member sequence.
+
+**Proof sketch.** The base case is the verified member sequence itself. Each
+packaging layer records no stronger semantics than:
+
+- the ordered member list,
+- the first and last carried-state boundaries,
+- recomputable package commitments derived from members,
+- verifier checks that replay nested verification and continuity constraints.
+
+Since each packaging layer rejects order drift, continuity drift, boundary-pair
+drift, and package-commitment drift, induction over the ordered members yields
+the same start-to-end relation as the underlying verified sequence. The result
+is statement preservation, not recursive proof compression.
+
+### 4.2 Architectural view
+
+The repository’s carried-state ladder is therefore best read as an artifact
+graph over one relation.
+
+![Carried-state packaging ladder](../figures/section5-carried-state-ladder.svg)
+
+The figure remains useful for this paper, but the caption emphasis changes for a
+crypto audience: it is a map of statement-preserving packaging objects, not a
+claim about recursive accumulation.
+
+______________________________________________________________________
+
+## 5. Artifact Realization in the Repository
+
+The current repository realizes this picture in two connected but distinct
+surfaces.
+
+### 5.1 Proof-carrying decode and carried-state packaging
+
+The strongest paper-2 surface is the phase line that now reaches:
+
+- step and chain artifacts,
+- state-relation accumulation,
+- honest intervalization,
+- folded interval accumulation,
+- chained fold-of-folds packaging,
+- proof-carrying outer aggregation,
+- a recursive-compression input contract,
+- a step-proof envelope manifest.
+
+In publication-facing prose, those layers are best described as chain, segment,
+interval bundle, rollup, matrix, and pre-recursive aggregation boundary. The
+repository still retains phase-numbered artifact names for checksum stability,
+but the semantics are those packaging layers over a fixed decode relation.
+Appendix D gives the exact artifact-to-claim mapping.
+
+### 5.2 Semantic-agreement artifacts
+
+The repository also contains a bounded multi-runtime semantic-agreement line.
+It lockstep-executes a fixed program across transformer, native, Burn, and ONNX
+surfaces, records canonical events and traces, and binds them through runtime-
+specific hashes plus a canonical relation hash.
+
+This matters because proof artifacts should not lean on an informal assumption
+that different runtime frontends are “obviously the same.” The artifact provides
+deterministic bounded evidence against that risk. But it is still not a general
+equivalence theorem over compilers, exporter graphs, or arbitrary model graphs.
+
+### 5.3 Release-provenance manifests
+
+The Hugging Face provenance line binds model, tokenizer, ONNX, transcript, and
+safetensors identities to explicit local-file hashes and pinned release
+coordinates. In the ONNX-facing path, that boundary now includes the exported
+graph, its metadata companion, and declared external-data side files. This is
+operationally valuable, especially for frozen artifact bundles. It should not
+be confused with a proof relation. It is a release boundary, not a theorem that
+exporter or supply-chain semantics are preserved.
+
+______________________________________________________________________
+
+## 6. Negative Results and Non-Claims
+
+This section is the most important one to keep honest.
+
+The repository does not yet support the following stronger claims:
+
+1. recursive cryptographic accumulation or verifier-closed recursive
+   compression,
+2. incrementally verifiable computation in the formal sense of systems such as
+   HyperNova, NeutronNova, ProtoStar, SnarkFold, or related folding lines,
+3. general implementation-equivalence proofs over runtime/compiler frontends,
+4. full standard-softmax transformer proving on the `stwo` path,
+5. supply-chain attestation theorems comparable to a complete in-toto or SLSA
+   provenance story.
+
+These are not cosmetic disclaimers. They define the boundary that protects the
+paper from overclaiming.
+
+### 6.1 Why the pre-recursive claim is still worthwhile
+
+A crypto audience may reasonably ask whether stopping before recursion is too
+weak to merit a paper. The answer is no, provided the statement is precise.
+
+Recursive systems need a stable public statement to recurse over. The current
+artifact contributes exactly that:
+
+- one decode relation,
+- explicit carried-state boundaries,
+- verifier-recomputed packaging commitments,
+- stable semantics across richer artifact layers.
+
+That is a meaningful intermediate result because it constrains what later
+recursive work must preserve instead of leaving the statement surface implicit.
+
+______________________________________________________________________
+
+## 7. Threat Model and Verifier Discipline
+
+The engineering contribution is most defensible when phrased as verifier
+discipline over trusted-core boundaries.
+
+The repository’s hardening strategy already treats the following as primary
+threat classes:
+
+- verifier acceptance of malformed or semantically drifted artifacts,
+- parser or decoder unsoundness on adversarial structured input,
+- runtime-semantics drift across transformer/native/Burn/ONNX lanes,
+- statement drift between implementation and public artifact semantics,
+- overclaiming induced by review tooling rather than evidence.
+
+For paper 2, the relevant point is that the hardening line is aligned with the
+paper’s statement surface. The step-envelope manifests, recursive-compression
+input contracts, semantic-agreement artifacts, and provenance manifests are all
+being tested at the exact boundaries the paper names.
+
+That alignment matters. A crypto paper should not point to “engineering
+hardening” in the abstract. It should point to the same artifact boundaries that
+carry the public claim.
+
+______________________________________________________________________
+
+## 8. Positioning Relative to Folding and PCD
+
+This artifact line sits adjacent to, but outside, the current recursive
+literature.
+
+Relative to folding and IVC systems, the repository contributes:
+
+- statement stabilization over a concrete decode relation,
+- explicit carried-state boundary semantics,
+- packaging-layer validity conditions,
+- proof-carrying pre-recursive aggregation objects,
+- bounded runtime-consistency and release-provenance guardrails.
+
+It does not contribute:
+
+- a folding scheme,
+- a recursive verifier,
+- a compressed accumulator theorem,
+- a knowledge-soundness theorem for recursive composition.
+
+That distinction is not a weakness in exposition; it is the core honesty
+condition of the draft.
+
+______________________________________________________________________
+
+## 9. Engineering Status and Next Milestones
+
+The repository is now strong enough for this bounded paper, but not for a
+stronger one.
+
+### 9.1 Good enough now
+
+For the bounded claim of this paper, the repository is in publishable shape
+provided the prose stays disciplined:
+
+- proof-carrying decode surfaces are real,
+- carried-state packaging validity is real,
+- the pre-recursive aggregation boundary is real,
+- semantic-agreement artifacts are real as bounded evidence,
+- provenance manifests are real as release guardrails.
+
+### 9.2 Still missing
+
+For a stronger follow-on paper, the missing milestones are clear:
+
+- recursive cryptographic compression over the same decode statement,
+- recursive shared-table accumulation as a compressed proof object,
+- stronger exporter/provenance binding for ONNX-facing release artifacts,
+- broader supply-chain attestations,
+- broader `stwo` transformer coverage beyond the current narrow experimental
+  boundary.
+
+These gaps do not invalidate the current paper. They define the next engineering
+program.
+
+______________________________________________________________________
+
+## 10. Conclusion
+
+The correct current claim is not “the repository already has recursive zkML
+inference.” The correct claim is more disciplined and, for that reason, more
+useful:
+
+the repository already exposes a stable proof-carrying decode relation with
+explicit carried-state boundaries and statement-preserving pre-recursive
+packaging layers.
+
+That is enough for a real crypto-systems paper because it gives later recursive
+work a fixed public statement to preserve. The artifact is therefore not the end
+state. It is the first honest recursive-adjacent boundary that does not need to
+pretend recursion already exists.
+
+______________________________________________________________________
+
+## Selected References
+
+- HyperNova: [https://eprint.iacr.org/2023/573](https://eprint.iacr.org/2023/573)
+- ProtoStar: [https://eprint.iacr.org/2023/620](https://eprint.iacr.org/2023/620)
+- NeutronNova: [https://eprint.iacr.org/2024/1606](https://eprint.iacr.org/2024/1606)
+- SnarkFold: [https://eprint.iacr.org/2023/1946](https://eprint.iacr.org/2023/1946)
+- SLSA provenance overview: [https://slsa.dev/provenance](https://slsa.dev/provenance)
+- SLSA build provenance: [https://slsa.dev/spec/v1.2-rc2/build-provenance](https://slsa.dev/spec/v1.2-rc2/build-provenance)
+- in-toto attestation framework: [https://github.com/in-toto/attestation](https://github.com/in-toto/attestation)
+- ONNX external-data documentation: [https://onnx.ai/onnx/repo-docs/ExternalData.html](https://onnx.ai/onnx/repo-docs/ExternalData.html)
+- PyTorch export IR specification: [https://docs.pytorch.org/docs/main/user_guide/torch_compiler/export/ir_spec.html](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/export/ir_spec.html)

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -188,6 +188,26 @@ run_logged() {
   fi
 }
 
+resolve_tvm_test_binary_path() {
+  local manifest_dir target_dir profile binary_name target_triple
+  manifest_dir="$ROOT_DIR"
+  target_dir="${CARGO_TARGET_DIR:-$manifest_dir/target}"
+  if [[ "$target_dir" != /* ]]; then
+    target_dir="$manifest_dir/$target_dir"
+  fi
+  profile="${PROFILE:-debug}"
+  binary_name="tvm"
+  if [[ "${OS:-}" == "Windows_NT" ]]; then
+    binary_name="${binary_name}.exe"
+  fi
+  target_triple="${CARGO_BUILD_TARGET:-${TARGET:-}}"
+  if [[ -n "$target_triple" ]]; then
+    printf '%s\n' "$target_dir/$target_triple/$profile/$binary_name"
+  else
+    printf '%s\n' "$target_dir/$profile/$binary_name"
+  fi
+}
+
 while (($#)); do
   case "$1" in
     --repo)
@@ -601,7 +621,9 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged cargo-fmt-check cargo fmt --check
   run_conditional_quick_audits
   run_logged cargo-lib-tests cargo test -q --lib
-  run_logged cargo-lib-and-integration-tests cargo test -q --lib --tests
+  run_logged cargo-build-tvm cargo build -q --bin tvm
+  tvm_test_binary="$(resolve_tvm_test_binary_path)"
+  run_logged cargo-lib-and-integration-tests env TVM_TEST_BINARY="$tvm_test_binary" cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
@@ -619,7 +641,9 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged cargo-fmt-check cargo fmt --check
   run_conditional_quick_audits
   run_logged cargo-lib-tests cargo test -q --lib
-  run_logged cargo-lib-and-integration-tests cargo test -q --lib --tests
+  run_logged cargo-build-tvm cargo build -q --bin tvm
+  tvm_test_binary="$(resolve_tvm_test_binary_path)"
+  run_logged cargo-lib-and-integration-tests env TVM_TEST_BINARY="$tvm_test_binary" cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -527,8 +527,13 @@ run_tvm_bin_smoke_targets() {
 
 run_stwo_cli_smoke_targets() {
   local stwo_cli_smoke
+  local tvm_test_binary
+  run_logged stwo-backend-cli-build cargo +nightly-2025-07-14 build -q \
+    --features stwo-backend \
+    --bin tvm
+  tvm_test_binary="$(resolve_tvm_test_binary_path)"
   for stwo_cli_smoke in "${stwo_cli_smoke_targets[@]}"; do
-    run_logged "stwo-backend-cli-smoke-${stwo_cli_smoke}" cargo +nightly-2025-07-14 test -q \
+    run_logged "stwo-backend-cli-smoke-${stwo_cli_smoke}" env TVM_TEST_BINARY="$tvm_test_binary" cargo +nightly-2025-07-14 test -q \
       --features stwo-backend \
       --test cli "$stwo_cli_smoke" \
       -- \
@@ -550,7 +555,12 @@ run_research_v3_smoke_targets() {
 }
 
 run_research_v3_cli_smoke_target() {
-  run_logged research-v3-equivalence-cli cargo test -q \
+  local tvm_test_binary
+  run_logged research-v3-equivalence-cli-build cargo build -q \
+    --features full \
+    --bin tvm
+  tvm_test_binary="$(resolve_tvm_test_binary_path)"
+  run_logged research-v3-equivalence-cli env TVM_TEST_BINARY="$tvm_test_binary" cargo test -q \
     --features full \
     --test cli cli_supports_research_v3_equivalence_command \
     -- \

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -189,23 +189,24 @@ run_logged() {
 }
 
 resolve_tvm_test_binary_path() {
-  local manifest_dir target_dir profile binary_name target_triple
+  local manifest_dir target_dir binary_name target_triple resolved_path
   manifest_dir="$ROOT_DIR"
   target_dir="${CARGO_TARGET_DIR:-$manifest_dir/target}"
   if [[ "$target_dir" != /* ]]; then
     target_dir="$manifest_dir/$target_dir"
   fi
-  profile="${PROFILE:-debug}"
   binary_name="tvm"
   if [[ "${OS:-}" == "Windows_NT" ]]; then
     binary_name="${binary_name}.exe"
   fi
-  target_triple="${CARGO_BUILD_TARGET:-${TARGET:-}}"
+  target_triple="${CARGO_BUILD_TARGET:-}"
   if [[ -n "$target_triple" ]]; then
-    printf '%s\n' "$target_dir/$target_triple/$profile/$binary_name"
+    resolved_path="$target_dir/$target_triple/debug/$binary_name"
   else
-    printf '%s\n' "$target_dir/$profile/$binary_name"
+    resolved_path="$target_dir/debug/$binary_name"
   fi
+  [[ -f "$resolved_path" ]] || fail "expected built tvm binary at $resolved_path after cargo build (CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-}, CARGO_BUILD_TARGET=${CARGO_BUILD_TARGET:-})"
+  printf '%s\n' "$resolved_path"
 }
 
 while (($#)); do

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -631,10 +631,10 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
   run_logged cargo-fmt-check cargo fmt --check
   run_conditional_quick_audits
-  run_logged cargo-lib-tests cargo test -q --lib
+  run_logged cargo-lib-tests env RUST_TEST_THREADS=1 cargo test -q --lib
   run_logged cargo-build-tvm cargo build -q --bin tvm
   tvm_test_binary="$(resolve_tvm_test_binary_path)"
-  run_logged cargo-lib-and-integration-tests env TVM_TEST_BINARY="$tvm_test_binary" cargo test -q --lib --tests
+  run_logged cargo-lib-and-integration-tests env RUST_TEST_THREADS=1 TVM_TEST_BINARY="$tvm_test_binary" cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets
@@ -651,10 +651,10 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
   run_logged cargo-fmt-check cargo fmt --check
   run_conditional_quick_audits
-  run_logged cargo-lib-tests cargo test -q --lib
+  run_logged cargo-lib-tests env RUST_TEST_THREADS=1 cargo test -q --lib
   run_logged cargo-build-tvm cargo build -q --bin tvm
   tvm_test_binary="$(resolve_tvm_test_binary_path)"
-  run_logged cargo-lib-and-integration-tests env TVM_TEST_BINARY="$tvm_test_binary" cargo test -q --lib --tests
+  run_logged cargo-lib-and-integration-tests env RUST_TEST_THREADS=1 TVM_TEST_BINARY="$tvm_test_binary" cargo test -q --lib --tests
   run_logged cargo-doc-tests cargo test -q --workspace --doc
   if changed_path_is_onnx_surface; then
     run_onnx_smoke_targets

--- a/spec/hf-provenance-manifest.schema.json
+++ b/spec/hf-provenance-manifest.schema.json
@@ -109,7 +109,7 @@
     },
     "onnx_export": {
       "type": "object",
-      "required": ["exporter", "exporter_version", "graph"],
+      "required": ["exporter", "exporter_version", "graph", "metadata", "external_data_files"],
       "properties": {
         "exporter": { "type": "string", "minLength": 1 },
         "exporter_version": {
@@ -118,7 +118,17 @@
             { "type": "null" }
           ]
         },
-        "graph": { "$ref": "#/$defs/file_commitment" }
+        "graph": { "$ref": "#/$defs/file_commitment" },
+        "metadata": {
+          "anyOf": [
+            { "$ref": "#/$defs/file_commitment" },
+            { "type": "null" }
+          ]
+        },
+        "external_data_files": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/file_commitment" }
+        }
       },
       "additionalProperties": false
     },

--- a/spec/hf-provenance-manifest.schema.json
+++ b/spec/hf-provenance-manifest.schema.json
@@ -17,7 +17,7 @@
     "commitments"
   ],
   "properties": {
-    "manifest_version": { "const": "hf-provenance-manifest-v1" },
+    "manifest_version": { "const": "hf-provenance-manifest-v2" },
     "semantic_scope": { "const": "hf-release-provenance-boundary-v1" },
     "hash_function": { "const": "blake2b-256" },
     "hub_repo": { "type": "string", "minLength": 1 },

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4806,12 +4806,71 @@ fn verify_hf_file_commitment(
     )
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum HfFileIdentity {
+    #[cfg(unix)]
+    Unix { dev: u64, ino: u64 },
+    #[cfg(windows)]
+    Windows {
+        volume_serial_number: u32,
+        file_index: u64,
+    },
+    #[cfg(not(any(unix, windows)))]
+    CanonicalPath(PathBuf),
+}
+
+fn hf_file_identity(path: &Path, label: &str) -> llm_provable_computer::Result<HfFileIdentity> {
+    let (file, _) = open_checked_regular_file(path, label, None)?;
+    let metadata = file.metadata().map_err(|err| {
+        VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        return Ok(HfFileIdentity::Unix {
+            dev: metadata.dev(),
+            ino: metadata.ino(),
+        });
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+
+        let (volume_serial_number, file_index) = require_windows_regular_file_identity(
+            path,
+            label,
+            metadata.volume_serial_number(),
+            metadata.file_index(),
+            "after open",
+        )?;
+        return Ok(HfFileIdentity::Windows {
+            volume_serial_number,
+            file_index,
+        });
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let canonical = fs::canonicalize(path).map_err(|err| {
+            VmError::InvalidConfig(format!(
+                "failed to canonicalize {label} {}: {err}",
+                path.display()
+            ))
+        })?;
+        Ok(HfFileIdentity::CanonicalPath(canonical))
+    }
+}
+
 fn ensure_unique_hf_file_commitment_path(
     label: &str,
     commitment: &HfFileCommitment,
-    seen_paths: &mut std::collections::BTreeSet<String>,
+    seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
 ) -> llm_provable_computer::Result<()> {
-    if !seen_paths.insert(commitment.path.clone()) {
+    let identity = hf_file_identity(Path::new(&commitment.path), "HF provenance ONNX artifact")?;
+    if !seen_paths.insert(identity) {
         return Err(VmError::InvalidConfig(format!(
             "{label} reuses ONNX artifact path `{}`",
             commitment.path

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -688,6 +688,12 @@ enum Command {
         /// Optional local ONNX graph exported from the HF/Optimum path.
         #[arg(long)]
         onnx_model: Option<PathBuf>,
+        /// Optional local ONNX metadata companion file to hash into the manifest.
+        #[arg(long)]
+        onnx_metadata: Option<PathBuf>,
+        /// Optional ONNX external-data side files to hash into the manifest.
+        #[arg(long = "onnx-external-data")]
+        onnx_external_data_files: Vec<PathBuf>,
         /// Name of the ONNX exporter used when `--onnx-model` is supplied.
         #[arg(long, default_value = "optimum-onnx")]
         onnx_exporter: String,
@@ -899,6 +905,8 @@ struct HfProvenanceManifestCommand {
     tokenization_transcript: Option<PathBuf>,
     safetensors_files: Vec<PathBuf>,
     onnx_model: Option<PathBuf>,
+    onnx_metadata: Option<PathBuf>,
+    onnx_external_data_files: Vec<PathBuf>,
     onnx_exporter: String,
     onnx_exporter_version: Option<String>,
     model_card: Option<PathBuf>,
@@ -907,7 +915,7 @@ struct HfProvenanceManifestCommand {
     notes: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct HfFileCommitment {
     path: String,
@@ -915,7 +923,7 @@ struct HfFileCommitment {
     blake2b_256: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct HfSafetensorsFileCommitment {
     path: String,
@@ -925,7 +933,7 @@ struct HfSafetensorsFileCommitment {
     tensor_count: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct HfTokenizerProvenance {
     tokenizer_id: String,
@@ -935,15 +943,17 @@ struct HfTokenizerProvenance {
     tokenization_transcript: Option<HfFileCommitment>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct HfOnnxExportProvenance {
     exporter: String,
     exporter_version: Option<String>,
     graph: HfFileCommitment,
+    metadata: Option<HfFileCommitment>,
+    external_data_files: Vec<HfFileCommitment>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct HfReleaseMetadata {
     model_card: Option<HfFileCommitment>,
@@ -1567,6 +1577,8 @@ fn run() -> llm_provable_computer::Result<()> {
             tokenization_transcript,
             safetensors_files,
             onnx_model,
+            onnx_metadata,
+            onnx_external_data_files,
             onnx_exporter,
             onnx_exporter_version,
             model_card,
@@ -1584,6 +1596,8 @@ fn run() -> llm_provable_computer::Result<()> {
             tokenization_transcript,
             safetensors_files,
             onnx_model,
+            onnx_metadata,
+            onnx_external_data_files,
             onnx_exporter,
             onnx_exporter_version,
             model_card,
@@ -4209,14 +4223,29 @@ fn prepare_hf_provenance_manifest_command(
         .iter()
         .map(|path| hf_safetensors_file_commitment(path))
         .collect::<llm_provable_computer::Result<Vec<_>>>()?;
+    if command.onnx_model.is_none()
+        && (command.onnx_metadata.is_some() || !command.onnx_external_data_files.is_empty())
+    {
+        return Err(VmError::InvalidConfig(
+            "HF provenance ONNX metadata or external-data files require --onnx-model".to_string(),
+        ));
+    }
     let onnx_export = command
         .onnx_model
         .as_deref()
         .map(|path| {
+            let mut external_data_files = command
+                .onnx_external_data_files
+                .iter()
+                .map(|path| hf_file_commitment(path))
+                .collect::<llm_provable_computer::Result<Vec<_>>>()?;
+            external_data_files.sort_by(|a, b| a.path.cmp(&b.path));
             Ok::<HfOnnxExportProvenance, VmError>(HfOnnxExportProvenance {
                 exporter: command.onnx_exporter.clone(),
                 exporter_version: command.onnx_exporter_version.clone(),
                 graph: hf_file_commitment(path)?,
+                metadata: hf_optional_file_commitment(command.onnx_metadata.as_deref())?,
+                external_data_files,
             })
         })
         .transpose()?;
@@ -4575,6 +4604,14 @@ fn verify_hf_provenance_manifest(
             ));
         }
         verify_hf_file_commitment("onnx_export.graph", &onnx_export.graph)?;
+        verify_hf_optional_file_commitment("onnx_export.metadata", &onnx_export.metadata)?;
+        ensure_unique_hf_file_commitment_paths(
+            "HF provenance onnx_export.external_data_files",
+            &onnx_export.external_data_files,
+        )?;
+        for commitment in &onnx_export.external_data_files {
+            verify_hf_file_commitment("onnx_export.external_data_files[]", commitment)?;
+        }
     }
     verify_hf_optional_file_commitment("model_card", &manifest.release.model_card)?;
     validate_hf_optional_identifier("release.doi", manifest.release.doi.as_deref())?;
@@ -4598,6 +4635,7 @@ fn hf_provenance_limitations() -> Vec<String> {
         "the manifest does not prove tokenizer algorithm correctness",
         "the manifest does not prove safetensors weights implement a model architecture",
         "the manifest does not prove Optimum or ONNX exporter semantic equivalence",
+        "the manifest does not prove ONNX metadata or external-data semantic correctness",
         "the manifest does not perform live Hugging Face Hub downloads or DOI verification",
     ]
     .into_iter()
@@ -4694,6 +4732,22 @@ fn verify_hf_file_commitment(
         &commitment.blake2b_256,
         &blake2b_256,
     )
+}
+
+fn ensure_unique_hf_file_commitment_paths(
+    label: &str,
+    commitments: &[HfFileCommitment],
+) -> llm_provable_computer::Result<()> {
+    let mut paths = std::collections::BTreeSet::new();
+    for commitment in commitments {
+        if !paths.insert(commitment.path.clone()) {
+            return Err(VmError::InvalidConfig(format!(
+                "{label} contains duplicate path `{}`",
+                commitment.path
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn verify_hf_safetensors_file_commitment(
@@ -6992,6 +7046,8 @@ mod hf_provenance_manifest_tests {
                 "size_bytes": 16,
                 "blake2b_256": "5".repeat(64)
             },
+            "metadata": null,
+            "external_data_files": [],
             "unexpected_field": 7
         });
         write_hf_provenance_test_manifest(file.path(), &value);
@@ -7055,6 +7111,8 @@ mod hf_provenance_manifest_tests {
             tokenization_transcript: None,
             safetensors_files: Vec::new(),
             onnx_model: None,
+            onnx_metadata: None,
+            onnx_external_data_files: Vec::new(),
             onnx_exporter: "optimum-onnx".to_string(),
             onnx_exporter_version: None,
             model_card: Some(model_card),
@@ -7171,6 +7229,110 @@ mod hf_provenance_manifest_tests {
         let err = verify_hf_provenance_manifest(&manifest)
             .expect_err("non-regular bound file should fail verification");
         assert!(err.to_string().contains("not a regular file"));
+    }
+
+    #[test]
+    fn prepare_hf_provenance_manifest_rejects_onnx_sidecars_without_graph() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let output = dir.path().join("manifest.json");
+        let metadata = dir.path().join("metadata.json");
+        fs::write(&metadata, b"{}").expect("write metadata");
+
+        let err = prepare_hf_provenance_manifest_command(HfProvenanceManifestCommand {
+            output,
+            hub_repo: "example/test-model".to_string(),
+            hub_revision: "0123456789abcdef".to_string(),
+            tokenizer_id: "example/test-model".to_string(),
+            tokenizer_revision: None,
+            tokenizer_json: None,
+            tokenizer_config: None,
+            tokenization_transcript: None,
+            safetensors_files: Vec::new(),
+            onnx_model: None,
+            onnx_metadata: Some(metadata),
+            onnx_external_data_files: Vec::new(),
+            onnx_exporter: "optimum-onnx".to_string(),
+            onnx_exporter_version: None,
+            model_card: None,
+            doi: None,
+            datasets: Vec::new(),
+            notes: vec!["release note".to_string()],
+        })
+        .expect_err("ONNX sidecars without graph should fail");
+
+        assert!(err
+            .to_string()
+            .contains("ONNX metadata or external-data files require --onnx-model"));
+    }
+
+    #[test]
+    fn verify_hf_provenance_manifest_rejects_duplicate_onnx_external_data_paths() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let graph = dir.path().join("model.onnx");
+        let sidecar = dir.path().join("weights.bin");
+        fs::write(&graph, b"onnx").expect("write graph");
+        fs::write(&sidecar, b"weights").expect("write sidecar");
+
+        let tokenizer = HfTokenizerProvenance {
+            tokenizer_id: "example/test-model".to_string(),
+            tokenizer_revision: "0123456789abcdef".to_string(),
+            tokenizer_json: None,
+            tokenizer_config: None,
+            tokenization_transcript: None,
+        };
+        let safetensors = Vec::new();
+        let onnx_export = Some(HfOnnxExportProvenance {
+            exporter: "optimum-onnx".to_string(),
+            exporter_version: None,
+            graph: hf_file_commitment(&graph).expect("graph commitment"),
+            metadata: None,
+            external_data_files: vec![
+                hf_file_commitment(&sidecar).expect("sidecar commitment"),
+                hf_file_commitment(&sidecar).expect("sidecar commitment"),
+            ],
+        });
+        let release = HfReleaseMetadata {
+            model_card: None,
+            doi: None,
+            datasets: Vec::new(),
+            notes: vec!["release note".to_string()],
+        };
+        let limitations = hf_provenance_limitations();
+        let manifest = HfProvenanceManifest {
+            manifest_version: HF_PROVENANCE_MANIFEST_VERSION.to_string(),
+            semantic_scope: HF_PROVENANCE_SEMANTIC_SCOPE.to_string(),
+            hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
+            hub_repo: "example/test-model".to_string(),
+            hub_revision: "0123456789abcdef".to_string(),
+            tokenizer,
+            safetensors,
+            onnx_export: onnx_export.clone(),
+            release: release.clone(),
+            limitations: limitations.clone(),
+            commitments: HfProvenanceCommitments {
+                tokenizer_hash: hash_json_projection_hex(&HfTokenizerProvenance {
+                    tokenizer_id: "example/test-model".to_string(),
+                    tokenizer_revision: "0123456789abcdef".to_string(),
+                    tokenizer_json: None,
+                    tokenizer_config: None,
+                    tokenization_transcript: None,
+                })
+                .expect("tokenizer hash"),
+                safetensors_manifest_hash: hash_json_projection_hex(&Vec::<
+                    HfSafetensorsFileCommitment,
+                >::new())
+                .expect("safetensors hash"),
+                onnx_export_hash: hash_json_projection_hex(&onnx_export).expect("onnx hash"),
+                release_metadata_hash: hash_json_projection_hex(&release).expect("release hash"),
+                limitations_hash: hash_json_projection_hex(&limitations).expect("limitations hash"),
+            },
+        };
+
+        let err = verify_hf_provenance_manifest(&manifest)
+            .expect_err("duplicate ONNX sidecar paths should fail");
+        assert!(err
+            .to_string()
+            .contains("onnx_export.external_data_files contains duplicate path"));
     }
 }
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4225,10 +4225,12 @@ fn prepare_hf_provenance_manifest_command(
         .map(|path| hf_safetensors_file_commitment(path))
         .collect::<llm_provable_computer::Result<Vec<_>>>()?;
     if command.onnx_model.is_none()
-        && (command.onnx_metadata.is_some() || !command.onnx_external_data_files.is_empty())
+        && (command.onnx_metadata.is_some()
+            || !command.onnx_external_data_files.is_empty()
+            || command.onnx_exporter_version.is_some())
     {
         return Err(VmError::InvalidConfig(
-            "HF provenance ONNX metadata or external-data files require --onnx-model".to_string(),
+            "HF provenance ONNX metadata, exporter version, or external-data files require --onnx-model".to_string(),
         ));
     }
     let onnx_export = command
@@ -7469,7 +7471,7 @@ mod hf_provenance_manifest_tests {
             onnx_metadata: Some(metadata),
             onnx_external_data_files: Vec::new(),
             onnx_exporter: "optimum-onnx".to_string(),
-            onnx_exporter_version: None,
+            onnx_exporter_version: Some("1.17.0".to_string()),
             model_card: None,
             doi: None,
             datasets: Vec::new(),
@@ -7477,9 +7479,9 @@ mod hf_provenance_manifest_tests {
         })
         .expect_err("ONNX sidecars without graph should fail");
 
-        assert!(err
-            .to_string()
-            .contains("ONNX metadata or external-data files require --onnx-model"));
+        assert!(err.to_string().contains(
+            "ONNX metadata, exporter version, or external-data files require --onnx-model"
+        ));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4603,13 +4603,27 @@ fn verify_hf_provenance_manifest(
                 "HF provenance ONNX exporter must be non-empty".to_string(),
             ));
         }
-        verify_hf_file_commitment("onnx_export.graph", &onnx_export.graph)?;
-        verify_hf_optional_file_commitment("onnx_export.metadata", &onnx_export.metadata)?;
-        ensure_unique_hf_file_commitment_paths(
-            "HF provenance onnx_export.external_data_files",
-            &onnx_export.external_data_files,
+        let mut onnx_paths = std::collections::BTreeSet::new();
+        ensure_unique_hf_file_commitment_path(
+            "HF provenance onnx_export.graph",
+            &onnx_export.graph,
+            &mut onnx_paths,
         )?;
+        verify_hf_file_commitment("onnx_export.graph", &onnx_export.graph)?;
+        if let Some(metadata) = &onnx_export.metadata {
+            ensure_unique_hf_file_commitment_path(
+                "HF provenance onnx_export.metadata",
+                metadata,
+                &mut onnx_paths,
+            )?;
+        }
+        verify_hf_optional_file_commitment("onnx_export.metadata", &onnx_export.metadata)?;
         for commitment in &onnx_export.external_data_files {
+            ensure_unique_hf_file_commitment_path(
+                "HF provenance onnx_export.external_data_files[]",
+                commitment,
+                &mut onnx_paths,
+            )?;
             verify_hf_file_commitment("onnx_export.external_data_files[]", commitment)?;
         }
     }
@@ -4734,18 +4748,16 @@ fn verify_hf_file_commitment(
     )
 }
 
-fn ensure_unique_hf_file_commitment_paths(
+fn ensure_unique_hf_file_commitment_path(
     label: &str,
-    commitments: &[HfFileCommitment],
+    commitment: &HfFileCommitment,
+    seen_paths: &mut std::collections::BTreeSet<String>,
 ) -> llm_provable_computer::Result<()> {
-    let mut paths = std::collections::BTreeSet::new();
-    for commitment in commitments {
-        if !paths.insert(commitment.path.clone()) {
-            return Err(VmError::InvalidConfig(format!(
-                "{label} contains duplicate path `{}`",
-                commitment.path
-            )));
-        }
+    if !seen_paths.insert(commitment.path.clone()) {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} reuses ONNX artifact path `{}`",
+            commitment.path
+        )));
     }
     Ok(())
 }
@@ -7019,6 +7031,48 @@ mod hf_provenance_manifest_tests {
         fs::write(path, bytes).expect("write HF provenance manifest");
     }
 
+    fn sample_hf_provenance_manifest_with_onnx_export(
+        onnx_export: Option<HfOnnxExportProvenance>,
+    ) -> HfProvenanceManifest {
+        let tokenizer = HfTokenizerProvenance {
+            tokenizer_id: "example/test-model".to_string(),
+            tokenizer_revision: "0123456789abcdef".to_string(),
+            tokenizer_json: None,
+            tokenizer_config: None,
+            tokenization_transcript: None,
+        };
+        let safetensors = Vec::new();
+        let release = HfReleaseMetadata {
+            model_card: None,
+            doi: None,
+            datasets: Vec::new(),
+            notes: vec!["release note".to_string()],
+        };
+        let limitations = hf_provenance_limitations();
+        HfProvenanceManifest {
+            manifest_version: HF_PROVENANCE_MANIFEST_VERSION.to_string(),
+            semantic_scope: HF_PROVENANCE_SEMANTIC_SCOPE.to_string(),
+            hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
+            hub_repo: "example/test-model".to_string(),
+            hub_revision: "0123456789abcdef".to_string(),
+            tokenizer: tokenizer.clone(),
+            safetensors,
+            onnx_export: onnx_export.clone(),
+            release: release.clone(),
+            limitations: limitations.clone(),
+            commitments: HfProvenanceCommitments {
+                tokenizer_hash: hash_json_projection_hex(&tokenizer).expect("tokenizer hash"),
+                safetensors_manifest_hash: hash_json_projection_hex(&Vec::<
+                    HfSafetensorsFileCommitment,
+                >::new())
+                .expect("safetensors hash"),
+                onnx_export_hash: hash_json_projection_hex(&onnx_export).expect("onnx hash"),
+                release_metadata_hash: hash_json_projection_hex(&release).expect("release hash"),
+                limitations_hash: hash_json_projection_hex(&limitations).expect("limitations hash"),
+            },
+        }
+    }
+
     #[test]
     fn load_hf_provenance_manifest_rejects_unknown_top_level_field() {
         let file = hf_provenance_test_manifest_file("extra-top");
@@ -7273,14 +7327,6 @@ mod hf_provenance_manifest_tests {
         fs::write(&graph, b"onnx").expect("write graph");
         fs::write(&sidecar, b"weights").expect("write sidecar");
 
-        let tokenizer = HfTokenizerProvenance {
-            tokenizer_id: "example/test-model".to_string(),
-            tokenizer_revision: "0123456789abcdef".to_string(),
-            tokenizer_json: None,
-            tokenizer_config: None,
-            tokenization_transcript: None,
-        };
-        let safetensors = Vec::new();
         let onnx_export = Some(HfOnnxExportProvenance {
             exporter: "optimum-onnx".to_string(),
             exporter_version: None,
@@ -7291,48 +7337,59 @@ mod hf_provenance_manifest_tests {
                 hf_file_commitment(&sidecar).expect("sidecar commitment"),
             ],
         });
-        let release = HfReleaseMetadata {
-            model_card: None,
-            doi: None,
-            datasets: Vec::new(),
-            notes: vec!["release note".to_string()],
-        };
-        let limitations = hf_provenance_limitations();
-        let manifest = HfProvenanceManifest {
-            manifest_version: HF_PROVENANCE_MANIFEST_VERSION.to_string(),
-            semantic_scope: HF_PROVENANCE_SEMANTIC_SCOPE.to_string(),
-            hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
-            hub_repo: "example/test-model".to_string(),
-            hub_revision: "0123456789abcdef".to_string(),
-            tokenizer,
-            safetensors,
-            onnx_export: onnx_export.clone(),
-            release: release.clone(),
-            limitations: limitations.clone(),
-            commitments: HfProvenanceCommitments {
-                tokenizer_hash: hash_json_projection_hex(&HfTokenizerProvenance {
-                    tokenizer_id: "example/test-model".to_string(),
-                    tokenizer_revision: "0123456789abcdef".to_string(),
-                    tokenizer_json: None,
-                    tokenizer_config: None,
-                    tokenization_transcript: None,
-                })
-                .expect("tokenizer hash"),
-                safetensors_manifest_hash: hash_json_projection_hex(&Vec::<
-                    HfSafetensorsFileCommitment,
-                >::new())
-                .expect("safetensors hash"),
-                onnx_export_hash: hash_json_projection_hex(&onnx_export).expect("onnx hash"),
-                release_metadata_hash: hash_json_projection_hex(&release).expect("release hash"),
-                limitations_hash: hash_json_projection_hex(&limitations).expect("limitations hash"),
-            },
-        };
+        let manifest = sample_hf_provenance_manifest_with_onnx_export(onnx_export);
 
         let err = verify_hf_provenance_manifest(&manifest)
             .expect_err("duplicate ONNX sidecar paths should fail");
         assert!(err
             .to_string()
-            .contains("onnx_export.external_data_files contains duplicate path"));
+            .contains("onnx_export.external_data_files[] reuses ONNX artifact path"));
+    }
+
+    #[test]
+    fn verify_hf_provenance_manifest_rejects_onnx_metadata_path_reusing_graph() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let graph = dir.path().join("model.onnx");
+        fs::write(&graph, b"onnx").expect("write graph");
+
+        let graph_commitment = hf_file_commitment(&graph).expect("graph commitment");
+        let manifest =
+            sample_hf_provenance_manifest_with_onnx_export(Some(HfOnnxExportProvenance {
+                exporter: "optimum-onnx".to_string(),
+                exporter_version: None,
+                graph: graph_commitment.clone(),
+                metadata: Some(graph_commitment),
+                external_data_files: Vec::new(),
+            }));
+
+        let err = verify_hf_provenance_manifest(&manifest)
+            .expect_err("duplicate ONNX graph/metadata path should fail");
+        assert!(err
+            .to_string()
+            .contains("onnx_export.metadata reuses ONNX artifact path"));
+    }
+
+    #[test]
+    fn verify_hf_provenance_manifest_rejects_onnx_external_data_path_reusing_graph() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let graph = dir.path().join("model.onnx");
+        fs::write(&graph, b"onnx").expect("write graph");
+
+        let graph_commitment = hf_file_commitment(&graph).expect("graph commitment");
+        let manifest =
+            sample_hf_provenance_manifest_with_onnx_export(Some(HfOnnxExportProvenance {
+                exporter: "optimum-onnx".to_string(),
+                exporter_version: None,
+                graph: graph_commitment.clone(),
+                metadata: None,
+                external_data_files: vec![graph_commitment],
+            }));
+
+        let err = verify_hf_provenance_manifest(&manifest)
+            .expect_err("duplicate ONNX graph/external-data path should fail");
+        assert!(err
+            .to_string()
+            .contains("onnx_export.external_data_files[] reuses ONNX artifact path"));
     }
 }
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4871,7 +4871,7 @@ fn ensure_unique_hf_file_commitment_path(
     commitment: &HfFileCommitment,
     seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
 ) -> llm_provable_computer::Result<()> {
-    let identity = hf_file_identity(Path::new(&commitment.path), "HF provenance ONNX artifact")?;
+    let identity = hf_file_identity(Path::new(&commitment.path), label)?;
     if !seen_paths.insert(identity) {
         return Err(VmError::InvalidConfig(format!(
             "{label} reuses ONNX artifact path `{}`",

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -890,7 +890,8 @@ const FRONTEND_RUNTIME_RESEARCH_WATCH_LANES: [&str; 9] = [
     "sglang",
     "egg-emerge",
 ];
-const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v1";
+const HF_PROVENANCE_MANIFEST_VERSION_V1_LEGACY: &str = "hf-provenance-manifest-v1";
+const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v2";
 const HF_PROVENANCE_SEMANTIC_SCOPE: &str = "hf-release-provenance-boundary-v1";
 const HF_PROVENANCE_HASH_FUNCTION: &str = "blake2b-256";
 
@@ -4516,12 +4517,65 @@ fn load_hf_provenance_manifest(
         )));
     }
 
-    serde_json::from_slice(&manifest_bytes).map_err(|err| {
-        VmError::Serialization(format!(
-            "failed to parse HF provenance manifest {}: {err}",
+    let manifest_value: serde_json::Value =
+        serde_json::from_slice(&manifest_bytes).map_err(|err| {
+            VmError::Serialization(format!(
+                "failed to parse HF provenance manifest {}: {err}",
+                manifest_path.display()
+            ))
+        })?;
+    let manifest_version = manifest_value
+        .get("manifest_version")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            VmError::Serialization(format!(
+                "failed to parse HF provenance manifest {}: missing or non-string field `manifest_version`",
+                manifest_path.display()
+            ))
+        })?;
+    match manifest_version {
+        HF_PROVENANCE_MANIFEST_VERSION_V1_LEGACY => Err(VmError::Serialization(format!(
+            "failed to parse HF provenance manifest {}: legacy manifest_version `{}` is no longer accepted after the ONNX sidecar format bump; regenerate the manifest as {}",
+            manifest_path.display(),
+            HF_PROVENANCE_MANIFEST_VERSION_V1_LEGACY,
+            HF_PROVENANCE_MANIFEST_VERSION
+        ))),
+        HF_PROVENANCE_MANIFEST_VERSION => {
+            ensure_hf_provenance_manifest_v2_required_fields(manifest_path, &manifest_value)?;
+            serde_json::from_value(manifest_value).map_err(|err| {
+                VmError::Serialization(format!(
+                    "failed to parse HF provenance manifest {}: {err}",
+                    manifest_path.display()
+                ))
+            })
+        }
+        other => Err(VmError::Serialization(format!(
+            "failed to parse HF provenance manifest {}: unsupported manifest_version `{other}`",
             manifest_path.display()
-        ))
-    })
+        ))),
+    }
+}
+
+fn ensure_hf_provenance_manifest_v2_required_fields(
+    manifest_path: &Path,
+    manifest_value: &serde_json::Value,
+) -> llm_provable_computer::Result<()> {
+    let Some(onnx_export) = manifest_value.get("onnx_export") else {
+        return Ok(());
+    };
+    let Some(onnx_export_obj) = onnx_export.as_object() else {
+        return Ok(());
+    };
+    for field in ["exporter_version", "metadata", "external_data_files"] {
+        if !onnx_export_obj.contains_key(field) {
+            return Err(VmError::Serialization(format!(
+                "failed to parse HF provenance manifest {}: missing field `{field}` in `onnx_export` for {}",
+                manifest_path.display(),
+                HF_PROVENANCE_MANIFEST_VERSION
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn verify_hf_provenance_manifest(
@@ -4603,6 +4657,10 @@ fn verify_hf_provenance_manifest(
                 "HF provenance ONNX exporter must be non-empty".to_string(),
             ));
         }
+        validate_hf_optional_identifier(
+            "onnx_export.exporter_version",
+            onnx_export.exporter_version.as_deref(),
+        )?;
         let mut onnx_paths = std::collections::BTreeSet::new();
         ensure_unique_hf_file_commitment_path(
             "HF provenance onnx_export.graph",
@@ -7112,6 +7170,52 @@ mod hf_provenance_manifest_tests {
     }
 
     #[test]
+    fn load_hf_provenance_manifest_rejects_v2_missing_onnx_metadata_field() {
+        let file = hf_provenance_test_manifest_file("missing-onnx-metadata");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["onnx_export"] = serde_json::json!({
+            "exporter": "optimum",
+            "exporter_version": null,
+            "graph": {
+                "path": "model.onnx",
+                "size_bytes": 16,
+                "blake2b_256": "5".repeat(64)
+            },
+            "external_data_files": []
+        });
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("v2 manifest missing onnx metadata field should fail");
+        assert!(err
+            .to_string()
+            .contains("missing field `metadata` in `onnx_export`"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_legacy_v1_onnx_export_with_upgrade_message() {
+        let file = hf_provenance_test_manifest_file("legacy-v1-onnx");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["manifest_version"] = serde_json::json!(HF_PROVENANCE_MANIFEST_VERSION_V1_LEGACY);
+        value["onnx_export"] = serde_json::json!({
+            "exporter": "optimum",
+            "exporter_version": null,
+            "graph": {
+                "path": "model.onnx",
+                "size_bytes": 16,
+                "blake2b_256": "5".repeat(64)
+            }
+        });
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("legacy v1 manifest should require regeneration");
+        assert!(err
+            .to_string()
+            .contains("legacy manifest_version `hf-provenance-manifest-v1` is no longer accepted"));
+    }
+
+    #[test]
     fn load_hf_provenance_manifest_reports_malformed_json_as_serialization() {
         let file = hf_provenance_test_manifest_file("malformed");
         fs::write(file.path(), b"{").expect("write malformed manifest");
@@ -7390,6 +7494,28 @@ mod hf_provenance_manifest_tests {
         assert!(err
             .to_string()
             .contains("onnx_export.external_data_files[] reuses ONNX artifact path"));
+    }
+
+    #[test]
+    fn verify_hf_provenance_manifest_rejects_empty_onnx_exporter_version() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let graph = dir.path().join("model.onnx");
+        fs::write(&graph, b"onnx").expect("write graph");
+
+        let manifest =
+            sample_hf_provenance_manifest_with_onnx_export(Some(HfOnnxExportProvenance {
+                exporter: "optimum-onnx".to_string(),
+                exporter_version: Some(String::new()),
+                graph: hf_file_commitment(&graph).expect("graph commitment"),
+                metadata: None,
+                external_data_files: Vec::new(),
+            }));
+
+        let err = verify_hf_provenance_manifest(&manifest)
+            .expect_err("empty ONNX exporter version should fail");
+        assert!(err
+            .to_string()
+            .contains("HF provenance onnx_export.exporter_version must be non-empty"));
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5068,6 +5068,13 @@ fn cli_verifier_rejects_tampered_onnx_metadata() {
     );
     prepare.assert().success();
 
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .success();
+
     std::fs::write(&onnx_metadata, br#"{"producer":"tamperd"}"#).expect("tamper ONNX metadata");
 
     let mut verify = tvm_command();
@@ -5103,6 +5110,13 @@ fn cli_verifier_rejects_tampered_onnx_external_data() {
         &[&onnx_external],
     );
     prepare.assert().success();
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .success();
 
     std::fs::write(&onnx_external, b"tampered-external!").expect("tamper ONNX external data");
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5001,6 +5001,34 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_external_data_reuses_graph_path(
 }
 
 #[test]
+fn cli_rejects_hf_provenance_manifest_when_onnx_exporter_version_has_no_graph() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-exporter-version-without-graph");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--onnx-exporter-version")
+        .arg("1.17.0")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "ONNX metadata, exporter version, or external-data files require --onnx-model",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
 fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_aliases_graph_path() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-alias-metadata");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4938,6 +4938,72 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
     let _ = std::fs::remove_dir_all(fixture_dir);
 }
 
+#[test]
+fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_reuses_graph_path() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-duplicate-metadata");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let onnx_model = fixture_dir.join("model.onnx");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--onnx-model")
+        .arg(&onnx_model)
+        .arg("--onnx-metadata")
+        .arg(&onnx_model)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "onnx_export.metadata reuses ONNX artifact path",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_rejects_hf_provenance_manifest_when_onnx_external_data_reuses_graph_path() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-duplicate-external-data");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let onnx_model = fixture_dir.join("model.onnx");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--onnx-model")
+        .arg(&onnx_model)
+        .arg("--onnx-external-data")
+        .arg(&onnx_model)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "onnx_export.external_data_files[] reuses ONNX artifact path",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
 #[cfg(feature = "onnx-export")]
 #[test]
 fn cli_supports_export_onnx_command() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4858,7 +4858,7 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
         manifest_json
             .get("manifest_version")
             .and_then(serde_json::Value::as_str),
-        Some("hf-provenance-manifest-v1")
+        Some("hf-provenance-manifest-v2")
     );
     assert_eq!(
         manifest_json

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -89,38 +89,12 @@ fn phase27_cli_test_guard() -> std::sync::MutexGuard<'static, ()> {
 
 fn tvm_command() -> Command {
     let binary = std::env::var_os("CARGO_BIN_EXE_tvm")
+        .or_else(|| std::env::var_os("TVM_TEST_BINARY"))
         .map(PathBuf::from)
         .unwrap_or_else(|| {
-            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-            let target_dir = std::env::var_os("CARGO_TARGET_DIR")
-                .map(PathBuf::from)
-                .map(|path| {
-                    if path.is_absolute() {
-                        path
-                    } else {
-                        manifest_dir.join(path)
-                    }
-                })
-                .unwrap_or_else(|| manifest_dir.join("target"));
-            let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
-            let binary_name = format!("tvm{}", std::env::consts::EXE_SUFFIX);
-            let mut candidates = Vec::new();
-            if let Some(target_triple) = std::env::var_os("CARGO_BUILD_TARGET")
-                .or_else(|| std::env::var_os("TARGET"))
-            {
-                candidates.push(target_dir.join(target_triple).join(&profile).join(&binary_name));
-            }
-            candidates.push(target_dir.join(&profile).join(&binary_name));
-            candidates.push(manifest_dir.join("target").join(&profile).join(&binary_name));
-            candidates
-                .into_iter()
-                .find(|candidate| candidate.exists())
-                .unwrap_or_else(|| {
-                    panic!(
-                        "could not resolve `tvm` binary; checked CARGO_BIN_EXE_tvm and fallback candidates under `{}`",
-                        target_dir.display()
-                    )
-                })
+            panic!(
+                "could not resolve current-feature `tvm` binary; set `TVM_TEST_BINARY` when `CARGO_BIN_EXE_tvm` is unavailable"
+            )
         });
     Command::from_std(std::process::Command::new(binary))
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4938,6 +4938,34 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
     let _ = std::fs::remove_dir_all(fixture_dir);
 }
 
+fn hf_provenance_prepare_command(
+    manifest: &std::path::Path,
+    onnx_model: &std::path::Path,
+    onnx_metadata: Option<&std::path::Path>,
+    onnx_external_data: &[&std::path::Path],
+) -> Command {
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--onnx-model")
+        .arg(onnx_model);
+    if let Some(onnx_metadata) = onnx_metadata {
+        prepare.arg("--onnx-metadata").arg(onnx_metadata);
+    }
+    for path in onnx_external_data {
+        prepare.arg("--onnx-external-data").arg(path);
+    }
+    prepare
+}
+
 #[test]
 fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_reuses_graph_path() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-duplicate-metadata");
@@ -4947,26 +4975,10 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_reuses_graph_path() {
 
     std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
 
-    let mut prepare = tvm_command();
-    prepare
-        .arg("prepare-hf-provenance-manifest")
-        .arg("-o")
-        .arg(&manifest)
-        .arg("--hub-repo")
-        .arg("example/test-model")
-        .arg("--hub-revision")
-        .arg("0123456789abcdef")
-        .arg("--tokenizer-id")
-        .arg("example/test-model")
-        .arg("--onnx-model")
-        .arg(&onnx_model)
-        .arg("--onnx-metadata")
-        .arg(&onnx_model)
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "onnx_export.metadata reuses ONNX artifact path",
-        ));
+    let mut prepare = hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_model), &[]);
+    prepare.assert().failure().stderr(predicate::str::contains(
+        "onnx_export.metadata reuses ONNX artifact path",
+    ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
 }
@@ -4980,25 +4992,100 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_external_data_reuses_graph_path(
 
     std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
 
-    let mut prepare = tvm_command();
-    prepare
-        .arg("prepare-hf-provenance-manifest")
-        .arg("-o")
+    let mut prepare = hf_provenance_prepare_command(&manifest, &onnx_model, None, &[&onnx_model]);
+    prepare.assert().failure().stderr(predicate::str::contains(
+        "onnx_export.external_data_files[] reuses ONNX artifact path",
+    ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_aliases_graph_path() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-alias-metadata");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let onnx_model = fixture_dir.join("model.onnx");
+    let aliased_onnx_model = fixture_dir.join("./model.onnx");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
+
+    let mut prepare =
+        hf_provenance_prepare_command(&manifest, &onnx_model, Some(&aliased_onnx_model), &[]);
+    prepare.assert().failure().stderr(predicate::str::contains(
+        "onnx_export.metadata reuses ONNX artifact path",
+    ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_tampered_onnx_metadata() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-tampered-metadata");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let onnx_model = fixture_dir.join("model.onnx");
+    let onnx_metadata = fixture_dir.join("metadata.json");
+    let onnx_external = fixture_dir.join("model.onnx_data");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
+    std::fs::write(&onnx_metadata, br#"{"producer":"optimum"}"#).expect("write ONNX metadata");
+    std::fs::write(&onnx_external, b"onnx-external-data").expect("write ONNX external data");
+
+    let mut prepare = hf_provenance_prepare_command(
+        &manifest,
+        &onnx_model,
+        Some(&onnx_metadata),
+        &[&onnx_external],
+    );
+    prepare.assert().success();
+
+    std::fs::write(&onnx_metadata, br#"{"producer":"tamperd"}"#).expect("tamper ONNX metadata");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
         .arg(&manifest)
-        .arg("--hub-repo")
-        .arg("example/test-model")
-        .arg("--hub-revision")
-        .arg("0123456789abcdef")
-        .arg("--tokenizer-id")
-        .arg("example/test-model")
-        .arg("--onnx-model")
-        .arg(&onnx_model)
-        .arg("--onnx-external-data")
-        .arg(&onnx_model)
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "onnx_export.external_data_files[] reuses ONNX artifact path",
+            "onnx_export.metadata blake2b_256 commitment mismatch",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_tampered_onnx_external_data() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-tampered-external");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let onnx_model = fixture_dir.join("model.onnx");
+    let onnx_metadata = fixture_dir.join("metadata.json");
+    let onnx_external = fixture_dir.join("model.onnx_data");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
+    std::fs::write(&onnx_metadata, br#"{"producer":"optimum"}"#).expect("write ONNX metadata");
+    std::fs::write(&onnx_external, b"onnx-external-data").expect("write ONNX external data");
+
+    let mut prepare = hf_provenance_prepare_command(
+        &manifest,
+        &onnx_model,
+        Some(&onnx_metadata),
+        &[&onnx_external],
+    );
+    prepare.assert().success();
+
+    std::fs::write(&onnx_external, b"tampered-external!").expect("tamper ONNX external data");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "onnx_export.external_data_files[] blake2b_256 commitment mismatch",
         ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);


### PR DESCRIPTION
## What changed

This PR does three connected things:

- adds the draft paper-2 package centered on proof-carrying decode surfaces, carried-state validity, and pre-recursive aggregation boundaries
- adds the engineering roadmap that turns the bounded paper-2 claim into concrete repo work
- hardens the HF provenance manifest so ONNX-facing releases bind not just the graph file, but also the metadata companion and declared external-data side files

## Why

The repo is now strong enough for a bounded second paper, but not for a stronger recursion or supply-chain-attestation claim.

This PR makes that boundary explicit in the paper package and tightens the repo surface that was still too thin for that paper: ONNX export provenance.

## Impact

- crypto-facing paper wording is now centered on the public statement, carried-state boundary, and statement-preserving packaging semantics
- the draft explicitly distinguishes the current artifact line from HyperNova / NeutronNova / ProtoStar / SnarkFold style recursive closure
- HF provenance verification now covers the fuller ONNX artifact set for release reproducibility

## Validation

- `cargo fmt --all`
- `cargo test --bin tvm hf_provenance_manifest -- --nocapture`
- `git diff --check`
- `python3 scripts/paper/paper_preflight.py --repo-root .`

## Hardening

- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
  - N/A for this slice: the change tightens manifest binding and rejection behavior rather than cross-engine semantic comparison logic
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below
  - N/A for this slice: no arithmetic proof kernel or formal-contract surface changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifests can include optional ONNX metadata and repeatable ONNX external-data sidecars; manifest wire format upgraded to hf-provenance-manifest-v2.

* **Improvements**
  * CLI and verifier enforce required ONNX fields for v2, reject legacy v1 manifests, require a model when sidecars are supplied, ensure unique ONNX artifact identities, and deterministically order sidecars. Added explicit note that manifests do not prove ONNX metadata/external-data semantic correctness.

* **Tests**
  * Added CLI tests covering v2 validation, legacy-v1 rejection, sidecar-without-model rejection, and duplicate/aliasing ONNX path failures.

* **Documentation**
  * Updated README CLI example and expanded paper/engineering documentation and appendices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->