### PR TITLE
Refine paper2 framing and roadmap wording

### DIFF
--- a/docs/engineering/paper2-roadmap.md
+++ b/docs/engineering/paper2-roadmap.md
@@ -11,8 +11,8 @@ Implementation goals this roadmap supports:
 - carried-state validity,
 - statement-preserving pre-recursive aggregation boundaries.
 
-The roadmap below is intentionally scoped to those verifier boundaries and does
-not assume that recursive compression is already available.
+The roadmap below stays inside those verifier boundaries and does not assume
+that recursive compression is already available.
 
 ## Current status
 
@@ -40,8 +40,8 @@ Focus on:
 - `research-v3` artifact verification,
 - HF provenance manifest verification.
 
-This work remains highest leverage because the paper’s main claim is about
-these verifier boundaries define the repository’s current reproducibility and
+This work remains highest leverage because the paper’s main claim is that these
+verifier boundaries define the repository’s current reproducibility and
 statement-stability envelope.
 
 ### 2. Extend provenance binding toward attestation-friendly release metadata

--- a/docs/paper/paper2/appendix-engineering-gaps.md
+++ b/docs/paper/paper2/appendix-engineering-gaps.md
@@ -1,7 +1,7 @@
 # Appendix C. Remaining Engineering Gaps
 
-This appendix records what is still missing before the repository can honestly
-support a stronger follow-on claim than the current paper.
+This appendix records the concrete engineering gaps that still separate the
+current bounded claim from a stronger follow-on claim.
 
 ## C1. Gaps that matter most
 
@@ -9,7 +9,7 @@ support a stronger follow-on claim than the current paper.
 
 The repository still stops before recursive cryptographic accumulation. The
 current aggregation line preserves statements across ordered artifacts, but it
-does not produce a recursively verifiable compressed proof.
+does not yet produce a recursively verifiable compressed proof object.
 
 ### Shared-table recursive reuse
 

--- a/docs/paper/paper2/appendix-ivc-positioning.md
+++ b/docs/paper/paper2/appendix-ivc-positioning.md
@@ -12,7 +12,7 @@ The repository currently provides:
 - verifier-recomputed package commitments,
 - ordered packaging layers over verified members,
 - a pre-recursive aggregation boundary,
-- a recursive-compression input contract that remains an input-boundary artifact,
+- a recursive-compression input contract that remains a pre-recursive boundary,
   not a recursive proof system.
 
 ## B2. What recursive systems additionally provide

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -11,12 +11,11 @@ Starknet Foundation
 ## Abstract
 
 This paper studies a narrower systems question than end-to-end zkML deployment:
-what cryptographically meaningful public statement can already be supported by a
-repository-backed proof artifact before recursive compression closure exists. We
-answer that question for `provable-transformer-vm` by isolating a
-proof-carrying decode relation over explicit carried-state boundaries and by
-formalizing the statement-preserving packaging layers that the repository
-already realizes.
+what cryptographically meaningful public statement a repository-backed proof
+artifact can already support before recursive compression exists. We answer
+that question for `provable-transformer-vm` by isolating a proof-carrying
+decode relation over explicit carried-state boundaries and by formalizing the
+statement-preserving packaging layers that the repository already realizes.
 
 The artifact surface is bounded but nontrivial. Verified step artifacts compose
 into chains, segments, interval bundles, rollups, matrices, and a
@@ -25,8 +24,8 @@ end-state decode semantics. We formalize carried-state boundary tuples,
 packaging-layer validity, and a preservation proposition for these ordered
 artifacts. We also separate two adjacent but distinct engineering surfaces:
 bounded multi-runtime semantic-agreement artifacts and release-provenance
-manifests. Both matter operationally, but neither is part of the proof
-relation.
+manifests. Both matter operationally, but neither belongs inside the proof
+relation itself.
 
 The result is not recursive proof-carrying data, incrementally verifiable
 computation, or compressed recursive verification in the sense of HyperNova,
@@ -52,7 +51,7 @@ general implementation-equivalence proofs.
 
 This paper takes the opposite approach. It asks for the strongest honest claim
 that the current repository can defend to a cryptography audience. The answer
-is a bounded one:
+is bounded:
 
 - there is a stable proof-carrying decode relation over explicit carried-state
   boundaries,
@@ -64,8 +63,8 @@ is a bounded one:
 
 That claim is narrower than full recursive accumulation, but it is also more
 useful than a vague “artifact supports future recursion” sentence. It specifies
-what later recursive machinery would need to preserve, namely the same public
-decode boundary semantics already exposed by the current implementation.
+what later recursive machinery would need to preserve: the same public decode
+boundary semantics already exposed by the current implementation.
 
 The paper makes four contributions.
 
@@ -260,7 +259,7 @@ surfaces.
 
 ### 5.1 Proof-carrying decode and carried-state packaging
 
-The strongest paper-2 surface is the phase line that now reaches:
+The strongest paper-2 surface is the phase line that reaches:
 
 - step and chain artifacts,
 - state-relation accumulation,


### PR DESCRIPTION
## Summary
- tighten the paper2 framing around the bounded decode claim
- align appendix wording with the current engineering gaps and IVC positioning
- update the paper2 roadmap wording to better match the repo-backed sequence

## Validation
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pure editorial pass over four paper-2 documentation files: tightens the bounded-decode framing in the abstract and introduction, fixes a grammar error in the roadmap ("is about these … define" → "is that these … define"), sharpens appendix terminology ("pre-recursive boundary" vs "input-boundary artifact"), and removes a stray "now" in §5.1. No code, proof semantics, manifest schema, or test surface is touched; all changes narrow or preserve existing claims rather than overstating them.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are documentation-only editorial fixes with no impact on proof semantics, code, or CI.

All four changed files are paper draft and roadmap markdown. No proof logic, manifest schema, version constants, or test coverage is affected. The rewording tightens claims rather than overstating them, so doc-claim-drift is not a concern. No P0/P1 findings; no findings at all.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/paper/paper2/proof-carrying-decode-surfaces-2026.md | Editorial rewording of abstract, intro, and §5.1 to tighten the bounded-decode claim; no new claims introduced, existing scope is preserved or narrowed. |
| docs/engineering/paper2-roadmap.md | Two small wording fixes: one grammar correction and one tighter verb choice; meaning unchanged. |
| docs/paper/paper2/appendix-engineering-gaps.md | Intro reframed around the bounded claim; added 'yet' and 'object' to the compressed-proof sentence for accuracy; no scope changes. |
| docs/paper/paper2/appendix-ivc-positioning.md | Single-line clarification: 'input-boundary artifact' renamed 'pre-recursive boundary' to better align with the bounded-decode framing. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Refine paper2 framing and roadmap wordin..."](https://github.com/omarespejel/provable-transformer-vm/commit/831af1472199a12d63eedd8454dcf26fefbe9903) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28476982)</sub>

<!-- /greptile_comment -->