### PR TITLE
[codex] Add attestation-friendly HF provenance digests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4131,6 +4131,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "sha2",
  "sha3",
  "stwo",
  "stwo-constraint-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ protobuf = { version = "=3.7.2", optional = true }
 ratatui = "0.29.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+sha2 = "0.10"
 sha3 = "0.10"
 stwo = { version = "2.2.0", default-features = false, features = ["std", "prover"], optional = true }
 stwo-constraint-framework = { version = "2.2.0", default-features = false, features = ["std", "prover"], optional = true }

--- a/README.md
+++ b/README.md
@@ -842,12 +842,16 @@ optional model-card/DOI/dataset release metadata. The verifier rejects floating 
 revisions such as `main`, recomputes local file hashes, recomputes the manifest
 commitments, and rejects safetensors metadata drift. It does not prove tokenizer
 algorithm correctness, safetensors architectural semantics, ONNX exporter semantic
-equivalence, ONNX metadata semantic correctness, live Hub availability, or DOI
-validity.
+equivalence, ONNX metadata semantic correctness, live Hub availability, DOI
+validity, or GitHub/Sigstore/in-toto/SLSA attestation validity. The current wire
+format also carries `sha256` digests for bound files so release assets can be
+matched against attestation subject digests without turning the manifest into an
+attestation verifier.
 
-The current manifest wire format is `hf-provenance-manifest-v2`. Older
-`hf-provenance-manifest-v1` files must be regenerated before verification
-because the ONNX sidecar surface now has an explicit versioned format boundary.
+The current manifest wire format is `hf-provenance-manifest-v3`. Older
+`hf-provenance-manifest-v1` and `hf-provenance-manifest-v2` files must be
+regenerated before verification because the ONNX sidecar surface and
+attestation-digest inventory now have explicit versioned format boundaries.
 
 Canonical HF provenance spec file:
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
-# Keep the cargo-deny advisory exceptions here aligned with
-# docs/engineering/dependency-audit-exceptions.md. Unsound advisories that are
-# currently only surfaced by cargo-audit are tracked in the audit script.
+# Keep the cargo-deny advisory and yanked-package exceptions here aligned with
+# docs/engineering/dependency-audit-exceptions.md. Unsound advisories and
+# package-scoped yanked exceptions are also enforced by the audit script
+# because cargo-audit cannot ignore individual yanked crate versions.
 [graph]
 all-features = true
 
@@ -10,6 +11,7 @@ feature-depth = 1
 [advisories]
 yanked = "deny"
 ignore = [
+  { crate = "core2@0.4.0", reason = "burn-dataset/image/ravif still pin the only currently-compatible yanked core2 release; remove this once the upstream chain moves off core2 0.4.0." },
   { id = "RUSTSEC-2025-0141", reason = "burn 0.20.1 still depends on bincode 2.0.1; no compatible patch release is available and the burn-model surface remains optional." },
   { id = "RUSTSEC-2024-0388", reason = "stwo 2.2.0 transitively depends on derivative 2.2.0 via starknet-ff 0.3.7; no compatible patch release is available." },
   { id = "RUSTSEC-2024-0436", reason = "paste 1.0.15 remains in the ark-ff 0.5.0 and ratatui 0.29.0 dependency chains; no compatible patch release is available." },

--- a/docs/engineering/dependency-audit-exceptions.md
+++ b/docs/engineering/dependency-audit-exceptions.md
@@ -6,6 +6,8 @@ The dependency audit gate is intentionally strict:
   repository-owned checker that still fails on every vulnerability,
   unmaintained dependency, unsound dependency, and yanked crate unless the
   exact advisory ID or yanked `crate@version` is documented here.
+- The checker also fails on stale allowlist entries, so each exception must
+  remain scoped to the lockfile that still exhibits it (`root` versus `fuzz`).
 - `cargo deny check advisories bans licenses sources` enforces the graph,
   licensing, and source policy from `deny.toml` against both manifests.
 - Yanked-package exceptions must stay duplicated in `deny.toml` because
@@ -18,8 +20,8 @@ reason, an owning surface, and an exit condition.
 
 | Advisory | Tooling surface | Current owner | Why it is still present | Exit condition |
 | --- | --- | --- | --- | --- |
-| `core2@0.4.0` (yanked) | `cargo-audit`, `cargo-deny` | optional Burn image/export chain | `burn-dataset 0.20.1` still reaches `core2 0.4.0` through `image 0.25.10 -> ravif 0.13.0 -> rav1e 0.8.1 -> bitstream-io 4.9.0`; no semver-compatible non-yanked replacement is available in the current graph | Upgrade or patch the Burn/image/ravif chain so the lockfile no longer resolves `core2 0.4.0`, or fence that optional surface into a separate package/workspace |
-| `RUSTSEC-2025-0141` (`bincode 2.0.1`) | `cargo-audit`, `cargo-deny` | optional Burn model/runtime surface | `burn 0.20.1` still depends on `bincode 2.0.1`; no compatible patch release is available in the current graph | Upgrade Burn to a release that removes `bincode 2.0.1`, or fence the optional Burn surface behind a separate workspace/package |
+| `core2@0.4.0` (yanked) | `cargo-audit root`, `cargo-deny` | optional Burn image/export chain | `burn-dataset 0.20.1` still reaches `core2 0.4.0` through `image 0.25.10 -> ravif 0.13.0 -> rav1e 0.8.1 -> bitstream-io 4.9.0`; no semver-compatible non-yanked replacement is available in the current graph | Upgrade or patch the Burn/image/ravif chain so the root lockfile no longer resolves `core2 0.4.0`, or fence that optional surface into a separate package/workspace |
+| `RUSTSEC-2025-0141` (`bincode 2.0.1`) | `cargo-audit root`, `cargo-deny` | optional Burn model/runtime surface | `burn 0.20.1` still depends on `bincode 2.0.1`; no compatible patch release is available in the current graph | Upgrade Burn to a release that removes `bincode 2.0.1`, or fence the optional Burn surface behind a separate workspace/package |
 | `RUSTSEC-2024-0388` (`derivative 2.2.0`) | `cargo-audit`, `cargo-deny` | `stwo` / Starknet finite-field chain | `stwo 2.2.0` transitively depends on `derivative 2.2.0` via `starknet-ff 0.3.7`; no compatible patch release is available | Upgrade the `stwo` / `starknet-ff` chain once a compatible maintained replacement lands |
 | `RUSTSEC-2024-0436` (`paste 1.0.15`) | `cargo-audit`, `cargo-deny` | `ark-ff 0.5.0`, `ratatui 0.29.0`, MLIR/Burn support chain | Several transitive chains still pull `paste 1.0.15`; no compatible patch release is available without broader dependency churn | Upgrade the affected upstream chains or remove the optional surfaces that require them |
 | `RUSTSEC-2026-0002` (`lru 0.12.5`) | `cargo-audit` | TUI surface via `ratatui 0.29.0` | `ratatui 0.29.0` still depends on `lru 0.12.5`; `cargo-deny` does not currently surface this advisory on this graph, so `cargo-audit` is the enforcement point | Migrate the TUI surface to a `ratatui` release that removes `lru 0.12.5` |

--- a/docs/engineering/dependency-audit-exceptions.md
+++ b/docs/engineering/dependency-audit-exceptions.md
@@ -2,19 +2,23 @@
 
 The dependency audit gate is intentionally strict:
 
-- `scripts/run_dependency_audit_suite.sh` runs `cargo audit --deny warnings`
-  with an explicit allowlist for accepted upstream advisories against both the
-  repository root `Cargo.lock` and `fuzz/Cargo.lock`.
+- `scripts/run_dependency_audit_suite.sh` runs `cargo audit --json` plus a
+  repository-owned checker that still fails on every vulnerability,
+  unmaintained dependency, unsound dependency, and yanked crate unless the
+  exact advisory ID or yanked `crate@version` is documented here.
 - `cargo deny check advisories bans licenses sources` enforces the graph,
   licensing, and source policy from `deny.toml` against both manifests.
+- Yanked-package exceptions must stay duplicated in `deny.toml` because
+  `cargo-audit` only ignores advisory IDs, not individual yanked packages.
 
 Any new advisory must fail the gate unless it is added here with a specific
 reason, an owning surface, and an exit condition.
 
-## Current accepted advisories
+## Current accepted exceptions
 
 | Advisory | Tooling surface | Current owner | Why it is still present | Exit condition |
 | --- | --- | --- | --- | --- |
+| `core2@0.4.0` (yanked) | `cargo-audit`, `cargo-deny` | optional Burn image/export chain | `burn-dataset 0.20.1` still reaches `core2 0.4.0` through `image 0.25.10 -> ravif 0.13.0 -> rav1e 0.8.1 -> bitstream-io 4.9.0`; no semver-compatible non-yanked replacement is available in the current graph | Upgrade or patch the Burn/image/ravif chain so the lockfile no longer resolves `core2 0.4.0`, or fence that optional surface into a separate package/workspace |
 | `RUSTSEC-2025-0141` (`bincode 2.0.1`) | `cargo-audit`, `cargo-deny` | optional Burn model/runtime surface | `burn 0.20.1` still depends on `bincode 2.0.1`; no compatible patch release is available in the current graph | Upgrade Burn to a release that removes `bincode 2.0.1`, or fence the optional Burn surface behind a separate workspace/package |
 | `RUSTSEC-2024-0388` (`derivative 2.2.0`) | `cargo-audit`, `cargo-deny` | `stwo` / Starknet finite-field chain | `stwo 2.2.0` transitively depends on `derivative 2.2.0` via `starknet-ff 0.3.7`; no compatible patch release is available | Upgrade the `stwo` / `starknet-ff` chain once a compatible maintained replacement lands |
 | `RUSTSEC-2024-0436` (`paste 1.0.15`) | `cargo-audit`, `cargo-deny` | `ark-ff 0.5.0`, `ratatui 0.29.0`, MLIR/Burn support chain | Several transitive chains still pull `paste 1.0.15`; no compatible patch release is available without broader dependency churn | Upgrade the affected upstream chains or remove the optional surfaces that require them |

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -294,10 +294,13 @@ equivalence theorem over compilers, exporter graphs, or arbitrary model graphs.
 The Hugging Face provenance line binds model, tokenizer, ONNX, transcript, and
 safetensors identities to explicit local-file hashes and pinned release
 coordinates. In the ONNX-facing path, that boundary now includes the exported
-graph, its metadata companion, and declared external-data side files. This is
-operationally valuable, especially for frozen artifact bundles. It should not
-be confused with a proof relation. It is a release boundary, not a theorem that
-exporter or supply-chain semantics are preserved.
+graph, its metadata companion, declared external-data side files, and
+attestation-friendly SHA-256 subject digests alongside the repository's local
+BLAKE2b-256 commitments. This is operationally valuable, especially for frozen
+artifact bundles and release-verification workflows that already key on
+SHA-256. It should not be confused with a proof relation or a verified
+attestation pipeline. It is a release boundary, not a theorem that exporter or
+supply-chain semantics are preserved.
 
 ______________________________________________________________________
 
@@ -410,7 +413,7 @@ For a stronger follow-on paper, the missing milestones are clear:
 - recursive cryptographic compression over the same decode statement,
 - recursive shared-table accumulation as a compressed proof object,
 - stronger exporter/provenance binding for ONNX-facing release artifacts,
-- broader supply-chain attestations,
+- broader signed supply-chain attestations with verified builder identity,
 - broader `stwo` transformer coverage beyond the current narrow experimental
   boundary.
 
@@ -445,5 +448,7 @@ ______________________________________________________________________
 - SLSA provenance overview: [https://slsa.dev/provenance](https://slsa.dev/provenance)
 - SLSA build provenance: [https://slsa.dev/spec/v1.2-rc2/build-provenance](https://slsa.dev/spec/v1.2-rc2/build-provenance)
 - in-toto attestation framework: [https://github.com/in-toto/attestation](https://github.com/in-toto/attestation)
+- GitHub artifact attestations: [https://docs.github.com/en/actions/how-tos/security-for-github-actions/using-artifact-attestations](https://docs.github.com/en/actions/how-tos/security-for-github-actions/using-artifact-attestations)
+- GitHub build provenance workflow: [https://docs.github.com/en/actions/how-tos/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds](https://docs.github.com/en/actions/how-tos/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
 - ONNX external-data documentation: [https://onnx.ai/onnx/repo-docs/ExternalData.html](https://onnx.ai/onnx/repo-docs/ExternalData.html)
 - PyTorch export IR specification: [https://docs.pytorch.org/docs/main/user_guide/torch_compiler/export/ir_spec.html](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/export/ir_spec.html)

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -868,6 +868,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "sha2",
  "sha3",
  "stwo",
  "stwo-constraint-framework",

--- a/scripts/check_cargo_audit_report.py
+++ b/scripts/check_cargo_audit_report.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate cargo-audit JSON output with explicit yanked-package exceptions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+KNOWN_WARNING_KINDS = ("unmaintained", "unsound", "yanked")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument(
+        "--allow-yanked",
+        action="append",
+        default=[],
+        metavar="CRATE@VERSION",
+        help="Allow a specific yanked crate version while still failing on all others.",
+    )
+    return parser.parse_args()
+
+
+def format_package(entry: dict) -> str:
+    package = entry.get("package", {})
+    return f"{package.get('name', '<unknown>')}@{package.get('version', '<unknown>')}"
+
+
+def advisory_label(entry: dict) -> str:
+    advisory = entry.get("advisory") or {}
+    advisory_id = advisory.get("id")
+    package = format_package(entry)
+    if advisory_id:
+        return f"{advisory_id} ({package})"
+    return package
+
+
+def main() -> int:
+    args = parse_args()
+    report = json.loads(args.report.read_text())
+    allowed_yanked = set(args.allow_yanked)
+
+    vulnerabilities = report.get("vulnerabilities", {}).get("list", [])
+    warnings = report.get("warnings", {})
+    warning_kinds = set(warnings)
+    unexpected_warning_kinds = sorted(warning_kinds.difference(KNOWN_WARNING_KINDS))
+
+    unexpected_yanked = []
+    allowed_yanked_hits = []
+    for entry in warnings.get("yanked", []):
+        package = format_package(entry)
+        if package in allowed_yanked:
+            allowed_yanked_hits.append(package)
+        else:
+            unexpected_yanked.append(package)
+
+    failures: list[str] = []
+    for entry in vulnerabilities:
+        failures.append(f"vulnerability: {advisory_label(entry)}")
+    for kind in ("unmaintained", "unsound"):
+        for entry in warnings.get(kind, []):
+            failures.append(f"{kind}: {advisory_label(entry)}")
+    for package in unexpected_yanked:
+        failures.append(f"yanked: {package}")
+    for kind in unexpected_warning_kinds:
+        failures.append(f"unexpected warning category: {kind}")
+
+    if failures:
+        print("[dependency-audit] unexpected cargo-audit findings:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    if allowed_yanked_hits:
+        unique_hits = sorted(set(allowed_yanked_hits))
+        print(
+            "[dependency-audit] allowed yanked crates: "
+            + ", ".join(unique_hits)
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_cargo_audit_report.py
+++ b/scripts/check_cargo_audit_report.py
@@ -16,6 +16,13 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--report", required=True, type=Path)
     parser.add_argument(
+        "--allow-advisory",
+        action="append",
+        default=[],
+        metavar="RUSTSEC-...",
+        help="Allow a specific advisory ID while still failing on all others.",
+    )
+    parser.add_argument(
         "--allow-yanked",
         action="append",
         default=[],
@@ -41,8 +48,20 @@ def advisory_label(entry: dict) -> str:
 
 def main() -> int:
     args = parse_args()
-    report = json.loads(args.report.read_text())
+    try:
+        report = json.loads(args.report.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as err:
+        print(
+            "[dependency-audit] failed to read or parse cargo-audit JSON report "
+            f"{args.report}: {err}",
+            file=sys.stderr,
+        )
+        return 1
+
+    allowed_advisories = set(args.allow_advisory)
     allowed_yanked = set(args.allow_yanked)
+    seen_advisories: set[str] = set()
+    seen_yanked: set[str] = set()
 
     vulnerabilities = report.get("vulnerabilities", {}).get("list", [])
     warnings = report.get("warnings", {})
@@ -55,26 +74,44 @@ def main() -> int:
         package = format_package(entry)
         if package in allowed_yanked:
             allowed_yanked_hits.append(package)
+            seen_yanked.add(package)
         else:
             unexpected_yanked.append(package)
 
     failures: list[str] = []
     for entry in vulnerabilities:
+        advisory_id = (entry.get("advisory") or {}).get("id")
+        if advisory_id and advisory_id in allowed_advisories:
+            seen_advisories.add(advisory_id)
+            continue
         failures.append(f"vulnerability: {advisory_label(entry)}")
     for kind in ("unmaintained", "unsound"):
         for entry in warnings.get(kind, []):
+            advisory_id = (entry.get("advisory") or {}).get("id")
+            if advisory_id and advisory_id in allowed_advisories:
+                seen_advisories.add(advisory_id)
+                continue
             failures.append(f"{kind}: {advisory_label(entry)}")
     for package in unexpected_yanked:
         failures.append(f"yanked: {package}")
     for kind in unexpected_warning_kinds:
         failures.append(f"unexpected warning category: {kind}")
+    for advisory_id in sorted(allowed_advisories.difference(seen_advisories)):
+        failures.append(f"stale allowed advisory: {advisory_id}")
+    for package in sorted(allowed_yanked.difference(seen_yanked)):
+        failures.append(f"stale allowed yanked package: {package}")
 
     if failures:
-        print("[dependency-audit] unexpected cargo-audit findings:")
+        print("[dependency-audit] unexpected cargo-audit findings:", file=sys.stderr)
         for failure in failures:
-            print(f"  - {failure}")
+            print(f"  - {failure}", file=sys.stderr)
         return 1
 
+    if seen_advisories:
+        print(
+            "[dependency-audit] allowed advisories: "
+            + ", ".join(sorted(seen_advisories))
+        )
     if allowed_yanked_hits:
         unique_hits = sorted(set(allowed_yanked_hits))
         print(

--- a/scripts/run_dependency_audit_suite.sh
+++ b/scripts/run_dependency_audit_suite.sh
@@ -7,16 +7,23 @@ cd "$ROOT_DIR"
 CARGO_AUDIT_VERSION="${CARGO_AUDIT_VERSION:-0.22.1}"
 CARGO_DENY_VERSION="${CARGO_DENY_VERSION:-0.19.0}"
 # Keep this list aligned with docs/engineering/dependency-audit-exceptions.md.
-IGNORED_AUDIT_ADVISORIES=(
+ROOT_IGNORED_AUDIT_ADVISORIES=(
   "RUSTSEC-2025-0141"
   "RUSTSEC-2024-0388"
   "RUSTSEC-2024-0436"
   "RUSTSEC-2026-0002"
   "RUSTSEC-2026-0097"
 )
-IGNORED_YANKED_PACKAGES=(
+FUZZ_IGNORED_AUDIT_ADVISORIES=(
+  "RUSTSEC-2024-0388"
+  "RUSTSEC-2024-0436"
+  "RUSTSEC-2026-0002"
+  "RUSTSEC-2026-0097"
+)
+ROOT_IGNORED_YANKED_PACKAGES=(
   "core2@0.4.0"
 )
+FUZZ_IGNORED_YANKED_PACKAGES=()
 
 require_command() {
   local command_name="$1"
@@ -38,6 +45,7 @@ require_exact_version() {
 
 require_command cargo-audit
 require_command cargo-deny
+require_command python3
 
 cargo_audit_version="$(cargo-audit --version | awk '{print $2}')"
 require_exact_version cargo-audit "$cargo_audit_version" "$CARGO_AUDIT_VERSION"
@@ -49,27 +57,47 @@ cargo_audit_args=(
   "--json"
 )
 
-for advisory_id in "${IGNORED_AUDIT_ADVISORIES[@]}"; do
-  cargo_audit_args+=("--ignore" "$advisory_id")
-done
-
 run_cargo_audit() {
   local label="$1"
   local lockfile="$2"
   local report_path
+  local -a allowed_advisories=()
+  local -a allowed_yanked_packages=()
   local check_args=(
     "--report"
   )
 
+  case "$label" in
+    root)
+      allowed_advisories=("${ROOT_IGNORED_AUDIT_ADVISORIES[@]}")
+      allowed_yanked_packages=("${ROOT_IGNORED_YANKED_PACKAGES[@]}")
+      ;;
+    fuzz)
+      allowed_advisories=("${FUZZ_IGNORED_AUDIT_ADVISORIES[@]}")
+      allowed_yanked_packages=("${FUZZ_IGNORED_YANKED_PACKAGES[@]}")
+      ;;
+    *)
+      echo "unknown dependency-audit label: $label" >&2
+      return 1
+      ;;
+  esac
+
   echo "[dependency-audit] cargo audit: ${label} (${lockfile})"
-  report_path="$(mktemp)"
+  if ! report_path="$(mktemp "${TMPDIR:-/tmp}/cargo-audit-report.XXXXXX")"; then
+    echo "failed to allocate cargo-audit temp file for ${label} (${lockfile})" >&2
+    return 1
+  fi
   if ! cargo audit "${cargo_audit_args[@]}" --file "$lockfile" >"$report_path"; then
     rm -f "$report_path"
     return 1
   fi
   check_args+=("$report_path")
 
-  for package_spec in "${IGNORED_YANKED_PACKAGES[@]}"; do
+  for advisory_id in "${allowed_advisories[@]}"; do
+    check_args+=("--allow-advisory" "$advisory_id")
+  done
+
+  for package_spec in "${allowed_yanked_packages[@]}"; do
     check_args+=("--allow-yanked" "$package_spec")
   done
 

--- a/scripts/run_dependency_audit_suite.sh
+++ b/scripts/run_dependency_audit_suite.sh
@@ -14,6 +14,9 @@ IGNORED_AUDIT_ADVISORIES=(
   "RUSTSEC-2026-0002"
   "RUSTSEC-2026-0097"
 )
+IGNORED_YANKED_PACKAGES=(
+  "core2@0.4.0"
+)
 
 require_command() {
   local command_name="$1"
@@ -43,7 +46,7 @@ cargo_deny_version="$(cargo-deny --version | awk '{print $2}')"
 require_exact_version cargo-deny "$cargo_deny_version" "$CARGO_DENY_VERSION"
 
 cargo_audit_args=(
-  "--deny" "warnings"
+  "--json"
 )
 
 for advisory_id in "${IGNORED_AUDIT_ADVISORIES[@]}"; do
@@ -53,8 +56,28 @@ done
 run_cargo_audit() {
   local label="$1"
   local lockfile="$2"
+  local report_path
+  local check_args=(
+    "--report"
+  )
+
   echo "[dependency-audit] cargo audit: ${label} (${lockfile})"
-  cargo audit "${cargo_audit_args[@]}" --file "$lockfile"
+  report_path="$(mktemp)"
+  if ! cargo audit "${cargo_audit_args[@]}" --file "$lockfile" >"$report_path"; then
+    rm -f "$report_path"
+    return 1
+  fi
+  check_args+=("$report_path")
+
+  for package_spec in "${IGNORED_YANKED_PACKAGES[@]}"; do
+    check_args+=("--allow-yanked" "$package_spec")
+  done
+
+  if ! python3 "$ROOT_DIR/scripts/check_cargo_audit_report.py" "${check_args[@]}"; then
+    rm -f "$report_path"
+    return 1
+  fi
+  rm -f "$report_path"
 }
 
 run_cargo_deny() {

--- a/spec/hf-provenance-manifest.schema.json
+++ b/spec/hf-provenance-manifest.schema.json
@@ -6,7 +6,7 @@
   "required": [
     "manifest_version",
     "semantic_scope",
-    "hash_function",
+    "commitment_hash_function",
     "hub_repo",
     "hub_revision",
     "tokenizer",
@@ -19,7 +19,7 @@
   "properties": {
     "manifest_version": { "const": "hf-provenance-manifest-v3" },
     "semantic_scope": { "const": "hf-release-provenance-boundary-v1" },
-    "hash_function": { "const": "blake2b-256" },
+    "commitment_hash_function": { "const": "blake2b-256" },
     "hub_repo": { "type": "string", "minLength": 1 },
     "hub_revision": { "type": "string", "minLength": 1 },
     "tokenizer": { "$ref": "#/$defs/tokenizer" },

--- a/spec/hf-provenance-manifest.schema.json
+++ b/spec/hf-provenance-manifest.schema.json
@@ -17,7 +17,7 @@
     "commitments"
   ],
   "properties": {
-    "manifest_version": { "const": "hf-provenance-manifest-v2" },
+    "manifest_version": { "const": "hf-provenance-manifest-v3" },
     "semantic_scope": { "const": "hf-release-provenance-boundary-v1" },
     "hash_function": { "const": "blake2b-256" },
     "hub_repo": { "type": "string", "minLength": 1 },
@@ -46,13 +46,18 @@
       "type": "string",
       "pattern": "^[0-9a-fA-F]{64}$"
     },
+    "hash_sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    },
     "file_commitment": {
       "type": "object",
-      "required": ["path", "size_bytes", "blake2b_256"],
+      "required": ["path", "size_bytes", "blake2b_256", "sha256"],
       "properties": {
         "path": { "type": "string", "minLength": 1 },
         "size_bytes": { "type": "integer", "minimum": 0 },
-        "blake2b_256": { "$ref": "#/$defs/hash_blake2b_256_hex" }
+        "blake2b_256": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "sha256": { "$ref": "#/$defs/hash_sha256_hex" }
       },
       "additionalProperties": false
     },
@@ -62,6 +67,7 @@
         "path",
         "size_bytes",
         "blake2b_256",
+        "sha256",
         "metadata_hash",
         "tensor_count"
       ],
@@ -69,6 +75,7 @@
         "path": { "type": "string", "minLength": 1 },
         "size_bytes": { "type": "integer", "minimum": 0 },
         "blake2b_256": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "sha256": { "$ref": "#/$defs/hash_sha256_hex" },
         "metadata_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "tensor_count": { "type": "integer", "minimum": 0 }
       },

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -5172,7 +5172,7 @@ fn expect_eq(label: &str, actual: &str, expected: &str) -> llm_provable_computer
 fn expect_hash_hex(label: &str, value: &str) -> llm_provable_computer::Result<()> {
     if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err(VmError::InvalidConfig(format!(
-            "{label} must be a 64-character hex Blake2b-256 hash"
+            "{label} must be a 64-character hex hash"
         )));
     }
     Ok(())

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -119,6 +119,7 @@ use llm_provable_computer::{
 #[cfg(feature = "burn-model")]
 use llm_provable_computer::{BurnExecutionRuntime, BurnTransformerVm};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 #[cfg(feature = "burn-model")]
 type CliBurnBackend = NdArray<f64>;
@@ -891,7 +892,8 @@ const FRONTEND_RUNTIME_RESEARCH_WATCH_LANES: [&str; 9] = [
     "egg-emerge",
 ];
 const HF_PROVENANCE_MANIFEST_VERSION_V1_LEGACY: &str = "hf-provenance-manifest-v1";
-const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v2";
+const HF_PROVENANCE_MANIFEST_VERSION_V2_LEGACY: &str = "hf-provenance-manifest-v2";
+const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v3";
 const HF_PROVENANCE_SEMANTIC_SCOPE: &str = "hf-release-provenance-boundary-v1";
 const HF_PROVENANCE_HASH_FUNCTION: &str = "blake2b-256";
 
@@ -922,6 +924,7 @@ struct HfFileCommitment {
     path: String,
     size_bytes: u64,
     blake2b_256: String,
+    sha256: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -930,6 +933,7 @@ struct HfSafetensorsFileCommitment {
     path: String,
     size_bytes: u64,
     blake2b_256: String,
+    sha256: String,
     metadata_hash: String,
     tensor_count: usize,
 }
@@ -4542,8 +4546,14 @@ fn load_hf_provenance_manifest(
             HF_PROVENANCE_MANIFEST_VERSION_V1_LEGACY,
             HF_PROVENANCE_MANIFEST_VERSION
         ))),
+        HF_PROVENANCE_MANIFEST_VERSION_V2_LEGACY => Err(VmError::Serialization(format!(
+            "failed to parse HF provenance manifest {}: legacy manifest_version `{}` is no longer accepted after the attestation-digest format bump; regenerate the manifest as {}",
+            manifest_path.display(),
+            HF_PROVENANCE_MANIFEST_VERSION_V2_LEGACY,
+            HF_PROVENANCE_MANIFEST_VERSION
+        ))),
         HF_PROVENANCE_MANIFEST_VERSION => {
-            ensure_hf_provenance_manifest_v2_required_fields(manifest_path, &manifest_value)?;
+            ensure_hf_provenance_manifest_v3_required_fields(manifest_path, &manifest_value)?;
             serde_json::from_value(manifest_value).map_err(|err| {
                 VmError::Serialization(format!(
                     "failed to parse HF provenance manifest {}: {err}",
@@ -4558,7 +4568,7 @@ fn load_hf_provenance_manifest(
     }
 }
 
-fn ensure_hf_provenance_manifest_v2_required_fields(
+fn ensure_hf_provenance_manifest_v3_required_fields(
     manifest_path: &Path,
     manifest_value: &serde_json::Value,
 ) -> llm_provable_computer::Result<()> {
@@ -4706,6 +4716,7 @@ fn verify_hf_provenance_manifest(
 fn hf_provenance_limitations() -> Vec<String> {
     [
         "HF provenance manifests pin artifact identity and local file hashes only",
+        "attestation-friendly SHA-256 digests do not by themselves verify GitHub, Sigstore, in-toto, or SLSA attestations",
         "the manifest does not prove tokenizer algorithm correctness",
         "the manifest does not prove safetensors weights implement a model architecture",
         "the manifest does not prove Optimum or ONNX exporter semantic equivalence",
@@ -4759,22 +4770,25 @@ fn hf_optional_file_commitment(
 }
 
 fn hf_file_commitment(path: &Path) -> llm_provable_computer::Result<HfFileCommitment> {
-    let (size_bytes, blake2b_256) = hash_hf_commitment_file(path)?;
+    let (size_bytes, blake2b_256, sha256) = hash_hf_commitment_file(path)?;
     Ok(HfFileCommitment {
         path: path.display().to_string(),
         size_bytes,
         blake2b_256,
+        sha256,
     })
 }
 
 fn hf_safetensors_file_commitment(
     path: &Path,
 ) -> llm_provable_computer::Result<HfSafetensorsFileCommitment> {
-    let (size_bytes, blake2b_256, metadata_hash, tensor_count) = inspect_hf_safetensors_file(path)?;
+    let (size_bytes, blake2b_256, sha256, metadata_hash, tensor_count) =
+        inspect_hf_safetensors_file(path)?;
     Ok(HfSafetensorsFileCommitment {
         path: path.display().to_string(),
         size_bytes,
         blake2b_256,
+        sha256,
         metadata_hash,
         tensor_count,
     })
@@ -4794,7 +4808,7 @@ fn verify_hf_file_commitment(
     label: &str,
     commitment: &HfFileCommitment,
 ) -> llm_provable_computer::Result<()> {
-    let (size_bytes, blake2b_256) = hash_hf_commitment_file(Path::new(&commitment.path))?;
+    let (size_bytes, blake2b_256, sha256) = hash_hf_commitment_file(Path::new(&commitment.path))?;
     if commitment.size_bytes != size_bytes {
         return Err(VmError::InvalidConfig(format!(
             "HF provenance {label} size_bytes mismatch: expected {}, got {}",
@@ -4805,6 +4819,11 @@ fn verify_hf_file_commitment(
         &format!("HF provenance {label} blake2b_256"),
         &commitment.blake2b_256,
         &blake2b_256,
+    )?;
+    verify_hash_commitment(
+        &format!("HF provenance {label} sha256"),
+        &commitment.sha256,
+        &sha256,
     )
 }
 
@@ -4884,7 +4903,7 @@ fn ensure_unique_hf_file_commitment_path(
 fn verify_hf_safetensors_file_commitment(
     commitment: &HfSafetensorsFileCommitment,
 ) -> llm_provable_computer::Result<()> {
-    let (size_bytes, blake2b_256, metadata_hash, tensor_count) =
+    let (size_bytes, blake2b_256, sha256, metadata_hash, tensor_count) =
         inspect_hf_safetensors_file(Path::new(&commitment.path))?;
     if commitment.size_bytes != size_bytes {
         return Err(VmError::InvalidConfig(format!(
@@ -4896,6 +4915,11 @@ fn verify_hf_safetensors_file_commitment(
         &format!("HF provenance safetensors {} blake2b_256", commitment.path),
         &commitment.blake2b_256,
         &blake2b_256,
+    )?;
+    verify_hash_commitment(
+        &format!("HF provenance safetensors {} sha256", commitment.path),
+        &commitment.sha256,
+        &sha256,
     )?;
     verify_hash_commitment(
         &format!(
@@ -4914,10 +4938,11 @@ fn verify_hf_safetensors_file_commitment(
     Ok(())
 }
 
-fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, String)> {
+fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, String, String)> {
     let (mut file, size_bytes) = open_checked_regular_file(path, "HF provenance file", None)?;
     let mut output = [0u8; 32];
     let mut hasher = Blake2bVar::new(output.len()).expect("blake2b-256 hasher");
+    let mut sha256_hasher = Sha256::new();
     let mut observed_size = 0u64;
     let mut remaining = size_bytes;
     let mut buffer = vec![0u8; HF_PROVENANCE_FILE_READ_CHUNK_BYTES];
@@ -4946,6 +4971,7 @@ fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, S
             })?;
         remaining -= read_bytes as u64;
         hasher.update(&buffer[..read_bytes]);
+        Digest::update(&mut sha256_hasher, &buffer[..read_bytes]);
     }
     let mut extra_byte = [0u8; 1];
     if file.read(&mut extra_byte).map_err(|err| {
@@ -4964,15 +4990,17 @@ fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, S
     hasher
         .finalize_variable(&mut output)
         .expect("blake2b-256 finalization");
+    let sha256_output = sha256_hasher.finalize();
     Ok((
         size_bytes,
-        output.iter().map(|byte| format!("{byte:02x}")).collect(),
+        encode_hex(&output),
+        encode_hex(sha256_output.as_slice()),
     ))
 }
 
 fn inspect_hf_safetensors_file(
     path: &Path,
-) -> llm_provable_computer::Result<(u64, String, String, usize)> {
+) -> llm_provable_computer::Result<(u64, String, String, String, usize)> {
     const MAX_SAFETENSORS_HEADER_BYTES: u64 = 16 * 1024 * 1024;
 
     let (mut file, size_bytes) = open_checked_regular_file(path, "HF provenance file", None)?;
@@ -4985,6 +5013,7 @@ fn inspect_hf_safetensors_file(
 
     let mut output = [0u8; 32];
     let mut hasher = Blake2bVar::new(output.len()).expect("blake2b-256 hasher");
+    let mut sha256_hasher = Sha256::new();
 
     let mut header_len_bytes = [0u8; 8];
     file.read_exact(&mut header_len_bytes).map_err(|err| {
@@ -4994,6 +5023,7 @@ fn inspect_hf_safetensors_file(
         ))
     })?;
     hasher.update(&header_len_bytes);
+    Digest::update(&mut sha256_hasher, &header_len_bytes);
 
     let header_len = u64::from_le_bytes(header_len_bytes);
     if header_len > MAX_SAFETENSORS_HEADER_BYTES {
@@ -5030,6 +5060,7 @@ fn inspect_hf_safetensors_file(
         ))
     })?;
     hasher.update(&header_bytes);
+    Digest::update(&mut sha256_hasher, &header_bytes);
     let (metadata_hash, tensor_count) =
         hf_safetensors_metadata_commitment_from_header(path, &header_bytes)?;
 
@@ -5061,6 +5092,7 @@ fn inspect_hf_safetensors_file(
             })?;
         remaining -= read_bytes as u64;
         hasher.update(&buffer[..read_bytes]);
+        Digest::update(&mut sha256_hasher, &buffer[..read_bytes]);
     }
     let mut extra_byte = [0u8; 1];
     if file.read(&mut extra_byte).map_err(|err| {
@@ -5080,9 +5112,11 @@ fn inspect_hf_safetensors_file(
     hasher
         .finalize_variable(&mut output)
         .expect("blake2b-256 finalization");
+    let sha256_output = sha256_hasher.finalize();
     Ok((
         size_bytes,
-        output.iter().map(|byte| format!("{byte:02x}")).collect(),
+        encode_hex(&output),
+        encode_hex(sha256_output.as_slice()),
         metadata_hash,
         tensor_count,
     ))
@@ -7024,7 +7058,11 @@ fn hash_bytes_hex(bytes: &[u8]) -> String {
     hasher
         .finalize_variable(&mut output)
         .expect("blake2b-256 finalization");
-    output.iter().map(|byte| format!("{byte:02x}")).collect()
+    encode_hex(&output)
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 fn write_bytes_atomically(path: &Path, bytes: &[u8]) -> llm_provable_computer::Result<()> {
@@ -7217,7 +7255,8 @@ mod hf_provenance_manifest_tests {
             "graph": {
                 "path": "model.onnx",
                 "size_bytes": 16,
-                "blake2b_256": "5".repeat(64)
+                "blake2b_256": "5".repeat(64),
+                "sha256": "6".repeat(64)
             },
             "metadata": null,
             "external_data_files": [],
@@ -7231,7 +7270,7 @@ mod hf_provenance_manifest_tests {
     }
 
     #[test]
-    fn load_hf_provenance_manifest_rejects_v2_missing_onnx_metadata_field() {
+    fn load_hf_provenance_manifest_rejects_v3_missing_onnx_metadata_field() {
         let file = hf_provenance_test_manifest_file("missing-onnx-metadata");
         let mut value = sample_hf_provenance_manifest_value();
         value["onnx_export"] = serde_json::json!({
@@ -7240,17 +7279,16 @@ mod hf_provenance_manifest_tests {
             "graph": {
                 "path": "model.onnx",
                 "size_bytes": 16,
-                "blake2b_256": "5".repeat(64)
+                "blake2b_256": "5".repeat(64),
+                "sha256": "6".repeat(64)
             },
             "external_data_files": []
         });
         write_hf_provenance_test_manifest(file.path(), &value);
 
         let err = load_hf_provenance_manifest(file.path())
-            .expect_err("v2 manifest missing onnx metadata field should fail");
-        assert!(err
-            .to_string()
-            .contains("missing field `metadata` in `onnx_export`"));
+            .expect_err("v3 manifest missing onnx metadata field should fail");
+        assert!(err.to_string().contains("missing field `metadata`"));
     }
 
     #[test]
@@ -7274,6 +7312,20 @@ mod hf_provenance_manifest_tests {
         assert!(err
             .to_string()
             .contains("legacy manifest_version `hf-provenance-manifest-v1` is no longer accepted"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_legacy_v2_with_upgrade_message() {
+        let file = hf_provenance_test_manifest_file("legacy-v2");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["manifest_version"] = serde_json::json!(HF_PROVENANCE_MANIFEST_VERSION_V2_LEGACY);
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("legacy v2 manifest should require regeneration");
+        assert!(err
+            .to_string()
+            .contains("legacy manifest_version `hf-provenance-manifest-v2` is no longer accepted"));
     }
 
     #[test]
@@ -7397,6 +7449,7 @@ mod hf_provenance_manifest_tests {
                 path: bound_dir.display().to_string(),
                 size_bytes: 0,
                 blake2b_256: "0".repeat(64),
+                sha256: "1".repeat(64),
             }),
             doi: None,
             datasets: Vec::new(),
@@ -7434,6 +7487,7 @@ mod hf_provenance_manifest_tests {
                         path: bound_dir.display().to_string(),
                         size_bytes: 0,
                         blake2b_256: "0".repeat(64),
+                        sha256: "1".repeat(64),
                     }),
                     doi: None,
                     datasets: Vec::new(),
@@ -7577,6 +7631,30 @@ mod hf_provenance_manifest_tests {
         assert!(err
             .to_string()
             .contains("HF provenance onnx_export.exporter_version must be non-empty"));
+    }
+
+    #[test]
+    fn verify_hf_provenance_manifest_rejects_sha256_drift() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let graph = dir.path().join("model.onnx");
+        fs::write(&graph, b"onnx").expect("write graph");
+
+        let mut commitment = hf_file_commitment(&graph).expect("graph commitment");
+        commitment.sha256 = "0".repeat(64);
+        let manifest =
+            sample_hf_provenance_manifest_with_onnx_export(Some(HfOnnxExportProvenance {
+                exporter: "optimum-onnx".to_string(),
+                exporter_version: None,
+                graph: commitment,
+                metadata: None,
+                external_data_files: Vec::new(),
+            }));
+
+        let err = verify_hf_provenance_manifest(&manifest)
+            .expect_err("sha256 drift should fail verification");
+        assert!(err
+            .to_string()
+            .contains("HF provenance onnx_export.graph sha256 commitment mismatch"));
     }
 }
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -982,7 +982,7 @@ struct HfProvenanceCommitments {
 struct HfProvenanceManifest {
     manifest_version: String,
     semantic_scope: String,
-    hash_function: String,
+    commitment_hash_function: String,
     hub_repo: String,
     hub_revision: String,
     tokenizer: HfTokenizerProvenance,
@@ -4266,7 +4266,7 @@ fn prepare_hf_provenance_manifest_command(
     let manifest = HfProvenanceManifest {
         manifest_version: HF_PROVENANCE_MANIFEST_VERSION.to_string(),
         semantic_scope: HF_PROVENANCE_SEMANTIC_SCOPE.to_string(),
-        hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
+        commitment_hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
         hub_repo: command.hub_repo,
         hub_revision: command.hub_revision,
         commitments: HfProvenanceCommitments {
@@ -4604,8 +4604,8 @@ fn verify_hf_provenance_manifest(
         HF_PROVENANCE_SEMANTIC_SCOPE,
     )?;
     expect_eq(
-        "hf hash_function",
-        &manifest.hash_function,
+        "hf commitment_hash_function",
+        &manifest.commitment_hash_function,
         HF_PROVENANCE_HASH_FUNCTION,
     )?;
     validate_hf_identifier("hub_repo", &manifest.hub_repo)?;
@@ -7154,7 +7154,7 @@ mod hf_provenance_manifest_tests {
         serde_json::json!({
             "manifest_version": HF_PROVENANCE_MANIFEST_VERSION,
             "semantic_scope": HF_PROVENANCE_SEMANTIC_SCOPE,
-            "hash_function": HF_PROVENANCE_HASH_FUNCTION,
+            "commitment_hash_function": HF_PROVENANCE_HASH_FUNCTION,
             "hub_repo": "example/test-model",
             "hub_revision": "0123456789abcdef",
             "tokenizer": {
@@ -7209,7 +7209,7 @@ mod hf_provenance_manifest_tests {
         HfProvenanceManifest {
             manifest_version: HF_PROVENANCE_MANIFEST_VERSION.to_string(),
             semantic_scope: HF_PROVENANCE_SEMANTIC_SCOPE.to_string(),
-            hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
+            commitment_hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
             hub_repo: "example/test-model".to_string(),
             hub_revision: "0123456789abcdef".to_string(),
             tokenizer: tokenizer.clone(),
@@ -7459,7 +7459,7 @@ mod hf_provenance_manifest_tests {
         let manifest = HfProvenanceManifest {
             manifest_version: HF_PROVENANCE_MANIFEST_VERSION.to_string(),
             semantic_scope: HF_PROVENANCE_SEMANTIC_SCOPE.to_string(),
-            hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
+            commitment_hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
             hub_repo: "example/test-model".to_string(),
             hub_revision: "0123456789abcdef".to_string(),
             tokenizer,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4835,6 +4835,12 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
             .map(str::len),
         Some(64)
     );
+    assert!(
+        manifest_json["tokenizer"]["tokenizer_json"]["sha256"]
+            .as_str()
+            .is_some_and(|digest| digest.chars().all(|c| c.is_ascii_hexdigit())),
+        "tokenizer.tokenizer_json.sha256 must be hex",
+    );
     assert_eq!(
         manifest_json
             .get("safetensors")
@@ -5024,6 +5030,58 @@ fn cli_verifier_rejects_hf_manifest_safetensors_sha256_tamper() {
         .failure()
         .stderr(predicate::str::contains("HF provenance safetensors"))
         .stderr(predicate::str::contains("sha256 commitment mismatch"));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_legacy_hf_manifest_v2() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-legacy-v2");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let tokenizer_json = fixture_dir.join("tokenizer.json");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(
+        &tokenizer_json,
+        br#"{"version":"1.0","model":{"type":"WordPiece","unk_token":"[UNK]"}}"#,
+    )
+    .expect("write tokenizer json");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&tokenizer_json)
+        .assert()
+        .success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["manifest_version"] = serde_json::json!("hf-provenance-manifest-v2");
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize legacy v2 manifest"),
+    )
+    .expect("write legacy v2 manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "legacy manifest_version `hf-provenance-manifest-v2` is no longer accepted",
+        ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4832,7 +4832,16 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
         manifest_json
             .get("manifest_version")
             .and_then(serde_json::Value::as_str),
-        Some("hf-provenance-manifest-v2")
+        Some("hf-provenance-manifest-v3")
+    );
+    assert_eq!(
+        manifest_json
+            .get("tokenizer")
+            .and_then(|tokenizer| tokenizer.get("tokenizer_json"))
+            .and_then(|value| value.get("sha256"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::len),
+        Some(64)
     );
     assert_eq!(
         manifest_json
@@ -4907,6 +4916,63 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
         .failure()
         .stderr(predicate::str::contains(
             "hub_revision must be pinned to an immutable commit or release tag",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_hf_manifest_sha256_tamper() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-sha256-tamper");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let tokenizer_json = fixture_dir.join("tokenizer.json");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(
+        &tokenizer_json,
+        br#"{"version":"1.0","model":{"type":"WordPiece","unk_token":"[UNK]"}}"#,
+    )
+    .expect("write tokenizer json");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&tokenizer_json)
+        .assert()
+        .success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["tokenizer"]["tokenizer_json"]["sha256"] = serde_json::json!("0".repeat(64));
+    manifest_json["commitments"]["tokenizer_hash"] = serde_json::Value::String(hash_json_value(
+        manifest_json
+            .get("tokenizer")
+            .expect("tokenizer section after sha256 tamper"),
+    ));
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "tokenizer_json sha256 commitment mismatch",
         ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5035,7 +5035,7 @@ fn cli_verifier_rejects_hf_manifest_safetensors_sha256_tamper() {
 }
 
 #[test]
-fn cli_verifier_rejects_legacy_hf_manifest_v2() {
+fn cli_verifier_rejects_legacy_hf_manifest_versions() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-legacy-v2");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
     let tokenizer_json = fixture_dir.join("tokenizer.json");
@@ -5066,22 +5066,24 @@ fn cli_verifier_rejects_legacy_hf_manifest_v2() {
     let mut manifest_json: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
             .expect("manifest json");
-    manifest_json["manifest_version"] = serde_json::json!("hf-provenance-manifest-v2");
-    std::fs::write(
-        &manifest,
-        serde_json::to_vec_pretty(&manifest_json).expect("serialize legacy v2 manifest"),
-    )
-    .expect("write legacy v2 manifest");
+    for legacy_version in ["hf-provenance-manifest-v1", "hf-provenance-manifest-v2"] {
+        manifest_json["manifest_version"] = serde_json::json!(legacy_version);
+        std::fs::write(
+            &manifest,
+            serde_json::to_vec_pretty(&manifest_json).expect("serialize legacy manifest"),
+        )
+        .expect("write legacy manifest");
 
-    let mut verify = tvm_command();
-    verify
-        .arg("verify-hf-provenance-manifest")
-        .arg(&manifest)
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "legacy manifest_version `hf-provenance-manifest-v2` is no longer accepted",
-        ));
+        let mut verify = tvm_command();
+        verify
+            .arg("verify-hf-provenance-manifest")
+            .arg(&manifest)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(format!(
+                "legacy manifest_version `{legacy_version}` is no longer accepted",
+            )));
+    }
 
     let _ = std::fs::remove_dir_all(fixture_dir);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,9 +2,7 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use assert_cmd::Command;
-#[cfg(any(feature = "onnx-export", feature = "stwo-backend"))]
 use blake2::digest::{Update, VariableOutput};
-#[cfg(any(feature = "onnx-export", feature = "stwo-backend"))]
 use blake2::Blake2bVar;
 #[cfg(feature = "stwo-backend")]
 use flate2::GzBuilder;
@@ -228,11 +226,6 @@ fn read_repo_file(relative_path: &str) -> Vec<u8> {
     std::fs::read(path).expect("repo file")
 }
 
-#[cfg(any(feature = "onnx-export", feature = "stwo-backend"))]
-#[cfg_attr(
-    all(feature = "stwo-backend", not(feature = "onnx-export")),
-    allow(dead_code)
-)]
 fn blake2b_256_hex(bytes: &[u8]) -> String {
     let mut output = [0u8; 32];
     let mut hasher = Blake2bVar::new(output.len()).expect("blake2b-256 hasher");
@@ -524,7 +517,6 @@ fn assert_research_v2_spec_commitments(
     );
 }
 
-#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 fn hash_json_value(value: &serde_json::Value) -> String {
     blake2b_256_hex(&serde_json::to_vec(value).expect("json hash payload"))
 }
@@ -4974,6 +4966,64 @@ fn cli_verifier_rejects_hf_manifest_sha256_tamper() {
         .stderr(predicate::str::contains(
             "tokenizer_json sha256 commitment mismatch",
         ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_hf_manifest_safetensors_sha256_tamper() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-safetensors-sha256-tamper");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let safetensors = fixture_dir.join("model.safetensors");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    let safetensors_header = br#"{"weight":{"dtype":"F32","shape":[1],"data_offsets":[0,4]},"__metadata__":{"format":"pt"}}"#;
+    let mut safetensors_bytes = Vec::new();
+    safetensors_bytes.extend_from_slice(&(safetensors_header.len() as u64).to_le_bytes());
+    safetensors_bytes.extend_from_slice(safetensors_header);
+    safetensors_bytes.extend_from_slice(&[0, 0, 0, 0]);
+    std::fs::write(&safetensors, safetensors_bytes).expect("write safetensors fixture");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--safetensors")
+        .arg(&safetensors)
+        .assert()
+        .success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["safetensors"][0]["sha256"] = serde_json::json!("0".repeat(64));
+    manifest_json["commitments"]["safetensors_manifest_hash"] =
+        serde_json::Value::String(hash_json_value(
+            manifest_json
+                .get("safetensors")
+                .expect("safetensors section after sha256 tamper"),
+        ));
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("HF provenance safetensors"))
+        .stderr(predicate::str::contains("sha256 commitment mismatch"));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4828,6 +4828,12 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
     );
     assert_eq!(
         manifest_json
+            .get("commitment_hash_function")
+            .and_then(serde_json::Value::as_str),
+        Some("blake2b-256")
+    );
+    assert_eq!(
+        manifest_json
             .get("tokenizer")
             .and_then(|tokenizer| tokenizer.get("tokenizer_json"))
             .and_then(|value| value.get("sha256"))


### PR DESCRIPTION
## What changed

- bump the HF provenance manifest wire format to `hf-provenance-manifest-v3`
- add `sha256` to every HF file commitment and safetensors commitment alongside the existing `blake2b_256`
- keep strict loader semantics for explicit `onnx_export` fields in `v3`
- add unit and CLI tamper coverage for `sha256` drift and legacy `v2` rejection
- update the paper-2 draft and README to describe the attestation-friendly boundary honestly

## Why

The paper-facing gap after PR #131 was not another vague provenance note. It was attestation interoperability.

Current GitHub/SLSA/in-toto style release verification workflows key on SHA-256 subject digests. The repo already had strong local BLAKE2b-based reproducibility checks, but it did not carry an attestation-friendly subject digest inventory on the same bounded manifest surface.

This change closes that gap without overclaiming:

- the manifest is still a bounded provenance artifact
- it is still not a proof relation
- it still does not verify GitHub, Sigstore, in-toto, or SLSA attestations

## User / developer impact

- new manifests are generated as `hf-provenance-manifest-v3`
- legacy `hf-provenance-manifest-v1` and `hf-provenance-manifest-v2` files are rejected with upgrade guidance
- bound files now carry both local reproducibility digests and attestation-friendly SHA-256 digests
- the paper text now says this more precisely for a crypto audience

## Root cause

The repo's HF provenance surface was good enough for local reproducibility, but thinner than current attestation ecosystems on subject-digest interoperability.

## Hardening

- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Notes:
- oracle / differential checks: not applicable beyond the existing manifest verifier, because this slice hardens provenance binding rather than execution semantics
- Kani / formal-kernel impact: not applicable for this CLI/schema/documentation surface

## Validation

- `cargo test --features full --bin tvm hf_provenance -- --nocapture`
- `TVM_TEST_BINARY=$PWD/target/debug/tvm cargo test --features full --test cli hf_provenance -- --nocapture`
- `TVM_TEST_BINARY=$PWD/target/debug/tvm cargo test --features full --test cli cli_verifier_rejects_hf_manifest_sha256_tamper -- --nocapture`
- `python3 scripts/paper/paper_preflight.py --repo-root /Users/espejelomar/StarkNet/starknet-ai/llm-provable-computer`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HF provenance manifest upgraded to v3 and now records SHA-256 digests alongside BLAKE2b-256 for stronger file identity matching.

* **Documentation**
  * Clarified verifier non‑proving scope, updated manifest wire format/version guidance, broadened provenance boundary language, and added references on signed supply‑chain attestations and CI build provenance.

* **Improvements**
  * Legacy v1/v2 manifests explicitly rejected with regeneration guidance; tamper‑detection checks strengthened.

* **Tests**
  * New CLI/verifier tests for SHA‑256 mismatch and legacy manifest rejection.

* **Chores**
  * Added a cargo-audit JSON checker and updated the dependency-audit runner and exceptions list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->