### PR TITLE
Add shared lookup identity example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 name = "tvm"
 path = "src/bin/tvm.rs"
 
-[[example]]
-name = "shared_lookup_identity"
-required-features = ["stwo-backend"]
-
 [features]
 default = []
 burn-model = ["dep:burn"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 name = "tvm"
 path = "src/bin/tvm.rs"
 
+[[example]]
+name = "shared_lookup_identity"
+required-features = ["stwo-backend"]
+
 [features]
 default = []
 burn-model = ["dep:burn"]

--- a/README.md
+++ b/README.md
@@ -415,6 +415,9 @@ cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
 cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
   verify-stwo-shared-normalization-demo shared-normalization.stwo.proof.json
 
+# Run the minimal shared-lookup identity example
+cargo +nightly-2025-07-14 run --features stwo-backend --example shared_lookup_identity
+
 # Produce and verify the fixed-shape proof-carrying decoding demo chain
 cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
   prove-stwo-decoding-demo -o decoding.stwo.chain.json

--- a/examples/shared_lookup_identity.rs
+++ b/examples/shared_lookup_identity.rs
@@ -1,0 +1,43 @@
+//! Minimal shared-lookup identity example.
+//!
+//! This example keeps runtime tiny by using a small hardcoded shared-lookup row set.
+//! It demonstrates the public commitment helper, then shows that a registry keyed
+//! by the commitment can deduplicate identical row sets without ambiguity.
+
+use std::collections::BTreeMap;
+
+use llm_provable_computer::stwo_backend::commit_phase12_shared_lookup_rows;
+
+fn main() {
+    let layout_commitment = "example-layout-commitment-v1";
+    let shared_lookup_rows = vec![1, 0, 1, 1, 0, 1, 0, 0];
+
+    let first_commitment =
+        commit_phase12_shared_lookup_rows(layout_commitment, &shared_lookup_rows);
+    let second_commitment =
+        commit_phase12_shared_lookup_rows(layout_commitment, &shared_lookup_rows);
+
+    assert_eq!(
+        first_commitment, second_commitment,
+        "the same shared-lookup rows must always produce the same commitment"
+    );
+
+    let mut registry: BTreeMap<String, Vec<i16>> = BTreeMap::new();
+    let replaced = registry.insert(first_commitment.clone(), shared_lookup_rows.clone());
+    assert!(
+        replaced.is_none(),
+        "first insertion should populate the registry"
+    );
+
+    let deduped = registry.insert(second_commitment.clone(), shared_lookup_rows.clone());
+    assert!(
+        deduped.is_some(),
+        "a second insertion under the same commitment should be recognized as the same identity"
+    );
+
+    println!("shared_lookup_identity: ok");
+    println!("layout_commitment: {}", layout_commitment);
+    println!("shared_lookup_commitment: {}", first_commitment);
+    println!("shared_lookup_row_count: {}", shared_lookup_rows.len());
+    println!("registry_size: {}", registry.len());
+}

--- a/examples/shared_lookup_identity.rs
+++ b/examples/shared_lookup_identity.rs
@@ -4,10 +4,19 @@
 //! It demonstrates the public commitment helper, then shows that a registry keyed
 //! by the commitment can deduplicate identical row sets without ambiguity.
 
+#[cfg(not(feature = "stwo-backend"))]
+fn main() {
+    eprintln!("This example requires the `stwo-backend` feature.");
+    std::process::exit(1);
+}
+
+#[cfg(feature = "stwo-backend")]
 use std::collections::BTreeMap;
 
+#[cfg(feature = "stwo-backend")]
 use llm_provable_computer::stwo_backend::commit_phase12_shared_lookup_rows;
 
+#[cfg(feature = "stwo-backend")]
 fn main() {
     let layout_commitment = "example-layout-commitment-v1";
     let shared_lookup_rows = vec![1, 0, 1, 1, 0, 1, 0, 0];


### PR DESCRIPTION
## Summary
- add a minimal shared lookup identity example under examples/
- document the example run command in the README
- keep the example tiny and commitment-focused rather than turning it into a heavy artifact demo

## Validation
- cargo +nightly-2025-07-14 run --features stwo-backend --example shared_lookup_identity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added command to run a minimal shared-lookup identity example in the experimental proving CLI demo sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a minimal `shared_lookup_identity` example under `examples/` and documents its run command in the README. The example correctly demonstrates commitment determinism via `commit_phase12_shared_lookup_rows` with proper `#[cfg(feature = "stwo-backend")]` gating; no proof semantics, verification paths, or manifest schemas are changed.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no proof-soundness, verification, or carried-state concerns; only two P2 quality suggestions remain.

All remaining findings are P2: one suggests adding a negative-input assertion to make the example more robust against API drift, and one notes that examples/** is absent from the CI path filter. Neither is a correctness or security issue in the proof system.

No files require special attention; both P2 suggestions are in examples/shared_lookup_identity.rs.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/shared_lookup_identity.rs | New example demonstrating commitment determinism for shared-lookup rows; logic is correct, feature-gating is properly handled |
| README.md | Added one-liner run command for the new example in the correct sequence; toolchain pin matches project convention |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: examples/shared_lookup_identity.rs
Line: 29-45

Comment:
**Example only tests trivial determinism and BTreeMap mechanics**

The three assertions prove that the hash function is deterministic (trivially true for Blake2b) and that `BTreeMap::insert` returns `Some` on a duplicate key. Neither assertion would catch a regression where, for example, `commit_phase12_shared_lookup_rows` always returned the same hash regardless of its inputs. Adding a complementary assertion that a *different* row set (or a different `layout_commitment`) produces a *different* commitment would make the example meaningfully exercise the function's isolation properties and serve as a safeguard against future API drift.

```rust
let other_rows = vec![0i16; 8];
let other_commitment = commit_phase12_shared_lookup_rows(layout_commitment, &other_rows);
assert_ne!(
    first_commitment, other_commitment,
    "distinct row sets must produce distinct commitments"
);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: examples/shared_lookup_identity.rs
Line: 7-11

Comment:
**Example not covered by CI path filter**

The CI workflow's `pull_request` path filter (`src/**/*.rs`, `tests/**`, etc.) does not include `examples/**`, so this file is never compiled or run in CI. If `commit_phase12_shared_lookup_rows`'s signature or behaviour changes, the broken README command won't be caught automatically. Consider adding `examples/**` to the CI path filter, or adding a quick `cargo build --features stwo-backend --examples` step to the existing `stwo-backend` job.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Add stwo feature fallback for shared loo..."](https://github.com/omarespejel/provable-transformer-vm/commit/7d1e5313aa3ee85d0ed2e9398f2205cc0af82d17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28476882)</sub>

<!-- /greptile_comment -->