### PR TITLE
[codex] Add attestation-friendly HF provenance metadata

### DIFF
--- a/docs/engineering/paper2-roadmap.md
+++ b/docs/engineering/paper2-roadmap.md
@@ -25,6 +25,8 @@ The repository is already strong enough for the bounded paper-2 claim:
 - Hugging Face provenance manifests exist as reproducibility artifacts,
 - ONNX-facing provenance now binds exported graph, metadata companion, and
   declared external-data side files,
+- attestation-friendly subject digests plus optional builder/source release
+  metadata now exist on the HF provenance surface,
 - parser/verifier hardening has materially improved the trust boundary around
   those surfaces.
 
@@ -44,18 +46,19 @@ This work remains highest leverage because the paper’s main claim is that thes
 verifier boundaries define the repository’s current reproducibility and
 statement-stability envelope.
 
-### 2. Extend provenance binding toward attestation-friendly release metadata
+### 2. Deepen provenance binding beyond the new attestation-friendly release layer
 
-The next substantive gap is no longer basic ONNX sidecar binding. It is richer
-attestation-friendly provenance over the same release surface.
+The next substantive gap is no longer basic ONNX sidecar binding or release-side
+subject digests. It is stronger exporter and externally signed provenance over
+the same release surface.
 
 Concrete targets:
 
 - bind exporter identity more explicitly,
 - bind graph-constraint identity where exporter metadata exposes it,
 - preserve external-file identity where ONNX layout requires it,
-- add richer release/build metadata without letting the claim drift into proof
-  semantics,
+- keep the new builder/source metadata aligned with signed attestation subjects
+  rather than proof semantics,
 - keep the claim phrased as provenance/reproducibility, not proof semantics.
 
 ### 3. Keep semantic-agreement artifacts bounded
@@ -95,6 +98,6 @@ exists to sequence the implementation work that keeps those boundaries honest.
 The next concrete engineering slice should be:
 
 1. one more targeted verifier/tamper pass over the expanded HF provenance
-   manifest surface,
-2. then attestation-friendly release-metadata hardening over the same bounded
-   provenance claim.
+   attestation block and the exact paper-facing `research-v3` boundary,
+2. then explicit exporter-identity or graph-constraint binding over the same
+   bounded provenance claim.

--- a/docs/engineering/reproducibility.md
+++ b/docs/engineering/reproducibility.md
@@ -119,9 +119,10 @@ bundle-looking directory unless that override is set. Its outputs are:
   opaque-kernel tests, or cryptographic implementation-equivalence proofs.
 - HF provenance manifests are release/provenance artifacts only. They bind
   pinned Hub and tokenizer identifiers plus local tokenizer, safetensors, ONNX,
-  model-card, DOI, and dataset metadata where supplied, but they do not prove
-  tokenizer algorithm correctness, model-weight semantics, Optimum export
-  equivalence, live Hub availability, or DOI validity.
+  model-card, DOI, dataset, attestation-subject, and optional builder/source
+  metadata where supplied, but they do not prove tokenizer algorithm
+  correctness, model-weight semantics, Optimum export equivalence, live Hub
+  availability, or DOI validity.
 
 ## Paper figure regeneration
 

--- a/docs/paper/paper2/appendix-engineering-gaps.md
+++ b/docs/paper/paper2/appendix-engineering-gaps.md
@@ -21,12 +21,13 @@ compressed proof object.
 
 The Hugging Face provenance line is strong as a bounded reproducibility surface,
 but it is not yet a complete supply-chain attestation story. In particular,
-stronger binding of exporter-side ONNX provenance and attestation-compatible
-release metadata remains a live engineering gap. Today the repository binds the
+stronger binding of exporter-side ONNX provenance and externally signed
+attestations remains a live engineering gap. Today the repository binds the
 produced ONNX-facing graph, metadata, and external-file identities together with
-local file hashes, but it does not yet expose a broader attestation-compatible
-layer for exporter graph identity, shape/range constraints, or richer build
-provenance.
+local file hashes, attestation-friendly subject digests, and optional
+builder/source release metadata, but it does not yet expose a verified external
+attestation layer for exporter graph identity, shape/range constraints, or
+builder trust.
 
 ### Runtime-consistency scope
 
@@ -45,8 +46,8 @@ proving.
 1. keep hardening parser, verifier, and manifest boundaries that sit directly on
    the paper-2 claim surface,
 2. extend the current ONNX graph/metadata/external-file provenance binding
-   toward exporter identity, graph-constraint identity, and
-   attestation-compatible release metadata,
+   toward exporter identity, graph-constraint identity, and externally signed
+   attestations,
 3. keep semantic-agreement artifacts bounded and explicit rather than pretending
    they are full equivalence proofs,
 4. move to recursive compression only after the public decode statement is

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -295,11 +295,12 @@ safetensors identities to explicit local-file hashes and pinned release
 coordinates. In the ONNX-facing path, that boundary now includes the exported
 graph, its metadata companion, declared external-data side files, and
 attestation-friendly SHA-256 subject digests alongside the repository's local
-BLAKE2b-256 commitments. This is operationally valuable, especially for frozen
-artifact bundles and release-verification workflows that already key on
-SHA-256. It should not be confused with a proof relation or a verified
-attestation pipeline. It is a release boundary, not a theorem that exporter or
-supply-chain semantics are preserved.
+BLAKE2b-256 commitments and optional builder/source release metadata. This is
+operationally valuable, especially for frozen artifact bundles and
+release-verification workflows that already key on SHA-256. It should not be
+confused with a proof relation or a verified attestation pipeline. It is a
+release boundary, not a theorem that exporter or supply-chain semantics are
+preserved.
 
 ______________________________________________________________________
 

--- a/spec/hf-provenance-manifest.schema.json
+++ b/spec/hf-provenance-manifest.schema.json
@@ -34,6 +34,12 @@
       ]
     },
     "release": { "$ref": "#/$defs/release" },
+    "attestation": {
+      "anyOf": [
+        { "$ref": "#/$defs/attestation" },
+        { "type": "null" }
+      ]
+    },
     "limitations": {
       "type": "array",
       "minItems": 1,
@@ -198,6 +204,59 @@
       },
       "additionalProperties": false
     },
+    "attestation_subject": {
+      "type": "object",
+      "required": ["role", "path", "sha256"],
+      "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "$ref": "#/$defs/hash_sha256_hex" }
+      },
+      "additionalProperties": false
+    },
+    "attestation": {
+      "type": "object",
+      "required": [
+        "attestation_version",
+        "builder_id",
+        "build_invocation_id",
+        "source_repository",
+        "source_revision",
+        "subjects"
+      ],
+      "properties": {
+        "attestation_version": { "const": "hf-attestation-metadata-v1" },
+        "builder_id": {
+          "anyOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
+        },
+        "build_invocation_id": {
+          "anyOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
+        },
+        "source_repository": {
+          "anyOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
+        },
+        "source_revision": {
+          "anyOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
+        },
+        "subjects": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/attestation_subject" }
+        }
+      },
+      "additionalProperties": false
+    },
     "commitments": {
       "type": "object",
       "required": [
@@ -216,6 +275,7 @@
         "onnx_export_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "onnx_metadata_identity_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "release_metadata_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "attestation_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "limitations_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" }
       },
       "additionalProperties": false

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -717,6 +717,18 @@ enum Command {
         /// Extra manifest note (repeatable).
         #[arg(long = "note")]
         notes: Vec<String>,
+        /// Optional attestation-friendly builder identity, for example a GitHub workflow URI.
+        #[arg(long = "attestation-builder-id")]
+        attestation_builder_id: Option<String>,
+        /// Optional attestation-friendly build invocation identifier.
+        #[arg(long = "attestation-build-invocation-id")]
+        attestation_build_invocation_id: Option<String>,
+        /// Optional source repository coordinate for build provenance metadata.
+        #[arg(long = "attestation-source-repository")]
+        attestation_source_repository: Option<String>,
+        /// Optional pinned source revision for build provenance metadata.
+        #[arg(long = "attestation-source-revision")]
+        attestation_source_revision: Option<String>,
     },
     /// Verify a Hugging Face release/provenance manifest and local file bindings.
     VerifyHfProvenanceManifest {
@@ -912,6 +924,7 @@ const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v5";
 const HF_PROVENANCE_SEMANTIC_SCOPE: &str = "hf-release-provenance-boundary-v1";
 const HF_PROVENANCE_HASH_FUNCTION: &str = "blake2b-256";
 const HF_ONNX_METADATA_IDENTITY_VERSION: &str = "onnx-program-metadata-identity-v1";
+const HF_ATTESTATION_METADATA_VERSION: &str = "hf-attestation-metadata-v1";
 
 struct HfProvenanceManifestCommand {
     output: PathBuf,
@@ -932,6 +945,10 @@ struct HfProvenanceManifestCommand {
     doi: Option<String>,
     datasets: Vec<String>,
     notes: Vec<String>,
+    attestation_builder_id: Option<String>,
+    attestation_build_invocation_id: Option<String>,
+    attestation_source_repository: Option<String>,
+    attestation_source_revision: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -998,6 +1015,25 @@ struct HfReleaseMetadata {
     notes: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HfAttestationSubject {
+    role: String,
+    path: String,
+    sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HfAttestationMetadata {
+    attestation_version: String,
+    builder_id: Option<String>,
+    build_invocation_id: Option<String>,
+    source_repository: Option<String>,
+    source_revision: Option<String>,
+    subjects: Vec<HfAttestationSubject>,
+}
+
 #[derive(Debug, Serialize)]
 struct HfHubBinding<'a> {
     hub_repo: &'a str,
@@ -1013,6 +1049,8 @@ struct HfProvenanceCommitments {
     onnx_export_hash: String,
     onnx_metadata_identity_hash: String,
     release_metadata_hash: String,
+    #[serde(default = "default_hf_attestation_hash")]
+    attestation_hash: String,
     limitations_hash: String,
 }
 
@@ -1028,8 +1066,15 @@ struct HfProvenanceManifest {
     safetensors: Vec<HfSafetensorsFileCommitment>,
     onnx_export: Option<HfOnnxExportProvenance>,
     release: HfReleaseMetadata,
+    #[serde(default)]
+    attestation: Option<HfAttestationMetadata>,
     limitations: Vec<String>,
     commitments: HfProvenanceCommitments,
+}
+
+fn default_hf_attestation_hash() -> String {
+    hash_json_projection_hex(&Option::<HfAttestationMetadata>::None)
+        .expect("default HF attestation hash")
 }
 
 #[cfg(feature = "onnx-export")]
@@ -1629,6 +1674,10 @@ fn run() -> llm_provable_computer::Result<()> {
             doi,
             datasets,
             notes,
+            attestation_builder_id,
+            attestation_build_invocation_id,
+            attestation_source_repository,
+            attestation_source_revision,
         } => prepare_hf_provenance_manifest_command(HfProvenanceManifestCommand {
             output,
             hub_repo,
@@ -1648,6 +1697,10 @@ fn run() -> llm_provable_computer::Result<()> {
             doi,
             datasets,
             notes,
+            attestation_builder_id,
+            attestation_build_invocation_id,
+            attestation_source_repository,
+            attestation_source_revision,
         })?,
         Command::VerifyHfProvenanceManifest { manifest } => {
             verify_hf_provenance_manifest_command(&manifest)?
@@ -4344,6 +4397,19 @@ fn prepare_hf_provenance_manifest_command(
         datasets: command.datasets,
         notes: command.notes,
     };
+    let attestation = Some(HfAttestationMetadata {
+        attestation_version: HF_ATTESTATION_METADATA_VERSION.to_string(),
+        builder_id: command.attestation_builder_id,
+        build_invocation_id: command.attestation_build_invocation_id,
+        source_repository: command.attestation_source_repository,
+        source_revision: command.attestation_source_revision,
+        subjects: derive_hf_attestation_subjects(
+            &tokenizer,
+            &safetensors,
+            onnx_export.as_ref(),
+            &release,
+        ),
+    });
     let limitations = hf_provenance_limitations();
     let hub_binding_hash = hash_json_projection_hex(&HfHubBinding {
         hub_repo: &command.hub_repo,
@@ -4366,12 +4432,14 @@ fn prepare_hf_provenance_manifest_command(
                     .and_then(|export| export.metadata_identity.as_ref()),
             )?,
             release_metadata_hash: hash_json_projection_hex(&release)?,
+            attestation_hash: hash_json_projection_hex(&attestation)?,
             limitations_hash: hash_json_projection_hex(&limitations)?,
         },
         tokenizer,
         safetensors,
         onnx_export,
         release,
+        attestation,
         limitations,
     };
     verify_hf_provenance_manifest(&manifest)?;
@@ -4385,6 +4453,13 @@ fn prepare_hf_provenance_manifest_command(
     println!("hub_revision: {}", manifest.hub_revision);
     println!("tokenizer_id: {}", manifest.tokenizer.tokenizer_id);
     println!("safetensors_files: {}", manifest.safetensors.len());
+    println!(
+        "attestation_subjects: {}",
+        manifest
+            .attestation
+            .as_ref()
+            .map_or(0, |attestation| attestation.subjects.len())
+    );
     println!(
         "commitment_safetensors_manifest_hash: {}",
         manifest.commitments.safetensors_manifest_hash
@@ -4828,6 +4903,11 @@ fn verify_hf_provenance_manifest(
         &hash_json_projection_hex(&manifest.release)?,
     )?;
     verify_hash_commitment(
+        "hf attestation_hash",
+        &manifest.commitments.attestation_hash,
+        &hash_json_projection_hex(&manifest.attestation)?,
+    )?;
+    verify_hash_commitment(
         "hf limitations_hash",
         &manifest.commitments.limitations_hash,
         &hash_json_projection_hex(&manifest.limitations)?,
@@ -4950,6 +5030,56 @@ fn verify_hf_provenance_manifest(
             )));
         }
     }
+    if let Some(attestation) = &manifest.attestation {
+        expect_eq(
+            "hf attestation.attestation_version",
+            &attestation.attestation_version,
+            HF_ATTESTATION_METADATA_VERSION,
+        )?;
+        validate_hf_optional_identifier(
+            "attestation.builder_id",
+            attestation.builder_id.as_deref(),
+        )?;
+        validate_hf_optional_identifier(
+            "attestation.build_invocation_id",
+            attestation.build_invocation_id.as_deref(),
+        )?;
+        validate_hf_optional_identifier(
+            "attestation.source_repository",
+            attestation.source_repository.as_deref(),
+        )?;
+        match (
+            attestation.source_repository.as_deref(),
+            attestation.source_revision.as_deref(),
+        ) {
+            (Some(_), Some(source_revision)) => {
+                validate_hf_pinned_revision("attestation.source_revision", source_revision)?;
+            }
+            (Some(_), None) => {
+                return Err(VmError::InvalidConfig(
+                    "HF provenance attestation.source_revision must be present when attestation.source_repository is set".to_string(),
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(VmError::InvalidConfig(
+                    "HF provenance attestation.source_repository must be present when attestation.source_revision is set".to_string(),
+                ));
+            }
+            (None, None) => {}
+        }
+        let expected_subjects = derive_hf_attestation_subjects(
+            &manifest.tokenizer,
+            &manifest.safetensors,
+            manifest.onnx_export.as_ref(),
+            &manifest.release,
+        );
+        if attestation.subjects != expected_subjects {
+            return Err(VmError::InvalidConfig(
+                "HF provenance attestation.subjects do not match the bound local-file surface"
+                    .to_string(),
+            ));
+        }
+    }
 
     Ok(())
 }
@@ -4967,6 +5097,73 @@ fn hf_provenance_limitations() -> Vec<String> {
     .into_iter()
     .map(str::to_string)
     .collect()
+}
+
+fn derive_hf_attestation_subjects(
+    tokenizer: &HfTokenizerProvenance,
+    safetensors: &[HfSafetensorsFileCommitment],
+    onnx_export: Option<&HfOnnxExportProvenance>,
+    release: &HfReleaseMetadata,
+) -> Vec<HfAttestationSubject> {
+    let mut subjects = Vec::new();
+
+    push_hf_attestation_file_subject(
+        &mut subjects,
+        "tokenizer_json",
+        tokenizer.tokenizer_json.as_ref(),
+    );
+    push_hf_attestation_file_subject(
+        &mut subjects,
+        "tokenizer_config",
+        tokenizer.tokenizer_config.as_ref(),
+    );
+    push_hf_attestation_file_subject(
+        &mut subjects,
+        "tokenization_transcript",
+        tokenizer.tokenization_transcript.as_ref(),
+    );
+    for commitment in safetensors {
+        subjects.push(HfAttestationSubject {
+            role: "safetensors".to_string(),
+            path: commitment.path.clone(),
+            sha256: commitment.sha256.clone(),
+        });
+    }
+    if let Some(onnx_export) = onnx_export {
+        push_hf_attestation_file_subject(
+            &mut subjects,
+            "onnx_export.graph",
+            Some(&onnx_export.graph),
+        );
+        push_hf_attestation_file_subject(
+            &mut subjects,
+            "onnx_export.metadata",
+            onnx_export.metadata.as_ref(),
+        );
+        for commitment in &onnx_export.external_data_files {
+            subjects.push(HfAttestationSubject {
+                role: "onnx_export.external_data_files".to_string(),
+                path: commitment.path.clone(),
+                sha256: commitment.sha256.clone(),
+            });
+        }
+    }
+    push_hf_attestation_file_subject(&mut subjects, "model_card", release.model_card.as_ref());
+    subjects
+}
+
+fn push_hf_attestation_file_subject(
+    subjects: &mut Vec<HfAttestationSubject>,
+    role: &str,
+    commitment: Option<&HfFileCommitment>,
+) {
+    if let Some(commitment) = commitment {
+        subjects.push(HfAttestationSubject {
+            role: role.to_string(),
+            path: commitment.path.clone(),
+            sha256: commitment.sha256.clone(),
+        });
+    }
 }
 
 fn validate_hf_identifier(label: &str, value: &str) -> llm_provable_computer::Result<()> {
@@ -8136,6 +8333,7 @@ mod hf_provenance_manifest_tests {
                 "datasets": [],
                 "notes": []
             },
+            "attestation": null,
             "limitations": hf_provenance_limitations(),
             "commitments": {
                 "hub_binding_hash": "f".repeat(64),
@@ -8144,6 +8342,7 @@ mod hf_provenance_manifest_tests {
                 "onnx_export_hash": "2".repeat(64),
                 "onnx_metadata_identity_hash": "3".repeat(64),
                 "release_metadata_hash": "5".repeat(64),
+                "attestation_hash": default_hf_attestation_hash(),
                 "limitations_hash": "4".repeat(64)
             }
         })
@@ -8184,6 +8383,19 @@ mod hf_provenance_manifest_tests {
             safetensors,
             onnx_export: onnx_export.clone(),
             release: release.clone(),
+            attestation: Some(HfAttestationMetadata {
+                attestation_version: HF_ATTESTATION_METADATA_VERSION.to_string(),
+                builder_id: None,
+                build_invocation_id: None,
+                source_repository: None,
+                source_revision: None,
+                subjects: derive_hf_attestation_subjects(
+                    &tokenizer,
+                    &Vec::<HfSafetensorsFileCommitment>::new(),
+                    onnx_export.as_ref(),
+                    &release,
+                ),
+            }),
             limitations: limitations.clone(),
             commitments: HfProvenanceCommitments {
                 hub_binding_hash: hash_json_projection_hex(&HfHubBinding {
@@ -8204,6 +8416,20 @@ mod hf_provenance_manifest_tests {
                 )
                 .expect("onnx metadata identity hash"),
                 release_metadata_hash: hash_json_projection_hex(&release).expect("release hash"),
+                attestation_hash: hash_json_projection_hex(&Some(HfAttestationMetadata {
+                    attestation_version: HF_ATTESTATION_METADATA_VERSION.to_string(),
+                    builder_id: None,
+                    build_invocation_id: None,
+                    source_repository: None,
+                    source_revision: None,
+                    subjects: derive_hf_attestation_subjects(
+                        &tokenizer,
+                        &Vec::<HfSafetensorsFileCommitment>::new(),
+                        onnx_export.as_ref(),
+                        &release,
+                    ),
+                }))
+                .expect("attestation hash"),
                 limitations_hash: hash_json_projection_hex(&limitations).expect("limitations hash"),
             },
         }
@@ -8448,6 +8674,10 @@ mod hf_provenance_manifest_tests {
             doi: None,
             datasets: Vec::new(),
             notes: vec!["x".repeat(MAX_HF_PROVENANCE_MANIFEST_JSON_BYTES)],
+            attestation_builder_id: None,
+            attestation_build_invocation_id: None,
+            attestation_source_repository: None,
+            attestation_source_revision: None,
         })
         .expect_err("oversized manifest output should fail");
 
@@ -8524,6 +8754,18 @@ mod hf_provenance_manifest_tests {
             safetensors,
             onnx_export,
             release,
+            attestation: Some(HfAttestationMetadata {
+                attestation_version: HF_ATTESTATION_METADATA_VERSION.to_string(),
+                builder_id: None,
+                build_invocation_id: None,
+                source_repository: None,
+                source_revision: None,
+                subjects: vec![HfAttestationSubject {
+                    role: "model_card".to_string(),
+                    path: bound_dir.display().to_string(),
+                    sha256: "1".repeat(64),
+                }],
+            }),
             limitations,
             commitments: HfProvenanceCommitments {
                 hub_binding_hash: hash_json_projection_hex(&HfHubBinding {
@@ -8561,6 +8803,19 @@ mod hf_provenance_manifest_tests {
                     notes: Vec::new(),
                 })
                 .expect("release hash"),
+                attestation_hash: hash_json_projection_hex(&Some(HfAttestationMetadata {
+                    attestation_version: HF_ATTESTATION_METADATA_VERSION.to_string(),
+                    builder_id: None,
+                    build_invocation_id: None,
+                    source_repository: None,
+                    source_revision: None,
+                    subjects: vec![HfAttestationSubject {
+                        role: "model_card".to_string(),
+                        path: bound_dir.display().to_string(),
+                        sha256: "1".repeat(64),
+                    }],
+                }))
+                .expect("attestation hash"),
                 limitations_hash: hash_json_projection_hex(&hf_provenance_limitations())
                     .expect("limitations hash"),
             },
@@ -8597,6 +8852,10 @@ mod hf_provenance_manifest_tests {
             doi: None,
             datasets: Vec::new(),
             notes: vec!["release note".to_string()],
+            attestation_builder_id: None,
+            attestation_build_invocation_id: None,
+            attestation_source_repository: None,
+            attestation_source_revision: None,
         })
         .expect_err("ONNX sidecars without graph should fail");
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4832,10 +4832,19 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
         .arg("example/prompts")
         .arg("--note")
         .arg("fixture only")
+        .arg("--attestation-builder-id")
+        .arg("https://github.com/example/workflows/release.yml@refs/tags/v1")
+        .arg("--attestation-build-invocation-id")
+        .arg("build-123")
+        .arg("--attestation-source-repository")
+        .arg("omarespejel/provable-transformer-vm")
+        .arg("--attestation-source-revision")
+        .arg("45706ff0776fd2e5a36b22b4c3cb85533d0676c6")
         .assert()
         .success()
         .stdout(predicate::str::contains("hf_provenance_manifest:"))
-        .stdout(predicate::str::contains("safetensors_files: 1"));
+        .stdout(predicate::str::contains("safetensors_files: 1"))
+        .stdout(predicate::str::contains("attestation_subjects: 6"));
 
     let manifest_json: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
@@ -4847,6 +4856,32 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
             .get("manifest_version")
             .and_then(serde_json::Value::as_str),
         Some("hf-provenance-manifest-v5")
+    );
+    assert_eq!(
+        manifest_json["attestation"]["attestation_version"].as_str(),
+        Some("hf-attestation-metadata-v1")
+    );
+    assert_eq!(
+        manifest_json["attestation"]["builder_id"].as_str(),
+        Some("https://github.com/example/workflows/release.yml@refs/tags/v1")
+    );
+    assert_eq!(
+        manifest_json["attestation"]["build_invocation_id"].as_str(),
+        Some("build-123")
+    );
+    assert_eq!(
+        manifest_json["attestation"]["source_repository"].as_str(),
+        Some("omarespejel/provable-transformer-vm")
+    );
+    assert_eq!(
+        manifest_json["attestation"]["source_revision"].as_str(),
+        Some("45706ff0776fd2e5a36b22b4c3cb85533d0676c6")
+    );
+    assert_eq!(
+        manifest_json["attestation"]["subjects"]
+            .as_array()
+            .map(|subjects| subjects.len()),
+        Some(6)
     );
     assert_eq!(
         manifest_json
@@ -4869,6 +4904,14 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
                 digest.len() == 64 && digest.chars().all(|c| c.is_ascii_hexdigit())
             }),
         "commitments.onnx_metadata_identity_hash must be hex",
+    );
+    assert!(
+        manifest_json["commitments"]["attestation_hash"]
+            .as_str()
+            .is_some_and(|digest| {
+                digest.len() == 64 && digest.chars().all(|c| c.is_ascii_hexdigit())
+            }),
+        "commitments.attestation_hash must be hex",
     );
     assert!(manifest_json["onnx_export"]["metadata_identity"].is_null());
     assert_eq!(
@@ -5532,6 +5575,117 @@ fn cli_prepare_hf_manifest_emits_onnx_metadata_identity() {
             }),
         "commitments.onnx_metadata_identity_hash must be hex",
     );
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_tampered_hf_attestation_hash() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-attestation-hash-tamper");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let tokenizer_json = fixture_dir.join("tokenizer.json");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(
+        &tokenizer_json,
+        br#"{"version":"1.0","model":{"type":"WordPiece","unk_token":"[UNK]"}}"#,
+    )
+    .expect("write tokenizer json");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&tokenizer_json)
+        .arg("--attestation-builder-id")
+        .arg("https://github.com/example/workflows/release.yml@refs/tags/v1")
+        .assert()
+        .success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["commitments"]["attestation_hash"] = serde_json::json!("0".repeat(64));
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "hf attestation_hash commitment mismatch",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_tampered_hf_attestation_subjects() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-attestation-subjects-tamper");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let tokenizer_json = fixture_dir.join("tokenizer.json");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(
+        &tokenizer_json,
+        br#"{"version":"1.0","model":{"type":"WordPiece","unk_token":"[UNK]"}}"#,
+    )
+    .expect("write tokenizer json");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&tokenizer_json)
+        .assert()
+        .success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["attestation"]["subjects"][0]["sha256"] = serde_json::json!("0".repeat(64));
+    manifest_json["commitments"]["attestation_hash"] = serde_json::Value::String(hash_json_value(
+        manifest_json
+            .get("attestation")
+            .expect("attestation section after tamper"),
+    ));
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "HF provenance attestation.subjects do not match the bound local-file surface",
+        ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);
 }


### PR DESCRIPTION
## What changed

- add an optional top-level HF attestation block with derived SHA-256 subjects over every bound local file
- bind optional builder/source release metadata without changing proof semantics or the paper-2 claim boundary
- add an explicit `attestation_hash` commitment with a backward-compatible default for older manifests
- extend the HF provenance schema, verifier logic, and CLI tests around the new attestation surface
- update the paper-2 engineering roadmap and claim-boundary docs to reflect the stronger release boundary

## Why

Paper 2 already has the pre-recursive decode boundary work through Phase 30. The repo's own roadmap says the next concrete engineering slice is attestation-friendly provenance over the HF release surface. This PR implements that bounded next step instead of inventing a new theorem layer.

## Validation

- `cargo test -q --features full --bin tvm hf_provenance_manifest_tests::prepare_hf_provenance_manifest_rejects_oversized_output -- --exact`
- `cargo build -q --features full --bin tvm`
- `TVM_TEST_BINARY=target/debug/tvm cargo test -q --features full --test cli cli_can_prepare_and_verify_hf_provenance_manifest -- --exact`
- `TVM_TEST_BINARY=target/debug/tvm cargo test -q --features full --test cli cli_verifier_rejects_tampered_hf_attestation_hash -- --exact`
- `TVM_TEST_BINARY=target/debug/tvm cargo test -q --features full --test cli cli_verifier_rejects_tampered_hf_attestation_subjects -- --exact`
- `TVM_TEST_BINARY=target/debug/tvm cargo test -q --features full --test cli cli_prepare_hf_manifest_emits_onnx_metadata_identity -- --exact`
- `cargo test -q --features full --bin tvm hf_provenance_manifest_tests::load_hf_provenance_manifest_rejects_unknown_top_level_field -- --exact`
- `cargo test -q --features full --bin tvm hf_provenance_manifest_tests::verify_hf_provenance_manifest_rejects_non_regular_bound_file -- --exact`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended HF provenance manifest support with attestation data capture and validation.
  * Added CLI options to specify builder identity, build invocation ID, and source repository information for attestation binding.

* **Tests**
  * Enhanced verification test coverage for attestation integrity and field validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->