### PR TITLE
Harden HF provenance hub binding and inventory identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,9 +848,10 @@ format also carries `sha256` digests for bound files so release assets can be
 matched against attestation subject digests without turning the manifest into an
 attestation verifier.
 
-The current manifest wire format is `hf-provenance-manifest-v3`. Older
-`hf-provenance-manifest-v1` and `hf-provenance-manifest-v2` files must be
-regenerated before verification because the ONNX sidecar surface and
+The current manifest wire format is `hf-provenance-manifest-v4`. Older
+`hf-provenance-manifest-v1`, `hf-provenance-manifest-v2`, and
+`hf-provenance-manifest-v3` files must be regenerated before verification
+because the ONNX sidecar surface, hub-binding commitment, and
 attestation-digest inventory now have explicit versioned format boundaries.
 
 Canonical HF provenance spec file:

--- a/spec/hf-provenance-manifest.schema.json
+++ b/spec/hf-provenance-manifest.schema.json
@@ -17,7 +17,7 @@
     "commitments"
   ],
   "properties": {
-    "manifest_version": { "const": "hf-provenance-manifest-v3" },
+    "manifest_version": { "const": "hf-provenance-manifest-v4" },
     "semantic_scope": { "const": "hf-release-provenance-boundary-v1" },
     "commitment_hash_function": { "const": "blake2b-256" },
     "hub_repo": { "type": "string", "minLength": 1 },
@@ -169,6 +169,7 @@
     "commitments": {
       "type": "object",
       "required": [
+        "hub_binding_hash",
         "tokenizer_hash",
         "safetensors_manifest_hash",
         "onnx_export_hash",
@@ -176,6 +177,7 @@
         "limitations_hash"
       ],
       "properties": {
+        "hub_binding_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "tokenizer_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "safetensors_manifest_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "onnx_export_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -893,7 +893,8 @@ const FRONTEND_RUNTIME_RESEARCH_WATCH_LANES: [&str; 9] = [
 ];
 const HF_PROVENANCE_MANIFEST_VERSION_V1_LEGACY: &str = "hf-provenance-manifest-v1";
 const HF_PROVENANCE_MANIFEST_VERSION_V2_LEGACY: &str = "hf-provenance-manifest-v2";
-const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v3";
+const HF_PROVENANCE_MANIFEST_VERSION_V3_LEGACY: &str = "hf-provenance-manifest-v3";
+const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v4";
 const HF_PROVENANCE_SEMANTIC_SCOPE: &str = "hf-release-provenance-boundary-v1";
 const HF_PROVENANCE_HASH_FUNCTION: &str = "blake2b-256";
 
@@ -967,9 +968,16 @@ struct HfReleaseMetadata {
     notes: Vec<String>,
 }
 
+#[derive(Debug, Serialize)]
+struct HfHubBinding<'a> {
+    hub_repo: &'a str,
+    hub_revision: &'a str,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct HfProvenanceCommitments {
+    hub_binding_hash: String,
     tokenizer_hash: String,
     safetensors_manifest_hash: String,
     onnx_export_hash: String,
@@ -4263,6 +4271,10 @@ fn prepare_hf_provenance_manifest_command(
         notes: command.notes,
     };
     let limitations = hf_provenance_limitations();
+    let hub_binding_hash = hash_json_projection_hex(&HfHubBinding {
+        hub_repo: &command.hub_repo,
+        hub_revision: &command.hub_revision,
+    })?;
     let manifest = HfProvenanceManifest {
         manifest_version: HF_PROVENANCE_MANIFEST_VERSION.to_string(),
         semantic_scope: HF_PROVENANCE_SEMANTIC_SCOPE.to_string(),
@@ -4270,6 +4282,7 @@ fn prepare_hf_provenance_manifest_command(
         hub_repo: command.hub_repo,
         hub_revision: command.hub_revision,
         commitments: HfProvenanceCommitments {
+            hub_binding_hash,
             tokenizer_hash: hash_json_projection_hex(&tokenizer)?,
             safetensors_manifest_hash: hash_json_projection_hex(&safetensors)?,
             onnx_export_hash: hash_json_projection_hex(&onnx_export)?,
@@ -4552,8 +4565,14 @@ fn load_hf_provenance_manifest(
             HF_PROVENANCE_MANIFEST_VERSION_V2_LEGACY,
             HF_PROVENANCE_MANIFEST_VERSION
         ))),
+        HF_PROVENANCE_MANIFEST_VERSION_V3_LEGACY => Err(VmError::Serialization(format!(
+            "failed to parse HF provenance manifest {}: legacy manifest_version `{}` is no longer accepted after the hub-binding hardening update; regenerate the manifest as {}",
+            manifest_path.display(),
+            HF_PROVENANCE_MANIFEST_VERSION_V3_LEGACY,
+            HF_PROVENANCE_MANIFEST_VERSION
+        ))),
         HF_PROVENANCE_MANIFEST_VERSION => {
-            ensure_hf_provenance_manifest_v3_required_fields(manifest_path, &manifest_value)?;
+            ensure_hf_provenance_manifest_v4_required_fields(manifest_path, &manifest_value)?;
             serde_json::from_value(manifest_value).map_err(|err| {
                 VmError::Serialization(format!(
                     "failed to parse HF provenance manifest {}: {err}",
@@ -4568,7 +4587,7 @@ fn load_hf_provenance_manifest(
     }
 }
 
-fn ensure_hf_provenance_manifest_v3_required_fields(
+fn ensure_hf_provenance_manifest_v4_required_fields(
     manifest_path: &Path,
     manifest_value: &serde_json::Value,
 ) -> llm_provable_computer::Result<()> {
@@ -4607,6 +4626,14 @@ fn verify_hf_provenance_manifest(
         "hf commitment_hash_function",
         &manifest.commitment_hash_function,
         HF_PROVENANCE_HASH_FUNCTION,
+    )?;
+    verify_hash_commitment(
+        "hf hub_binding_hash",
+        &manifest.commitments.hub_binding_hash,
+        &hash_json_projection_hex(&HfHubBinding {
+            hub_repo: &manifest.hub_repo,
+            hub_revision: &manifest.hub_revision,
+        })?,
     )?;
     validate_hf_identifier("hub_repo", &manifest.hub_repo)?;
     validate_hf_pinned_revision("hub_revision", &manifest.hub_revision)?;
@@ -4654,13 +4681,28 @@ fn verify_hf_provenance_manifest(
         &manifest.commitments.limitations_hash,
         &hash_json_projection_hex(&manifest.limitations)?,
     )?;
-    verify_hf_optional_file_commitment("tokenizer_json", &manifest.tokenizer.tokenizer_json)?;
-    verify_hf_optional_file_commitment("tokenizer_config", &manifest.tokenizer.tokenizer_config)?;
+    let mut bound_paths = std::collections::BTreeSet::new();
+    verify_hf_optional_file_commitment(
+        "tokenizer_json",
+        &manifest.tokenizer.tokenizer_json,
+        &mut bound_paths,
+    )?;
+    verify_hf_optional_file_commitment(
+        "tokenizer_config",
+        &manifest.tokenizer.tokenizer_config,
+        &mut bound_paths,
+    )?;
     verify_hf_optional_file_commitment(
         "tokenization_transcript",
         &manifest.tokenizer.tokenization_transcript,
+        &mut bound_paths,
     )?;
     for safetensors in &manifest.safetensors {
+        ensure_unique_hf_bound_path(
+            "HF provenance safetensors",
+            &safetensors.path,
+            &mut bound_paths,
+        )?;
         verify_hf_safetensors_file_commitment(safetensors)?;
     }
     if let Some(onnx_export) = &manifest.onnx_export {
@@ -4673,31 +4715,31 @@ fn verify_hf_provenance_manifest(
             "onnx_export.exporter_version",
             onnx_export.exporter_version.as_deref(),
         )?;
-        let mut onnx_paths = std::collections::BTreeSet::new();
         ensure_unique_hf_file_commitment_path(
             "HF provenance onnx_export.graph",
             &onnx_export.graph,
-            &mut onnx_paths,
+            &mut bound_paths,
         )?;
         verify_hf_file_commitment("onnx_export.graph", &onnx_export.graph)?;
-        if let Some(metadata) = &onnx_export.metadata {
-            ensure_unique_hf_file_commitment_path(
-                "HF provenance onnx_export.metadata",
-                metadata,
-                &mut onnx_paths,
-            )?;
-        }
-        verify_hf_optional_file_commitment("onnx_export.metadata", &onnx_export.metadata)?;
+        verify_hf_optional_file_commitment(
+            "onnx_export.metadata",
+            &onnx_export.metadata,
+            &mut bound_paths,
+        )?;
         for commitment in &onnx_export.external_data_files {
             ensure_unique_hf_file_commitment_path(
                 "HF provenance onnx_export.external_data_files[]",
                 commitment,
-                &mut onnx_paths,
+                &mut bound_paths,
             )?;
             verify_hf_file_commitment("onnx_export.external_data_files[]", commitment)?;
         }
     }
-    verify_hf_optional_file_commitment("model_card", &manifest.release.model_card)?;
+    verify_hf_optional_file_commitment(
+        "model_card",
+        &manifest.release.model_card,
+        &mut bound_paths,
+    )?;
     validate_hf_optional_identifier("release.doi", manifest.release.doi.as_deref())?;
     for (idx, dataset) in manifest.release.datasets.iter().enumerate() {
         validate_hf_identifier(&format!("release.datasets[{idx}]"), dataset)?;
@@ -4797,8 +4839,14 @@ fn hf_safetensors_file_commitment(
 fn verify_hf_optional_file_commitment(
     label: &str,
     commitment: &Option<HfFileCommitment>,
+    seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
 ) -> llm_provable_computer::Result<()> {
     if let Some(commitment) = commitment {
+        ensure_unique_hf_file_commitment_path(
+            &format!("HF provenance {label}"),
+            commitment,
+            seen_paths,
+        )?;
         verify_hf_file_commitment(label, commitment)?;
     }
     Ok(())
@@ -4890,11 +4938,18 @@ fn ensure_unique_hf_file_commitment_path(
     commitment: &HfFileCommitment,
     seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
 ) -> llm_provable_computer::Result<()> {
-    let identity = hf_file_identity(Path::new(&commitment.path), label)?;
+    ensure_unique_hf_bound_path(label, &commitment.path, seen_paths)
+}
+
+fn ensure_unique_hf_bound_path(
+    label: &str,
+    path: &str,
+    seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
+) -> llm_provable_computer::Result<()> {
+    let identity = hf_file_identity(Path::new(path), label)?;
     if !seen_paths.insert(identity) {
         return Err(VmError::InvalidConfig(format!(
-            "{label} reuses ONNX artifact path `{}`",
-            commitment.path
+            "{label} reuses HF artifact path `{path}`",
         )));
     }
     Ok(())
@@ -7174,6 +7229,7 @@ mod hf_provenance_manifest_tests {
             },
             "limitations": hf_provenance_limitations(),
             "commitments": {
+                "hub_binding_hash": "f".repeat(64),
                 "tokenizer_hash": "0".repeat(64),
                 "safetensors_manifest_hash": "1".repeat(64),
                 "onnx_export_hash": "2".repeat(64),
@@ -7206,18 +7262,25 @@ mod hf_provenance_manifest_tests {
             notes: vec!["release note".to_string()],
         };
         let limitations = hf_provenance_limitations();
+        let hub_repo = "example/test-model".to_string();
+        let hub_revision = "0123456789abcdef".to_string();
         HfProvenanceManifest {
             manifest_version: HF_PROVENANCE_MANIFEST_VERSION.to_string(),
             semantic_scope: HF_PROVENANCE_SEMANTIC_SCOPE.to_string(),
             commitment_hash_function: HF_PROVENANCE_HASH_FUNCTION.to_string(),
-            hub_repo: "example/test-model".to_string(),
-            hub_revision: "0123456789abcdef".to_string(),
+            hub_repo: hub_repo.clone(),
+            hub_revision: hub_revision.clone(),
             tokenizer: tokenizer.clone(),
             safetensors,
             onnx_export: onnx_export.clone(),
             release: release.clone(),
             limitations: limitations.clone(),
             commitments: HfProvenanceCommitments {
+                hub_binding_hash: hash_json_projection_hex(&HfHubBinding {
+                    hub_repo: &hub_repo,
+                    hub_revision: &hub_revision,
+                })
+                .expect("hub binding hash"),
                 tokenizer_hash: hash_json_projection_hex(&tokenizer).expect("tokenizer hash"),
                 safetensors_manifest_hash: hash_json_projection_hex(&Vec::<
                     HfSafetensorsFileCommitment,
@@ -7326,6 +7389,20 @@ mod hf_provenance_manifest_tests {
         assert!(err
             .to_string()
             .contains("legacy manifest_version `hf-provenance-manifest-v2` is no longer accepted"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_legacy_v3_with_upgrade_message() {
+        let file = hf_provenance_test_manifest_file("legacy-v3");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["manifest_version"] = serde_json::json!(HF_PROVENANCE_MANIFEST_VERSION_V3_LEGACY);
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("legacy v3 manifest should require regeneration");
+        assert!(err
+            .to_string()
+            .contains("legacy manifest_version `hf-provenance-manifest-v3` is no longer accepted"));
     }
 
     #[test]
@@ -7468,6 +7545,11 @@ mod hf_provenance_manifest_tests {
             release,
             limitations,
             commitments: HfProvenanceCommitments {
+                hub_binding_hash: hash_json_projection_hex(&HfHubBinding {
+                    hub_repo: "example/test-model",
+                    hub_revision: "0123456789abcdef",
+                })
+                .expect("hub binding hash"),
                 tokenizer_hash: hash_json_projection_hex(&HfTokenizerProvenance {
                     tokenizer_id: "example/test-model".to_string(),
                     tokenizer_revision: "0123456789abcdef".to_string(),
@@ -7562,7 +7644,7 @@ mod hf_provenance_manifest_tests {
             .expect_err("duplicate ONNX sidecar paths should fail");
         assert!(err
             .to_string()
-            .contains("onnx_export.external_data_files[] reuses ONNX artifact path"));
+            .contains("onnx_export.external_data_files[] reuses HF artifact path"));
     }
 
     #[test]
@@ -7585,7 +7667,7 @@ mod hf_provenance_manifest_tests {
             .expect_err("duplicate ONNX graph/metadata path should fail");
         assert!(err
             .to_string()
-            .contains("onnx_export.metadata reuses ONNX artifact path"));
+            .contains("onnx_export.metadata reuses HF artifact path"));
     }
 
     #[test]
@@ -7608,7 +7690,50 @@ mod hf_provenance_manifest_tests {
             .expect_err("duplicate ONNX graph/external-data path should fail");
         assert!(err
             .to_string()
-            .contains("onnx_export.external_data_files[] reuses ONNX artifact path"));
+            .contains("onnx_export.external_data_files[] reuses HF artifact path"));
+    }
+
+    #[test]
+    fn verify_hf_provenance_manifest_rejects_cross_role_duplicate_bound_paths() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let shared = dir.path().join("shared.json");
+        fs::write(&shared, b"{\"shared\":true}").expect("write shared file");
+
+        let tokenizer_json = hf_file_commitment(&shared).expect("tokenizer commitment");
+        let mut manifest = sample_hf_provenance_manifest_with_onnx_export(None);
+        manifest.tokenizer = HfTokenizerProvenance {
+            tokenizer_id: "example/test-model".to_string(),
+            tokenizer_revision: "0123456789abcdef".to_string(),
+            tokenizer_json: Some(tokenizer_json.clone()),
+            tokenizer_config: None,
+            tokenization_transcript: None,
+        };
+        manifest.release = HfReleaseMetadata {
+            model_card: Some(tokenizer_json),
+            doi: None,
+            datasets: Vec::new(),
+            notes: vec!["release note".to_string()],
+        };
+        manifest.commitments.tokenizer_hash =
+            hash_json_projection_hex(&manifest.tokenizer).expect("tokenizer hash");
+        manifest.commitments.release_metadata_hash =
+            hash_json_projection_hex(&manifest.release).expect("release hash");
+
+        let err = verify_hf_provenance_manifest(&manifest)
+            .expect_err("reused bound file across roles should fail");
+        assert!(err.to_string().contains("reuses HF artifact path"));
+    }
+
+    #[test]
+    fn verify_hf_provenance_manifest_rejects_hub_binding_hash_drift() {
+        let mut manifest = sample_hf_provenance_manifest_with_onnx_export(None);
+        manifest.hub_revision = "fedcba9876543210".to_string();
+
+        let err =
+            verify_hf_provenance_manifest(&manifest).expect_err("hub binding drift should fail");
+        assert!(err
+            .to_string()
+            .contains("hf hub_binding_hash commitment mismatch"));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -7660,6 +7660,35 @@ mod hf_provenance_manifest_tests {
     }
 
     #[test]
+    fn verify_hf_provenance_manifest_rejects_duplicate_onnx_external_data_hard_links() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let graph = dir.path().join("model.onnx");
+        let sidecar = dir.path().join("weights.bin");
+        let aliased_sidecar = dir.path().join("weights-alias.bin");
+        fs::write(&graph, b"onnx").expect("write graph");
+        fs::write(&sidecar, b"weights").expect("write sidecar");
+        fs::hard_link(&sidecar, &aliased_sidecar).expect("hard link sidecar alias");
+
+        let onnx_export = Some(HfOnnxExportProvenance {
+            exporter: "optimum-onnx".to_string(),
+            exporter_version: None,
+            graph: hf_file_commitment(&graph).expect("graph commitment"),
+            metadata: None,
+            external_data_files: vec![
+                hf_file_commitment(&sidecar).expect("sidecar commitment"),
+                hf_file_commitment(&aliased_sidecar).expect("aliased sidecar commitment"),
+            ],
+        });
+        let manifest = sample_hf_provenance_manifest_with_onnx_export(onnx_export);
+
+        let err = verify_hf_provenance_manifest(&manifest)
+            .expect_err("hard-linked ONNX sidecar paths should fail");
+        assert!(err
+            .to_string()
+            .contains("onnx_export.external_data_files[] reuses the same underlying HF artifact"));
+    }
+
+    #[test]
     fn verify_hf_provenance_manifest_rejects_onnx_metadata_path_reusing_graph() {
         let dir = tempfile::tempdir().expect("create temp dir");
         let graph = dir.path().join("model.onnx");

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4959,9 +4959,9 @@ fn ensure_unique_hf_bound_path(
     seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
 ) -> llm_provable_computer::Result<()> {
     let identity = hf_file_identity(Path::new(path), label)?;
-    if !seen_paths.insert(identity.clone()) {
+    if !seen_paths.insert(identity) {
         return Err(VmError::InvalidConfig(format!(
-            "{label} reuses HF artifact identity {identity:?} at `{path}`",
+            "{label} reuses the same underlying HF artifact as an earlier bound path via `{path}`",
         )));
     }
     Ok(())
@@ -7656,7 +7656,7 @@ mod hf_provenance_manifest_tests {
             .expect_err("duplicate ONNX sidecar paths should fail");
         assert!(err
             .to_string()
-            .contains("onnx_export.external_data_files[] reuses HF artifact identity"));
+            .contains("onnx_export.external_data_files[] reuses the same underlying HF artifact"));
     }
 
     #[test]
@@ -7679,7 +7679,7 @@ mod hf_provenance_manifest_tests {
             .expect_err("duplicate ONNX graph/metadata path should fail");
         assert!(err
             .to_string()
-            .contains("onnx_export.metadata reuses HF artifact identity"));
+            .contains("onnx_export.metadata reuses the same underlying HF artifact"));
     }
 
     #[test]
@@ -7702,7 +7702,7 @@ mod hf_provenance_manifest_tests {
             .expect_err("duplicate ONNX graph/external-data path should fail");
         assert!(err
             .to_string()
-            .contains("onnx_export.external_data_files[] reuses HF artifact identity"));
+            .contains("onnx_export.external_data_files[] reuses the same underlying HF artifact"));
     }
 
     #[test]
@@ -7733,7 +7733,9 @@ mod hf_provenance_manifest_tests {
 
         let err = verify_hf_provenance_manifest(&manifest)
             .expect_err("reused bound file across roles should fail");
-        assert!(err.to_string().contains("reuses HF artifact identity"));
+        assert!(err
+            .to_string()
+            .contains("reuses the same underlying HF artifact"));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4710,12 +4710,13 @@ fn verify_hf_provenance_manifest(
         &mut bound_paths,
     )?;
     for safetensors in &manifest.safetensors {
-        ensure_unique_hf_bound_path(
+        let identity = verify_hf_safetensors_file_commitment(safetensors)?;
+        ensure_unique_hf_identity(
             "HF provenance safetensors",
             &safetensors.path,
+            identity,
             &mut bound_paths,
         )?;
-        verify_hf_safetensors_file_commitment(safetensors)?;
     }
     if let Some(onnx_export) = &manifest.onnx_export {
         if onnx_export.exporter.trim().is_empty() {
@@ -4727,24 +4728,27 @@ fn verify_hf_provenance_manifest(
             "onnx_export.exporter_version",
             onnx_export.exporter_version.as_deref(),
         )?;
-        ensure_unique_hf_file_commitment_path(
+        let graph_identity = verify_hf_file_commitment("onnx_export.graph", &onnx_export.graph)?;
+        ensure_unique_hf_identity(
             "HF provenance onnx_export.graph",
-            &onnx_export.graph,
+            &onnx_export.graph.path,
+            graph_identity,
             &mut bound_paths,
         )?;
-        verify_hf_file_commitment("onnx_export.graph", &onnx_export.graph)?;
         verify_hf_optional_file_commitment(
             "onnx_export.metadata",
             &onnx_export.metadata,
             &mut bound_paths,
         )?;
         for commitment in &onnx_export.external_data_files {
-            ensure_unique_hf_file_commitment_path(
+            let identity =
+                verify_hf_file_commitment("onnx_export.external_data_files[]", commitment)?;
+            ensure_unique_hf_identity(
                 "HF provenance onnx_export.external_data_files[]",
-                commitment,
+                &commitment.path,
+                identity,
                 &mut bound_paths,
             )?;
-            verify_hf_file_commitment("onnx_export.external_data_files[]", commitment)?;
         }
     }
     verify_hf_optional_file_commitment(
@@ -4824,7 +4828,7 @@ fn hf_optional_file_commitment(
 }
 
 fn hf_file_commitment(path: &Path) -> llm_provable_computer::Result<HfFileCommitment> {
-    let (size_bytes, blake2b_256, sha256) = hash_hf_commitment_file(path)?;
+    let (_, size_bytes, blake2b_256, sha256) = hash_hf_commitment_file(path, "HF provenance file")?;
     Ok(HfFileCommitment {
         path: path.display().to_string(),
         size_bytes,
@@ -4836,8 +4840,8 @@ fn hf_file_commitment(path: &Path) -> llm_provable_computer::Result<HfFileCommit
 fn hf_safetensors_file_commitment(
     path: &Path,
 ) -> llm_provable_computer::Result<HfSafetensorsFileCommitment> {
-    let (size_bytes, blake2b_256, sha256, metadata_hash, tensor_count) =
-        inspect_hf_safetensors_file(path)?;
+    let (_, size_bytes, blake2b_256, sha256, metadata_hash, tensor_count) =
+        inspect_hf_safetensors_file(path, "HF provenance file")?;
     Ok(HfSafetensorsFileCommitment {
         path: path.display().to_string(),
         size_bytes,
@@ -4854,12 +4858,13 @@ fn verify_hf_optional_file_commitment(
     seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
 ) -> llm_provable_computer::Result<()> {
     if let Some(commitment) = commitment {
-        ensure_unique_hf_file_commitment_path(
+        let identity = verify_hf_file_commitment(label, commitment)?;
+        ensure_unique_hf_identity(
             &format!("HF provenance {label}"),
-            commitment,
+            &commitment.path,
+            identity,
             seen_paths,
         )?;
-        verify_hf_file_commitment(label, commitment)?;
     }
     Ok(())
 }
@@ -4867,8 +4872,10 @@ fn verify_hf_optional_file_commitment(
 fn verify_hf_file_commitment(
     label: &str,
     commitment: &HfFileCommitment,
-) -> llm_provable_computer::Result<()> {
-    let (size_bytes, blake2b_256, sha256) = hash_hf_commitment_file(Path::new(&commitment.path))?;
+) -> llm_provable_computer::Result<HfFileIdentity> {
+    let identity_label = format!("HF provenance {label}");
+    let (identity, size_bytes, blake2b_256, sha256) =
+        hash_hf_commitment_file(Path::new(&commitment.path), &identity_label)?;
     if commitment.size_bytes != size_bytes {
         return Err(VmError::InvalidConfig(format!(
             "HF provenance {label} size_bytes mismatch: expected {}, got {}",
@@ -4884,7 +4891,8 @@ fn verify_hf_file_commitment(
         &format!("HF provenance {label} sha256"),
         &commitment.sha256,
         &sha256,
-    )
+    )?;
+    Ok(identity)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -4900,8 +4908,11 @@ enum HfFileIdentity {
     CanonicalPath(PathBuf),
 }
 
-fn hf_file_identity(path: &Path, label: &str) -> llm_provable_computer::Result<HfFileIdentity> {
-    let (file, _) = open_checked_regular_file(path, label, None)?;
+fn hf_file_identity_from_open_file(
+    path: &Path,
+    label: &str,
+    file: &fs::File,
+) -> llm_provable_computer::Result<HfFileIdentity> {
     let metadata = file.metadata().map_err(|err| {
         VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
     })?;
@@ -4945,20 +4956,12 @@ fn hf_file_identity(path: &Path, label: &str) -> llm_provable_computer::Result<H
     }
 }
 
-fn ensure_unique_hf_file_commitment_path(
-    label: &str,
-    commitment: &HfFileCommitment,
-    seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
-) -> llm_provable_computer::Result<()> {
-    ensure_unique_hf_bound_path(label, &commitment.path, seen_paths)
-}
-
-fn ensure_unique_hf_bound_path(
+fn ensure_unique_hf_identity(
     label: &str,
     path: &str,
+    identity: HfFileIdentity,
     seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
 ) -> llm_provable_computer::Result<()> {
-    let identity = hf_file_identity(Path::new(path), label)?;
     if !seen_paths.insert(identity) {
         return Err(VmError::InvalidConfig(format!(
             "{label} reuses the same underlying HF artifact as an earlier bound path via `{path}`",
@@ -4969,9 +4972,9 @@ fn ensure_unique_hf_bound_path(
 
 fn verify_hf_safetensors_file_commitment(
     commitment: &HfSafetensorsFileCommitment,
-) -> llm_provable_computer::Result<()> {
-    let (size_bytes, blake2b_256, sha256, metadata_hash, tensor_count) =
-        inspect_hf_safetensors_file(Path::new(&commitment.path))?;
+) -> llm_provable_computer::Result<HfFileIdentity> {
+    let (identity, size_bytes, blake2b_256, sha256, metadata_hash, tensor_count) =
+        inspect_hf_safetensors_file(Path::new(&commitment.path), "HF provenance safetensors")?;
     if commitment.size_bytes != size_bytes {
         return Err(VmError::InvalidConfig(format!(
             "HF provenance safetensors {} size_bytes mismatch: expected {}, got {}",
@@ -5002,11 +5005,15 @@ fn verify_hf_safetensors_file_commitment(
             commitment.path, commitment.tensor_count, tensor_count
         )));
     }
-    Ok(())
+    Ok(identity)
 }
 
-fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, String, String)> {
-    let (mut file, size_bytes) = open_checked_regular_file(path, "HF provenance file", None)?;
+fn hash_hf_commitment_file(
+    path: &Path,
+    label: &str,
+) -> llm_provable_computer::Result<(HfFileIdentity, u64, String, String)> {
+    let (mut file, size_bytes) = open_checked_regular_file(path, label, None)?;
+    let identity = hf_file_identity_from_open_file(path, label, &file)?;
     let mut output = [0u8; 32];
     let mut hasher = Blake2bVar::new(output.len()).expect("blake2b-256 hasher");
     let mut sha256_hasher = Sha256::new();
@@ -5059,6 +5066,7 @@ fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, S
         .expect("blake2b-256 finalization");
     let sha256_output = sha256_hasher.finalize();
     Ok((
+        identity,
         size_bytes,
         encode_hex(&output),
         encode_hex(sha256_output.as_slice()),
@@ -5067,10 +5075,12 @@ fn hash_hf_commitment_file(path: &Path) -> llm_provable_computer::Result<(u64, S
 
 fn inspect_hf_safetensors_file(
     path: &Path,
-) -> llm_provable_computer::Result<(u64, String, String, String, usize)> {
+    label: &str,
+) -> llm_provable_computer::Result<(HfFileIdentity, u64, String, String, String, usize)> {
     const MAX_SAFETENSORS_HEADER_BYTES: u64 = 16 * 1024 * 1024;
 
-    let (mut file, size_bytes) = open_checked_regular_file(path, "HF provenance file", None)?;
+    let (mut file, size_bytes) = open_checked_regular_file(path, label, None)?;
+    let identity = hf_file_identity_from_open_file(path, label, &file)?;
     if size_bytes < 8 {
         return Err(VmError::InvalidConfig(format!(
             "HF provenance safetensors {} is shorter than the 8-byte metadata length header",
@@ -5181,6 +5191,7 @@ fn inspect_hf_safetensors_file(
         .expect("blake2b-256 finalization");
     let sha256_output = sha256_hasher.finalize();
     Ok((
+        identity,
         size_bytes,
         encode_hex(&output),
         encode_hex(sha256_output.as_slice()),

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -5023,14 +5023,11 @@ fn hash_hf_commitment_file(
     while remaining > 0 {
         let chunk_len = remaining.min(buffer.len() as u64) as usize;
         let read_bytes = file.read(&mut buffer[..chunk_len]).map_err(|err| {
-            VmError::InvalidConfig(format!(
-                "failed to read HF provenance file {}: {err}",
-                path.display()
-            ))
+            VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
         })?;
         if read_bytes == 0 {
             return Err(VmError::InvalidConfig(format!(
-                "HF provenance file {} ended before the expected {} bytes were read",
+                "{label} {} ended before the expected {} bytes were read",
                 path.display(),
                 size_bytes
             )));
@@ -5039,7 +5036,7 @@ fn hash_hf_commitment_file(
             .checked_add(read_bytes as u64)
             .ok_or_else(|| {
                 VmError::InvalidConfig(format!(
-                    "HF provenance file {} exceeded supported size accounting during read",
+                    "{label} {} exceeded supported size accounting during read",
                     path.display()
                 ))
             })?;
@@ -5049,14 +5046,11 @@ fn hash_hf_commitment_file(
     }
     let mut extra_byte = [0u8; 1];
     if file.read(&mut extra_byte).map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read HF provenance file {}: {err}",
-            path.display()
-        ))
+        VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
     })? != 0
     {
         return Err(VmError::InvalidConfig(format!(
-            "HF provenance file {} grew while being hashed after {} bytes were expected",
+            "{label} {} grew while being hashed after {} bytes were expected",
             path.display(),
             size_bytes
         )));
@@ -5094,10 +5088,7 @@ fn inspect_hf_safetensors_file(
 
     let mut header_len_bytes = [0u8; 8];
     file.read_exact(&mut header_len_bytes).map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read HF provenance file {}: {err}",
-            path.display()
-        ))
+        VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
     })?;
     hasher.update(&header_len_bytes);
     Digest::update(&mut sha256_hasher, &header_len_bytes);
@@ -5131,10 +5122,7 @@ fn inspect_hf_safetensors_file(
     })?;
     let mut header_bytes = vec![0u8; header_len];
     file.read_exact(&mut header_bytes).map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read HF provenance file {}: {err}",
-            path.display()
-        ))
+        VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
     })?;
     hasher.update(&header_bytes);
     Digest::update(&mut sha256_hasher, &header_bytes);
@@ -5147,14 +5135,11 @@ fn inspect_hf_safetensors_file(
     while remaining > 0 {
         let chunk_len = remaining.min(buffer.len() as u64) as usize;
         let read_bytes = file.read(&mut buffer[..chunk_len]).map_err(|err| {
-            VmError::InvalidConfig(format!(
-                "failed to read HF provenance file {}: {err}",
-                path.display()
-            ))
+            VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
         })?;
         if read_bytes == 0 {
             return Err(VmError::InvalidConfig(format!(
-                "HF provenance file {} ended before the expected {} bytes were read",
+                "{label} {} ended before the expected {} bytes were read",
                 path.display(),
                 size_bytes
             )));
@@ -5163,7 +5148,7 @@ fn inspect_hf_safetensors_file(
             .checked_add(read_bytes as u64)
             .ok_or_else(|| {
                 VmError::InvalidConfig(format!(
-                    "HF provenance file {} exceeded supported size accounting during read",
+                    "{label} {} exceeded supported size accounting during read",
                     path.display()
                 ))
             })?;
@@ -5173,14 +5158,11 @@ fn inspect_hf_safetensors_file(
     }
     let mut extra_byte = [0u8; 1];
     if file.read(&mut extra_byte).map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read HF provenance file {}: {err}",
-            path.display()
-        ))
+        VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
     })? != 0
     {
         return Err(VmError::InvalidConfig(format!(
-            "HF provenance file {} grew while being hashed after {} bytes were expected",
+            "{label} {} grew while being hashed after {} bytes were expected",
             path.display(),
             size_bytes
         )));
@@ -7375,6 +7357,23 @@ mod hf_provenance_manifest_tests {
         let err = load_hf_provenance_manifest(file.path())
             .expect_err("v3 manifest missing onnx metadata field should fail");
         assert!(err.to_string().contains("missing field `metadata`"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_v4_missing_hub_binding_hash_field() {
+        let file = hf_provenance_test_manifest_file("missing-hub-binding-hash");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["commitments"]
+            .as_object_mut()
+            .expect("commitments object")
+            .remove("hub_binding_hash");
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("v4 manifest missing hub_binding_hash should fail");
+        let err_text = err.to_string();
+        assert!(err_text.contains(HF_PROVENANCE_MANIFEST_VERSION));
+        assert!(err_text.contains("hub_binding_hash"));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4591,6 +4591,18 @@ fn ensure_hf_provenance_manifest_v4_required_fields(
     manifest_path: &Path,
     manifest_value: &serde_json::Value,
 ) -> llm_provable_computer::Result<()> {
+    if let Some(commitments_obj) = manifest_value
+        .get("commitments")
+        .and_then(|v| v.as_object())
+    {
+        if !commitments_obj.contains_key("hub_binding_hash") {
+            return Err(VmError::Serialization(format!(
+                "failed to parse HF provenance manifest {}: missing field `hub_binding_hash` in `commitments` for {}",
+                manifest_path.display(),
+                HF_PROVENANCE_MANIFEST_VERSION
+            )));
+        }
+    }
     let Some(onnx_export) = manifest_value.get("onnx_export") else {
         return Ok(());
     };
@@ -4947,9 +4959,9 @@ fn ensure_unique_hf_bound_path(
     seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
 ) -> llm_provable_computer::Result<()> {
     let identity = hf_file_identity(Path::new(path), label)?;
-    if !seen_paths.insert(identity) {
+    if !seen_paths.insert(identity.clone()) {
         return Err(VmError::InvalidConfig(format!(
-            "{label} reuses HF artifact path `{path}`",
+            "{label} reuses HF artifact identity {identity:?} at `{path}`",
         )));
     }
     Ok(())
@@ -7333,7 +7345,7 @@ mod hf_provenance_manifest_tests {
     }
 
     #[test]
-    fn load_hf_provenance_manifest_rejects_v3_missing_onnx_metadata_field() {
+    fn load_hf_provenance_manifest_rejects_v4_missing_onnx_metadata_field() {
         let file = hf_provenance_test_manifest_file("missing-onnx-metadata");
         let mut value = sample_hf_provenance_manifest_value();
         value["onnx_export"] = serde_json::json!({
@@ -7644,7 +7656,7 @@ mod hf_provenance_manifest_tests {
             .expect_err("duplicate ONNX sidecar paths should fail");
         assert!(err
             .to_string()
-            .contains("onnx_export.external_data_files[] reuses HF artifact path"));
+            .contains("onnx_export.external_data_files[] reuses HF artifact identity"));
     }
 
     #[test]
@@ -7667,7 +7679,7 @@ mod hf_provenance_manifest_tests {
             .expect_err("duplicate ONNX graph/metadata path should fail");
         assert!(err
             .to_string()
-            .contains("onnx_export.metadata reuses HF artifact path"));
+            .contains("onnx_export.metadata reuses HF artifact identity"));
     }
 
     #[test]
@@ -7690,7 +7702,7 @@ mod hf_provenance_manifest_tests {
             .expect_err("duplicate ONNX graph/external-data path should fail");
         assert!(err
             .to_string()
-            .contains("onnx_export.external_data_files[] reuses HF artifact path"));
+            .contains("onnx_export.external_data_files[] reuses HF artifact identity"));
     }
 
     #[test]
@@ -7721,7 +7733,7 @@ mod hf_provenance_manifest_tests {
 
         let err = verify_hf_provenance_manifest(&manifest)
             .expect_err("reused bound file across roles should fail");
-        assert!(err.to_string().contains("reuses HF artifact path"));
+        assert!(err.to_string().contains("reuses HF artifact identity"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4824,13 +4824,19 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
         manifest_json
             .get("manifest_version")
             .and_then(serde_json::Value::as_str),
-        Some("hf-provenance-manifest-v3")
+        Some("hf-provenance-manifest-v4")
     );
     assert_eq!(
         manifest_json
             .get("commitment_hash_function")
             .and_then(serde_json::Value::as_str),
         Some("blake2b-256")
+    );
+    assert!(
+        manifest_json["commitments"]["hub_binding_hash"]
+            .as_str()
+            .is_some_and(|digest| digest.chars().all(|c| c.is_ascii_hexdigit())),
+        "commitments.hub_binding_hash must be hex",
     );
     assert_eq!(
         manifest_json
@@ -4926,6 +4932,58 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
 }
 
 #[test]
+fn cli_verifier_rejects_hf_manifest_hub_binding_tamper() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-hub-binding-tamper");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let tokenizer_json = fixture_dir.join("tokenizer.json");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(
+        &tokenizer_json,
+        br#"{"version":"1.0","model":{"type":"WordPiece","unk_token":"[UNK]"}}"#,
+    )
+    .expect("write tokenizer json");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&tokenizer_json)
+        .assert()
+        .success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["hub_revision"] = serde_json::json!("fedcba9876543210");
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "hf hub_binding_hash commitment mismatch",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
 fn cli_verifier_rejects_hf_manifest_sha256_tamper() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-sha256-tamper");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
@@ -4977,6 +5035,68 @@ fn cli_verifier_rejects_hf_manifest_sha256_tamper() {
         .failure()
         .stderr(predicate::str::contains(
             "tokenizer_json sha256 commitment mismatch",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_hf_manifest_model_card_sha256_tamper() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-model-card-sha256-tamper");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let tokenizer_json = fixture_dir.join("tokenizer.json");
+    let model_card = fixture_dir.join("README.md");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(
+        &tokenizer_json,
+        br#"{"version":"1.0","model":{"type":"WordPiece","unk_token":"[UNK]"}}"#,
+    )
+    .expect("write tokenizer json");
+    std::fs::write(&model_card, b"# Card\n").expect("write model card");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&tokenizer_json)
+        .arg("--model-card")
+        .arg(&model_card)
+        .assert()
+        .success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["release"]["model_card"]["sha256"] = serde_json::json!("0".repeat(64));
+    manifest_json["commitments"]["release_metadata_hash"] =
+        serde_json::Value::String(hash_json_value(
+            manifest_json
+                .get("release")
+                .expect("release section after sha256 tamper"),
+        ));
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "model_card sha256 commitment mismatch",
         ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
@@ -5072,7 +5192,11 @@ fn cli_verifier_rejects_legacy_hf_manifest_versions() {
     let mut manifest_json: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
             .expect("manifest json");
-    for legacy_version in ["hf-provenance-manifest-v1", "hf-provenance-manifest-v2"] {
+    for legacy_version in [
+        "hf-provenance-manifest-v1",
+        "hf-provenance-manifest-v2",
+        "hf-provenance-manifest-v3",
+    ] {
         manifest_json["manifest_version"] = serde_json::json!(legacy_version);
         std::fs::write(
             &manifest,
@@ -5133,7 +5257,7 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_reuses_graph_path() {
 
     let mut prepare = hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_model), &[]);
     prepare.assert().failure().stderr(predicate::str::contains(
-        "onnx_export.metadata reuses ONNX artifact path",
+        "onnx_export.metadata reuses HF artifact path",
     ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
@@ -5150,7 +5274,7 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_external_data_reuses_graph_path(
 
     let mut prepare = hf_provenance_prepare_command(&manifest, &onnx_model, None, &[&onnx_model]);
     prepare.assert().failure().stderr(predicate::str::contains(
-        "onnx_export.external_data_files[] reuses ONNX artifact path",
+        "onnx_export.external_data_files[] reuses HF artifact path",
     ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
@@ -5197,8 +5321,45 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_aliases_graph_path() {
     let mut prepare =
         hf_provenance_prepare_command(&manifest, &onnx_model, Some(&aliased_onnx_model), &[]);
     prepare.assert().failure().stderr(predicate::str::contains(
-        "onnx_export.metadata reuses ONNX artifact path",
+        "onnx_export.metadata reuses HF artifact path",
     ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_rejects_hf_provenance_manifest_when_model_card_reuses_tokenizer_json_path() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-duplicate-model-card");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let shared = fixture_dir.join("shared.json");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(
+        &shared,
+        br#"{"version":"1.0","model":{"type":"WordPiece","unk_token":"[UNK]"}}"#,
+    )
+    .expect("write shared fixture");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&shared)
+        .arg("--model-card")
+        .arg(&shared)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "model_card reuses HF artifact path",
+        ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4835,7 +4835,9 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
     assert!(
         manifest_json["commitments"]["hub_binding_hash"]
             .as_str()
-            .is_some_and(|digest| digest.chars().all(|c| c.is_ascii_hexdigit())),
+            .is_some_and(|digest| {
+                digest.len() == 64 && digest.chars().all(|c| c.is_ascii_hexdigit())
+            }),
         "commitments.hub_binding_hash must be hex",
     );
     assert_eq!(
@@ -4960,25 +4962,31 @@ fn cli_verifier_rejects_hf_manifest_hub_binding_tamper() {
         .assert()
         .success();
 
-    let mut manifest_json: serde_json::Value =
+    let base_manifest_json: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
             .expect("manifest json");
-    manifest_json["hub_revision"] = serde_json::json!("fedcba9876543210");
-    std::fs::write(
-        &manifest,
-        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
-    )
-    .expect("write tampered manifest");
+    for (field, replacement) in [
+        ("hub_revision", serde_json::json!("fedcba9876543210")),
+        ("hub_repo", serde_json::json!("example/other-model")),
+    ] {
+        let mut manifest_json = base_manifest_json.clone();
+        manifest_json[field] = replacement;
+        std::fs::write(
+            &manifest,
+            serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+        )
+        .expect("write tampered manifest");
 
-    let mut verify = tvm_command();
-    verify
-        .arg("verify-hf-provenance-manifest")
-        .arg(&manifest)
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "hf hub_binding_hash commitment mismatch",
-        ));
+        let mut verify = tvm_command();
+        verify
+            .arg("verify-hf-provenance-manifest")
+            .arg(&manifest)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "hf hub_binding_hash commitment mismatch",
+            ));
+    }
 
     let _ = std::fs::remove_dir_all(fixture_dir);
 }
@@ -5192,10 +5200,19 @@ fn cli_verifier_rejects_legacy_hf_manifest_versions() {
     let mut manifest_json: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
             .expect("manifest json");
-    for legacy_version in [
-        "hf-provenance-manifest-v1",
-        "hf-provenance-manifest-v2",
-        "hf-provenance-manifest-v3",
+    for (legacy_version, reason) in [
+        (
+            "hf-provenance-manifest-v1",
+            "after the ONNX sidecar format bump",
+        ),
+        (
+            "hf-provenance-manifest-v2",
+            "after the attestation-digest format bump",
+        ),
+        (
+            "hf-provenance-manifest-v3",
+            "after the hub-binding hardening update",
+        ),
     ] {
         manifest_json["manifest_version"] = serde_json::json!(legacy_version);
         std::fs::write(
@@ -5212,7 +5229,8 @@ fn cli_verifier_rejects_legacy_hf_manifest_versions() {
             .failure()
             .stderr(predicate::str::contains(format!(
                 "legacy manifest_version `{legacy_version}` is no longer accepted",
-            )));
+            )))
+            .stderr(predicate::str::contains(reason));
     }
 
     let _ = std::fs::remove_dir_all(fixture_dir);
@@ -5257,7 +5275,7 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_reuses_graph_path() {
 
     let mut prepare = hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_model), &[]);
     prepare.assert().failure().stderr(predicate::str::contains(
-        "onnx_export.metadata reuses HF artifact path",
+        "onnx_export.metadata reuses HF artifact identity",
     ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
@@ -5274,7 +5292,7 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_external_data_reuses_graph_path(
 
     let mut prepare = hf_provenance_prepare_command(&manifest, &onnx_model, None, &[&onnx_model]);
     prepare.assert().failure().stderr(predicate::str::contains(
-        "onnx_export.external_data_files[] reuses HF artifact path",
+        "onnx_export.external_data_files[] reuses HF artifact identity",
     ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
@@ -5321,7 +5339,7 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_aliases_graph_path() {
     let mut prepare =
         hf_provenance_prepare_command(&manifest, &onnx_model, Some(&aliased_onnx_model), &[]);
     prepare.assert().failure().stderr(predicate::str::contains(
-        "onnx_export.metadata reuses HF artifact path",
+        "onnx_export.metadata reuses HF artifact identity",
     ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
@@ -5358,7 +5376,7 @@ fn cli_rejects_hf_provenance_manifest_when_model_card_reuses_tokenizer_json_path
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "model_card reuses HF artifact path",
+            "model_card reuses HF artifact identity",
         ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5275,7 +5275,7 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_reuses_graph_path() {
 
     let mut prepare = hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_model), &[]);
     prepare.assert().failure().stderr(predicate::str::contains(
-        "onnx_export.metadata reuses HF artifact identity",
+        "onnx_export.metadata reuses the same underlying HF artifact",
     ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
@@ -5292,7 +5292,7 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_external_data_reuses_graph_path(
 
     let mut prepare = hf_provenance_prepare_command(&manifest, &onnx_model, None, &[&onnx_model]);
     prepare.assert().failure().stderr(predicate::str::contains(
-        "onnx_export.external_data_files[] reuses HF artifact identity",
+        "onnx_export.external_data_files[] reuses the same underlying HF artifact",
     ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
@@ -5339,7 +5339,7 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_aliases_graph_path() {
     let mut prepare =
         hf_provenance_prepare_command(&manifest, &onnx_model, Some(&aliased_onnx_model), &[]);
     prepare.assert().failure().stderr(predicate::str::contains(
-        "onnx_export.metadata reuses HF artifact identity",
+        "onnx_export.metadata reuses the same underlying HF artifact",
     ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
@@ -5376,7 +5376,7 @@ fn cli_rejects_hf_provenance_manifest_when_model_card_reuses_tokenizer_json_path
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "model_card reuses HF artifact identity",
+            "model_card reuses the same underlying HF artifact",
         ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5197,7 +5197,7 @@ fn cli_verifier_rejects_legacy_hf_manifest_versions() {
         .assert()
         .success();
 
-    let mut manifest_json: serde_json::Value =
+    let base_manifest_json: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
             .expect("manifest json");
     for (legacy_version, reason) in [
@@ -5214,7 +5214,14 @@ fn cli_verifier_rejects_legacy_hf_manifest_versions() {
             "after the hub-binding hardening update",
         ),
     ] {
+        let mut manifest_json = base_manifest_json.clone();
         manifest_json["manifest_version"] = serde_json::json!(legacy_version);
+        if legacy_version == "hf-provenance-manifest-v3" {
+            manifest_json["commitments"]
+                .as_object_mut()
+                .expect("commitments object")
+                .remove("hub_binding_hash");
+        }
         std::fs::write(
             &manifest,
             serde_json::to_vec_pretty(&manifest_json).expect("serialize legacy manifest"),
@@ -5350,6 +5357,7 @@ fn cli_rejects_hf_provenance_manifest_when_model_card_reuses_tokenizer_json_path
     let fixture_dir = unique_temp_dir("cli-hf-provenance-duplicate-model-card");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
     let shared = fixture_dir.join("shared.json");
+    let aliased_shared = fixture_dir.join("./shared.json");
     let manifest = fixture_dir.join("hf-provenance.json");
 
     std::fs::write(
@@ -5373,6 +5381,27 @@ fn cli_rejects_hf_provenance_manifest_when_model_card_reuses_tokenizer_json_path
         .arg(&shared)
         .arg("--model-card")
         .arg(&shared)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "model_card reuses the same underlying HF artifact",
+        ));
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&shared)
+        .arg("--model-card")
+        .arg(&aliased_shared)
         .assert()
         .failure()
         .stderr(predicate::str::contains(


### PR DESCRIPTION
## Summary
- bump HF provenance manifests to v4 and bind hub_repo/hub_revision into commitments.hub_binding_hash
- reject duplicate local artifact bindings across the full HF inventory instead of only ONNX sidecars
- extend CLI/unit coverage for hub-binding tamper, cross-role duplicate bindings, model-card SHA-256 tamper, and v3 legacy rejection

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below
- Skipped trusted-core default harness layers:
  - Oracle / differential checks: not applicable beyond verifier-side recomputation because this PR hardens manifest-boundary validation rather than adding a new execution engine.
  - Resource-bound / untrusted-input impact: reviewed. This PR tightens untrusted manifest and bound-file identity handling and preserves the existing bounded-manifest and regular-file checks; no new unbounded parser or host-resource surface was introduced.
  - Kani / formal-kernel impact: not applicable for this manifest/verifier slice; the change is bounded to parser, commitment, and duplicate-binding checks.
  - Miri / ASAN / UB impact: no new unsafe code or pointer-manipulating kernel surface was introduced in this slice, so the existing sanitizer coverage remains unchanged and no new sanitizer-specific harness was required for this PR.

## Validation
- cargo test -q --bin tvm hf_provenance_manifest_tests:: -- --test-threads=1
- cargo build -q --bin tvm
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_can_prepare_and_verify_hf_provenance_manifest -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_verifier_rejects_hf_manifest_hub_binding_tamper -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_verifier_rejects_hf_manifest_model_card_sha256_tamper -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_rejects_hf_provenance_manifest_when_model_card_reuses_tokenizer_json_path -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_verifier_rejects_legacy_hf_manifest_versions -- --exact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hub-binding integrity checks to manifest verification (detects tampering of hub repo/revision).

* **Documentation**
  * Updated provenance manifest format to v4; manifests from v1, v2, and v3 must be regenerated. README notes updated compatibility and upgrade guidance.

* **Bug Fixes**
  * Stronger duplicate-artifact detection to prevent reuse of the same underlying artifact across roles; clearer rejection messages.

* **Tests**
  * Expanded verifier and preparation tests for legacy-version rejection, v4 requirements, and new commitment mismatch cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the HF provenance manifest format to v4, binds `hub_repo`/`hub_revision` into a new `commitments.hub_binding_hash` field, and extends the duplicate-artifact check from ONNX-only to the full inventory (tokenizer, safetensors, ONNX, model card). Legacy v1/v2/v3 manifests are now rejected at load time with an upgrade message. The implementation, verification ordering, and test coverage are all sound.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — implementation is correct, version drift is handled consistently, and all tamper/negative paths are covered.

All remaining findings are P2 or lower. The hub-binding hash correctly ties hub_repo/hub_revision into the commitment set and is verified before identifier validation. The duplicate-binding check uses a single BTreeSet shared across all roles, eliminating the ONNX-only scope gap. Version constants, schema, and README are aligned. Test coverage includes unit and CLI paths for hub-binding tamper, model-card SHA tamper, cross-role duplicates, hard-link identity, and legacy v3 rejection.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/bin/tvm.rs | Hub-binding hash commitment added, verified before identifier validation; bound_paths set promoted to cover all roles; file identity now derived from the already-open file handle, eliminating a redundant open. |
| spec/hf-provenance-manifest.schema.json | Schema bumped to v4 with hub_binding_hash added to commitments required fields and properties; consistent with code constants. |
| tests/cli.rs | New CLI tests for hub-binding tamper, model-card SHA tamper, cross-role duplicate binding, and v3 legacy rejection; existing version-rejection test extended to cover v3. |
| README.md | Wire-format version reference updated from v3 to v4; v3 added to the list of legacy formats that must be regenerated; reasoning updated to mention hub-binding commitment. |

</details>

</details>

<sub>Reviews (4): Last reviewed commit: ["Tighten HF manifest error context and ma..."](https://github.com/omarespejel/provable-transformer-vm/commit/b3206f9f6a109098b0ea415d95648f53fdf0e9a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28426264)</sub>

<!-- /greptile_comment -->