### PR TITLE
Bind ONNX metadata identity in HF provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,13 +846,16 @@ equivalence, ONNX metadata semantic correctness, live Hub availability, DOI
 validity, or GitHub/Sigstore/in-toto/SLSA attestation validity. The current wire
 format also carries `sha256` digests for bound files so release assets can be
 matched against attestation subject digests without turning the manifest into an
-attestation verifier.
+attestation verifier. When an ONNX metadata sidecar is bound, the manifest now
+also carries a versioned metadata-identity projection over the exporter-facing
+format/opset/shape/encoding surface and instruction-table cardinality.
 
-The current manifest wire format is `hf-provenance-manifest-v4`. Older
-`hf-provenance-manifest-v1`, `hf-provenance-manifest-v2`, and
-`hf-provenance-manifest-v3` files must be regenerated before verification
-because the ONNX sidecar surface, hub-binding commitment, and
-attestation-digest inventory now have explicit versioned format boundaries.
+The current manifest wire format is `hf-provenance-manifest-v5`. Older
+`hf-provenance-manifest-v1`, `hf-provenance-manifest-v2`,
+`hf-provenance-manifest-v3`, and `hf-provenance-manifest-v4` files must be
+regenerated before verification because the ONNX sidecar surface, hub-binding
+commitment, metadata-identity projection, and attestation-digest inventory now
+have explicit versioned format boundaries.
 
 Canonical HF provenance spec file:
 

--- a/spec/hf-provenance-manifest.schema.json
+++ b/spec/hf-provenance-manifest.schema.json
@@ -17,7 +17,7 @@
     "commitments"
   ],
   "properties": {
-    "manifest_version": { "const": "hf-provenance-manifest-v4" },
+    "manifest_version": { "const": "hf-provenance-manifest-v5" },
     "semantic_scope": { "const": "hf-release-provenance-boundary-v1" },
     "commitment_hash_function": { "const": "blake2b-256" },
     "hub_repo": { "type": "string", "minLength": 1 },
@@ -116,7 +116,7 @@
     },
     "onnx_export": {
       "type": "object",
-      "required": ["exporter", "exporter_version", "graph", "metadata", "external_data_files"],
+      "required": ["exporter", "exporter_version", "graph", "metadata", "metadata_identity", "external_data_files"],
       "properties": {
         "exporter": { "type": "string", "minLength": 1 },
         "exporter_version": {
@@ -132,10 +132,42 @@
             { "type": "null" }
           ]
         },
+        "metadata_identity": {
+          "anyOf": [
+            { "$ref": "#/$defs/onnx_metadata_identity" },
+            { "type": "null" }
+          ]
+        },
         "external_data_files": {
           "type": "array",
           "items": { "$ref": "#/$defs/file_commitment" }
         }
+      },
+      "additionalProperties": false
+    },
+    "onnx_metadata_identity": {
+      "type": "object",
+      "required": [
+        "identity_version",
+        "format_version",
+        "ir_version",
+        "opset_version",
+        "input_dim",
+        "output_dim",
+        "input_encoding",
+        "output_encoding",
+        "instruction_count"
+      ],
+      "properties": {
+        "identity_version": { "const": "onnx-program-metadata-identity-v1" },
+        "format_version": { "type": "integer", "minimum": 0 },
+        "ir_version": { "type": "integer", "minimum": 0 },
+        "opset_version": { "type": "integer", "minimum": 0 },
+        "input_dim": { "type": "integer", "minimum": 0 },
+        "output_dim": { "type": "integer", "minimum": 0 },
+        "input_encoding": { "type": "string", "minLength": 1 },
+        "output_encoding": { "type": "string", "minLength": 1 },
+        "instruction_count": { "type": "integer", "minimum": 0 }
       },
       "additionalProperties": false
     },
@@ -173,6 +205,7 @@
         "tokenizer_hash",
         "safetensors_manifest_hash",
         "onnx_export_hash",
+        "onnx_metadata_identity_hash",
         "release_metadata_hash",
         "limitations_hash"
       ],
@@ -181,6 +214,7 @@
         "tokenizer_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "safetensors_manifest_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "onnx_export_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "onnx_metadata_identity_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "release_metadata_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "limitations_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" }
       },

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -5146,21 +5146,32 @@ fn metadata_u32_field(
     path: &Path,
     field: &str,
 ) -> llm_provable_computer::Result<u32> {
-    let value = metadata
-        .get(field)
-        .and_then(serde_json::Value::as_u64)
-        .ok_or_else(|| {
-            VmError::InvalidConfig(format!(
-                "HF provenance ONNX metadata {} missing integer field `{field}`",
-                path.display()
-            ))
-        })?;
-    u32::try_from(value).map_err(|_| {
+    let value = metadata.get(field).ok_or_else(|| {
         VmError::InvalidConfig(format!(
-            "HF provenance ONNX metadata {} field `{field}` exceeds u32",
+            "HF provenance ONNX metadata {} missing integer field `{field}`",
             path.display()
         ))
-    })
+    })?;
+    if let Some(unsigned) = value.as_u64() {
+        return u32::try_from(unsigned).map_err(|_| {
+            VmError::InvalidConfig(format!(
+                "HF provenance ONNX metadata {} field `{field}` exceeds u32",
+                path.display()
+            ))
+        });
+    }
+    if let Some(signed) = value.as_i64() {
+        if signed < 0 {
+            return Err(VmError::InvalidConfig(format!(
+                "HF provenance ONNX metadata {} field `{field}` must be non-negative",
+                path.display()
+            )));
+        }
+    }
+    Err(VmError::InvalidConfig(format!(
+        "HF provenance ONNX metadata {} missing integer field `{field}`",
+        path.display()
+    )))
 }
 
 fn metadata_u64_field(
@@ -5196,21 +5207,32 @@ fn metadata_usize_field(
     path: &Path,
     field: &str,
 ) -> llm_provable_computer::Result<usize> {
-    let value = metadata
-        .get(field)
-        .and_then(serde_json::Value::as_u64)
-        .ok_or_else(|| {
-            VmError::InvalidConfig(format!(
-                "HF provenance ONNX metadata {} missing integer field `{field}`",
-                path.display()
-            ))
-        })?;
-    usize::try_from(value).map_err(|_| {
+    let value = metadata.get(field).ok_or_else(|| {
         VmError::InvalidConfig(format!(
-            "HF provenance ONNX metadata {} field `{field}` exceeds usize",
+            "HF provenance ONNX metadata {} missing integer field `{field}`",
             path.display()
         ))
-    })
+    })?;
+    if let Some(unsigned) = value.as_u64() {
+        return usize::try_from(unsigned).map_err(|_| {
+            VmError::InvalidConfig(format!(
+                "HF provenance ONNX metadata {} field `{field}` exceeds usize",
+                path.display()
+            ))
+        });
+    }
+    if let Some(signed) = value.as_i64() {
+        if signed < 0 {
+            return Err(VmError::InvalidConfig(format!(
+                "HF provenance ONNX metadata {} field `{field}` must be non-negative",
+                path.display()
+            )));
+        }
+    }
+    Err(VmError::InvalidConfig(format!(
+        "HF provenance ONNX metadata {} missing integer field `{field}`",
+        path.display()
+    )))
 }
 
 fn verify_hf_optional_file_commitment(

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -5163,6 +5163,17 @@ fn hf_file_identity_from_open_file(
     }
 }
 
+fn ensure_unique_hf_bound_path(
+    label: &str,
+    path: &str,
+    seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
+) -> llm_provable_computer::Result<()> {
+    let path = Path::new(path);
+    let (file, _) = open_checked_regular_file(path, label, None)?;
+    let identity = hf_file_identity_from_open_file(path, label, &file)?;
+    ensure_unique_hf_identity(label, &path.display().to_string(), identity, seen_paths)
+}
+
 fn ensure_unique_hf_identity(
     label: &str,
     path: &str,
@@ -7921,6 +7932,7 @@ mod hf_provenance_manifest_tests {
             exporter_version: None,
             graph: hf_file_commitment(&graph).expect("graph commitment"),
             metadata: None,
+            metadata_identity: None,
             external_data_files: vec![
                 hf_file_commitment(&sidecar).expect("sidecar commitment"),
                 hf_file_commitment(&aliased_sidecar).expect("aliased sidecar commitment"),

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -968,8 +968,8 @@ struct HfOnnxExportProvenance {
 struct HfOnnxMetadataIdentity {
     identity_version: String,
     format_version: u32,
-    ir_version: i64,
-    opset_version: i64,
+    ir_version: u64,
+    opset_version: u64,
     input_dim: usize,
     output_dim: usize,
     input_encoding: String,
@@ -5070,8 +5070,8 @@ fn derive_hf_onnx_metadata_identity_from_value(
     Ok(HfOnnxMetadataIdentity {
         identity_version: HF_ONNX_METADATA_IDENTITY_VERSION.to_string(),
         format_version: metadata_u32_field(&metadata, path, "format_version")?,
-        ir_version: metadata_i64_field(&metadata, path, "ir_version")?,
-        opset_version: metadata_i64_field(&metadata, path, "opset_version")?,
+        ir_version: metadata_u64_field(&metadata, path, "ir_version")?,
+        opset_version: metadata_u64_field(&metadata, path, "opset_version")?,
         input_dim: metadata_usize_field(&metadata, path, "input_dim")?,
         output_dim: metadata_usize_field(&metadata, path, "output_dim")?,
         input_encoding: metadata_string_field(&metadata, path, "input_encoding")?,
@@ -5134,20 +5134,32 @@ fn metadata_u32_field(
     })
 }
 
-fn metadata_i64_field(
+fn metadata_u64_field(
     metadata: &serde_json::Value,
     path: &Path,
     field: &str,
-) -> llm_provable_computer::Result<i64> {
-    metadata
-        .get(field)
-        .and_then(serde_json::Value::as_i64)
-        .ok_or_else(|| {
-            VmError::InvalidConfig(format!(
-                "HF provenance ONNX metadata {} missing integer field `{field}`",
+) -> llm_provable_computer::Result<u64> {
+    let value = metadata.get(field).ok_or_else(|| {
+        VmError::InvalidConfig(format!(
+            "HF provenance ONNX metadata {} missing integer field `{field}`",
+            path.display()
+        ))
+    })?;
+    if let Some(unsigned) = value.as_u64() {
+        return Ok(unsigned);
+    }
+    if let Some(signed) = value.as_i64() {
+        if signed < 0 {
+            return Err(VmError::InvalidConfig(format!(
+                "HF provenance ONNX metadata {} field `{field}` must be non-negative",
                 path.display()
-            ))
-        })
+            )));
+        }
+    }
+    Err(VmError::InvalidConfig(format!(
+        "HF provenance ONNX metadata {} missing integer field `{field}`",
+        path.display()
+    )))
 }
 
 fn metadata_usize_field(

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4622,29 +4622,18 @@ fn verify_hf_provenance_manifest_command(
 fn load_hf_provenance_manifest(
     manifest_path: &Path,
 ) -> llm_provable_computer::Result<HfProvenanceManifest> {
-    let (file, _) = open_checked_regular_file(
+    let (file, size_bytes) = open_checked_regular_file(
         manifest_path,
         "HF provenance manifest",
         Some(MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES as u64),
     )?;
-    let mut manifest_bytes = Vec::new();
-    let mut limited_reader = file.take(MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES as u64 + 1);
-    limited_reader
-        .read_to_end(&mut manifest_bytes)
-        .map_err(|err| {
-            VmError::InvalidConfig(format!(
-                "failed to read HF provenance manifest {}: {err}",
-                manifest_path.display()
-            ))
-        })?;
-    if manifest_bytes.len() > MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES {
-        return Err(VmError::InvalidConfig(format!(
-            "HF provenance manifest {} is {} bytes after read, exceeding the limit of {} bytes",
-            manifest_path.display(),
-            manifest_bytes.len(),
-            MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES
-        )));
-    }
+    let manifest_bytes = read_checked_bounded_file_bytes(
+        file,
+        manifest_path,
+        "HF provenance manifest",
+        size_bytes,
+        MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES as u64,
+    )?;
 
     let manifest_value: serde_json::Value =
         serde_json::from_slice(&manifest_bytes).map_err(|err| {
@@ -5132,6 +5121,7 @@ fn metadata_string_field(
     metadata
         .get(field)
         .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
         .map(str::to_string)
         .ok_or_else(|| {
             VmError::InvalidConfig(format!(

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -4269,36 +4269,42 @@ fn prepare_hf_provenance_manifest_command(
         .as_deref()
         .map(|path| {
             let mut bound_paths = std::collections::BTreeSet::new();
-            ensure_unique_hf_bound_path(
+            let (graph_identity, graph_commitment) =
+                inspect_hf_commitment_file(path, "HF provenance onnx_export.graph")?;
+            ensure_unique_hf_identity(
                 "HF provenance onnx_export.graph",
                 &path.display().to_string(),
+                graph_identity,
                 &mut bound_paths,
             )?;
-            if let Some(metadata_path) = command.onnx_metadata.as_deref() {
-                ensure_unique_hf_bound_path(
-                    "HF provenance onnx_export.metadata",
-                    &metadata_path.display().to_string(),
-                    &mut bound_paths,
-                )?;
-            }
+            let mut external_data_files =
+                Vec::with_capacity(command.onnx_external_data_files.len());
             for external_data_path in &command.onnx_external_data_files {
-                ensure_unique_hf_bound_path(
+                let (external_data_identity, external_data_commitment) =
+                    inspect_hf_commitment_file(
+                        external_data_path,
+                        "HF provenance onnx_export.external_data_files[]",
+                    )?;
+                ensure_unique_hf_identity(
                     "HF provenance onnx_export.external_data_files[]",
                     &external_data_path.display().to_string(),
+                    external_data_identity,
                     &mut bound_paths,
                 )?;
+                external_data_files.push(external_data_commitment);
             }
-            let mut external_data_files = command
-                .onnx_external_data_files
-                .iter()
-                .map(|path| hf_file_commitment(path))
-                .collect::<llm_provable_computer::Result<Vec<_>>>()?;
             external_data_files.sort_by(|a, b| a.path.cmp(&b.path));
             let (metadata, metadata_identity) = if let Some(metadata_path) =
                 command.onnx_metadata.as_deref()
             {
-                let (_, metadata_commitment, metadata_bytes) =
+                let (metadata_identity_binding, metadata_commitment, metadata_bytes) =
                     inspect_hf_onnx_metadata_file(metadata_path)?;
+                ensure_unique_hf_identity(
+                    "HF provenance onnx_export.metadata",
+                    &metadata_path.display().to_string(),
+                    metadata_identity_binding,
+                    &mut bound_paths,
+                )?;
                 let metadata_json = parse_hf_onnx_metadata_json(metadata_path, &metadata_bytes)?;
                 (
                     Some(metadata_commitment),
@@ -4313,7 +4319,7 @@ fn prepare_hf_provenance_manifest_command(
             Ok::<HfOnnxExportProvenance, VmError>(HfOnnxExportProvenance {
                 exporter: command.onnx_exporter.clone(),
                 exporter_version: command.onnx_exporter_version.clone(),
-                graph: hf_file_commitment(path)?,
+                graph: graph_commitment,
                 metadata,
                 metadata_identity,
                 external_data_files,
@@ -4712,6 +4718,13 @@ fn ensure_hf_provenance_manifest_v5_required_fields(
                 HF_PROVENANCE_MANIFEST_VERSION
             )));
         }
+        if !commitments_obj.contains_key("onnx_metadata_identity_hash") {
+            return Err(VmError::Serialization(format!(
+                "failed to parse HF provenance manifest {}: missing field `onnx_metadata_identity_hash` in `commitments` for {}",
+                manifest_path.display(),
+                HF_PROVENANCE_MANIFEST_VERSION
+            )));
+        }
     }
     let Some(onnx_export) = manifest_value.get("onnx_export") else {
         return Ok(());
@@ -5004,6 +5017,22 @@ fn hf_file_commitment(path: &Path) -> llm_provable_computer::Result<HfFileCommit
         blake2b_256,
         sha256,
     })
+}
+
+fn inspect_hf_commitment_file(
+    path: &Path,
+    label: &str,
+) -> llm_provable_computer::Result<(HfFileIdentity, HfFileCommitment)> {
+    let (identity, size_bytes, blake2b_256, sha256) = hash_hf_commitment_file(path, label)?;
+    Ok((
+        identity,
+        HfFileCommitment {
+            path: path.display().to_string(),
+            size_bytes,
+            blake2b_256,
+            sha256,
+        },
+    ))
 }
 
 fn hf_safetensors_file_commitment(
@@ -5317,17 +5346,6 @@ fn hf_file_identity_from_open_file(
         })?;
         Ok(HfFileIdentity::CanonicalPath(canonical))
     }
-}
-
-fn ensure_unique_hf_bound_path(
-    label: &str,
-    path: &str,
-    seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
-) -> llm_provable_computer::Result<()> {
-    let path = Path::new(path);
-    let (file, _) = open_checked_regular_file(path, label, None)?;
-    let identity = hf_file_identity_from_open_file(path, label, &file)?;
-    ensure_unique_hf_identity(label, &path.display().to_string(), identity, seen_paths)
 }
 
 fn ensure_unique_hf_identity(
@@ -7613,7 +7631,7 @@ mod hf_provenance_manifest_tests {
                 "safetensors_manifest_hash": "1".repeat(64),
                 "onnx_export_hash": "2".repeat(64),
                 "onnx_metadata_identity_hash": "3".repeat(64),
-                "release_metadata_hash": "3".repeat(64),
+                "release_metadata_hash": "5".repeat(64),
                 "limitations_hash": "4".repeat(64)
             }
         })
@@ -7742,6 +7760,36 @@ mod hf_provenance_manifest_tests {
         assert!(err
             .to_string()
             .contains("missing field `metadata_identity`"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_v5_missing_onnx_metadata_identity_hash_field() {
+        let file = hf_provenance_test_manifest_file("missing-onnx-metadata-identity-hash");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["onnx_export"] = serde_json::json!({
+            "exporter": "optimum",
+            "exporter_version": null,
+            "graph": {
+                "path": "model.onnx",
+                "size_bytes": 16,
+                "blake2b_256": "5".repeat(64),
+                "sha256": "6".repeat(64)
+            },
+            "metadata": null,
+            "metadata_identity": null,
+            "external_data_files": []
+        });
+        value["commitments"]
+            .as_object_mut()
+            .expect("commitments object")
+            .remove("onnx_metadata_identity_hash");
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("v5 manifest missing onnx_metadata_identity_hash field should fail");
+        assert!(err
+            .to_string()
+            .contains("missing field `onnx_metadata_identity_hash`"));
     }
 
     #[test]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -869,6 +869,7 @@ const RESEARCH_V2_HASH_FUNCTION: &str = "blake2b-256";
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const RESEARCH_V3_RELATION_FORMAT: &str = "multi-engine-trace-relation-v1-no-egraph-no-smt";
 const MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES: usize = 8 * 1024 * 1024;
+const MAX_HF_ONNX_METADATA_JSON_BYTES: usize = 8 * 1024 * 1024;
 const HF_PROVENANCE_FILE_READ_CHUNK_BYTES: usize = 1024 * 1024;
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES: usize = 32 * 1024 * 1024;
@@ -4293,16 +4294,27 @@ fn prepare_hf_provenance_manifest_command(
                 .map(|path| hf_file_commitment(path))
                 .collect::<llm_provable_computer::Result<Vec<_>>>()?;
             external_data_files.sort_by(|a, b| a.path.cmp(&b.path));
-            let metadata_identity = command
-                .onnx_metadata
-                .as_deref()
-                .map(derive_hf_onnx_metadata_identity)
-                .transpose()?;
+            let (metadata, metadata_identity) = if let Some(metadata_path) =
+                command.onnx_metadata.as_deref()
+            {
+                let (_, metadata_commitment, metadata_bytes) =
+                    inspect_hf_onnx_metadata_file(metadata_path)?;
+                let metadata_json = parse_hf_onnx_metadata_json(metadata_path, &metadata_bytes)?;
+                (
+                    Some(metadata_commitment),
+                    Some(derive_hf_onnx_metadata_identity_from_value(
+                        metadata_path,
+                        &metadata_json,
+                    )?),
+                )
+            } else {
+                (None, None)
+            };
             Ok::<HfOnnxExportProvenance, VmError>(HfOnnxExportProvenance {
                 exporter: command.onnx_exporter.clone(),
                 exporter_version: command.onnx_exporter_version.clone(),
                 graph: hf_file_commitment(path)?,
-                metadata: hf_optional_file_commitment(command.onnx_metadata.as_deref())?,
+                metadata,
                 metadata_identity,
                 external_data_files,
             })
@@ -4539,6 +4551,49 @@ fn open_checked_regular_file(
         }
     }
     Ok((file, opened_metadata.len()))
+}
+
+fn read_checked_bounded_file_bytes(
+    file: fs::File,
+    path: &Path,
+    label: &str,
+    size_bytes: u64,
+    max_bytes: u64,
+) -> llm_provable_computer::Result<Vec<u8>> {
+    if size_bytes > max_bytes {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} {} is {} bytes, exceeding the limit of {} bytes",
+            path.display(),
+            size_bytes,
+            max_bytes
+        )));
+    }
+
+    let mut bytes = Vec::with_capacity(usize::try_from(size_bytes).map_err(|_| {
+        VmError::InvalidConfig(format!(
+            "{label} {} size {} does not fit in memory accounting",
+            path.display(),
+            size_bytes
+        ))
+    })?);
+    let mut limited_reader = file.take(size_bytes.saturating_add(1));
+    limited_reader.read_to_end(&mut bytes).map_err(|err| {
+        VmError::InvalidConfig(format!("failed to read {label} {}: {err}", path.display()))
+    })?;
+    if bytes.len() as u64 > size_bytes {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} {} changed after opening while it was being read",
+            path.display()
+        )));
+    }
+    if bytes.len() as u64 != size_bytes {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} {} ended before the expected {} bytes were read",
+            path.display(),
+            size_bytes
+        )));
+    }
+    Ok(bytes)
 }
 
 fn verify_hf_provenance_manifest_command(
@@ -4805,11 +4860,6 @@ fn verify_hf_provenance_manifest(
             graph_identity,
             &mut bound_paths,
         )?;
-        verify_hf_optional_file_commitment(
-            "onnx_export.metadata",
-            &onnx_export.metadata,
-            &mut bound_paths,
-        )?;
         for commitment in &onnx_export.external_data_files {
             let identity =
                 verify_hf_file_commitment("onnx_export.external_data_files[]", commitment)?;
@@ -4820,10 +4870,36 @@ fn verify_hf_provenance_manifest(
                 &mut bound_paths,
             )?;
         }
-        match (&onnx_export.metadata, &onnx_export.metadata_identity) {
-            (Some(metadata), Some(metadata_identity)) => {
-                let derived_metadata_identity =
-                    derive_hf_onnx_metadata_identity(Path::new(&metadata.path))?;
+        let verified_metadata_json = if let Some(metadata) = &onnx_export.metadata {
+            let (metadata_file_identity, computed_metadata_commitment, metadata_bytes) =
+                inspect_hf_onnx_metadata_file(Path::new(&metadata.path))?;
+            ensure_hf_file_commitment_matches(
+                "onnx_export.metadata",
+                metadata,
+                &computed_metadata_commitment,
+                metadata_file_identity,
+                &mut bound_paths,
+            )?;
+            Some(parse_hf_onnx_metadata_json(
+                Path::new(&metadata.path),
+                &metadata_bytes,
+            )?)
+        } else {
+            None
+        };
+        match (verified_metadata_json.as_ref(), &onnx_export.metadata_identity) {
+            (Some(metadata_json), Some(metadata_identity)) => {
+                let metadata_path = Path::new(
+                    &onnx_export
+                        .metadata
+                        .as_ref()
+                        .expect("verified metadata path")
+                        .path,
+                );
+                let derived_metadata_identity = derive_hf_onnx_metadata_identity_from_value(
+                    metadata_path,
+                    metadata_json,
+                )?;
                 if metadata_identity != &derived_metadata_identity {
                     return Err(VmError::InvalidConfig(format!(
                         "hf onnx_export.metadata_identity mismatch: expected {:?}, got {:?}",
@@ -4945,21 +5021,43 @@ fn hf_safetensors_file_commitment(
     })
 }
 
-fn derive_hf_onnx_metadata_identity(
+fn inspect_hf_onnx_metadata_file(
     path: &Path,
-) -> llm_provable_computer::Result<HfOnnxMetadataIdentity> {
-    let bytes = fs::read(path).map_err(|err| {
-        VmError::InvalidConfig(format!(
-            "failed to read HF provenance ONNX metadata {}: {err}",
-            path.display()
-        ))
-    })?;
-    let metadata: serde_json::Value = serde_json::from_slice(&bytes).map_err(|err| {
+) -> llm_provable_computer::Result<(HfFileIdentity, HfFileCommitment, Vec<u8>)> {
+    let label = "HF provenance ONNX metadata";
+    let max_bytes = MAX_HF_ONNX_METADATA_JSON_BYTES as u64;
+    let (file, size_bytes) = open_checked_regular_file(path, label, Some(max_bytes))?;
+    let identity = hf_file_identity_from_open_file(path, label, &file)?;
+    let bytes = read_checked_bounded_file_bytes(file, path, label, size_bytes, max_bytes)?;
+    let (blake2b_256, sha256) = hash_hf_commitment_bytes(&bytes)?;
+    Ok((
+        identity,
+        HfFileCommitment {
+            path: path.display().to_string(),
+            size_bytes,
+            blake2b_256,
+            sha256,
+        },
+        bytes,
+    ))
+}
+
+fn parse_hf_onnx_metadata_json(
+    path: &Path,
+    bytes: &[u8],
+) -> llm_provable_computer::Result<serde_json::Value> {
+    serde_json::from_slice(bytes).map_err(|err| {
         VmError::Serialization(format!(
             "failed to parse HF provenance ONNX metadata {}: {err}",
             path.display()
         ))
-    })?;
+    })
+}
+
+fn derive_hf_onnx_metadata_identity_from_value(
+    path: &Path,
+    metadata: &serde_json::Value,
+) -> llm_provable_computer::Result<HfOnnxMetadataIdentity> {
     let instructions = metadata
         .get("instructions")
         .and_then(serde_json::Value::as_array)
@@ -4980,6 +5078,21 @@ fn derive_hf_onnx_metadata_identity(
         output_encoding: metadata_string_field(&metadata, path, "output_encoding")?,
         instruction_count: instructions.len(),
     })
+}
+
+fn hash_hf_commitment_bytes(bytes: &[u8]) -> llm_provable_computer::Result<(String, String)> {
+    let mut output = [0u8; 32];
+    let mut blake2b = Blake2bVar::new(output.len()).expect("blake2b-256 hasher");
+    blake2b.update(bytes);
+    blake2b
+        .finalize_variable(&mut output)
+        .expect("blake2b finalize");
+    let blake2b_256 = encode_hex(&output);
+    let mut sha256 = Sha256::new();
+    Digest::update(&mut sha256, bytes);
+    let sha256_output = sha256.finalize();
+    let sha256 = encode_hex(sha256_output.as_slice());
+    Ok((blake2b_256, sha256))
 }
 
 fn metadata_string_field(
@@ -5074,6 +5187,37 @@ fn verify_hf_optional_file_commitment(
         )?;
     }
     Ok(())
+}
+
+fn ensure_hf_file_commitment_matches(
+    label: &str,
+    commitment: &HfFileCommitment,
+    computed_commitment: &HfFileCommitment,
+    identity: HfFileIdentity,
+    seen_paths: &mut std::collections::BTreeSet<HfFileIdentity>,
+) -> llm_provable_computer::Result<()> {
+    if commitment.size_bytes != computed_commitment.size_bytes {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance {label} size_bytes mismatch: expected {}, got {}",
+            commitment.size_bytes, computed_commitment.size_bytes
+        )));
+    }
+    verify_hash_commitment(
+        &format!("HF provenance {label} blake2b_256"),
+        &commitment.blake2b_256,
+        &computed_commitment.blake2b_256,
+    )?;
+    verify_hash_commitment(
+        &format!("HF provenance {label} sha256"),
+        &commitment.sha256,
+        &computed_commitment.sha256,
+    )?;
+    ensure_unique_hf_identity(
+        &format!("HF provenance {label}"),
+        &commitment.path,
+        identity,
+        seen_paths,
+    )
 }
 
 fn verify_hf_file_commitment(

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -894,9 +894,11 @@ const FRONTEND_RUNTIME_RESEARCH_WATCH_LANES: [&str; 9] = [
 const HF_PROVENANCE_MANIFEST_VERSION_V1_LEGACY: &str = "hf-provenance-manifest-v1";
 const HF_PROVENANCE_MANIFEST_VERSION_V2_LEGACY: &str = "hf-provenance-manifest-v2";
 const HF_PROVENANCE_MANIFEST_VERSION_V3_LEGACY: &str = "hf-provenance-manifest-v3";
-const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v4";
+const HF_PROVENANCE_MANIFEST_VERSION_V4_LEGACY: &str = "hf-provenance-manifest-v4";
+const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v5";
 const HF_PROVENANCE_SEMANTIC_SCOPE: &str = "hf-release-provenance-boundary-v1";
 const HF_PROVENANCE_HASH_FUNCTION: &str = "blake2b-256";
+const HF_ONNX_METADATA_IDENTITY_VERSION: &str = "onnx-program-metadata-identity-v1";
 
 struct HfProvenanceManifestCommand {
     output: PathBuf,
@@ -956,7 +958,22 @@ struct HfOnnxExportProvenance {
     exporter_version: Option<String>,
     graph: HfFileCommitment,
     metadata: Option<HfFileCommitment>,
+    metadata_identity: Option<HfOnnxMetadataIdentity>,
     external_data_files: Vec<HfFileCommitment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HfOnnxMetadataIdentity {
+    identity_version: String,
+    format_version: u32,
+    ir_version: i64,
+    opset_version: i64,
+    input_dim: usize,
+    output_dim: usize,
+    input_encoding: String,
+    output_encoding: String,
+    instruction_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -981,6 +998,7 @@ struct HfProvenanceCommitments {
     tokenizer_hash: String,
     safetensors_manifest_hash: String,
     onnx_export_hash: String,
+    onnx_metadata_identity_hash: String,
     release_metadata_hash: String,
     limitations_hash: String,
 }
@@ -4249,17 +4267,43 @@ fn prepare_hf_provenance_manifest_command(
         .onnx_model
         .as_deref()
         .map(|path| {
+            let mut bound_paths = std::collections::BTreeSet::new();
+            ensure_unique_hf_bound_path(
+                "HF provenance onnx_export.graph",
+                &path.display().to_string(),
+                &mut bound_paths,
+            )?;
+            if let Some(metadata_path) = command.onnx_metadata.as_deref() {
+                ensure_unique_hf_bound_path(
+                    "HF provenance onnx_export.metadata",
+                    &metadata_path.display().to_string(),
+                    &mut bound_paths,
+                )?;
+            }
+            for external_data_path in &command.onnx_external_data_files {
+                ensure_unique_hf_bound_path(
+                    "HF provenance onnx_export.external_data_files[]",
+                    &external_data_path.display().to_string(),
+                    &mut bound_paths,
+                )?;
+            }
             let mut external_data_files = command
                 .onnx_external_data_files
                 .iter()
                 .map(|path| hf_file_commitment(path))
                 .collect::<llm_provable_computer::Result<Vec<_>>>()?;
             external_data_files.sort_by(|a, b| a.path.cmp(&b.path));
+            let metadata_identity = command
+                .onnx_metadata
+                .as_deref()
+                .map(derive_hf_onnx_metadata_identity)
+                .transpose()?;
             Ok::<HfOnnxExportProvenance, VmError>(HfOnnxExportProvenance {
                 exporter: command.onnx_exporter.clone(),
                 exporter_version: command.onnx_exporter_version.clone(),
                 graph: hf_file_commitment(path)?,
                 metadata: hf_optional_file_commitment(command.onnx_metadata.as_deref())?,
+                metadata_identity,
                 external_data_files,
             })
         })
@@ -4286,6 +4330,11 @@ fn prepare_hf_provenance_manifest_command(
             tokenizer_hash: hash_json_projection_hex(&tokenizer)?,
             safetensors_manifest_hash: hash_json_projection_hex(&safetensors)?,
             onnx_export_hash: hash_json_projection_hex(&onnx_export)?,
+            onnx_metadata_identity_hash: hash_json_projection_hex(
+                &onnx_export
+                    .as_ref()
+                    .and_then(|export| export.metadata_identity.as_ref()),
+            )?,
             release_metadata_hash: hash_json_projection_hex(&release)?,
             limitations_hash: hash_json_projection_hex(&limitations)?,
         },
@@ -4571,8 +4620,14 @@ fn load_hf_provenance_manifest(
             HF_PROVENANCE_MANIFEST_VERSION_V3_LEGACY,
             HF_PROVENANCE_MANIFEST_VERSION
         ))),
+        HF_PROVENANCE_MANIFEST_VERSION_V4_LEGACY => Err(VmError::Serialization(format!(
+            "failed to parse HF provenance manifest {}: legacy manifest_version `{}` is no longer accepted after the ONNX metadata-identity hardening update; regenerate the manifest as {}",
+            manifest_path.display(),
+            HF_PROVENANCE_MANIFEST_VERSION_V4_LEGACY,
+            HF_PROVENANCE_MANIFEST_VERSION
+        ))),
         HF_PROVENANCE_MANIFEST_VERSION => {
-            ensure_hf_provenance_manifest_v4_required_fields(manifest_path, &manifest_value)?;
+            ensure_hf_provenance_manifest_v5_required_fields(manifest_path, &manifest_value)?;
             serde_json::from_value(manifest_value).map_err(|err| {
                 VmError::Serialization(format!(
                     "failed to parse HF provenance manifest {}: {err}",
@@ -4587,7 +4642,7 @@ fn load_hf_provenance_manifest(
     }
 }
 
-fn ensure_hf_provenance_manifest_v4_required_fields(
+fn ensure_hf_provenance_manifest_v5_required_fields(
     manifest_path: &Path,
     manifest_value: &serde_json::Value,
 ) -> llm_provable_computer::Result<()> {
@@ -4609,7 +4664,12 @@ fn ensure_hf_provenance_manifest_v4_required_fields(
     let Some(onnx_export_obj) = onnx_export.as_object() else {
         return Ok(());
     };
-    for field in ["exporter_version", "metadata", "external_data_files"] {
+    for field in [
+        "exporter_version",
+        "metadata",
+        "metadata_identity",
+        "external_data_files",
+    ] {
         if !onnx_export_obj.contains_key(field) {
             return Err(VmError::Serialization(format!(
                 "failed to parse HF provenance manifest {}: missing field `{field}` in `onnx_export` for {}",
@@ -4684,6 +4744,16 @@ fn verify_hf_provenance_manifest(
         &hash_json_projection_hex(&manifest.onnx_export)?,
     )?;
     verify_hash_commitment(
+        "hf onnx_metadata_identity_hash",
+        &manifest.commitments.onnx_metadata_identity_hash,
+        &hash_json_projection_hex(
+            &manifest
+                .onnx_export
+                .as_ref()
+                .and_then(|export| export.metadata_identity.as_ref()),
+        )?,
+    )?;
+    verify_hash_commitment(
         "hf release_metadata_hash",
         &manifest.commitments.release_metadata_hash,
         &hash_json_projection_hex(&manifest.release)?,
@@ -4749,6 +4819,29 @@ fn verify_hf_provenance_manifest(
                 identity,
                 &mut bound_paths,
             )?;
+        }
+        match (&onnx_export.metadata, &onnx_export.metadata_identity) {
+            (Some(metadata), Some(metadata_identity)) => {
+                let derived_metadata_identity =
+                    derive_hf_onnx_metadata_identity(Path::new(&metadata.path))?;
+                if metadata_identity != &derived_metadata_identity {
+                    return Err(VmError::InvalidConfig(format!(
+                        "hf onnx_export.metadata_identity mismatch: expected {:?}, got {:?}",
+                        metadata_identity, derived_metadata_identity
+                    )));
+                }
+            }
+            (Some(_), None) => {
+                return Err(VmError::InvalidConfig(
+                    "HF provenance onnx_export.metadata_identity must be present when metadata is bound".to_string(),
+                ))
+            }
+            (None, Some(_)) => {
+                return Err(VmError::InvalidConfig(
+                    "HF provenance onnx_export.metadata_identity requires onnx_export.metadata".to_string(),
+                ))
+            }
+            (None, None) => {}
         }
     }
     verify_hf_optional_file_commitment(
@@ -4849,6 +4942,120 @@ fn hf_safetensors_file_commitment(
         sha256,
         metadata_hash,
         tensor_count,
+    })
+}
+
+fn derive_hf_onnx_metadata_identity(
+    path: &Path,
+) -> llm_provable_computer::Result<HfOnnxMetadataIdentity> {
+    let bytes = fs::read(path).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to read HF provenance ONNX metadata {}: {err}",
+            path.display()
+        ))
+    })?;
+    let metadata: serde_json::Value = serde_json::from_slice(&bytes).map_err(|err| {
+        VmError::Serialization(format!(
+            "failed to parse HF provenance ONNX metadata {}: {err}",
+            path.display()
+        ))
+    })?;
+    let instructions = metadata
+        .get("instructions")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            VmError::InvalidConfig(format!(
+                "HF provenance ONNX metadata {} missing instructions array",
+                path.display()
+            ))
+        })?;
+    Ok(HfOnnxMetadataIdentity {
+        identity_version: HF_ONNX_METADATA_IDENTITY_VERSION.to_string(),
+        format_version: metadata_u32_field(&metadata, path, "format_version")?,
+        ir_version: metadata_i64_field(&metadata, path, "ir_version")?,
+        opset_version: metadata_i64_field(&metadata, path, "opset_version")?,
+        input_dim: metadata_usize_field(&metadata, path, "input_dim")?,
+        output_dim: metadata_usize_field(&metadata, path, "output_dim")?,
+        input_encoding: metadata_string_field(&metadata, path, "input_encoding")?,
+        output_encoding: metadata_string_field(&metadata, path, "output_encoding")?,
+        instruction_count: instructions.len(),
+    })
+}
+
+fn metadata_string_field(
+    metadata: &serde_json::Value,
+    path: &Path,
+    field: &str,
+) -> llm_provable_computer::Result<String> {
+    metadata
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            VmError::InvalidConfig(format!(
+                "HF provenance ONNX metadata {} missing string field `{field}`",
+                path.display()
+            ))
+        })
+}
+
+fn metadata_u32_field(
+    metadata: &serde_json::Value,
+    path: &Path,
+    field: &str,
+) -> llm_provable_computer::Result<u32> {
+    let value = metadata
+        .get(field)
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| {
+            VmError::InvalidConfig(format!(
+                "HF provenance ONNX metadata {} missing integer field `{field}`",
+                path.display()
+            ))
+        })?;
+    u32::try_from(value).map_err(|_| {
+        VmError::InvalidConfig(format!(
+            "HF provenance ONNX metadata {} field `{field}` exceeds u32",
+            path.display()
+        ))
+    })
+}
+
+fn metadata_i64_field(
+    metadata: &serde_json::Value,
+    path: &Path,
+    field: &str,
+) -> llm_provable_computer::Result<i64> {
+    metadata
+        .get(field)
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| {
+            VmError::InvalidConfig(format!(
+                "HF provenance ONNX metadata {} missing integer field `{field}`",
+                path.display()
+            ))
+        })
+}
+
+fn metadata_usize_field(
+    metadata: &serde_json::Value,
+    path: &Path,
+    field: &str,
+) -> llm_provable_computer::Result<usize> {
+    let value = metadata
+        .get(field)
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| {
+            VmError::InvalidConfig(format!(
+                "HF provenance ONNX metadata {} missing integer field `{field}`",
+                path.display()
+            ))
+        })?;
+    usize::try_from(value).map_err(|_| {
+        VmError::InvalidConfig(format!(
+            "HF provenance ONNX metadata {} field `{field}` exceeds usize",
+            path.display()
+        ))
     })
 }
 
@@ -7238,6 +7445,7 @@ mod hf_provenance_manifest_tests {
                 "tokenizer_hash": "0".repeat(64),
                 "safetensors_manifest_hash": "1".repeat(64),
                 "onnx_export_hash": "2".repeat(64),
+                "onnx_metadata_identity_hash": "3".repeat(64),
                 "release_metadata_hash": "3".repeat(64),
                 "limitations_hash": "4".repeat(64)
             }
@@ -7292,6 +7500,12 @@ mod hf_provenance_manifest_tests {
                 >::new())
                 .expect("safetensors hash"),
                 onnx_export_hash: hash_json_projection_hex(&onnx_export).expect("onnx hash"),
+                onnx_metadata_identity_hash: hash_json_projection_hex(
+                    &onnx_export
+                        .as_ref()
+                        .and_then(|export| export.metadata_identity.as_ref()),
+                )
+                .expect("onnx metadata identity hash"),
                 release_metadata_hash: hash_json_projection_hex(&release).expect("release hash"),
                 limitations_hash: hash_json_projection_hex(&limitations).expect("limitations hash"),
             },
@@ -7327,6 +7541,7 @@ mod hf_provenance_manifest_tests {
                 "sha256": "6".repeat(64)
             },
             "metadata": null,
+            "metadata_identity": null,
             "external_data_files": [],
             "unexpected_field": 7
         });
@@ -7338,7 +7553,7 @@ mod hf_provenance_manifest_tests {
     }
 
     #[test]
-    fn load_hf_provenance_manifest_rejects_v4_missing_onnx_metadata_field() {
+    fn load_hf_provenance_manifest_rejects_v5_missing_onnx_metadata_identity_field() {
         let file = hf_provenance_test_manifest_file("missing-onnx-metadata");
         let mut value = sample_hf_provenance_manifest_value();
         value["onnx_export"] = serde_json::json!({
@@ -7350,13 +7565,16 @@ mod hf_provenance_manifest_tests {
                 "blake2b_256": "5".repeat(64),
                 "sha256": "6".repeat(64)
             },
+            "metadata": null,
             "external_data_files": []
         });
         write_hf_provenance_test_manifest(file.path(), &value);
 
         let err = load_hf_provenance_manifest(file.path())
-            .expect_err("v3 manifest missing onnx metadata field should fail");
-        assert!(err.to_string().contains("missing field `metadata`"));
+            .expect_err("v5 manifest missing onnx metadata_identity field should fail");
+        assert!(err
+            .to_string()
+            .contains("missing field `metadata_identity`"));
     }
 
     #[test]
@@ -7425,6 +7643,20 @@ mod hf_provenance_manifest_tests {
         assert!(err
             .to_string()
             .contains("legacy manifest_version `hf-provenance-manifest-v3` is no longer accepted"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_legacy_v4_with_upgrade_message() {
+        let file = hf_provenance_test_manifest_file("legacy-v4");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["manifest_version"] = serde_json::json!(HF_PROVENANCE_MANIFEST_VERSION_V4_LEGACY);
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("legacy v4 manifest should require regeneration");
+        assert!(err
+            .to_string()
+            .contains("legacy manifest_version `hf-provenance-manifest-v4` is no longer accepted"));
     }
 
     #[test]
@@ -7586,6 +7818,10 @@ mod hf_provenance_manifest_tests {
                 .expect("safetensors hash"),
                 onnx_export_hash: hash_json_projection_hex(&Option::<HfOnnxExportProvenance>::None)
                     .expect("onnx hash"),
+                onnx_metadata_identity_hash: hash_json_projection_hex(
+                    &Option::<&HfOnnxMetadataIdentity>::None,
+                )
+                .expect("onnx metadata identity hash"),
                 release_metadata_hash: hash_json_projection_hex(&HfReleaseMetadata {
                     model_card: Some(HfFileCommitment {
                         path: bound_dir.display().to_string(),
@@ -7655,6 +7891,7 @@ mod hf_provenance_manifest_tests {
             exporter_version: None,
             graph: hf_file_commitment(&graph).expect("graph commitment"),
             metadata: None,
+            metadata_identity: None,
             external_data_files: vec![
                 hf_file_commitment(&sidecar).expect("sidecar commitment"),
                 hf_file_commitment(&sidecar).expect("sidecar commitment"),
@@ -7711,6 +7948,7 @@ mod hf_provenance_manifest_tests {
                 exporter_version: None,
                 graph: graph_commitment.clone(),
                 metadata: Some(graph_commitment),
+                metadata_identity: None,
                 external_data_files: Vec::new(),
             }));
 
@@ -7734,6 +7972,7 @@ mod hf_provenance_manifest_tests {
                 exporter_version: None,
                 graph: graph_commitment.clone(),
                 metadata: None,
+                metadata_identity: None,
                 external_data_files: vec![graph_commitment],
             }));
 
@@ -7801,6 +8040,7 @@ mod hf_provenance_manifest_tests {
                 exporter_version: Some(String::new()),
                 graph: hf_file_commitment(&graph).expect("graph commitment"),
                 metadata: None,
+                metadata_identity: None,
                 external_data_files: Vec::new(),
             }));
 
@@ -7825,6 +8065,7 @@ mod hf_provenance_manifest_tests {
                 exporter_version: None,
                 graph: commitment,
                 metadata: None,
+                metadata_identity: None,
                 external_data_files: Vec::new(),
             }));
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -8275,6 +8275,39 @@ mod hf_provenance_manifest_tests {
     }
 
     #[test]
+    fn verify_hf_provenance_manifest_rejects_metadata_identity_without_metadata() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let graph = dir.path().join("model.onnx");
+        fs::write(&graph, b"onnx").expect("write graph");
+
+        let manifest =
+            sample_hf_provenance_manifest_with_onnx_export(Some(HfOnnxExportProvenance {
+                exporter: "optimum-onnx".to_string(),
+                exporter_version: None,
+                graph: hf_file_commitment(&graph).expect("graph commitment"),
+                metadata: None,
+                metadata_identity: Some(HfOnnxMetadataIdentity {
+                    identity_version: HF_ONNX_METADATA_IDENTITY_VERSION.to_string(),
+                    format_version: 1,
+                    ir_version: 8,
+                    opset_version: 17,
+                    input_dim: 4,
+                    output_dim: 7,
+                    input_encoding: "token_ids".to_string(),
+                    output_encoding: "logits".to_string(),
+                    instruction_count: 3,
+                }),
+                external_data_files: Vec::new(),
+            }));
+
+        let err = verify_hf_provenance_manifest(&manifest)
+            .expect_err("metadata identity without metadata should fail");
+        assert!(err
+            .to_string()
+            .contains("HF provenance onnx_export.metadata_identity requires onnx_export.metadata"));
+    }
+
+    #[test]
     fn verify_hf_provenance_manifest_rejects_empty_onnx_exporter_version() {
         let dir = tempfile::tempdir().expect("create temp dir");
         let graph = dir.path().join("model.onnx");

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -5158,6 +5158,12 @@ fn metadata_u32_field(
             )));
         }
     }
+    if value.is_number() {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance ONNX metadata {} field `{field}` malformed: expected non-negative integer",
+            path.display()
+        )));
+    }
     Err(VmError::InvalidConfig(format!(
         "HF provenance ONNX metadata {} field `{field}` malformed: expected integer",
         path.display()
@@ -5185,6 +5191,12 @@ fn metadata_u64_field(
                 path.display()
             )));
         }
+    }
+    if value.is_number() {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance ONNX metadata {} field `{field}` malformed: expected non-negative integer",
+            path.display()
+        )));
     }
     Err(VmError::InvalidConfig(format!(
         "HF provenance ONNX metadata {} field `{field}` malformed: expected integer",
@@ -5218,6 +5230,12 @@ fn metadata_usize_field(
                 path.display()
             )));
         }
+    }
+    if value.is_number() {
+        return Err(VmError::InvalidConfig(format!(
+            "HF provenance ONNX metadata {} field `{field}` malformed: expected non-negative integer",
+            path.display()
+        )));
     }
     Err(VmError::InvalidConfig(format!(
         "HF provenance ONNX metadata {} field `{field}` malformed: expected integer",

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -5169,7 +5169,7 @@ fn metadata_u32_field(
         }
     }
     Err(VmError::InvalidConfig(format!(
-        "HF provenance ONNX metadata {} missing integer field `{field}`",
+        "HF provenance ONNX metadata {} field `{field}` malformed: expected integer",
         path.display()
     )))
 }
@@ -5197,7 +5197,7 @@ fn metadata_u64_field(
         }
     }
     Err(VmError::InvalidConfig(format!(
-        "HF provenance ONNX metadata {} missing integer field `{field}`",
+        "HF provenance ONNX metadata {} field `{field}` malformed: expected integer",
         path.display()
     )))
 }
@@ -5230,7 +5230,7 @@ fn metadata_usize_field(
         }
     }
     Err(VmError::InvalidConfig(format!(
-        "HF provenance ONNX metadata {} missing integer field `{field}`",
+        "HF provenance ONNX metadata {} field `{field}` malformed: expected integer",
         path.display()
     )))
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5704,6 +5704,31 @@ fn cli_prepare_hf_manifest_rejects_malformed_onnx_integer_metadata_fields() {
             )));
     }
 
+    for field in ["format_version", "ir_version", "input_dim"] {
+        let case_dir = fixture_dir.join(format!("{field}-fractional"));
+        std::fs::create_dir_all(&case_dir).expect("create fractional integer case dir");
+        let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&case_dir);
+
+        let mut metadata_json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&onnx_metadata).expect("metadata bytes"))
+                .expect("metadata json");
+        metadata_json[field] = serde_json::json!(1.5);
+        std::fs::write(
+            &onnx_metadata,
+            serde_json::to_vec_pretty(&metadata_json).expect("serialize tampered ONNX metadata"),
+        )
+        .expect("write tampered ONNX metadata");
+
+        let mut prepare =
+            hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+        prepare
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(format!(
+                "field `{field}` malformed: expected non-negative integer"
+            )));
+    }
+
     let _ = std::fs::remove_dir_all(fixture_dir);
 }
 
@@ -5737,6 +5762,29 @@ fn cli_prepare_hf_manifest_rejects_empty_onnx_string_metadata_fields() {
                 "missing string field `{field}`"
             )));
     }
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_prepare_hf_manifest_rejects_oversized_onnx_metadata_json() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-oversized-onnx-metadata");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(&onnx_metadata, vec![b'0'; 8 * 1024 * 1024 + 1])
+        .expect("write oversized ONNX metadata");
+
+    let mut prepare =
+        hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+    prepare
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("HF provenance ONNX metadata"))
+        .stderr(predicate::str::contains(
+            "exceeding the limit of 8388608 bytes",
+        ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5502,6 +5502,47 @@ fn cli_prepare_hf_manifest_emits_onnx_metadata_identity() {
 }
 
 #[test]
+fn cli_verifier_rejects_missing_onnx_metadata_identity_fields() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-missing-metadata-identity");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    let mut prepare =
+        hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+    prepare.assert().success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["onnx_export"]
+        .as_object_mut()
+        .expect("onnx_export object")
+        .remove("metadata_identity");
+    manifest_json["commitments"]
+        .as_object_mut()
+        .expect("commitments object")
+        .remove("onnx_metadata_identity_hash");
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "missing field `metadata_identity` in `onnx_export`",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
 fn cli_verifier_rejects_tampered_onnx_metadata() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-tampered-metadata");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5495,11 +5495,10 @@ fn cli_prepare_hf_manifest_emits_onnx_metadata_identity() {
         manifest_json["onnx_export"]["metadata_identity"]["output_encoding"].as_str(),
         Some("transition-v1")
     );
-    assert!(
-        manifest_json["onnx_export"]["metadata_identity"]["instruction_count"]
-            .as_u64()
-            .is_some_and(|count| count > 0),
-        "instruction_count must be positive",
+    assert_eq!(
+        manifest_json["onnx_export"]["metadata_identity"]["instruction_count"].as_u64(),
+        Some(3),
+        "instruction_count must match the deterministic ONNX metadata fixture",
     );
     assert!(
         manifest_json["commitments"]["onnx_metadata_identity_hash"]
@@ -5635,6 +5634,40 @@ fn cli_prepare_hf_manifest_rejects_negative_onnx_format_version() {
     prepare.assert().failure().stderr(predicate::str::contains(
         "field `format_version` must be non-negative",
     ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_prepare_hf_manifest_rejects_malformed_onnx_integer_metadata_fields() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-malformed-onnx-integer-fields");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    for field in ["format_version", "ir_version", "input_dim"] {
+        let case_dir = fixture_dir.join(field);
+        std::fs::create_dir_all(&case_dir).expect("create malformed integer case dir");
+        let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&case_dir);
+
+        let mut metadata_json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&onnx_metadata).expect("metadata bytes"))
+                .expect("metadata json");
+        metadata_json[field] = serde_json::json!("not-an-integer");
+        std::fs::write(
+            &onnx_metadata,
+            serde_json::to_vec_pretty(&metadata_json).expect("serialize tampered ONNX metadata"),
+        )
+        .expect("write tampered ONNX metadata");
+
+        let mut prepare =
+            hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+        prepare
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(format!(
+                "field `{field}` malformed: expected integer"
+            )));
+    }
 
     let _ = std::fs::remove_dir_all(fixture_dir);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4843,7 +4843,9 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
     assert!(
         manifest_json["commitments"]["onnx_metadata_identity_hash"]
             .as_str()
-            .is_some_and(|digest| digest.chars().all(|c| c.is_ascii_hexdigit())),
+            .is_some_and(|digest| {
+                digest.len() == 64 && digest.chars().all(|c| c.is_ascii_hexdigit())
+            }),
         "commitments.onnx_metadata_identity_hash must be hex",
     );
     assert!(manifest_json["onnx_export"]["metadata_identity"].is_null());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5614,6 +5614,32 @@ fn cli_prepare_hf_manifest_rejects_negative_onnx_versions() {
 }
 
 #[test]
+fn cli_prepare_hf_manifest_rejects_negative_onnx_format_version() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-negative-onnx-format-version");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    let mut metadata_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&onnx_metadata).expect("metadata bytes"))
+            .expect("metadata json");
+    metadata_json["format_version"] = serde_json::json!(-1);
+    std::fs::write(
+        &onnx_metadata,
+        serde_json::to_vec_pretty(&metadata_json).expect("serialize tampered ONNX metadata"),
+    )
+    .expect("write tampered ONNX metadata");
+
+    let mut prepare =
+        hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+    prepare.assert().failure().stderr(predicate::str::contains(
+        "field `format_version` must be non-negative",
+    ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
 fn cli_verifier_rejects_tampered_onnx_metadata() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-tampered-metadata");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5472,11 +5472,11 @@ fn cli_prepare_hf_manifest_emits_onnx_metadata_identity() {
         Some(1)
     );
     assert_eq!(
-        manifest_json["onnx_export"]["metadata_identity"]["ir_version"].as_i64(),
+        manifest_json["onnx_export"]["metadata_identity"]["ir_version"].as_u64(),
         Some(9)
     );
     assert_eq!(
-        manifest_json["onnx_export"]["metadata_identity"]["opset_version"].as_i64(),
+        manifest_json["onnx_export"]["metadata_identity"]["opset_version"].as_u64(),
         Some(19)
     );
     assert_eq!(
@@ -5538,6 +5538,32 @@ fn cli_verifier_rejects_missing_onnx_metadata_identity_fields() {
         .stderr(predicate::str::contains(
             "missing field `metadata_identity` in `onnx_export`",
         ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_prepare_hf_manifest_rejects_negative_onnx_versions() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-negative-onnx-version");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    let mut metadata_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&onnx_metadata).expect("metadata bytes"))
+            .expect("metadata json");
+    metadata_json["ir_version"] = serde_json::json!(-1);
+    std::fs::write(
+        &onnx_metadata,
+        serde_json::to_vec_pretty(&metadata_json).expect("serialize tampered ONNX metadata"),
+    )
+    .expect("write tampered ONNX metadata");
+
+    let mut prepare =
+        hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+    prepare.assert().failure().stderr(predicate::str::contains(
+        "field `ir_version` must be non-negative",
+    ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4824,7 +4824,7 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
         manifest_json
             .get("manifest_version")
             .and_then(serde_json::Value::as_str),
-        Some("hf-provenance-manifest-v4")
+        Some("hf-provenance-manifest-v5")
     );
     assert_eq!(
         manifest_json
@@ -4840,6 +4840,13 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
             }),
         "commitments.hub_binding_hash must be hex",
     );
+    assert!(
+        manifest_json["commitments"]["onnx_metadata_identity_hash"]
+            .as_str()
+            .is_some_and(|digest| digest.chars().all(|c| c.is_ascii_hexdigit())),
+        "commitments.onnx_metadata_identity_hash must be hex",
+    );
+    assert!(manifest_json["onnx_export"]["metadata_identity"].is_null());
     assert_eq!(
         manifest_json
             .get("tokenizer")
@@ -5213,6 +5220,10 @@ fn cli_verifier_rejects_legacy_hf_manifest_versions() {
             "hf-provenance-manifest-v3",
             "after the hub-binding hardening update",
         ),
+        (
+            "hf-provenance-manifest-v4",
+            "after the ONNX metadata-identity hardening update",
+        ),
     ] {
         let mut manifest_json = base_manifest_json.clone();
         manifest_json["manifest_version"] = serde_json::json!(legacy_version);
@@ -5271,14 +5282,42 @@ fn hf_provenance_prepare_command(
     prepare
 }
 
+fn hf_provenance_export_valid_onnx_fixture(
+    fixture_dir: &std::path::Path,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let export_dir = fixture_dir.join("onnx-export");
+    std::fs::create_dir_all(&export_dir).expect("create ONNX export fixture dir");
+    let graph = export_dir.join("instr_0.onnx");
+    let metadata = export_dir.join("metadata.json");
+    std::fs::write(&graph, b"fake-onnx-graph").expect("write ONNX graph fixture");
+    std::fs::write(
+        &metadata,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "format_version": 1,
+            "ir_version": 9,
+            "opset_version": 19,
+            "input_dim": 9,
+            "output_dim": 9,
+            "input_encoding": "operand-stack-v1",
+            "output_encoding": "transition-v1",
+            "instructions": [
+                {"opcode": "push", "value": 1},
+                {"opcode": "push", "value": 2},
+                {"opcode": "add"}
+            ]
+        }))
+        .expect("serialize ONNX metadata fixture"),
+    )
+    .expect("write ONNX metadata fixture");
+    (graph, metadata)
+}
+
 #[test]
 fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_reuses_graph_path() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-duplicate-metadata");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
-    let onnx_model = fixture_dir.join("model.onnx");
+    let (onnx_model, _) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
     let manifest = fixture_dir.join("hf-provenance.json");
-
-    std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
 
     let mut prepare = hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_model), &[]);
     prepare.assert().failure().stderr(predicate::str::contains(
@@ -5292,10 +5331,8 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_reuses_graph_path() {
 fn cli_rejects_hf_provenance_manifest_when_onnx_external_data_reuses_graph_path() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-duplicate-external-data");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
-    let onnx_model = fixture_dir.join("model.onnx");
+    let (onnx_model, _) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
     let manifest = fixture_dir.join("hf-provenance.json");
-
-    std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
 
     let mut prepare = hf_provenance_prepare_command(&manifest, &onnx_model, None, &[&onnx_model]);
     prepare.assert().failure().stderr(predicate::str::contains(
@@ -5337,11 +5374,12 @@ fn cli_rejects_hf_provenance_manifest_when_onnx_exporter_version_has_no_graph() 
 fn cli_rejects_hf_provenance_manifest_when_onnx_metadata_aliases_graph_path() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-alias-metadata");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
-    let onnx_model = fixture_dir.join("model.onnx");
-    let aliased_onnx_model = fixture_dir.join("./model.onnx");
+    let (onnx_model, _) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
+    let aliased_onnx_model = onnx_model
+        .parent()
+        .expect("onnx model parent")
+        .join("./instr_0.onnx");
     let manifest = fixture_dir.join("hf-provenance.json");
-
-    std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
 
     let mut prepare =
         hf_provenance_prepare_command(&manifest, &onnx_model, Some(&aliased_onnx_model), &[]);
@@ -5412,16 +5450,65 @@ fn cli_rejects_hf_provenance_manifest_when_model_card_reuses_tokenizer_json_path
 }
 
 #[test]
+fn cli_prepare_hf_manifest_emits_onnx_metadata_identity() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-metadata-identity");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    let mut prepare =
+        hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+    prepare.assert().success();
+
+    let manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    assert_eq!(
+        manifest_json["onnx_export"]["metadata_identity"]["identity_version"].as_str(),
+        Some("onnx-program-metadata-identity-v1")
+    );
+    assert_eq!(
+        manifest_json["onnx_export"]["metadata_identity"]["format_version"].as_u64(),
+        Some(1)
+    );
+    assert_eq!(
+        manifest_json["onnx_export"]["metadata_identity"]["ir_version"].as_i64(),
+        Some(9)
+    );
+    assert_eq!(
+        manifest_json["onnx_export"]["metadata_identity"]["opset_version"].as_i64(),
+        Some(19)
+    );
+    assert_eq!(
+        manifest_json["onnx_export"]["metadata_identity"]["input_dim"].as_u64(),
+        Some(9)
+    );
+    assert!(
+        manifest_json["onnx_export"]["metadata_identity"]["instruction_count"]
+            .as_u64()
+            .is_some_and(|count| count > 0),
+        "instruction_count must be positive",
+    );
+    assert!(
+        manifest_json["commitments"]["onnx_metadata_identity_hash"]
+            .as_str()
+            .is_some_and(|digest| {
+                digest.len() == 64 && digest.chars().all(|c| c.is_ascii_hexdigit())
+            }),
+        "commitments.onnx_metadata_identity_hash must be hex",
+    );
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
 fn cli_verifier_rejects_tampered_onnx_metadata() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-tampered-metadata");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
-    let onnx_model = fixture_dir.join("model.onnx");
-    let onnx_metadata = fixture_dir.join("metadata.json");
+    let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
     let onnx_external = fixture_dir.join("model.onnx_data");
     let manifest = fixture_dir.join("hf-provenance.json");
 
-    std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
-    std::fs::write(&onnx_metadata, br#"{"producer":"optimum"}"#).expect("write ONNX metadata");
     std::fs::write(&onnx_external, b"onnx-external-data").expect("write ONNX external data");
 
     let mut prepare = hf_provenance_prepare_command(
@@ -5439,7 +5526,15 @@ fn cli_verifier_rejects_tampered_onnx_metadata() {
         .assert()
         .success();
 
-    std::fs::write(&onnx_metadata, br#"{"producer":"tamperd"}"#).expect("tamper ONNX metadata");
+    let mut metadata_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&onnx_metadata).expect("metadata bytes"))
+            .expect("metadata json");
+    metadata_json["output_encoding"] = serde_json::json!("transition-v2");
+    std::fs::write(
+        &onnx_metadata,
+        serde_json::to_vec_pretty(&metadata_json).expect("serialize tampered ONNX metadata"),
+    )
+    .expect("tamper ONNX metadata");
 
     let mut verify = tvm_command();
     verify
@@ -5455,16 +5550,59 @@ fn cli_verifier_rejects_tampered_onnx_metadata() {
 }
 
 #[test]
+fn cli_verifier_rejects_tampered_onnx_metadata_identity() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-tampered-metadata-identity");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    let mut prepare =
+        hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+    prepare.assert().success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["onnx_export"]["metadata_identity"]["instruction_count"] = serde_json::json!(999);
+    manifest_json["commitments"]["onnx_metadata_identity_hash"] =
+        serde_json::Value::String(hash_json_value(
+            manifest_json
+                .get("onnx_export")
+                .and_then(|value| value.get("metadata_identity"))
+                .expect("metadata identity value"),
+        ));
+    manifest_json["commitments"]["onnx_export_hash"] = serde_json::Value::String(hash_json_value(
+        manifest_json
+            .get("onnx_export")
+            .expect("onnx export section after metadata identity tamper"),
+    ));
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "hf onnx_export.metadata_identity mismatch",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
 fn cli_verifier_rejects_tampered_onnx_external_data() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-tampered-external");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
-    let onnx_model = fixture_dir.join("model.onnx");
-    let onnx_metadata = fixture_dir.join("metadata.json");
+    let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
     let onnx_external = fixture_dir.join("model.onnx_data");
     let manifest = fixture_dir.join("hf-provenance.json");
 
-    std::fs::write(&onnx_model, b"fake-onnx-graph").expect("write ONNX fixture");
-    std::fs::write(&onnx_metadata, br#"{"producer":"optimum"}"#).expect("write ONNX metadata");
     std::fs::write(&onnx_external, b"onnx-external-data").expect("write ONNX external data");
 
     let mut prepare = hf_provenance_prepare_command(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5587,6 +5587,41 @@ fn cli_verifier_rejects_missing_onnx_metadata_identity_hash_field() {
 }
 
 #[test]
+fn cli_verifier_rejects_stale_onnx_metadata_identity_hash() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-stale-metadata-identity-hash");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    let mut prepare =
+        hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+    prepare.assert().success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["commitments"]["onnx_metadata_identity_hash"] =
+        serde_json::Value::String("0".repeat(64));
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "hf onnx_metadata_identity_hash commitment mismatch",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
 fn cli_prepare_hf_manifest_rejects_negative_onnx_versions() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-negative-onnx-version");
     std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
@@ -5666,6 +5701,40 @@ fn cli_prepare_hf_manifest_rejects_malformed_onnx_integer_metadata_fields() {
             .failure()
             .stderr(predicate::str::contains(format!(
                 "field `{field}` malformed: expected integer"
+            )));
+    }
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_prepare_hf_manifest_rejects_empty_onnx_string_metadata_fields() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-empty-onnx-string-fields");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    for field in ["input_encoding", "output_encoding"] {
+        let case_dir = fixture_dir.join(field);
+        std::fs::create_dir_all(&case_dir).expect("create empty string case dir");
+        let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&case_dir);
+
+        let mut metadata_json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&onnx_metadata).expect("metadata bytes"))
+                .expect("metadata json");
+        metadata_json[field] = serde_json::json!("");
+        std::fs::write(
+            &onnx_metadata,
+            serde_json::to_vec_pretty(&metadata_json).expect("serialize tampered ONNX metadata"),
+        )
+        .expect("write tampered ONNX metadata");
+
+        let mut prepare =
+            hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+        prepare
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(format!(
+                "missing string field `{field}`"
             )));
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5297,7 +5297,7 @@ fn hf_provenance_export_valid_onnx_fixture(
             "ir_version": 9,
             "opset_version": 19,
             "input_dim": 9,
-            "output_dim": 9,
+            "output_dim": 7,
             "input_encoding": "operand-stack-v1",
             "output_encoding": "transition-v1",
             "instructions": [
@@ -5483,6 +5483,18 @@ fn cli_prepare_hf_manifest_emits_onnx_metadata_identity() {
         manifest_json["onnx_export"]["metadata_identity"]["input_dim"].as_u64(),
         Some(9)
     );
+    assert_eq!(
+        manifest_json["onnx_export"]["metadata_identity"]["output_dim"].as_u64(),
+        Some(7)
+    );
+    assert_eq!(
+        manifest_json["onnx_export"]["metadata_identity"]["input_encoding"].as_str(),
+        Some("operand-stack-v1")
+    );
+    assert_eq!(
+        manifest_json["onnx_export"]["metadata_identity"]["output_encoding"].as_str(),
+        Some("transition-v1")
+    );
     assert!(
         manifest_json["onnx_export"]["metadata_identity"]["instruction_count"]
             .as_u64()
@@ -5519,6 +5531,39 @@ fn cli_verifier_rejects_missing_onnx_metadata_identity_fields() {
         .as_object_mut()
         .expect("onnx_export object")
         .remove("metadata_identity");
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "missing field `metadata_identity` in `onnx_export`",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_missing_onnx_metadata_identity_hash_field() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-missing-metadata-identity-hash");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let (onnx_model, onnx_metadata) = hf_provenance_export_valid_onnx_fixture(&fixture_dir);
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    let mut prepare =
+        hf_provenance_prepare_command(&manifest, &onnx_model, Some(&onnx_metadata), &[]);
+    prepare.assert().success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
     manifest_json["commitments"]
         .as_object_mut()
         .expect("commitments object")
@@ -5536,7 +5581,7 @@ fn cli_verifier_rejects_missing_onnx_metadata_identity_fields() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "missing field `metadata_identity` in `onnx_export`",
+            "missing field `onnx_metadata_identity_hash` in `commitments`",
         ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);


### PR DESCRIPTION
## Summary
- bump HF provenance manifests to v5 and bind ONNX metadata identity into both `onnx_export.metadata_identity` and `commitments.onnx_metadata_identity_hash`
- require v5 manifests to carry the ONNX metadata-identity field and reject legacy v4 after the metadata-identity hardening update
- extend CLI and verifier coverage for tampered metadata identity, aliased metadata-vs-graph bindings, and external-data path reuse

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below
- Skipped trusted-core default harness layers:
  - Oracle / differential checks: not applicable beyond verifier-side recomputation because this PR hardens ONNX metadata provenance binding rather than adding a new execution engine.
  - Resource-bound / untrusted-input impact: reviewed. This PR tightens untrusted metadata/provenance binding and local artifact alias rejection; it does not introduce a new unbounded parser beyond the existing metadata JSON load path.
  - Kani / formal-kernel impact: not applicable for this manifest/verifier slice; the change is bounded to parser, commitment, and duplicate-binding checks.
  - Miri / ASAN / UB impact: no new unsafe code or pointer-manipulating kernel surface was introduced in this slice, so the existing sanitizer coverage remains unchanged and no new sanitizer-specific harness was required for this PR.

## Validation
- cargo fmt --all
- cargo test -q --bin tvm hf_provenance_manifest_tests:: -- --test-threads=1
- cargo build -q --bin tvm
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_can_prepare_and_verify_hf_provenance_manifest -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_prepare_hf_manifest_emits_onnx_metadata_identity -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_verifier_rejects_tampered_onnx_metadata -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_verifier_rejects_tampered_onnx_metadata_identity -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_verifier_rejects_tampered_onnx_external_data -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_rejects_hf_provenance_manifest_when_onnx_metadata_reuses_graph_path -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_rejects_hf_provenance_manifest_when_onnx_metadata_aliases_graph_path -- --exact
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --test cli cli_rejects_hf_provenance_manifest_when_onnx_external_data_reuses_graph_path -- --exact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HF provenance manifest upgraded to v5 and adds an ONNX metadata-identity projection.

* **Improvements**
  * Verification now covers ONNX sidecar surface, metadata-identity, hub-binding commitment, and attestation inventory.
  * Legacy manifests v1–v4 are now flagged for regeneration before verification.

* **Tests**
  * CLI and verifier tests updated/added to enforce v5, metadata-identity presence, commitment checks, and related rejection cases.

* **Documentation**
  * README updated to describe the new manifest version and verification scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the HF provenance manifest to v5, binding ONNX metadata-identity into both `onnx_export.metadata_identity` and the new `commitments.onnx_metadata_identity_hash` field, and hard-rejects legacy v1–v4 manifests. The previously-flagged untested `(None, Some(_))` guard path is now covered by `verify_hf_provenance_manifest_rejects_metadata_identity_without_metadata`, and the tamper-path suite — including stale-hash, fully-consistent-but-fraudulent, missing-field, and alias/reuse rejection cases — is comprehensive.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — verification chain is sound, all four legacy versions are rejected, and the previously-untested null-binding guard is now covered.

All changed code paths have corresponding negative/tamper tests; the (None, Some(_)) branch flagged in the previous review is now unit-tested; commitment checks are correctly ordered (onnx_export_hash → onnx_metadata_identity_hash → live file derivation); schema matches Rust struct; README claims match implementation. No P0 or P1 findings remain.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/bin/tvm.rs | Adds v5 manifest parsing, metadata-identity derivation/binding, and the previously-missing unit test for the (None, Some) guard; all verification checks are sound and correctly ordered. |
| spec/hf-provenance-manifest.schema.json | Schema bumped to v5: adds required `metadata_identity` field to `onnx_export` (nullable) and `onnx_metadata_identity_hash` to `commitments`; `onnx_metadata_identity` def matches the Rust struct fields exactly. |
| tests/cli.rs | New and updated CLI tests cover prepare, verify, tamper-detection for metadata_identity and external_data, and alias/reuse rejection; all expected failure messages are correctly asserted. |
| README.md | Updated HF provenance section accurately reflects v5 format, metadata-identity projection, and required regeneration of legacy v1–v4 manifests. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/bin/tvm.rs`, line 4645-4681 ([link](https://github.com/omarespejel/provable-transformer-vm/blob/957a257c3fcfe70e66a03955b124ac03a8b5a0b8/src/bin/tvm.rs#L4645-L4681)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Pre-parse check omits `commitments.onnx_metadata_identity_hash`**

   This PR adds two new required v5 fields: `onnx_export.metadata_identity` and `commitments.onnx_metadata_identity_hash`. The pre-parse check validates `onnx_export.metadata_identity` (line 4670) and the pre-existing `commitments.hub_binding_hash` (line 4653), but does not validate `commitments.onnx_metadata_identity_hash`. A v5 manifest that was hand-patched or generated by old tooling (missing this field) falls through to serde deserialization with a generic "missing field `onnx_metadata_identity_hash`" error rather than the version-upgrade diagnostic that `hub_binding_hash` gets.

   The check should be symmetric:

   ```rust
       if let Some(commitments_obj) = manifest_value
           .get("commitments")
           .and_then(|v| v.as_object())
       {
           for field in ["hub_binding_hash", "onnx_metadata_identity_hash"] {
               if !commitments_obj.contains_key(field) {
                   return Err(VmError::Serialization(format!(
                       "failed to parse HF provenance manifest {}: missing field `{field}` in `commitments` for {}",
                       manifest_path.display(),
                       HF_PROVENANCE_MANIFEST_VERSION
                   )));
               }
           }
       }
   ```

   **Rule Used:** When proof semantics, carried-state structure, ver... ([source](https://app.greptile.com/review/custom-context?memory=test-gaps))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/bin/tvm.rs
   Line: 4645-4681
   
   Comment:
   **Pre-parse check omits `commitments.onnx_metadata_identity_hash`**
   
   This PR adds two new required v5 fields: `onnx_export.metadata_identity` and `commitments.onnx_metadata_identity_hash`. The pre-parse check validates `onnx_export.metadata_identity` (line 4670) and the pre-existing `commitments.hub_binding_hash` (line 4653), but does not validate `commitments.onnx_metadata_identity_hash`. A v5 manifest that was hand-patched or generated by old tooling (missing this field) falls through to serde deserialization with a generic "missing field `onnx_metadata_identity_hash`" error rather than the version-upgrade diagnostic that `hub_binding_hash` gets.
   
   The check should be symmetric:
   
   ```rust
       if let Some(commitments_obj) = manifest_value
           .get("commitments")
           .and_then(|v| v.as_object())
       {
           for field in ["hub_binding_hash", "onnx_metadata_identity_hash"] {
               if !commitments_obj.contains_key(field) {
                   return Err(VmError::Serialization(format!(
                       "failed to parse HF provenance manifest {}: missing field `{field}` in `commitments` for {}",
                       manifest_path.display(),
                       HF_PROVENANCE_MANIFEST_VERSION
                   )));
               }
           }
       }
   ```
   
   **Rule Used:** When proof semantics, carried-state structure, ver... ([source](https://app.greptile.com/review/custom-context?memory=test-gaps))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["Cover HF metadata identity null-binding ..."](https://github.com/omarespejel/provable-transformer-vm/commit/c376735a02fb8c30002009e2715846187b7c8501) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28464743)</sub>

<!-- /greptile_comment -->