### PR TITLE
Harden research-v3 witness ingestion

### DIFF
--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -61,6 +61,10 @@ hardening_research_v3_test_filters=(
   "tests::verify_research_v3_equivalence_artifact_rejects_unknown_engine_binding"
   "tests::verify_research_v3_equivalence_artifact_rejects_missing_pinned_engine"
   "tests::verify_research_v3_equivalence_artifact_rejects_extra_engine_events_beyond_checked_steps"
+  "tests::frontend_runtime_registry_validation_rejects_extra_watch_lane"
+  "tests::verify_research_v3_equivalence_artifact_rejects_checked_steps_budget_overflow"
+  "tests::verify_research_v3_equivalence_artifact_rejects_oversized_machine_state_memory"
+  "tests::verify_research_v3_equivalence_artifact_rejects_oversized_witness_instruction"
 )
 
 # Keep the heavier `stwo-backend` verifier gates on the sanitizer path. They are

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -409,6 +409,10 @@ research_v3_smoke_targets=(
   "tests::verify_research_v3_equivalence_artifact_rejects_unknown_engine_binding"
   "tests::verify_research_v3_equivalence_artifact_rejects_missing_pinned_engine"
   "tests::verify_research_v3_equivalence_artifact_rejects_extra_engine_events_beyond_checked_steps"
+  "tests::frontend_runtime_registry_validation_rejects_extra_watch_lane"
+  "tests::verify_research_v3_equivalence_artifact_rejects_checked_steps_budget_overflow"
+  "tests::verify_research_v3_equivalence_artifact_rejects_oversized_machine_state_memory"
+  "tests::verify_research_v3_equivalence_artifact_rejects_oversized_witness_instruction"
 )
 stwo_cli_smoke_targets=(
   "cli_can_verify_stwo_recursive_compression_input_contract"

--- a/spec/statement-v3-equivalence-kernel.schema.json
+++ b/spec/statement-v3-equivalence-kernel.schema.json
@@ -27,15 +27,17 @@
     "onnx_op_subset_version": { "type": "string" },
     "onnx_op_subset_size": { "type": "integer", "minimum": 1 },
     "program_path": { "type": "string" },
-    "requested_max_steps": { "type": "integer", "minimum": 1 },
-    "checked_steps": { "type": "integer", "minimum": 0 },
+    "requested_max_steps": { "type": "integer", "minimum": 1, "maximum": 4096 },
+    "checked_steps": { "type": "integer", "minimum": 0, "maximum": 4096 },
     "engines": {
       "type": "array",
       "minItems": 4,
+      "maxItems": 4,
       "items": { "$ref": "#/$defs/engine_summary" }
     },
     "rule_witnesses": {
       "type": "array",
+      "maxItems": 4096,
       "items": { "$ref": "#/$defs/rule_witness" }
     },
     "frontend_runtime_semantics_registry": {
@@ -117,7 +119,8 @@
         },
         "lanes": {
           "type": "array",
-          "minItems": 8,
+          "minItems": 13,
+          "maxItems": 13,
           "items": { "$ref": "#/$defs/frontend_runtime_lane" }
         },
         "global_non_claims": {
@@ -167,15 +170,17 @@
         "name": { "type": "string" },
         "steps": { "type": "integer", "minimum": 0 },
         "halted": { "type": "boolean" },
-        "trace_len": { "type": "integer", "minimum": 1 },
-        "events_len": { "type": "integer", "minimum": 0 },
+        "trace_len": { "type": "integer", "minimum": 1, "maximum": 4097 },
+        "events_len": { "type": "integer", "minimum": 0, "maximum": 4096 },
         "trace": {
           "type": "array",
           "minItems": 1,
+          "maxItems": 4097,
           "items": { "$ref": "#/$defs/machine_state" }
         },
         "canonical_events": {
           "type": "array",
+          "maxItems": 4096,
           "items": { "$ref": "#/$defs/canonical_event" }
         },
         "final_state": { "$ref": "#/$defs/machine_state" },
@@ -195,7 +200,7 @@
       ],
       "properties": {
         "step": { "type": "integer", "minimum": 1 },
-        "instruction": { "type": "string" },
+        "instruction": { "type": "string", "maxLength": 256 },
         "state_before_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "state_after_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" }
       },
@@ -219,25 +224,29 @@
         "step": { "type": "integer", "minimum": 1 },
         "rule_id": { "type": "string" },
         "relation": { "type": "string" },
-        "instruction": { "type": "string" },
+        "instruction": { "type": "string", "maxLength": 256 },
         "participating_engines": {
           "type": "array",
           "minItems": 4,
+          "maxItems": 4,
           "items": { "type": "string" }
         },
         "state_before_hashes": {
           "type": "object",
           "minProperties": 4,
+          "maxProperties": 4,
           "additionalProperties": { "$ref": "#/$defs/hash_blake2b_256_hex" }
         },
         "state_after_hashes": {
           "type": "object",
           "minProperties": 4,
+          "maxProperties": 4,
           "additionalProperties": { "$ref": "#/$defs/hash_blake2b_256_hex" }
         },
         "engine_transition_hashes": {
           "type": "object",
           "minProperties": 4,
+          "maxProperties": 4,
           "additionalProperties": { "$ref": "#/$defs/hash_blake2b_256_hex" }
         },
         "canonical_transition_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
@@ -280,6 +289,7 @@
         "halted": { "type": "boolean" },
         "memory": {
           "type": "array",
+          "maxItems": 4096,
           "items": { "type": "integer" }
         }
       },

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -8900,6 +8900,63 @@ mod tests {
 
     #[test]
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn verify_research_v3_equivalence_artifact_rejects_participating_engines_budget_overflow() {
+        let mut artifact = sample_research_v3_equivalence_artifact();
+        artifact.rule_witnesses[0]
+            .participating_engines
+            .push("surprise-engine".to_string());
+        refresh_research_v3_test_artifact_commitments(&mut artifact);
+
+        let err = verify_research_v3_equivalence_artifact(&artifact)
+            .expect_err("participating_engines ingest overflow should fail");
+        assert!(err.to_string().contains(&format!(
+            "participating_engines length {} exceeds ingest cap {}",
+            RESEARCH_V3_PINNED_ENGINE_LANE_BINDINGS.len() + 1,
+            RESEARCH_V3_PINNED_ENGINE_LANE_BINDINGS.len()
+        )));
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn verify_research_v3_equivalence_artifact_rejects_witness_hash_budget_overflow() {
+        for map_name in [
+            "state_before_hashes",
+            "state_after_hashes",
+            "engine_transition_hashes",
+        ] {
+            let mut artifact = sample_research_v3_equivalence_artifact();
+            match map_name {
+                "state_before_hashes" => {
+                    artifact.rule_witnesses[0]
+                        .state_before_hashes
+                        .insert("surprise-engine".to_string(), "0".repeat(64));
+                }
+                "state_after_hashes" => {
+                    artifact.rule_witnesses[0]
+                        .state_after_hashes
+                        .insert("surprise-engine".to_string(), "0".repeat(64));
+                }
+                "engine_transition_hashes" => {
+                    artifact.rule_witnesses[0]
+                        .engine_transition_hashes
+                        .insert("surprise-engine".to_string(), "0".repeat(64));
+                }
+                _ => unreachable!(),
+            }
+            refresh_research_v3_test_artifact_commitments(&mut artifact);
+
+            let err = verify_research_v3_equivalence_artifact(&artifact)
+                .expect_err("witness hash ingest overflow should fail");
+            assert!(err.to_string().contains(&format!(
+                "{map_name} length {} exceeds ingest cap {}",
+                RESEARCH_V3_PINNED_ENGINE_LANE_BINDINGS.len() + 1,
+                RESEARCH_V3_PINNED_ENGINE_LANE_BINDINGS.len()
+            )));
+        }
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
     fn verify_research_v3_equivalence_artifact_rejects_requested_max_steps_budget_overflow() {
         let mut artifact = sample_research_v3_equivalence_artifact();
         artifact.requested_max_steps = MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1;

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -638,8 +638,12 @@ enum Command {
         /// File where the equivalence-kernel artifact JSON will be written.
         #[arg(short = 'o', long = "output")]
         output: PathBuf,
-        /// Maximum number of execution steps to check.
-        #[arg(long, default_value_t = 32)]
+        /// Maximum number of execution steps to check (1..=4096).
+        #[arg(
+            long,
+            default_value_t = 32,
+            value_parser = parse_research_v3_equivalence_max_steps
+        )]
         max_steps: usize,
         /// Number of transformer layers to distribute instructions across.
         #[arg(long, default_value_t = 1)]
@@ -872,7 +876,6 @@ const MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES: usize = 8 * 1024 * 1024;
 const HF_PROVENANCE_FILE_READ_CHUNK_BYTES: usize = 1024 * 1024;
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES: usize = 32 * 1024 * 1024;
-#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const MAX_RESEARCH_V3_EQUIVALENCE_STEPS: usize = 4096;
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const MAX_RESEARCH_V3_STATE_MEMORY_WORDS: usize = 4096;
@@ -9346,6 +9349,19 @@ fn print_stwo_normalization_companion(proof: &VanillaStarkExecutionProof) {
 
 fn parse_attention_mode(input: &str) -> Result<Attention2DMode, String> {
     Attention2DMode::from_str(input)
+}
+
+fn parse_research_v3_equivalence_max_steps(input: &str) -> Result<usize, String> {
+    let max_steps = input
+        .parse::<usize>()
+        .map_err(|err| format!("invalid value `{input}` for --max-steps: {err}"))?;
+    if !(1..=MAX_RESEARCH_V3_EQUIVALENCE_STEPS).contains(&max_steps) {
+        return Err(format!(
+            "--max-steps must be in 1..={} for research-v3-equivalence",
+            MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+        ));
+    }
+    Ok(max_steps)
 }
 
 fn parse_execution_engine(input: &str) -> Result<CliExecutionEngine, String> {

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -6181,6 +6181,18 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("<unknown>");
 
+            if let Some(trace_len) = engine.get("trace_len").and_then(serde_json::Value::as_u64) {
+                if trace_len > max_trace_len as u64 {
+                    return Err(research_v3_artifact_budget_error(
+                        artifact_path,
+                        format!(
+                            "research-v3 engine {engine_name} trace_len {} exceeds ingest cap {}",
+                            trace_len, max_trace_len
+                        ),
+                    ));
+                }
+            }
+
             if let Some(trace) = engine.get("trace").and_then(serde_json::Value::as_array) {
                 if trace.len() > max_trace_len {
                     return Err(research_v3_artifact_budget_error(
@@ -6207,6 +6219,18 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
                     &format!("research-v3 engine {engine_name} final_state"),
                 )
                 .map_err(|err| prefix_research_v3_artifact_budget_error(artifact_path, err))?;
+            }
+
+            if let Some(events_len) = engine.get("events_len").and_then(serde_json::Value::as_u64) {
+                if events_len > MAX_RESEARCH_V3_EQUIVALENCE_STEPS as u64 {
+                    return Err(research_v3_artifact_budget_error(
+                        artifact_path,
+                        format!(
+                            "research-v3 engine {engine_name} events_len {} exceeds ingest cap {}",
+                            events_len, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+                        ),
+                    ));
+                }
             }
 
             if let Some(events) = engine

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -872,6 +872,12 @@ const MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES: usize = 8 * 1024 * 1024;
 const HF_PROVENANCE_FILE_READ_CHUNK_BYTES: usize = 1024 * 1024;
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const MAX_RESEARCH_V3_EQUIVALENCE_ARTIFACT_JSON_BYTES: usize = 32 * 1024 * 1024;
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+const MAX_RESEARCH_V3_EQUIVALENCE_STEPS: usize = 4096;
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+const MAX_RESEARCH_V3_STATE_MEMORY_WORDS: usize = 4096;
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+const MAX_RESEARCH_V3_INSTRUCTION_BYTES: usize = 256;
 #[cfg(feature = "onnx-export")]
 const RESEARCH_V3_PINNED_ENGINE_LANE_BINDINGS: [(&str, &str); 4] = [
     ("transformer", "transformer-vm"),
@@ -891,6 +897,9 @@ const FRONTEND_RUNTIME_RESEARCH_WATCH_LANES: [&str; 9] = [
     "sglang",
     "egg-emerge",
 ];
+#[cfg(feature = "onnx-export")]
+const MAX_FRONTEND_RUNTIME_SEMANTICS_LANES: usize =
+    RESEARCH_V3_PINNED_ENGINE_LANE_BINDINGS.len() + FRONTEND_RUNTIME_RESEARCH_WATCH_LANES.len();
 const HF_PROVENANCE_MANIFEST_VERSION_V1_LEGACY: &str = "hf-provenance-manifest-v1";
 const HF_PROVENANCE_MANIFEST_VERSION_V2_LEGACY: &str = "hf-provenance-manifest-v2";
 const HF_PROVENANCE_MANIFEST_VERSION_V3_LEGACY: &str = "hf-provenance-manifest-v3";
@@ -6070,6 +6079,7 @@ fn verify_research_v3_equivalence_artifact(
             "research-v3 requested_max_steps must be nonzero".to_string(),
         ));
     }
+    validate_research_v3_ingest_budget(artifact)?;
     if artifact.checked_steps > artifact.requested_max_steps {
         return Err(VmError::InvalidConfig(format!(
             "research-v3 checked_steps {} exceeds requested_max_steps {}",
@@ -6162,6 +6172,166 @@ fn verify_research_v3_equivalence_artifact(
     verify_research_v3_engine_summaries(artifact)?;
     verify_research_v3_rule_witnesses(artifact)?;
 
+    Ok(())
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn validate_research_v3_ingest_budget(
+    artifact: &ResearchV3EquivalenceArtifact,
+) -> llm_provable_computer::Result<()> {
+    let max_engines = RESEARCH_V3_PINNED_ENGINE_LANE_BINDINGS.len();
+    let max_trace_len = MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1;
+
+    if artifact.checked_steps > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
+        return Err(VmError::InvalidConfig(format!(
+            "research-v3 checked_steps {} exceeds ingest cap {}",
+            artifact.checked_steps, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+        )));
+    }
+    if artifact.requested_max_steps > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
+        return Err(VmError::InvalidConfig(format!(
+            "research-v3 requested_max_steps {} exceeds ingest cap {}",
+            artifact.requested_max_steps, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+        )));
+    }
+    if artifact.rule_witnesses.len() > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
+        return Err(VmError::InvalidConfig(format!(
+            "research-v3 rule_witnesses length {} exceeds ingest cap {}",
+            artifact.rule_witnesses.len(),
+            MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+        )));
+    }
+    if artifact.engines.len() > max_engines {
+        return Err(VmError::InvalidConfig(format!(
+            "research-v3 engine count {} exceeds ingest cap {}",
+            artifact.engines.len(),
+            max_engines
+        )));
+    }
+    if let Some(lanes) = artifact
+        .frontend_runtime_semantics_registry
+        .get("lanes")
+        .and_then(serde_json::Value::as_array)
+    {
+        if lanes.len() > MAX_FRONTEND_RUNTIME_SEMANTICS_LANES {
+            return Err(VmError::InvalidConfig(format!(
+                "frontend runtime semantics registry lane count {} exceeds ingest cap {}",
+                lanes.len(),
+                MAX_FRONTEND_RUNTIME_SEMANTICS_LANES
+            )));
+        }
+    }
+
+    for engine in &artifact.engines {
+        if engine.trace_len > max_trace_len {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 engine {} trace_len {} exceeds ingest cap {}",
+                engine.name, engine.trace_len, max_trace_len
+            )));
+        }
+        if engine.events_len > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 engine {} events_len {} exceeds ingest cap {}",
+                engine.name, engine.events_len, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+            )));
+        }
+        if engine.trace.len() > max_trace_len {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 engine {} trace length {} exceeds ingest cap {}",
+                engine.name,
+                engine.trace.len(),
+                max_trace_len
+            )));
+        }
+        if engine.canonical_events.len() > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 engine {} canonical_events length {} exceeds ingest cap {}",
+                engine.name,
+                engine.canonical_events.len(),
+                MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+            )));
+        }
+        validate_research_v3_machine_state_budget(
+            &engine.final_state,
+            &format!("research-v3 engine {} final_state", engine.name),
+        )?;
+        for (index, state) in engine.trace.iter().enumerate() {
+            validate_research_v3_machine_state_budget(
+                state,
+                &format!("research-v3 engine {} trace[{index}]", engine.name),
+            )?;
+        }
+        for event in &engine.canonical_events {
+            validate_research_v3_instruction_budget(
+                &event.instruction,
+                &format!(
+                    "research-v3 engine {} canonical event {} instruction",
+                    engine.name, event.step
+                ),
+            )?;
+        }
+    }
+
+    for witness in &artifact.rule_witnesses {
+        validate_research_v3_instruction_budget(
+            &witness.instruction,
+            &format!("research-v3 witness {} instruction", witness.step),
+        )?;
+        if witness.participating_engines.len() > max_engines {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 witness {} participating_engines length {} exceeds ingest cap {}",
+                witness.step,
+                witness.participating_engines.len(),
+                max_engines
+            )));
+        }
+        for (label, map_len) in [
+            ("state_before_hashes", witness.state_before_hashes.len()),
+            ("state_after_hashes", witness.state_after_hashes.len()),
+            (
+                "engine_transition_hashes",
+                witness.engine_transition_hashes.len(),
+            ),
+        ] {
+            if map_len > max_engines {
+                return Err(VmError::InvalidConfig(format!(
+                    "research-v3 witness {} {} length {} exceeds ingest cap {}",
+                    witness.step, label, map_len, max_engines
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn validate_research_v3_machine_state_budget(
+    state: &MachineState,
+    label: &str,
+) -> llm_provable_computer::Result<()> {
+    if state.memory.len() > MAX_RESEARCH_V3_STATE_MEMORY_WORDS {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} memory length {} exceeds ingest cap {}",
+            state.memory.len(),
+            MAX_RESEARCH_V3_STATE_MEMORY_WORDS
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn validate_research_v3_instruction_budget(
+    instruction: &str,
+    label: &str,
+) -> llm_provable_computer::Result<()> {
+    if instruction.len() > MAX_RESEARCH_V3_INSTRUCTION_BYTES {
+        return Err(VmError::InvalidConfig(format!(
+            "{label} length {} exceeds ingest cap {}",
+            instruction.len(),
+            MAX_RESEARCH_V3_INSTRUCTION_BYTES
+        )));
+    }
     Ok(())
 }
 
@@ -7092,6 +7262,23 @@ fn validate_frontend_runtime_semantics_registry(
         }
     }
 
+    let expected_lane_ids = RESEARCH_V3_PINNED_ENGINE_LANE_BINDINGS
+        .iter()
+        .map(|(_, lane_id)| *lane_id)
+        .chain(FRONTEND_RUNTIME_RESEARCH_WATCH_LANES.iter().copied())
+        .collect::<std::collections::BTreeSet<_>>();
+    let actual_lane_ids = lane_statuses
+        .keys()
+        .copied()
+        .collect::<std::collections::BTreeSet<_>>();
+    if actual_lane_ids != expected_lane_ids {
+        return Err(VmError::InvalidConfig(format!(
+            "frontend runtime semantics registry lane set does not match the pinned artifact boundary: expected [{}], got [{}]",
+            expected_lane_ids.iter().copied().collect::<Vec<_>>().join(", "),
+            actual_lane_ids.iter().copied().collect::<Vec<_>>().join(", ")
+        )));
+    }
+
     Ok(())
 }
 
@@ -7975,6 +8162,28 @@ mod tests {
     }
 
     #[test]
+    fn frontend_runtime_registry_validation_rejects_extra_watch_lane() {
+        let mut registry =
+            read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH).expect("registry json");
+        registry
+            .get_mut("lanes")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("registry lanes")
+            .push(serde_json::json!({
+                "lane_id": "surprise-watch",
+                "ecosystem": "surprise",
+                "role": "unexpected watch lane",
+                "status": "research_watch",
+                "artifact_binding": "No artifact binding in research-v3-equivalence.",
+                "claim_boundary": "This lane must not drift into the pinned registry without an explicit update."
+            }));
+        let err = validate_frontend_runtime_semantics_registry(&registry).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("lane set does not match the pinned artifact boundary"));
+    }
+
+    #[test]
     fn frontend_runtime_registry_validation_rejects_duplicate_lane_id() {
         let mut registry =
             read_repo_json_value(FRONTEND_RUNTIME_SEMANTICS_REGISTRY_PATH).expect("registry json");
@@ -8376,6 +8585,52 @@ mod tests {
             "events_len {} does not match checked_steps {}",
             expected_steps + 1,
             expected_steps
+        )));
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn verify_research_v3_equivalence_artifact_rejects_checked_steps_budget_overflow() {
+        let mut artifact = sample_research_v3_equivalence_artifact();
+        artifact.requested_max_steps = MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1;
+        artifact.checked_steps = MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1;
+
+        let err = verify_research_v3_equivalence_artifact(&artifact)
+            .expect_err("checked_steps ingest overflow should fail");
+        assert!(err.to_string().contains(&format!(
+            "checked_steps {} exceeds ingest cap {}",
+            MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1,
+            MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+        )));
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn verify_research_v3_equivalence_artifact_rejects_oversized_machine_state_memory() {
+        let mut artifact = sample_research_v3_equivalence_artifact();
+        artifact.engines[0].trace[0].memory = vec![0; MAX_RESEARCH_V3_STATE_MEMORY_WORDS + 1];
+
+        let err = verify_research_v3_equivalence_artifact(&artifact)
+            .expect_err("oversized trace memory should fail");
+        assert!(err.to_string().contains(&format!(
+            "trace[0] memory length {} exceeds ingest cap {}",
+            MAX_RESEARCH_V3_STATE_MEMORY_WORDS + 1,
+            MAX_RESEARCH_V3_STATE_MEMORY_WORDS
+        )));
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn verify_research_v3_equivalence_artifact_rejects_oversized_witness_instruction() {
+        let mut artifact = sample_research_v3_equivalence_artifact();
+        artifact.rule_witnesses[0].instruction = "N".repeat(MAX_RESEARCH_V3_INSTRUCTION_BYTES + 1);
+
+        let err = verify_research_v3_equivalence_artifact(&artifact)
+            .expect_err("oversized witness instruction should fail");
+        assert!(err.to_string().contains(&format!(
+            "witness 1 instruction length {} exceeds ingest cap {}",
+            MAX_RESEARCH_V3_INSTRUCTION_BYTES + 1,
+            MAX_RESEARCH_V3_INSTRUCTION_BYTES
         )));
     }
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -6081,6 +6081,57 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
             ));
         }
         for (index, witness) in rule_witnesses.iter().enumerate() {
+            if let Some(participating_engines) = witness
+                .get("participating_engines")
+                .and_then(serde_json::Value::as_array)
+            {
+                if participating_engines.len() > max_engines {
+                    return Err(research_v3_artifact_budget_error(
+                        artifact_path,
+                        format!(
+                            "research-v3 witness {} participating_engines length {} exceeds ingest cap {}",
+                            index + 1,
+                            participating_engines.len(),
+                            max_engines
+                        ),
+                    ));
+                }
+            }
+            for (label, entries) in [
+                (
+                    "state_before_hashes",
+                    witness
+                        .get("state_before_hashes")
+                        .and_then(serde_json::Value::as_object),
+                ),
+                (
+                    "state_after_hashes",
+                    witness
+                        .get("state_after_hashes")
+                        .and_then(serde_json::Value::as_object),
+                ),
+                (
+                    "engine_transition_hashes",
+                    witness
+                        .get("engine_transition_hashes")
+                        .and_then(serde_json::Value::as_object),
+                ),
+            ] {
+                if let Some(entries) = entries {
+                    if entries.len() > max_engines {
+                        return Err(research_v3_artifact_budget_error(
+                            artifact_path,
+                            format!(
+                                "research-v3 witness {} {} length {} exceeds ingest cap {}",
+                                index + 1,
+                                label,
+                                entries.len(),
+                                max_engines
+                            ),
+                        ));
+                    }
+                }
+            }
             if let Some(instruction) = witness
                 .get("instruction")
                 .and_then(serde_json::Value::as_str)
@@ -8812,13 +8863,27 @@ mod tests {
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
     fn verify_research_v3_equivalence_artifact_rejects_checked_steps_budget_overflow() {
         let mut artifact = sample_research_v3_equivalence_artifact();
-        artifact.requested_max_steps = MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1;
         artifact.checked_steps = MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1;
 
         let err = verify_research_v3_equivalence_artifact(&artifact)
             .expect_err("checked_steps ingest overflow should fail");
         assert!(err.to_string().contains(&format!(
             "checked_steps {} exceeds ingest cap {}",
+            MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1,
+            MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+        )));
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn verify_research_v3_equivalence_artifact_rejects_requested_max_steps_budget_overflow() {
+        let mut artifact = sample_research_v3_equivalence_artifact();
+        artifact.requested_max_steps = MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1;
+
+        let err = verify_research_v3_equivalence_artifact(&artifact)
+            .expect_err("requested_max_steps ingest overflow should fail");
+        assert!(err.to_string().contains(&format!(
+            "requested_max_steps {} exceeds ingest cap {}",
             MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1,
             MAX_RESEARCH_V3_EQUIVALENCE_STEPS
         )));

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -877,7 +877,7 @@ const MAX_RESEARCH_V3_EQUIVALENCE_STEPS: usize = 4096;
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
 const MAX_RESEARCH_V3_STATE_MEMORY_WORDS: usize = 4096;
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
-const MAX_RESEARCH_V3_INSTRUCTION_BYTES: usize = 256;
+const MAX_RESEARCH_V3_INSTRUCTION_CHARS: usize = 256;
 #[cfg(feature = "onnx-export")]
 const RESEARCH_V3_PINNED_ENGINE_LANE_BINDINGS: [(&str, &str); 4] = [
     ("transformer", "transformer-vm"),
@@ -6000,12 +6000,180 @@ fn load_research_v3_equivalence_artifact(
         )));
     }
 
-    serde_json::from_slice(&artifact_bytes).map_err(|err| {
+    let artifact_value: serde_json::Value =
+        serde_json::from_slice(&artifact_bytes).map_err(|err| {
+            VmError::Serialization(format!(
+                "failed to parse research-v3 artifact {}: {err}",
+                artifact_path.display()
+            ))
+        })?;
+    prevalidate_research_v3_equivalence_artifact_budget_json(artifact_path, &artifact_value)?;
+    serde_json::from_value(artifact_value).map_err(|err| {
         VmError::Serialization(format!(
             "failed to parse research-v3 artifact {}: {err}",
             artifact_path.display()
         ))
     })
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn prevalidate_research_v3_equivalence_artifact_budget_json(
+    artifact_path: &Path,
+    artifact_value: &serde_json::Value,
+) -> llm_provable_computer::Result<()> {
+    let max_engines = RESEARCH_V3_PINNED_ENGINE_LANE_BINDINGS.len();
+    let max_trace_len = MAX_RESEARCH_V3_EQUIVALENCE_STEPS + 1;
+
+    if let Some(requested_max_steps) = artifact_value
+        .get("requested_max_steps")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+    {
+        if requested_max_steps > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 requested_max_steps {} exceeds ingest cap {}",
+                requested_max_steps, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+            )));
+        }
+    }
+
+    if let Some(checked_steps) = artifact_value
+        .get("checked_steps")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+    {
+        if checked_steps > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 checked_steps {} exceeds ingest cap {}",
+                checked_steps, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+            )));
+        }
+    }
+
+    if let Some(rule_witnesses) = artifact_value
+        .get("rule_witnesses")
+        .and_then(serde_json::Value::as_array)
+    {
+        if rule_witnesses.len() > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 rule_witnesses length {} exceeds ingest cap {}",
+                rule_witnesses.len(),
+                MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+            )));
+        }
+        for (index, witness) in rule_witnesses.iter().enumerate() {
+            if let Some(instruction) = witness
+                .get("instruction")
+                .and_then(serde_json::Value::as_str)
+            {
+                validate_research_v3_instruction_budget(
+                    instruction,
+                    &format!("witness {} instruction", index + 1),
+                )?;
+            }
+        }
+    }
+
+    if let Some(lanes) = artifact_value
+        .pointer("/frontend_runtime_semantics_registry/lanes")
+        .and_then(serde_json::Value::as_array)
+    {
+        if lanes.len() > MAX_FRONTEND_RUNTIME_SEMANTICS_LANES {
+            return Err(VmError::InvalidConfig(format!(
+                "frontend runtime semantics registry lane count {} exceeds ingest cap {}",
+                lanes.len(),
+                MAX_FRONTEND_RUNTIME_SEMANTICS_LANES
+            )));
+        }
+    }
+
+    if let Some(engines) = artifact_value
+        .get("engines")
+        .and_then(serde_json::Value::as_array)
+    {
+        if engines.len() > max_engines {
+            return Err(VmError::InvalidConfig(format!(
+                "research-v3 engines length {} exceeds ingest cap {}",
+                engines.len(),
+                max_engines
+            )));
+        }
+        for engine in engines {
+            let engine_name = engine
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("<unknown>");
+
+            if let Some(trace) = engine.get("trace").and_then(serde_json::Value::as_array) {
+                if trace.len() > max_trace_len {
+                    return Err(VmError::InvalidConfig(format!(
+                        "research-v3 engine {engine_name} trace length {} exceeds ingest cap {}",
+                        trace.len(),
+                        max_trace_len
+                    )));
+                }
+                for (index, state) in trace.iter().enumerate() {
+                    prevalidate_research_v3_machine_state_budget_json(
+                        state,
+                        &format!("research-v3 engine {engine_name} trace[{index}]"),
+                    )?;
+                }
+            }
+
+            if let Some(final_state) = engine.get("final_state") {
+                prevalidate_research_v3_machine_state_budget_json(
+                    final_state,
+                    &format!("research-v3 engine {engine_name} final_state"),
+                )?;
+            }
+
+            if let Some(events) = engine
+                .get("canonical_events")
+                .and_then(serde_json::Value::as_array)
+            {
+                if events.len() > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
+                    return Err(VmError::InvalidConfig(format!(
+                        "research-v3 engine {engine_name} canonical_events length {} exceeds ingest cap {}",
+                        events.len(),
+                        MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+                    )));
+                }
+                for (index, event) in events.iter().enumerate() {
+                    if let Some(instruction) =
+                        event.get("instruction").and_then(serde_json::Value::as_str)
+                    {
+                        validate_research_v3_instruction_budget(
+                            instruction,
+                            &format!(
+                                "research-v3 engine {engine_name} canonical event {} instruction",
+                                index + 1
+                            ),
+                        )?;
+                    }
+                }
+            }
+        }
+    }
+
+    let _ = artifact_path;
+    Ok(())
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn prevalidate_research_v3_machine_state_budget_json(
+    state: &serde_json::Value,
+    label: &str,
+) -> llm_provable_computer::Result<()> {
+    if let Some(memory) = state.get("memory").and_then(serde_json::Value::as_array) {
+        if memory.len() > MAX_RESEARCH_V3_STATE_MEMORY_WORDS {
+            return Err(VmError::InvalidConfig(format!(
+                "{label} memory length {} exceeds ingest cap {}",
+                memory.len(),
+                MAX_RESEARCH_V3_STATE_MEMORY_WORDS
+            )));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
@@ -6325,11 +6493,11 @@ fn validate_research_v3_instruction_budget(
     instruction: &str,
     label: &str,
 ) -> llm_provable_computer::Result<()> {
-    if instruction.len() > MAX_RESEARCH_V3_INSTRUCTION_BYTES {
+    let instruction_chars = instruction.chars().count();
+    if instruction_chars > MAX_RESEARCH_V3_INSTRUCTION_CHARS {
         return Err(VmError::InvalidConfig(format!(
             "{label} length {} exceeds ingest cap {}",
-            instruction.len(),
-            MAX_RESEARCH_V3_INSTRUCTION_BYTES
+            instruction_chars, MAX_RESEARCH_V3_INSTRUCTION_CHARS
         )));
     }
     Ok(())
@@ -8623,14 +8791,33 @@ mod tests {
     #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
     fn verify_research_v3_equivalence_artifact_rejects_oversized_witness_instruction() {
         let mut artifact = sample_research_v3_equivalence_artifact();
-        artifact.rule_witnesses[0].instruction = "N".repeat(MAX_RESEARCH_V3_INSTRUCTION_BYTES + 1);
+        artifact.rule_witnesses[0].instruction = "N".repeat(MAX_RESEARCH_V3_INSTRUCTION_CHARS + 1);
 
         let err = verify_research_v3_equivalence_artifact(&artifact)
             .expect_err("oversized witness instruction should fail");
         assert!(err.to_string().contains(&format!(
             "witness 1 instruction length {} exceeds ingest cap {}",
-            MAX_RESEARCH_V3_INSTRUCTION_BYTES + 1,
-            MAX_RESEARCH_V3_INSTRUCTION_BYTES
+            MAX_RESEARCH_V3_INSTRUCTION_CHARS + 1,
+            MAX_RESEARCH_V3_INSTRUCTION_CHARS
+        )));
+    }
+
+    #[test]
+    #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+    fn validate_research_v3_instruction_budget_counts_characters() {
+        let within_budget = "ß".repeat(MAX_RESEARCH_V3_INSTRUCTION_CHARS);
+        validate_research_v3_instruction_budget(&within_budget, "unicode instruction")
+            .expect("unicode instruction within char cap should pass");
+
+        let err = validate_research_v3_instruction_budget(
+            &"ß".repeat(MAX_RESEARCH_V3_INSTRUCTION_CHARS + 1),
+            "unicode instruction",
+        )
+        .expect_err("unicode instruction above char cap should fail");
+        assert!(err.to_string().contains(&format!(
+            "unicode instruction length {} exceeds ingest cap {}",
+            MAX_RESEARCH_V3_INSTRUCTION_CHARS + 1,
+            MAX_RESEARCH_V3_INSTRUCTION_CHARS
         )));
     }
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -5603,6 +5603,12 @@ fn research_v3_equivalence_command_impl(
             "research-v3-equivalence requires max_steps >= 1".to_string(),
         ));
     }
+    if max_steps > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
+        return Err(VmError::InvalidConfig(format!(
+            "research-v3-equivalence max_steps {} exceeds artifact cap {}",
+            max_steps, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+        )));
+    }
 
     let bundle = load_research_v2_spec_bundle(
         STATEMENT_V3_EQUIVALENCE_SPEC_PATH,
@@ -5716,6 +5722,7 @@ fn research_v3_equivalence_command_impl(
             rule_witnesses_hash,
         },
     };
+    validate_research_v3_ingest_budget(&artifact)?;
     verify_research_v3_engine_lane_binding(&artifact)?;
 
     let bytes = serde_json::to_vec_pretty(&artifact)
@@ -6030,10 +6037,13 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
         .and_then(|value| usize::try_from(value).ok())
     {
         if requested_max_steps > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
-            return Err(VmError::InvalidConfig(format!(
-                "research-v3 requested_max_steps {} exceeds ingest cap {}",
-                requested_max_steps, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
-            )));
+            return Err(research_v3_artifact_budget_error(
+                artifact_path,
+                format!(
+                    "research-v3 requested_max_steps {} exceeds ingest cap {}",
+                    requested_max_steps, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+                ),
+            ));
         }
     }
 
@@ -6043,10 +6053,13 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
         .and_then(|value| usize::try_from(value).ok())
     {
         if checked_steps > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
-            return Err(VmError::InvalidConfig(format!(
-                "research-v3 checked_steps {} exceeds ingest cap {}",
-                checked_steps, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
-            )));
+            return Err(research_v3_artifact_budget_error(
+                artifact_path,
+                format!(
+                    "research-v3 checked_steps {} exceeds ingest cap {}",
+                    checked_steps, MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+                ),
+            ));
         }
     }
 
@@ -6055,11 +6068,14 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
         .and_then(serde_json::Value::as_array)
     {
         if rule_witnesses.len() > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
-            return Err(VmError::InvalidConfig(format!(
-                "research-v3 rule_witnesses length {} exceeds ingest cap {}",
-                rule_witnesses.len(),
-                MAX_RESEARCH_V3_EQUIVALENCE_STEPS
-            )));
+            return Err(research_v3_artifact_budget_error(
+                artifact_path,
+                format!(
+                    "research-v3 rule_witnesses length {} exceeds ingest cap {}",
+                    rule_witnesses.len(),
+                    MAX_RESEARCH_V3_EQUIVALENCE_STEPS
+                ),
+            ));
         }
         for (index, witness) in rule_witnesses.iter().enumerate() {
             if let Some(instruction) = witness
@@ -6069,7 +6085,8 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
                 validate_research_v3_instruction_budget(
                     instruction,
                     &format!("witness {} instruction", index + 1),
-                )?;
+                )
+                .map_err(|err| prefix_research_v3_artifact_budget_error(artifact_path, err))?;
             }
         }
     }
@@ -6079,11 +6096,14 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
         .and_then(serde_json::Value::as_array)
     {
         if lanes.len() > MAX_FRONTEND_RUNTIME_SEMANTICS_LANES {
-            return Err(VmError::InvalidConfig(format!(
-                "frontend runtime semantics registry lane count {} exceeds ingest cap {}",
-                lanes.len(),
-                MAX_FRONTEND_RUNTIME_SEMANTICS_LANES
-            )));
+            return Err(research_v3_artifact_budget_error(
+                artifact_path,
+                format!(
+                    "frontend runtime semantics registry lane count {} exceeds ingest cap {}",
+                    lanes.len(),
+                    MAX_FRONTEND_RUNTIME_SEMANTICS_LANES
+                ),
+            ));
         }
     }
 
@@ -6092,11 +6112,14 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
         .and_then(serde_json::Value::as_array)
     {
         if engines.len() > max_engines {
-            return Err(VmError::InvalidConfig(format!(
-                "research-v3 engines length {} exceeds ingest cap {}",
-                engines.len(),
-                max_engines
-            )));
+            return Err(research_v3_artifact_budget_error(
+                artifact_path,
+                format!(
+                    "research-v3 engines length {} exceeds ingest cap {}",
+                    engines.len(),
+                    max_engines
+                ),
+            ));
         }
         for engine in engines {
             let engine_name = engine
@@ -6106,17 +6129,21 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
 
             if let Some(trace) = engine.get("trace").and_then(serde_json::Value::as_array) {
                 if trace.len() > max_trace_len {
-                    return Err(VmError::InvalidConfig(format!(
+                    return Err(research_v3_artifact_budget_error(
+                        artifact_path,
+                        format!(
                         "research-v3 engine {engine_name} trace length {} exceeds ingest cap {}",
                         trace.len(),
                         max_trace_len
-                    )));
+                    ),
+                    ));
                 }
                 for (index, state) in trace.iter().enumerate() {
                     prevalidate_research_v3_machine_state_budget_json(
                         state,
                         &format!("research-v3 engine {engine_name} trace[{index}]"),
-                    )?;
+                    )
+                    .map_err(|err| prefix_research_v3_artifact_budget_error(artifact_path, err))?;
                 }
             }
 
@@ -6124,7 +6151,8 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
                 prevalidate_research_v3_machine_state_budget_json(
                     final_state,
                     &format!("research-v3 engine {engine_name} final_state"),
-                )?;
+                )
+                .map_err(|err| prefix_research_v3_artifact_budget_error(artifact_path, err))?;
             }
 
             if let Some(events) = engine
@@ -6132,7 +6160,7 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
                 .and_then(serde_json::Value::as_array)
             {
                 if events.len() > MAX_RESEARCH_V3_EQUIVALENCE_STEPS {
-                    return Err(VmError::InvalidConfig(format!(
+                    return Err(research_v3_artifact_budget_error(artifact_path, format!(
                         "research-v3 engine {engine_name} canonical_events length {} exceeds ingest cap {}",
                         events.len(),
                         MAX_RESEARCH_V3_EQUIVALENCE_STEPS
@@ -6148,15 +6176,36 @@ fn prevalidate_research_v3_equivalence_artifact_budget_json(
                                 "research-v3 engine {engine_name} canonical event {} instruction",
                                 index + 1
                             ),
-                        )?;
+                        )
+                        .map_err(|err| {
+                            prefix_research_v3_artifact_budget_error(artifact_path, err)
+                        })?;
                     }
                 }
             }
         }
     }
 
-    let _ = artifact_path;
     Ok(())
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn research_v3_artifact_budget_error(artifact_path: &Path, message: impl AsRef<str>) -> VmError {
+    VmError::InvalidConfig(format!(
+        "research-v3 artifact {}: {}",
+        artifact_path.display(),
+        message.as_ref()
+    ))
+}
+
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+fn prefix_research_v3_artifact_budget_error(artifact_path: &Path, err: VmError) -> VmError {
+    match err {
+        VmError::InvalidConfig(message) => {
+            research_v3_artifact_budget_error(artifact_path, message)
+        }
+        other => other,
+    }
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5755,10 +5755,17 @@ fn cli_supports_research_v3_equivalence_command() {
         unique_temp_dir("cli-research-v3-equivalence-extra-lane").with_extension("json");
     let swapped_lane_path =
         unique_temp_dir("cli-research-v3-equivalence-swapped-lane").with_extension("json");
+    let participating_engines_budget_path =
+        unique_temp_dir("cli-research-v3-equivalence-participating-engines-budget")
+            .with_extension("json");
     let step_budget_path =
         unique_temp_dir("cli-research-v3-equivalence-step-budget").with_extension("json");
     let requested_budget_path =
         unique_temp_dir("cli-research-v3-equivalence-requested-budget").with_extension("json");
+    let trace_len_budget_path =
+        unique_temp_dir("cli-research-v3-equivalence-trace-len-budget").with_extension("json");
+    let events_len_budget_path =
+        unique_temp_dir("cli-research-v3-equivalence-events-len-budget").with_extension("json");
     let mut command = tvm_command();
     command
         .arg("research-v3-equivalence")
@@ -6372,6 +6379,33 @@ fn cli_supports_research_v3_equivalence_command() {
             "frontend runtime semantics registry missing lane egg-emerge",
         ));
 
+    let mut participating_engines_budget = artifact_json.clone();
+    participating_engines_budget["rule_witnesses"][0]["participating_engines"]
+        .as_array_mut()
+        .expect("participating engines")
+        .push(serde_json::Value::String("surprise-engine".to_string()));
+    participating_engines_budget["commitments"]["rule_witnesses_hash"] =
+        serde_json::Value::String(hash_json_value(
+            participating_engines_budget
+                .get("rule_witnesses")
+                .expect("participating engines budget witnesses"),
+        ));
+    std::fs::write(
+        &participating_engines_budget_path,
+        serde_json::to_vec(&participating_engines_budget)
+            .expect("participating engines budget artifact json"),
+    )
+    .expect("write participating engines budget artifact");
+    let mut verify_participating_engines_budget = tvm_command();
+    verify_participating_engines_budget
+        .arg("verify-research-v3-equivalence")
+        .arg(&participating_engines_budget_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "research-v3 witness 1 participating_engines length 5 exceeds ingest cap 4",
+        ));
+
     let mut step_budget = artifact_json.clone();
     step_budget["checked_steps"] = serde_json::Value::from(4097_u64);
     std::fs::write(
@@ -6404,6 +6438,52 @@ fn cli_supports_research_v3_equivalence_command() {
         .failure()
         .stderr(predicate::str::contains(
             "requested_max_steps 4097 exceeds ingest cap 4096",
+        ));
+
+    let mut trace_len_budget = artifact_json.clone();
+    trace_len_budget["engines"][0]["trace_len"] = serde_json::Value::from(4098_u64);
+    trace_len_budget["commitments"]["engine_summaries_hash"] =
+        serde_json::Value::String(hash_json_value(
+            trace_len_budget
+                .get("engines")
+                .expect("trace len budget engines"),
+        ));
+    std::fs::write(
+        &trace_len_budget_path,
+        serde_json::to_vec(&trace_len_budget).expect("trace len budget artifact json"),
+    )
+    .expect("write trace len budget artifact");
+    let mut verify_trace_len_budget = tvm_command();
+    verify_trace_len_budget
+        .arg("verify-research-v3-equivalence")
+        .arg(&trace_len_budget_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "research-v3 engine transformer trace_len 4098 exceeds ingest cap 4097",
+        ));
+
+    let mut events_len_budget = artifact_json.clone();
+    events_len_budget["engines"][0]["events_len"] = serde_json::Value::from(4097_u64);
+    events_len_budget["commitments"]["engine_summaries_hash"] =
+        serde_json::Value::String(hash_json_value(
+            events_len_budget
+                .get("engines")
+                .expect("events len budget engines"),
+        ));
+    std::fs::write(
+        &events_len_budget_path,
+        serde_json::to_vec(&events_len_budget).expect("events len budget artifact json"),
+    )
+    .expect("write events len budget artifact");
+    let mut verify_events_len_budget = tvm_command();
+    verify_events_len_budget
+        .arg("verify-research-v3-equivalence")
+        .arg(&events_len_budget_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "research-v3 engine transformer events_len 4097 exceeds ingest cap 4096",
         ));
 
     let mut malformed_hash = artifact_json.clone();
@@ -6445,8 +6525,11 @@ fn cli_supports_research_v3_equivalence_command() {
     let _ = std::fs::remove_file(extra_trace_path);
     let _ = std::fs::remove_file(extra_lane_path);
     let _ = std::fs::remove_file(swapped_lane_path);
+    let _ = std::fs::remove_file(participating_engines_budget_path);
     let _ = std::fs::remove_file(step_budget_path);
     let _ = std::fs::remove_file(requested_budget_path);
+    let _ = std::fs::remove_file(trace_len_budget_path);
+    let _ = std::fs::remove_file(events_len_budget_path);
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5729,6 +5729,10 @@ fn cli_supports_research_v3_equivalence_command() {
         unique_temp_dir("cli-research-v3-equivalence-extra-event").with_extension("json");
     let extra_trace_path =
         unique_temp_dir("cli-research-v3-equivalence-extra-trace").with_extension("json");
+    let extra_lane_path =
+        unique_temp_dir("cli-research-v3-equivalence-extra-lane").with_extension("json");
+    let step_budget_path =
+        unique_temp_dir("cli-research-v3-equivalence-step-budget").with_extension("json");
     let mut command = tvm_command();
     command
         .arg("research-v3-equivalence")
@@ -6272,6 +6276,61 @@ fn cli_supports_research_v3_equivalence_command() {
             extra_trace_expected_steps + 1
         )));
 
+    let mut extra_lane = artifact_json.clone();
+    let lanes = extra_lane["frontend_runtime_semantics_registry"]["lanes"]
+        .as_array_mut()
+        .expect("registry lanes");
+    let replaced_lane = lanes
+        .iter_mut()
+        .find(|lane| lane.get("lane_id").and_then(serde_json::Value::as_str) == Some("egg-emerge"))
+        .expect("egg-emerge research watch lane");
+    *replaced_lane = serde_json::json!({
+        "lane_id": "surprise-watch",
+        "ecosystem": "surprise",
+        "role": "unexpected watch lane",
+        "status": "research_watch",
+        "artifact_binding": "No artifact binding in research-v3-equivalence.",
+        "claim_boundary": "This lane must not drift into the pinned registry without an explicit update."
+    });
+    extra_lane["commitments"]["frontend_runtime_semantics_registry_hash"] =
+        serde_json::Value::String(hash_json_value(
+            extra_lane
+                .get("frontend_runtime_semantics_registry")
+                .expect("extra lane registry"),
+        ));
+    std::fs::write(
+        &extra_lane_path,
+        serde_json::to_vec(&extra_lane).expect("extra lane artifact json"),
+    )
+    .expect("write extra lane artifact");
+    let mut verify_extra_lane = tvm_command();
+    verify_extra_lane
+        .arg("verify-research-v3-equivalence")
+        .arg(&extra_lane_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "frontend runtime semantics registry missing lane egg-emerge",
+        ));
+
+    let mut step_budget = artifact_json.clone();
+    step_budget["requested_max_steps"] = serde_json::Value::from(4097_u64);
+    step_budget["checked_steps"] = serde_json::Value::from(4097_u64);
+    std::fs::write(
+        &step_budget_path,
+        serde_json::to_vec(&step_budget).expect("step budget artifact json"),
+    )
+    .expect("write step budget artifact");
+    let mut verify_step_budget = tvm_command();
+    verify_step_budget
+        .arg("verify-research-v3-equivalence")
+        .arg(&step_budget_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "checked_steps 4097 exceeds ingest cap 4096",
+        ));
+
     let mut malformed_hash = artifact_json.clone();
     malformed_hash["commitments"]["relation_format_hash"] =
         serde_json::Value::String("not-a-blake2b-hash".to_string());
@@ -6309,6 +6368,8 @@ fn cli_supports_research_v3_equivalence_command() {
     let _ = std::fs::remove_file(missing_engine_path);
     let _ = std::fs::remove_file(extra_event_path);
     let _ = std::fs::remove_file(extra_trace_path);
+    let _ = std::fs::remove_file(extra_lane_path);
+    let _ = std::fs::remove_file(step_budget_path);
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4758,7 +4758,7 @@ fn cli_research_v3_equivalence_rejects_max_steps_above_artifact_cap() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "research-v3-equivalence max_steps 4097 exceeds artifact cap 4096",
+            "--max-steps must be in 1..=4096 for research-v3-equivalence",
         ));
 
     assert!(!output_path.exists());
@@ -5753,6 +5753,8 @@ fn cli_supports_research_v3_equivalence_command() {
         unique_temp_dir("cli-research-v3-equivalence-extra-trace").with_extension("json");
     let extra_lane_path =
         unique_temp_dir("cli-research-v3-equivalence-extra-lane").with_extension("json");
+    let swapped_lane_path =
+        unique_temp_dir("cli-research-v3-equivalence-swapped-lane").with_extension("json");
     let step_budget_path =
         unique_temp_dir("cli-research-v3-equivalence-step-budget").with_extension("json");
     let mut command = tvm_command();
@@ -6331,6 +6333,43 @@ fn cli_supports_research_v3_equivalence_command() {
             "frontend runtime semantics registry lane count 14 exceeds ingest cap 13",
         ));
 
+    let mut swapped_lane = artifact_json.clone();
+    let lanes = swapped_lane["frontend_runtime_semantics_registry"]["lanes"]
+        .as_array_mut()
+        .expect("registry lanes");
+    let replaced_lane = lanes
+        .iter_mut()
+        .find(|lane| lane.get("lane_id").and_then(serde_json::Value::as_str) == Some("egg-emerge"))
+        .expect("egg-emerge lane");
+    *replaced_lane = serde_json::json!({
+        "lane_id": "surprise-watch",
+        "ecosystem": "surprise",
+        "role": "unexpected watch lane",
+        "status": "research_watch",
+        "artifact_binding": "No artifact binding in research-v3-equivalence.",
+        "claim_boundary": "This lane must not drift into the pinned registry without an explicit update."
+    });
+    swapped_lane["commitments"]["frontend_runtime_semantics_registry_hash"] =
+        serde_json::Value::String(hash_json_value(
+            swapped_lane
+                .get("frontend_runtime_semantics_registry")
+                .expect("swapped lane registry"),
+        ));
+    std::fs::write(
+        &swapped_lane_path,
+        serde_json::to_vec(&swapped_lane).expect("swapped lane artifact json"),
+    )
+    .expect("write swapped lane artifact");
+    let mut verify_swapped_lane = tvm_command();
+    verify_swapped_lane
+        .arg("verify-research-v3-equivalence")
+        .arg(&swapped_lane_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "frontend runtime semantics registry missing lane egg-emerge",
+        ));
+
     let mut step_budget = artifact_json.clone();
     step_budget["checked_steps"] = serde_json::Value::from(4097_u64);
     std::fs::write(
@@ -6386,6 +6425,7 @@ fn cli_supports_research_v3_equivalence_command() {
     let _ = std::fs::remove_file(extra_event_path);
     let _ = std::fs::remove_file(extra_trace_path);
     let _ = std::fs::remove_file(extra_lane_path);
+    let _ = std::fs::remove_file(swapped_lane_path);
     let _ = std::fs::remove_file(step_budget_path);
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4742,6 +4742,28 @@ fn cli_reports_missing_features_for_research_v3_equivalence() {
         ));
 }
 
+#[cfg(all(feature = "burn-model", feature = "onnx-export"))]
+#[test]
+fn cli_research_v3_equivalence_rejects_max_steps_above_artifact_cap() {
+    let output_path =
+        unique_temp_dir("cli-research-v3-equivalence-over-cap").with_extension("json");
+    let mut command = tvm_command();
+    command
+        .arg("research-v3-equivalence")
+        .arg("programs/addition.tvm")
+        .arg("-o")
+        .arg(&output_path)
+        .arg("--max-steps")
+        .arg("4097")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "research-v3-equivalence max_steps 4097 exceeds artifact cap 4096",
+        ));
+
+    assert!(!output_path.exists());
+}
+
 #[test]
 fn cli_can_prepare_and_verify_hf_provenance_manifest() {
     let fixture_dir = unique_temp_dir("cli-hf-provenance-manifest");
@@ -6280,18 +6302,14 @@ fn cli_supports_research_v3_equivalence_command() {
     let lanes = extra_lane["frontend_runtime_semantics_registry"]["lanes"]
         .as_array_mut()
         .expect("registry lanes");
-    let replaced_lane = lanes
-        .iter_mut()
-        .find(|lane| lane.get("lane_id").and_then(serde_json::Value::as_str) == Some("egg-emerge"))
-        .expect("egg-emerge research watch lane");
-    *replaced_lane = serde_json::json!({
+    lanes.push(serde_json::json!({
         "lane_id": "surprise-watch",
         "ecosystem": "surprise",
         "role": "unexpected watch lane",
         "status": "research_watch",
         "artifact_binding": "No artifact binding in research-v3-equivalence.",
         "claim_boundary": "This lane must not drift into the pinned registry without an explicit update."
-    });
+    }));
     extra_lane["commitments"]["frontend_runtime_semantics_registry_hash"] =
         serde_json::Value::String(hash_json_value(
             extra_lane
@@ -6310,7 +6328,7 @@ fn cli_supports_research_v3_equivalence_command() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "frontend runtime semantics registry missing lane egg-emerge",
+            "frontend runtime semantics registry lane count 14 exceeds ingest cap 13",
         ));
 
     let mut step_budget = artifact_json.clone();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6314,7 +6314,6 @@ fn cli_supports_research_v3_equivalence_command() {
         ));
 
     let mut step_budget = artifact_json.clone();
-    step_budget["requested_max_steps"] = serde_json::Value::from(4097_u64);
     step_budget["checked_steps"] = serde_json::Value::from(4097_u64);
     std::fs::write(
         &step_budget_path,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5757,6 +5757,8 @@ fn cli_supports_research_v3_equivalence_command() {
         unique_temp_dir("cli-research-v3-equivalence-swapped-lane").with_extension("json");
     let step_budget_path =
         unique_temp_dir("cli-research-v3-equivalence-step-budget").with_extension("json");
+    let requested_budget_path =
+        unique_temp_dir("cli-research-v3-equivalence-requested-budget").with_extension("json");
     let mut command = tvm_command();
     command
         .arg("research-v3-equivalence")
@@ -6387,6 +6389,23 @@ fn cli_supports_research_v3_equivalence_command() {
             "checked_steps 4097 exceeds ingest cap 4096",
         ));
 
+    let mut requested_budget = artifact_json.clone();
+    requested_budget["requested_max_steps"] = serde_json::Value::from(4097_u64);
+    std::fs::write(
+        &requested_budget_path,
+        serde_json::to_vec(&requested_budget).expect("requested budget artifact json"),
+    )
+    .expect("write requested budget artifact");
+    let mut verify_requested_budget = tvm_command();
+    verify_requested_budget
+        .arg("verify-research-v3-equivalence")
+        .arg(&requested_budget_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "requested_max_steps 4097 exceeds ingest cap 4096",
+        ));
+
     let mut malformed_hash = artifact_json.clone();
     malformed_hash["commitments"]["relation_format_hash"] =
         serde_json::Value::String("not-a-blake2b-hash".to_string());
@@ -6427,6 +6446,7 @@ fn cli_supports_research_v3_equivalence_command() {
     let _ = std::fs::remove_file(extra_lane_path);
     let _ = std::fs::remove_file(swapped_lane_path);
     let _ = std::fs::remove_file(step_budget_path);
+    let _ = std::fs::remove_file(requested_budget_path);
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
@@ -6445,7 +6465,7 @@ fn cli_research_v3_equivalence_rejects_zero_max_steps() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "research-v3-equivalence requires max_steps >= 1",
+            "--max-steps must be in 1..=4096 for research-v3-equivalence",
         ));
 
     assert!(!output_path.exists());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5758,6 +5758,8 @@ fn cli_supports_research_v3_equivalence_command() {
     let participating_engines_budget_path =
         unique_temp_dir("cli-research-v3-equivalence-participating-engines-budget")
             .with_extension("json");
+    let witness_hash_budget_path =
+        unique_temp_dir("cli-research-v3-equivalence-witness-hash-budget").with_extension("json");
     let step_budget_path =
         unique_temp_dir("cli-research-v3-equivalence-step-budget").with_extension("json");
     let requested_budget_path =
@@ -6406,6 +6408,41 @@ fn cli_supports_research_v3_equivalence_command() {
             "research-v3 witness 1 participating_engines length 5 exceeds ingest cap 4",
         ));
 
+    for object_key in [
+        "state_before_hashes",
+        "state_after_hashes",
+        "engine_transition_hashes",
+    ] {
+        let mut witness_hash_budget = artifact_json.clone();
+        witness_hash_budget["rule_witnesses"][0][object_key]
+            .as_object_mut()
+            .expect("witness hash object")
+            .insert(
+                "surprise-engine".to_string(),
+                serde_json::Value::String("0".repeat(64)),
+            );
+        witness_hash_budget["commitments"]["rule_witnesses_hash"] =
+            serde_json::Value::String(hash_json_value(
+                witness_hash_budget
+                    .get("rule_witnesses")
+                    .expect("witness hash budget witnesses"),
+            ));
+        std::fs::write(
+            &witness_hash_budget_path,
+            serde_json::to_vec(&witness_hash_budget).expect("witness hash budget artifact json"),
+        )
+        .expect("write witness hash budget artifact");
+        let mut verify_witness_hash_budget = tvm_command();
+        verify_witness_hash_budget
+            .arg("verify-research-v3-equivalence")
+            .arg(&witness_hash_budget_path)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(format!(
+                "research-v3 witness 1 {object_key} length 5 exceeds ingest cap 4",
+            )));
+    }
+
     let mut step_budget = artifact_json.clone();
     step_budget["checked_steps"] = serde_json::Value::from(4097_u64);
     std::fs::write(
@@ -6526,6 +6563,7 @@ fn cli_supports_research_v3_equivalence_command() {
     let _ = std::fs::remove_file(extra_lane_path);
     let _ = std::fs::remove_file(swapped_lane_path);
     let _ = std::fs::remove_file(participating_engines_budget_path);
+    let _ = std::fs::remove_file(witness_hash_budget_path);
     let _ = std::fs::remove_file(step_budget_path);
     let _ = std::fs::remove_file(requested_budget_path);
     let _ = std::fs::remove_file(trace_len_budget_path);


### PR DESCRIPTION
## Summary
- add early ingest-budget checks for research-v3 witness artifacts and pin the frontend runtime registry lane boundary
- tighten the statement-v3 schema caps and extend the local hardening gate with the new negative tests
- add CLI and unit regressions for oversized witness packages, extra runtime lanes, and machine-state/instruction budget overflow

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below
- Skipped trusted-core default harness layers:
  - Oracle / differential checks: updated via the `research-v3-equivalence` CLI exact test plus the verifier-side lane/budget tamper regressions in `tests/cli.rs`.
  - Resource-bound / untrusted-input impact: reviewed. This PR is specifically about earlier rejection of oversized witness artifacts, lane drift, and machine-state/instruction growth on untrusted JSON inputs.
  - Kani / formal-kernel impact: not applicable for this slice; the change is bounded to verifier/parser/schema hardening around research-v3 artifacts, not a new formal kernel.
  - Miri / ASAN / UB impact: no new unsafe code or pointer-manipulating kernel surface was introduced in this slice, so the existing sanitizer coverage remains unchanged.

## Validation
- cargo fmt --all
- cargo test -q --features burn-model,onnx-export --bin tvm tests::frontend_runtime_registry_validation_rejects_extra_watch_lane -- --exact
- cargo test -q --features burn-model,onnx-export --bin tvm tests::verify_research_v3_equivalence_artifact_rejects_checked_steps_budget_overflow -- --exact
- cargo test -q --features burn-model,onnx-export --bin tvm tests::verify_research_v3_equivalence_artifact_rejects_oversized_machine_state_memory -- --exact
- cargo test -q --features burn-model,onnx-export --bin tvm tests::verify_research_v3_equivalence_artifact_rejects_oversized_witness_instruction -- --exact
- cargo build -q --features full --bin tvm
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --features full --test cli cli_supports_research_v3_equivalence_command -- --exact

## Testing
- cargo fmt --all
- cargo test -q --features burn-model,onnx-export --bin tvm tests::frontend_runtime_registry_validation_rejects_extra_watch_lane -- --exact
- cargo test -q --features burn-model,onnx-export --bin tvm tests::verify_research_v3_equivalence_artifact_rejects_checked_steps_budget_overflow -- --exact
- cargo test -q --features burn-model,onnx-export --bin tvm tests::verify_research_v3_equivalence_artifact_rejects_oversized_machine_state_memory -- --exact
- cargo test -q --features burn-model,onnx-export --bin tvm tests::verify_research_v3_equivalence_artifact_rejects_oversized_witness_instruction -- --exact
- cargo build -q --features full --bin tvm
- TVM_TEST_BINARY=target/debug/tvm cargo test -q --features full --test cli cli_supports_research_v3_equivalence_command -- --exact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced ingest-time caps for Research v3 artifacts: max steps (1..=4096), state memory, instruction size, trace/engine limits, and exact registry lane counts; CLI now rejects excessive --max-steps.

* **Tests**
  * Added tests for artifact rejections: step-budget overflow, oversized memory/trace, oversized instructions, extra/missing registry lanes, Unicode instruction counting, and CLI max-steps enforcement.

* **Chores**
  * Extended test target lists and hardening test filters to include the new Research v3 cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds defense-in-depth ingest-budget hardening for research-v3 witness artifacts: a pre-deserialization JSON-level cap check (`prevalidate_research_v3_equivalence_artifact_budget_json`), a post-deserialization struct-level check (`validate_research_v3_ingest_budget` extended with memory-word, instruction-char, and hash-map caps), and an exact lane-count pin in `validate_frontend_runtime_semantics_registry`. The schema caps, Rust constants (`MAX_RESEARCH_V3_STATE_MEMORY_WORDS = 4096`, `MAX_RESEARCH_V3_INSTRUCTION_CHARS = 256`, `MAX_FRONTEND_RUNTIME_SEMANTICS_LANES = 13`), pre-validation, and post-validation are all internally consistent. The Unicode codepoint counting for instruction budgets (`chars().count()`) is correctly aligned with JSON Schema's `maxLength` semantics, and the Unicode regression test confirms this. Hardening and smoke gate lists were updated in sync. One minor omission: four new budget-overflow tests are not added to the hardening/smoke filter lists (see inline comment).

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — new checks are additive, schema caps and runtime constants are consistent, and the verification flow is not weakened.

All findings are P2. The only gap is that four new budget-overflow unit tests are not included in the hardening/sanitizer target list, but they run in regular cargo test and don't involve unsafe code, so ASAN/Miri coverage would add little value. No proof-soundness, verification-boundary, or version-drift issues were found.

No files require special attention; the single P2 note is in scripts/hardening_test_names.sh.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/bin/tvm.rs | Adds pre-deserialization JSON budget checks, post-deserialization struct-level budget checks, and instruction/machine-state helpers; extends validate_frontend_runtime_semantics_registry to enforce exact lane count; adds CLI max-steps value parser. Logic is correct and consistent with the schema. |
| spec/statement-v3-equivalence-kernel.schema.json | Adds explicit maximum caps aligned with the Rust constants (4096 steps, 4097 trace entries, 256-char instructions, 4096-word memory, 13 lanes, 4 engine hash maps). Schema and runtime constants are consistent. |
| scripts/hardening_test_names.sh | Adds 4 new research-v3 test names to hardening_research_v3_test_filters; mirrors the same 4 entries that local_merge_gate.sh also added to research_v3_smoke_targets. |
| scripts/local_merge_gate.sh | Adds the same 4 new research-v3 test names to research_v3_smoke_targets; no logic changes to gate flow. |
| tests/cli.rs | Adds CLI-level tests for max-steps above artifact cap and zero max-steps; both test the new parse_research_v3_equivalence_max_steps value parser path correctly. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/hardening_test_names.sh
Line: 54-68

Comment:
**Four new budget-overflow tests not in hardening/smoke gate**

The PR adds four additional unit tests that exercise resource-bound rejection paths but are absent from both `hardening_research_v3_test_filters` (this file) and `research_v3_smoke_targets` in `local_merge_gate.sh`:

- `verify_research_v3_equivalence_artifact_rejects_participating_engines_budget_overflow`
- `verify_research_v3_equivalence_artifact_rejects_witness_hash_budget_overflow`
- `verify_research_v3_equivalence_artifact_rejects_requested_max_steps_budget_overflow`
- `validate_research_v3_instruction_budget_counts_characters`

These four tests cover `participating_engines`, the three witness hash maps, `requested_max_steps` upper-cap, and Unicode codepoint counting — all untrusted-input paths. They run as part of regular `cargo test`, but omitting them from the hardening/UB-check target list means they are not exercised under ASAN/Miri alongside the other budget-overflow guards.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Add direct research-v3 witness cap unit ..."](https://github.com/omarespejel/provable-transformer-vm/commit/4cba53367b3fd0df329b695af2347a36ef40f60f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28468456)</sub>

<!-- /greptile_comment -->