### PR TITLE
Add Phase 31 decode-boundary bridge manifest

### DIFF
--- a/docs/engineering/paper2-roadmap.md
+++ b/docs/engineering/paper2-roadmap.md
@@ -20,7 +20,8 @@ The repository is already strong enough for the bounded paper-2 claim:
 
 - carried-state packaging layers are implemented through the current
   pre-recursive aggregation boundary,
-- recursive-adjacent Phase 29 and Phase 30 boundary artifacts exist,
+- recursive-adjacent Phase 29, Phase 30, and Phase 31 boundary artifacts
+  exist,
 - bounded multi-runtime semantic-agreement artifacts exist,
 - Hugging Face provenance manifests exist as reproducibility artifacts,
 - ONNX-facing provenance now binds exported graph, metadata companion, and
@@ -41,6 +42,7 @@ Focus on:
 - carried-state package verification,
 - recursive-compression input contract verification,
 - step-envelope manifest verification,
+- decode-boundary bridge manifest verification,
 - `research-v3` artifact verification,
 - HF provenance manifest verification.
 
@@ -75,7 +77,20 @@ Concrete rule:
 - hardening should continue to focus on manifest, trace, event, and commitment
   mismatch rejection.
 
-### 4. Then move to recursive compression
+### 4. Keep the recursive-adjacent decode boundary explicit
+
+The repository now has the exact bridge that later recursive work should
+consume: a Phase 31 manifest that binds the Phase 29 recursive-compression
+input contract to the Phase 30 ordered decode-envelope manifest without
+changing the public decode statement.
+
+That means the next recursive work should preserve:
+
+- the existing decode statement,
+- the existing start/end carried-state boundary semantics,
+- the existing package commitments already exposed by the repository.
+
+### 5. Then move to recursive compression
 
 Recursive work should come after the public decode statement is stable enough
 that recursion preserves a claim the repository already exposes cleanly.
@@ -102,5 +117,8 @@ The next concrete engineering slice should be:
 1. keep the expanded HF provenance verifier narrow and explicit about what is
    local identity binding versus what would require external signed
    attestations,
-2. then recurse over the existing decode boundary rather than inventing a new
+2. keep the Phase 31 decode-boundary bridge narrow and explicit about what is
+   bound from Phase 29 and Phase 30 versus what would require actual recursive
+   verification,
+3. then recurse over the existing decode boundary rather than inventing a new
    statement surface.

--- a/docs/paper/paper2/appendix-artifact-map.md
+++ b/docs/paper/paper2/appendix-artifact-map.md
@@ -14,6 +14,7 @@ surfaces.
 | Phase 28 aggregated chained folded intervalized state relation | proof-carrying pre-recursive aggregation boundary | inside proof-carrying decode surface; still pre-recursive |
 | Phase 29 recursive-compression input contract | recursive-adjacent input boundary derived from a verified Phase 28 aggregate | boundary artifact only; not recursive proof closure |
 | Phase 30 decoding step proof envelope manifest | ordered manifest binding step proofs, boundaries, and package commitments | statement-preserving manifest layer; not recursive proof closure |
+| Phase 31 recursive-compression decode-boundary manifest | bridge binding the published recursion input contract to the ordered decode-envelope manifest | recursive-adjacent bridge only; not recursive proof closure |
 
 ## D2. Adjacent evidence surfaces
 

--- a/docs/paper/paper2/appendix-engineering-gaps.md
+++ b/docs/paper/paper2/appendix-engineering-gaps.md
@@ -8,8 +8,10 @@ current bounded claim from a stronger follow-on claim.
 ### Recursive closure
 
 The repository still stops before recursive cryptographic accumulation. The
-current aggregation line preserves statements across ordered artifacts, but it
-does not yet produce a recursively verifiable compressed proof object.
+current aggregation line preserves statements across ordered artifacts, and the
+new Phase 31 decode-boundary bridge now binds the published Phase 29 recursive
+input contract to the Phase 30 ordered decode-envelope manifest. But it still
+does not produce a recursively verifiable compressed proof object.
 
 ### Shared-table recursive reuse
 
@@ -48,7 +50,9 @@ proving.
    toward externally signed attestations without overstating the proof claim,
 3. keep semantic-agreement artifacts bounded and explicit rather than pretending
    they are full equivalence proofs,
-4. move to recursive compression only after the public decode statement is
+4. keep the new Phase 31 bridge explicit about what it binds and what it does
+   not claim,
+5. move to recursive compression only after the public decode statement is
    stable enough that recursion preserves an already well-defined claim.
 
 ## C3. Why this does not block the current paper

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -268,7 +268,9 @@ The strongest paper-2 surface is the phase line that reaches:
 - chained fold-of-folds packaging,
 - proof-carrying outer aggregation,
 - a recursive-compression input contract,
-- a step-proof envelope manifest.
+- a step-proof envelope manifest,
+- a decode-boundary bridge manifest that binds those two recursive-adjacent
+  surfaces together without changing the underlying decode statement.
 
 In publication-facing prose, those layers are best described as chain, segment,
 interval bundle, rollup, matrix, and pre-recursive aggregation boundary. The
@@ -357,8 +359,9 @@ threat classes:
 
 For paper 2, the relevant point is that the hardening line is aligned with the
 paper’s statement surface. The step-envelope manifests, recursive-compression
-input contracts, semantic-agreement artifacts, and provenance manifests are all
-being tested at the exact boundaries the paper names.
+input contracts, decode-boundary bridge manifests, semantic-agreement
+artifacts, and provenance manifests are all being tested at the exact
+boundaries the paper names.
 
 That alignment matters. A crypto paper should not point to “engineering
 hardening” in the abstract. It should point to the same artifact boundaries that
@@ -376,6 +379,8 @@ Relative to folding and IVC systems, the repository contributes:
 - statement stabilization over a concrete decode relation,
 - explicit carried-state boundary semantics,
 - packaging-layer validity conditions,
+- a recursive-adjacent bridge that binds the published recursion input contract
+  to the ordered decode-envelope surface without redefining the statement,
 - proof-carrying pre-recursive aggregation objects,
 - bounded runtime-consistency and release-provenance guardrails.
 
@@ -404,6 +409,8 @@ provided the prose stays disciplined:
 - proof-carrying decode surfaces are real,
 - carried-state packaging validity is real,
 - the pre-recursive aggregation boundary is real,
+- the decode-boundary bridge between the recursive-adjacent inputs and the
+  ordered step-envelope surface is real,
 - semantic-agreement artifacts are real as bounded evidence,
 - provenance manifests are real as release guardrails.
 

--- a/spec/stwo-phase31-recursive-compression-decode-boundary-manifest.schema.json
+++ b/spec/stwo-phase31-recursive-compression-decode-boundary-manifest.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://llm-provable-computer/spec/stwo-phase31-recursive-compression-decode-boundary-manifest.schema.json",
+  "title": "S-two Phase 31 Recursive Compression Decode Boundary Manifest",
+  "type": "object",
+  "required": [
+    "proof_backend",
+    "manifest_version",
+    "semantic_scope",
+    "proof_backend_version",
+    "statement_version",
+    "step_relation",
+    "required_recursion_posture",
+    "recursive_verification_claimed",
+    "cryptographic_compression_claimed",
+    "phase29_contract_version",
+    "phase29_semantic_scope",
+    "phase29_contract_commitment",
+    "phase30_manifest_version",
+    "phase30_semantic_scope",
+    "phase30_source_chain_commitment",
+    "phase30_step_envelopes_commitment",
+    "total_steps",
+    "chain_start_boundary_commitment",
+    "chain_end_boundary_commitment",
+    "source_template_commitment",
+    "aggregation_template_commitment",
+    "decode_boundary_bridge_commitment"
+  ],
+  "properties": {
+    "proof_backend": { "const": "stwo" },
+    "manifest_version": {
+      "const": "stwo-phase31-recursive-compression-decode-boundary-manifest-v1"
+    },
+    "semantic_scope": {
+      "const": "stwo_execution_parameterized_recursive_compression_decode_boundary_manifest"
+    },
+    "proof_backend_version": { "const": "stwo-phase12-decoding-family-v9" },
+    "statement_version": { "const": "statement-v1" },
+    "step_relation": { "const": "decoding_step_v2" },
+    "required_recursion_posture": {
+      "const": "pre-recursive-proof-carrying-aggregation"
+    },
+    "recursive_verification_claimed": { "const": false },
+    "cryptographic_compression_claimed": { "const": false },
+    "phase29_contract_version": {
+      "const": "stwo-phase29-recursive-compression-input-contract-v1"
+    },
+    "phase29_semantic_scope": {
+      "const": "stwo_phase29_recursive_compression_input_contract"
+    },
+    "phase29_contract_commitment": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+    "phase30_manifest_version": {
+      "const": "stwo-phase30-decoding-step-proof-envelope-manifest-v1"
+    },
+    "phase30_semantic_scope": {
+      "const": "stwo_execution_parameterized_decoding_step_proof_envelope_manifest"
+    },
+    "phase30_source_chain_commitment": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+    "phase30_step_envelopes_commitment": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+    "total_steps": { "type": "integer", "minimum": 1 },
+    "chain_start_boundary_commitment": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+    "chain_end_boundary_commitment": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+    "source_template_commitment": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+    "aggregation_template_commitment": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+    "decode_boundary_bridge_commitment": {
+      "$ref": "#/$defs/hash_blake2b_256_hex"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "hash_blake2b_256_hex": {
+      "type": "string",
+      "minLength": 64,
+      "maxLength": 64,
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -41,9 +41,11 @@ use llm_provable_computer::{
     load_phase27_chained_folded_intervalized_decoding_state_relation_with_proof_checks,
     load_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_proof_checks,
     load_phase29_recursive_compression_input_contract,
+    load_phase31_recursive_compression_decode_boundary_manifest,
     load_phase30_decoding_step_proof_envelope_manifest, load_phase3_binary_step_lookup_proof,
     load_phase5_normalization_lookup_proof,
     phase29_prepare_recursive_compression_input_contract_from_proof_checked_phase28,
+    phase31_prepare_recursive_compression_decode_boundary_manifest,
     phase30_prepare_decoding_step_proof_envelope_manifest,
     prove_phase10_shared_binary_step_lookup_envelope,
     prove_phase10_shared_normalization_lookup_envelope, prove_phase11_decoding_demo,
@@ -86,10 +88,12 @@ use llm_provable_computer::{
     verify_phase24_decoding_state_relation_accumulator_with_proof_checks,
     verify_phase25_intervalized_decoding_state_relation_with_proof_checks,
     verify_phase26_folded_intervalized_decoding_state_relation_with_proof_checks,
+    verify_phase31_recursive_compression_decode_boundary_manifest_against_sources,
     verify_phase30_decoding_step_proof_envelope_manifest_against_chain,
     verify_phase3_binary_step_lookup_demo_envelope,
     verify_phase5_normalization_lookup_demo_envelope, Phase29RecursiveCompressionInputContract,
     Phase30DecodingStepProofEnvelopeManifest,
+    Phase31RecursiveCompressionDecodeBoundaryManifest,
     STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE28,
     STWO_BACKEND_VERSION_PHASE12,
     STWO_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE27,
@@ -113,6 +117,8 @@ use llm_provable_computer::{
     STWO_LOOKUP_SEMANTIC_SCOPE_PHASE3, STWO_LOOKUP_STATEMENT_VERSION_PHASE3,
     STWO_NORMALIZATION_PROOF_VERSION_PHASE5, STWO_NORMALIZATION_SEMANTIC_SCOPE_PHASE5,
     STWO_NORMALIZATION_STATEMENT_VERSION_PHASE5,
+    STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31,
+    STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31,
     STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29,
     STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29,
 };
@@ -547,6 +553,32 @@ enum Command {
         /// Path to the serialized Phase 29 input contract JSON or JSON.gz file.
         #[arg(long = "input")]
         input: PathBuf,
+    },
+    /// Derive a Phase 31 decode-boundary manifest from a verified Phase 29 contract and a verified Phase 30 manifest.
+    #[cfg(feature = "stwo-backend")]
+    PrepareStwoRecursiveCompressionDecodeBoundaryManifest {
+        /// Path to the serialized Phase 29 input contract JSON or JSON.gz file.
+        #[arg(long = "contract")]
+        contract: PathBuf,
+        /// Path to the serialized Phase 30 manifest JSON or JSON.gz file.
+        #[arg(long = "manifest")]
+        manifest: PathBuf,
+        /// File where the serialized Phase 31 manifest JSON will be written.
+        #[arg(short = 'o', long = "output")]
+        output: PathBuf,
+    },
+    /// Verify a serialized Phase 31 recursive-compression decode-boundary manifest.
+    #[cfg(feature = "stwo-backend")]
+    VerifyStwoRecursiveCompressionDecodeBoundaryManifest {
+        /// Path to the serialized Phase 31 manifest JSON or JSON.gz file.
+        #[arg(long = "input")]
+        input: PathBuf,
+        /// Optional Phase 29 input contract JSON or JSON.gz file for exact source binding.
+        #[arg(long = "contract")]
+        contract: Option<PathBuf>,
+        /// Optional Phase 30 manifest JSON or JSON.gz file for exact source binding.
+        #[arg(long = "manifest")]
+        manifest: Option<PathBuf>,
     },
     /// Prepare a canonical multi-proof batch manifest for future S-two recursion.
     PrepareStwoRecursionBatch {
@@ -1633,6 +1665,26 @@ fn run() -> llm_provable_computer::Result<()> {
         Command::VerifyStwoRecursiveCompressionInputContract { input } => {
             verify_stwo_recursive_compression_input_contract_command(&input)?
         }
+        #[cfg(feature = "stwo-backend")]
+        Command::PrepareStwoRecursiveCompressionDecodeBoundaryManifest {
+            contract,
+            manifest,
+            output,
+        } => prepare_stwo_recursive_compression_decode_boundary_manifest_command(
+            &contract,
+            &manifest,
+            &output,
+        )?,
+        #[cfg(feature = "stwo-backend")]
+        Command::VerifyStwoRecursiveCompressionDecodeBoundaryManifest {
+            input,
+            contract,
+            manifest,
+        } => verify_stwo_recursive_compression_decode_boundary_manifest_command(
+            &input,
+            contract.as_deref(),
+            manifest.as_deref(),
+        )?,
         Command::PrepareStwoRecursionBatch { proofs, output } => {
             prepare_stwo_recursion_batch_command(&proofs, &output)?
         }
@@ -4183,6 +4235,125 @@ fn print_phase29_recursive_compression_input_contract_report(
     println!(
         "expected_semantic_scope: {}",
         STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29
+    );
+}
+
+#[cfg(feature = "stwo-backend")]
+fn prepare_stwo_recursive_compression_decode_boundary_manifest_command(
+    contract_path: &Path,
+    manifest_path: &Path,
+    output: &Path,
+) -> llm_provable_computer::Result<()> {
+    require_stwo_backend("S-two Phase 31 recursive-compression decode-boundary manifest")?;
+
+    reject_phase31_decode_boundary_manifest_plain_json_gzip_output(output)?;
+    let contract = load_phase29_recursive_compression_input_contract(contract_path)?;
+    let phase30 = load_phase30_decoding_step_proof_envelope_manifest(manifest_path)?;
+    let bridge = phase31_prepare_recursive_compression_decode_boundary_manifest(&contract, &phase30)?;
+    let json = serde_json::to_vec_pretty(&bridge)
+        .map_err(|error| VmError::Serialization(error.to_string()))?;
+    fs::write(output, json)?;
+
+    println!("output: {}", output.display());
+    println!("phase29_contract: {}", contract_path.display());
+    println!("phase30_manifest: {}", manifest_path.display());
+    println!("verified_phase29_contract: true");
+    println!("verified_phase30_manifest: true");
+    print_phase31_recursive_compression_decode_boundary_manifest_report(&bridge);
+
+    Ok(())
+}
+
+#[cfg(feature = "stwo-backend")]
+fn verify_stwo_recursive_compression_decode_boundary_manifest_command(
+    input_path: &Path,
+    contract_path: Option<&Path>,
+    manifest_path: Option<&Path>,
+) -> llm_provable_computer::Result<()> {
+    require_stwo_backend("S-two Phase 31 recursive-compression decode-boundary manifest")?;
+
+    let bridge = load_phase31_recursive_compression_decode_boundary_manifest(input_path)?;
+    match (contract_path, manifest_path) {
+        (Some(contract_path), Some(manifest_path)) => {
+            let contract = load_phase29_recursive_compression_input_contract(contract_path)?;
+            let phase30 = load_phase30_decoding_step_proof_envelope_manifest(manifest_path)?;
+            verify_phase31_recursive_compression_decode_boundary_manifest_against_sources(
+                &bridge, &contract, &phase30,
+            )?;
+            println!("source_bound_contract: {}", contract_path.display());
+            println!("source_bound_manifest: {}", manifest_path.display());
+            println!("verified_against_sources: true");
+        }
+        (None, None) => {}
+        _ => {
+            return Err(VmError::InvalidConfig(
+                "verify-stwo-recursive-compression-decode-boundary-manifest requires both `--contract` and `--manifest` when source binding is requested".to_string(),
+            ));
+        }
+    }
+
+    println!("input: {}", input_path.display());
+    println!("verified_manifest: true");
+    print_phase31_recursive_compression_decode_boundary_manifest_report(&bridge);
+
+    Ok(())
+}
+
+#[cfg(feature = "stwo-backend")]
+fn reject_phase31_decode_boundary_manifest_plain_json_gzip_output(
+    output: &Path,
+) -> llm_provable_computer::Result<()> {
+    if output.extension().and_then(|extension| extension.to_str()) == Some("gz") {
+        return Err(VmError::InvalidConfig(
+            "prepare-stwo-recursive-compression-decode-boundary-manifest writes plain JSON; use a `.json` output path"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "stwo-backend")]
+fn print_phase31_recursive_compression_decode_boundary_manifest_report(
+    manifest: &Phase31RecursiveCompressionDecodeBoundaryManifest,
+) {
+    println!("proof_backend: {}", manifest.proof_backend);
+    println!("manifest_version: {}", manifest.manifest_version);
+    println!("semantic_scope: {}", manifest.semantic_scope);
+    println!("proof_backend_version: {}", manifest.proof_backend_version);
+    println!("statement_version: {}", manifest.statement_version);
+    println!("step_relation: {}", manifest.step_relation);
+    println!(
+        "required_recursion_posture: {}",
+        manifest.required_recursion_posture
+    );
+    println!(
+        "recursive_verification_claimed: {}",
+        manifest.recursive_verification_claimed
+    );
+    println!(
+        "cryptographic_compression_claimed: {}",
+        manifest.cryptographic_compression_claimed
+    );
+    println!("total_steps: {}", manifest.total_steps);
+    println!(
+        "phase29_contract_commitment: {}",
+        manifest.phase29_contract_commitment
+    );
+    println!(
+        "phase30_step_envelopes_commitment: {}",
+        manifest.phase30_step_envelopes_commitment
+    );
+    println!(
+        "decode_boundary_bridge_commitment: {}",
+        manifest.decode_boundary_bridge_commitment
+    );
+    println!(
+        "expected_manifest_version: {}",
+        STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31
+    );
+    println!(
+        "expected_semantic_scope: {}",
+        STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31
     );
 }
 
@@ -10231,6 +10402,12 @@ mod cli_dispatch_tests {
         assert!(!needs_run_subcommand(
             "verify-stwo-recursive-compression-input-contract"
         ));
+        assert!(!needs_run_subcommand(
+            "prepare-stwo-recursive-compression-decode-boundary-manifest"
+        ));
+        assert!(!needs_run_subcommand(
+            "verify-stwo-recursive-compression-decode-boundary-manifest"
+        ));
     }
 }
 
@@ -10621,6 +10798,8 @@ fn needs_run_subcommand(first_arg: &str) -> bool {
                 | "verify-stwo-aggregated-chained-folded-intervalized-decoding-state-relation-demo"
                 | "prepare-stwo-recursive-compression-input-contract"
                 | "verify-stwo-recursive-compression-input-contract"
+                | "prepare-stwo-recursive-compression-decode-boundary-manifest"
+                | "verify-stwo-recursive-compression-decode-boundary-manifest"
                 | "prepare-stwo-recursion-batch"
                 | "research-v2-step"
                 | "research-v2-trace"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,20 @@ pub use state::{decode_state, encode_state, MachineState, MIN_D_MODEL};
 #[cfg(feature = "stwo-backend")]
 pub use stwo_backend::{
     commit_phase29_recursive_compression_input_contract,
+    commit_phase31_recursive_compression_decode_boundary_manifest,
     load_phase29_recursive_compression_input_contract,
+    load_phase31_recursive_compression_decode_boundary_manifest,
     parse_phase29_recursive_compression_input_contract_json,
+    parse_phase31_recursive_compression_decode_boundary_manifest_json,
     phase29_prepare_recursive_compression_input_contract,
     phase29_prepare_recursive_compression_input_contract_from_proof_checked_phase28,
-    verify_phase29_recursive_compression_input_contract, Phase29RecursiveCompressionInputContract,
+    phase31_prepare_recursive_compression_decode_boundary_manifest,
+    verify_phase29_recursive_compression_input_contract,
+    verify_phase31_recursive_compression_decode_boundary_manifest,
+    verify_phase31_recursive_compression_decode_boundary_manifest_against_sources,
+    Phase29RecursiveCompressionInputContract, Phase31RecursiveCompressionDecodeBoundaryManifest,
+    STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31,
+    STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31,
     STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29,
     STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29,
 };

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -209,11 +209,21 @@ pub use normalization_prover::{
 #[cfg(feature = "stwo-backend")]
 pub use recursion::{
     commit_phase29_recursive_compression_input_contract,
+    commit_phase31_recursive_compression_decode_boundary_manifest,
     load_phase29_recursive_compression_input_contract,
+    load_phase31_recursive_compression_decode_boundary_manifest,
     parse_phase29_recursive_compression_input_contract_json,
+    parse_phase31_recursive_compression_decode_boundary_manifest_json,
     phase29_prepare_recursive_compression_input_contract,
     phase29_prepare_recursive_compression_input_contract_from_proof_checked_phase28,
-    verify_phase29_recursive_compression_input_contract, Phase29RecursiveCompressionInputContract,
+    phase31_prepare_recursive_compression_decode_boundary_manifest,
+    verify_phase29_recursive_compression_input_contract,
+    verify_phase31_recursive_compression_decode_boundary_manifest,
+    verify_phase31_recursive_compression_decode_boundary_manifest_against_sources,
+    Phase29RecursiveCompressionInputContract,
+    Phase31RecursiveCompressionDecodeBoundaryManifest,
+    STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31,
+    STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31,
     STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29,
     STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29,
 };

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -8,8 +8,12 @@ use crate::proof::{ExecutionClaimCommitments, StarkProofBackend, VanillaStarkExe
 #[cfg(feature = "stwo-backend")]
 use super::decoding::{
     read_json_bytes_with_limit,
+    verify_phase30_decoding_step_proof_envelope_manifest,
     verify_phase28_aggregated_chained_folded_intervalized_decoding_state_relation_with_proof_checks,
     Phase28AggregatedChainedFoldedIntervalizedDecodingStateRelationManifest,
+    Phase30DecodingStepProofEnvelopeManifest, STWO_DECODING_STEP_ENVELOPE_MANIFEST_SCOPE_PHASE30,
+    STWO_DECODING_STEP_ENVELOPE_MANIFEST_VERSION_PHASE30,
+    STWO_DECODING_STEP_ENVELOPE_RELATION_PHASE30,
     STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28,
     STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE28,
     STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE,
@@ -35,6 +39,14 @@ pub const STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29: &str =
     "stwo_phase29_recursive_compression_input_contract";
 #[cfg(feature = "stwo-backend")]
 const MAX_PHASE29_RECURSIVE_COMPRESSION_INPUT_CONTRACT_JSON_BYTES: usize = 1024 * 1024;
+#[cfg(feature = "stwo-backend")]
+pub const STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31: &str =
+    "stwo-phase31-recursive-compression-decode-boundary-manifest-v1";
+#[cfg(feature = "stwo-backend")]
+pub const STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31: &str =
+    "stwo_execution_parameterized_recursive_compression_decode_boundary_manifest";
+#[cfg(feature = "stwo-backend")]
+const MAX_PHASE31_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_JSON_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Phase6RecursionBatchEntry {
@@ -135,6 +147,62 @@ struct Phase29RecursiveCompressionInputContractUnchecked {
 }
 
 #[cfg(feature = "stwo-backend")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "Phase31RecursiveCompressionDecodeBoundaryManifestUnchecked")]
+pub struct Phase31RecursiveCompressionDecodeBoundaryManifest {
+    pub proof_backend: StarkProofBackend,
+    pub manifest_version: String,
+    pub semantic_scope: String,
+    pub proof_backend_version: String,
+    pub statement_version: String,
+    pub step_relation: String,
+    pub required_recursion_posture: String,
+    pub recursive_verification_claimed: bool,
+    pub cryptographic_compression_claimed: bool,
+    pub phase29_contract_version: String,
+    pub phase29_semantic_scope: String,
+    pub phase29_contract_commitment: String,
+    pub phase30_manifest_version: String,
+    pub phase30_semantic_scope: String,
+    pub phase30_source_chain_commitment: String,
+    pub phase30_step_envelopes_commitment: String,
+    pub total_steps: usize,
+    pub chain_start_boundary_commitment: String,
+    pub chain_end_boundary_commitment: String,
+    pub source_template_commitment: String,
+    pub aggregation_template_commitment: String,
+    pub decode_boundary_bridge_commitment: String,
+}
+
+#[cfg(feature = "stwo-backend")]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Phase31RecursiveCompressionDecodeBoundaryManifestUnchecked {
+    pub proof_backend: StarkProofBackend,
+    pub manifest_version: String,
+    pub semantic_scope: String,
+    pub proof_backend_version: String,
+    pub statement_version: String,
+    pub step_relation: String,
+    pub required_recursion_posture: String,
+    pub recursive_verification_claimed: bool,
+    pub cryptographic_compression_claimed: bool,
+    pub phase29_contract_version: String,
+    pub phase29_semantic_scope: String,
+    pub phase29_contract_commitment: String,
+    pub phase30_manifest_version: String,
+    pub phase30_semantic_scope: String,
+    pub phase30_source_chain_commitment: String,
+    pub phase30_step_envelopes_commitment: String,
+    pub total_steps: usize,
+    pub chain_start_boundary_commitment: String,
+    pub chain_end_boundary_commitment: String,
+    pub source_template_commitment: String,
+    pub aggregation_template_commitment: String,
+    pub decode_boundary_bridge_commitment: String,
+}
+
+#[cfg(feature = "stwo-backend")]
 impl TryFrom<Phase29RecursiveCompressionInputContractUnchecked>
     for Phase29RecursiveCompressionInputContract
 {
@@ -179,6 +247,44 @@ impl TryFrom<Phase29RecursiveCompressionInputContractUnchecked>
         };
         verify_phase29_recursive_compression_input_contract(&contract)?;
         Ok(contract)
+    }
+}
+
+#[cfg(feature = "stwo-backend")]
+impl TryFrom<Phase31RecursiveCompressionDecodeBoundaryManifestUnchecked>
+    for Phase31RecursiveCompressionDecodeBoundaryManifest
+{
+    type Error = VmError;
+
+    fn try_from(
+        unchecked: Phase31RecursiveCompressionDecodeBoundaryManifestUnchecked,
+    ) -> std::result::Result<Self, Self::Error> {
+        let manifest = Self {
+            proof_backend: unchecked.proof_backend,
+            manifest_version: unchecked.manifest_version,
+            semantic_scope: unchecked.semantic_scope,
+            proof_backend_version: unchecked.proof_backend_version,
+            statement_version: unchecked.statement_version,
+            step_relation: unchecked.step_relation,
+            required_recursion_posture: unchecked.required_recursion_posture,
+            recursive_verification_claimed: unchecked.recursive_verification_claimed,
+            cryptographic_compression_claimed: unchecked.cryptographic_compression_claimed,
+            phase29_contract_version: unchecked.phase29_contract_version,
+            phase29_semantic_scope: unchecked.phase29_semantic_scope,
+            phase29_contract_commitment: unchecked.phase29_contract_commitment,
+            phase30_manifest_version: unchecked.phase30_manifest_version,
+            phase30_semantic_scope: unchecked.phase30_semantic_scope,
+            phase30_source_chain_commitment: unchecked.phase30_source_chain_commitment,
+            phase30_step_envelopes_commitment: unchecked.phase30_step_envelopes_commitment,
+            total_steps: unchecked.total_steps,
+            chain_start_boundary_commitment: unchecked.chain_start_boundary_commitment,
+            chain_end_boundary_commitment: unchecked.chain_end_boundary_commitment,
+            source_template_commitment: unchecked.source_template_commitment,
+            aggregation_template_commitment: unchecked.aggregation_template_commitment,
+            decode_boundary_bridge_commitment: unchecked.decode_boundary_bridge_commitment,
+        };
+        verify_phase31_recursive_compression_decode_boundary_manifest(&manifest)?;
+        Ok(manifest)
     }
 }
 
@@ -603,6 +709,323 @@ fn phase29_lower_hex(bytes: &[u8]) -> String {
     out
 }
 
+#[cfg(feature = "stwo-backend")]
+pub fn phase31_prepare_recursive_compression_decode_boundary_manifest(
+    contract: &Phase29RecursiveCompressionInputContract,
+    phase30: &Phase30DecodingStepProofEnvelopeManifest,
+) -> Result<Phase31RecursiveCompressionDecodeBoundaryManifest> {
+    verify_phase29_recursive_compression_input_contract(contract)?;
+    verify_phase30_decoding_step_proof_envelope_manifest(phase30)?;
+    if contract.phase28_proof_backend_version != phase30.proof_backend_version {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires matching proof backend version between Phase 29 (`{}`) and Phase 30 (`{}`)",
+            contract.phase28_proof_backend_version, phase30.proof_backend_version
+        )));
+    }
+    if contract.statement_version != phase30.statement_version {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires matching statement version between Phase 29 (`{}`) and Phase 30 (`{}`)",
+            contract.statement_version, phase30.statement_version
+        )));
+    }
+    if contract.total_steps != phase30.total_steps {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires matching total_steps between Phase 29 ({}) and Phase 30 ({})",
+            contract.total_steps, phase30.total_steps
+        )));
+    }
+    if contract.global_start_state_commitment != phase30.chain_start_boundary_commitment {
+        return Err(VmError::InvalidConfig(
+            "Phase 31 decode-boundary manifest requires Phase 29 global_start_state_commitment to match the Phase 30 chain_start_boundary_commitment".to_string(),
+        ));
+    }
+    if contract.global_end_state_commitment != phase30.chain_end_boundary_commitment {
+        return Err(VmError::InvalidConfig(
+            "Phase 31 decode-boundary manifest requires Phase 29 global_end_state_commitment to match the Phase 30 chain_end_boundary_commitment".to_string(),
+        ));
+    }
+
+    let mut manifest = Phase31RecursiveCompressionDecodeBoundaryManifest {
+        proof_backend: StarkProofBackend::Stwo,
+        manifest_version: STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31
+            .to_string(),
+        semantic_scope: STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31
+            .to_string(),
+        proof_backend_version: contract.phase28_proof_backend_version.clone(),
+        statement_version: contract.statement_version.clone(),
+        step_relation: STWO_DECODING_STEP_ENVELOPE_RELATION_PHASE30.to_string(),
+        required_recursion_posture: contract.required_recursion_posture.clone(),
+        recursive_verification_claimed: contract.recursive_verification_claimed,
+        cryptographic_compression_claimed: contract.cryptographic_compression_claimed,
+        phase29_contract_version: contract.contract_version.clone(),
+        phase29_semantic_scope: contract.semantic_scope.clone(),
+        phase29_contract_commitment: contract.input_contract_commitment.clone(),
+        phase30_manifest_version: phase30.manifest_version.clone(),
+        phase30_semantic_scope: phase30.semantic_scope.clone(),
+        phase30_source_chain_commitment: phase30.source_chain_commitment.clone(),
+        phase30_step_envelopes_commitment: phase30.step_envelopes_commitment.clone(),
+        total_steps: phase30.total_steps,
+        chain_start_boundary_commitment: phase30.chain_start_boundary_commitment.clone(),
+        chain_end_boundary_commitment: phase30.chain_end_boundary_commitment.clone(),
+        source_template_commitment: contract.source_template_commitment.clone(),
+        aggregation_template_commitment: contract.aggregation_template_commitment.clone(),
+        decode_boundary_bridge_commitment: String::new(),
+    };
+    manifest.decode_boundary_bridge_commitment =
+        commit_phase31_recursive_compression_decode_boundary_manifest(&manifest)?;
+    verify_phase31_recursive_compression_decode_boundary_manifest(&manifest)?;
+    Ok(manifest)
+}
+
+#[cfg(feature = "stwo-backend")]
+pub fn verify_phase31_recursive_compression_decode_boundary_manifest(
+    manifest: &Phase31RecursiveCompressionDecodeBoundaryManifest,
+) -> Result<()> {
+    if manifest.proof_backend != StarkProofBackend::Stwo {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires `stwo` backend, got `{}`",
+            manifest.proof_backend
+        )));
+    }
+    if manifest.manifest_version
+        != STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31
+    {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest version `{}` does not match expected `{}`",
+            manifest.manifest_version,
+            STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31
+        )));
+    }
+    if manifest.semantic_scope != STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31
+    {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest scope `{}` does not match expected `{}`",
+            manifest.semantic_scope,
+            STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31
+        )));
+    }
+    if manifest.proof_backend_version != STWO_BACKEND_VERSION_PHASE12 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires proof backend version `{}`, got `{}`",
+            STWO_BACKEND_VERSION_PHASE12, manifest.proof_backend_version
+        )));
+    }
+    if manifest.statement_version != CLAIM_STATEMENT_VERSION_V1 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires statement version `{}`, got `{}`",
+            CLAIM_STATEMENT_VERSION_V1, manifest.statement_version
+        )));
+    }
+    if manifest.step_relation != STWO_DECODING_STEP_ENVELOPE_RELATION_PHASE30 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires step relation `{}`, got `{}`",
+            STWO_DECODING_STEP_ENVELOPE_RELATION_PHASE30, manifest.step_relation
+        )));
+    }
+    if manifest.required_recursion_posture != STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires recursion posture `{}`, got `{}`",
+            STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE, manifest.required_recursion_posture
+        )));
+    }
+    if manifest.recursive_verification_claimed {
+        return Err(VmError::InvalidConfig(
+            "Phase 31 decode-boundary manifest must not claim recursive verification".to_string(),
+        ));
+    }
+    if manifest.cryptographic_compression_claimed {
+        return Err(VmError::InvalidConfig(
+            "Phase 31 decode-boundary manifest must not claim cryptographic compression"
+                .to_string(),
+        ));
+    }
+    if manifest.phase29_contract_version != STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29
+    {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires Phase 29 contract version `{}`, got `{}`",
+            STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29,
+            manifest.phase29_contract_version
+        )));
+    }
+    if manifest.phase29_semantic_scope != STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires Phase 29 semantic scope `{}`, got `{}`",
+            STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29,
+            manifest.phase29_semantic_scope
+        )));
+    }
+    if manifest.phase30_manifest_version != STWO_DECODING_STEP_ENVELOPE_MANIFEST_VERSION_PHASE30 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires Phase 30 manifest version `{}`, got `{}`",
+            STWO_DECODING_STEP_ENVELOPE_MANIFEST_VERSION_PHASE30,
+            manifest.phase30_manifest_version
+        )));
+    }
+    if manifest.phase30_semantic_scope != STWO_DECODING_STEP_ENVELOPE_MANIFEST_SCOPE_PHASE30 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest requires Phase 30 semantic scope `{}`, got `{}`",
+            STWO_DECODING_STEP_ENVELOPE_MANIFEST_SCOPE_PHASE30,
+            manifest.phase30_semantic_scope
+        )));
+    }
+    if manifest.total_steps == 0 {
+        return Err(VmError::InvalidConfig(
+            "Phase 31 decode-boundary manifest requires at least one decode step".to_string(),
+        ));
+    }
+    for (label, value) in [
+        (
+            "phase29_contract_commitment",
+            manifest.phase29_contract_commitment.as_str(),
+        ),
+        (
+            "phase30_source_chain_commitment",
+            manifest.phase30_source_chain_commitment.as_str(),
+        ),
+        (
+            "phase30_step_envelopes_commitment",
+            manifest.phase30_step_envelopes_commitment.as_str(),
+        ),
+        (
+            "chain_start_boundary_commitment",
+            manifest.chain_start_boundary_commitment.as_str(),
+        ),
+        (
+            "chain_end_boundary_commitment",
+            manifest.chain_end_boundary_commitment.as_str(),
+        ),
+        (
+            "source_template_commitment",
+            manifest.source_template_commitment.as_str(),
+        ),
+        (
+            "aggregation_template_commitment",
+            manifest.aggregation_template_commitment.as_str(),
+        ),
+        (
+            "decode_boundary_bridge_commitment",
+            manifest.decode_boundary_bridge_commitment.as_str(),
+        ),
+    ] {
+        if value.is_empty() {
+            return Err(VmError::InvalidConfig(format!(
+                "Phase 31 decode-boundary manifest `{label}` must be non-empty"
+            )));
+        }
+    }
+
+    let expected = commit_phase31_recursive_compression_decode_boundary_manifest(manifest)?;
+    if manifest.decode_boundary_bridge_commitment != expected {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 decode-boundary manifest commitment `{}` does not match recomputed `{}`",
+            manifest.decode_boundary_bridge_commitment, expected
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "stwo-backend")]
+pub fn verify_phase31_recursive_compression_decode_boundary_manifest_against_sources(
+    manifest: &Phase31RecursiveCompressionDecodeBoundaryManifest,
+    contract: &Phase29RecursiveCompressionInputContract,
+    phase30: &Phase30DecodingStepProofEnvelopeManifest,
+) -> Result<()> {
+    verify_phase31_recursive_compression_decode_boundary_manifest(manifest)?;
+    let expected = phase31_prepare_recursive_compression_decode_boundary_manifest(contract, phase30)?;
+    if manifest != &expected {
+        return Err(VmError::InvalidConfig(
+            "Phase 31 decode-boundary manifest does not match the recomputed Phase 29 + Phase 30 source artifacts".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "stwo-backend")]
+pub fn parse_phase31_recursive_compression_decode_boundary_manifest_json(
+    json: &str,
+) -> Result<Phase31RecursiveCompressionDecodeBoundaryManifest> {
+    if json.len() > MAX_PHASE31_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_JSON_BYTES {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 31 recursive-compression decode-boundary manifest JSON is {} bytes, exceeding the limit of {} bytes",
+            json.len(),
+            MAX_PHASE31_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_JSON_BYTES
+        )));
+    }
+    serde_json::from_str(json).map_err(phase31_json_error)
+}
+
+#[cfg(feature = "stwo-backend")]
+pub fn load_phase31_recursive_compression_decode_boundary_manifest(
+    path: &Path,
+) -> Result<Phase31RecursiveCompressionDecodeBoundaryManifest> {
+    let bytes = read_json_bytes_with_limit(
+        path,
+        MAX_PHASE31_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_JSON_BYTES,
+        "Phase 31 recursive-compression decode-boundary manifest",
+    )?;
+    serde_json::from_slice(&bytes).map_err(phase31_json_error)
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase31_json_error(error: serde_json::Error) -> VmError {
+    match error.classify() {
+        serde_json::error::Category::Data
+        | serde_json::error::Category::Syntax
+        | serde_json::error::Category::Eof => VmError::InvalidConfig(error.to_string()),
+        serde_json::error::Category::Io => VmError::Serialization(error.to_string()),
+    }
+}
+
+#[cfg(feature = "stwo-backend")]
+pub fn commit_phase31_recursive_compression_decode_boundary_manifest(
+    manifest: &Phase31RecursiveCompressionDecodeBoundaryManifest,
+) -> Result<String> {
+    let mut hasher = Blake2bVar::new(32).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to initialize Phase 31 decode-boundary commitment hash: {err}"
+        ))
+    })?;
+    phase29_update_len_prefixed(&mut hasher, b"phase31-decode-boundary");
+    phase29_update_len_prefixed(&mut hasher, manifest.proof_backend.to_string().as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.manifest_version.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.semantic_scope.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.proof_backend_version.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.statement_version.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.step_relation.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.required_recursion_posture.as_bytes());
+    phase29_update_bool(&mut hasher, manifest.recursive_verification_claimed);
+    phase29_update_bool(&mut hasher, manifest.cryptographic_compression_claimed);
+    phase29_update_len_prefixed(&mut hasher, manifest.phase29_contract_version.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.phase29_semantic_scope.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.phase29_contract_commitment.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.phase30_manifest_version.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.phase30_semantic_scope.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.phase30_source_chain_commitment.as_bytes());
+    phase29_update_len_prefixed(
+        &mut hasher,
+        manifest.phase30_step_envelopes_commitment.as_bytes(),
+    );
+    phase29_update_usize(&mut hasher, manifest.total_steps);
+    phase29_update_len_prefixed(
+        &mut hasher,
+        manifest.chain_start_boundary_commitment.as_bytes(),
+    );
+    phase29_update_len_prefixed(&mut hasher, manifest.chain_end_boundary_commitment.as_bytes());
+    phase29_update_len_prefixed(&mut hasher, manifest.source_template_commitment.as_bytes());
+    phase29_update_len_prefixed(
+        &mut hasher,
+        manifest.aggregation_template_commitment.as_bytes(),
+    );
+    let mut out = [0u8; 32];
+    hasher.finalize_variable(&mut out).map_err(|err| {
+        VmError::InvalidConfig(format!(
+            "failed to finalize Phase 31 decode-boundary commitment hash: {err}"
+        ))
+    })?;
+    Ok(phase29_lower_hex(&out))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -611,6 +1034,13 @@ mod tests {
         production_v1_stark_options, CLAIM_SEMANTIC_SCOPE_V1, CLAIM_STATEMENT_VERSION_V1,
     };
     use crate::state::MachineState;
+    #[cfg(feature = "stwo-backend")]
+    use crate::stwo_backend::{
+        phase12_default_decoding_layout, phase30_prepare_decoding_step_proof_envelope_manifest,
+        prove_phase12_decoding_demo_for_layout,
+        STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31,
+        STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31,
+    };
     use crate::Attention2DMode;
 
     fn sample_proof(program_source: &str, program_hash: &str) -> VanillaStarkExecutionProof {
@@ -703,6 +1133,29 @@ mod tests {
         contract.input_contract_commitment =
             commit_phase29_recursive_compression_input_contract(&contract)
                 .expect("commit Phase 29 contract");
+        contract
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    fn sample_phase30_manifest() -> Phase30DecodingStepProofEnvelopeManifest {
+        let layout = phase12_default_decoding_layout();
+        let chain = prove_phase12_decoding_demo_for_layout(&layout).expect("phase12 demo");
+        phase30_prepare_decoding_step_proof_envelope_manifest(&chain).expect("phase30 manifest")
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    fn sample_phase29_contract_for_phase30(
+        manifest: &Phase30DecodingStepProofEnvelopeManifest,
+    ) -> Phase29RecursiveCompressionInputContract {
+        let mut contract = sample_phase29_contract();
+        contract.phase28_proof_backend_version = manifest.proof_backend_version.clone();
+        contract.statement_version = manifest.statement_version.clone();
+        contract.total_steps = manifest.total_steps;
+        contract.global_start_state_commitment = manifest.chain_start_boundary_commitment.clone();
+        contract.global_end_state_commitment = manifest.chain_end_boundary_commitment.clone();
+        contract.input_contract_commitment =
+            commit_phase29_recursive_compression_input_contract(&contract)
+                .expect("recommit phase29 contract");
         contract
     }
 
@@ -1006,5 +1459,127 @@ mod tests {
         assert!(err
             .to_string()
             .contains("must contain at least two members"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase31_decode_boundary_manifest_accepts_matching_phase29_and_phase30_sources() {
+        let phase30 = sample_phase30_manifest();
+        let contract = sample_phase29_contract_for_phase30(&phase30);
+        let manifest =
+            phase31_prepare_recursive_compression_decode_boundary_manifest(&contract, &phase30)
+                .expect("prepare phase31 manifest");
+        assert_eq!(manifest.proof_backend, StarkProofBackend::Stwo);
+        assert_eq!(
+            manifest.manifest_version,
+            STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31
+        );
+        assert_eq!(
+            manifest.semantic_scope,
+            STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31
+        );
+        assert_eq!(manifest.phase29_contract_commitment, contract.input_contract_commitment);
+        assert_eq!(
+            manifest.phase30_step_envelopes_commitment,
+            phase30.step_envelopes_commitment
+        );
+        assert_eq!(
+            manifest.chain_start_boundary_commitment,
+            phase30.chain_start_boundary_commitment
+        );
+        assert_eq!(
+            manifest.chain_end_boundary_commitment,
+            phase30.chain_end_boundary_commitment
+        );
+        verify_phase31_recursive_compression_decode_boundary_manifest(&manifest)
+            .expect("verify phase31 manifest");
+        verify_phase31_recursive_compression_decode_boundary_manifest_against_sources(
+            &manifest, &contract, &phase30,
+        )
+        .expect("verify phase31 manifest against sources");
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase31_decode_boundary_manifest_rejects_step_count_mismatch() {
+        let phase30 = sample_phase30_manifest();
+        let mut contract = sample_phase29_contract_for_phase30(&phase30);
+        contract.total_steps += 1;
+        contract.input_contract_commitment =
+            commit_phase29_recursive_compression_input_contract(&contract)
+                .expect("recommit mismatched phase29 contract");
+        let err = phase31_prepare_recursive_compression_decode_boundary_manifest(&contract, &phase30)
+            .expect_err("step-count mismatch must fail");
+        assert!(err.to_string().contains("matching total_steps"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase31_decode_boundary_manifest_rejects_boundary_mismatch() {
+        let phase30 = sample_phase30_manifest();
+        let mut contract = sample_phase29_contract_for_phase30(&phase30);
+        contract.global_start_state_commitment = "tampered-start-boundary".to_string();
+        contract.input_contract_commitment =
+            commit_phase29_recursive_compression_input_contract(&contract)
+                .expect("recommit mismatched boundary contract");
+        let err = phase31_prepare_recursive_compression_decode_boundary_manifest(&contract, &phase30)
+            .expect_err("boundary mismatch must fail");
+        assert!(err
+            .to_string()
+            .contains("global_start_state_commitment to match the Phase 30 chain_start_boundary_commitment"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase31_decode_boundary_manifest_rejects_tampered_commitment() {
+        let phase30 = sample_phase30_manifest();
+        let contract = sample_phase29_contract_for_phase30(&phase30);
+        let mut manifest =
+            phase31_prepare_recursive_compression_decode_boundary_manifest(&contract, &phase30)
+                .expect("prepare phase31 manifest");
+        manifest.total_steps += 1;
+        let err = verify_phase31_recursive_compression_decode_boundary_manifest(&manifest)
+            .expect_err("tampered phase31 manifest must fail");
+        assert!(err.to_string().contains("commitment"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase31_decode_boundary_manifest_deserialization_verifies_manifest() {
+        let phase30 = sample_phase30_manifest();
+        let contract = sample_phase29_contract_for_phase30(&phase30);
+        let manifest =
+            phase31_prepare_recursive_compression_decode_boundary_manifest(&contract, &phase30)
+                .expect("prepare phase31 manifest");
+        let json = serde_json::to_string(&manifest).expect("serialize phase31 manifest");
+        let parsed = parse_phase31_recursive_compression_decode_boundary_manifest_json(&json)
+            .expect("parse phase31 manifest");
+        assert_eq!(parsed, manifest);
+
+        let mut tampered = serde_json::to_value(&manifest).expect("serialize phase31 value");
+        tampered["decode_boundary_bridge_commitment"] =
+            serde_json::json!("0".repeat(64));
+        let err =
+            serde_json::from_value::<Phase31RecursiveCompressionDecodeBoundaryManifest>(tampered)
+                .expect_err("tampered phase31 manifest must be rejected");
+        assert!(err.to_string().contains("commitment"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase31_decode_boundary_manifest_parse_rejects_unknown_fields() {
+        let phase30 = sample_phase30_manifest();
+        let contract = sample_phase29_contract_for_phase30(&phase30);
+        let manifest =
+            phase31_prepare_recursive_compression_decode_boundary_manifest(&contract, &phase30)
+                .expect("prepare phase31 manifest");
+        let mut value = serde_json::to_value(&manifest).expect("serialize phase31 value");
+        value["unexpected_phase31_field"] = serde_json::json!(true);
+        let json = serde_json::to_string(&value).expect("json with unknown field");
+
+        let err = parse_phase31_recursive_compression_decode_boundary_manifest_json(&json)
+            .expect_err("unknown fields must be rejected");
+        assert!(matches!(err, VmError::InvalidConfig(_)));
+        assert!(err.to_string().contains("unknown field"));
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -37,6 +37,8 @@ use llm_provable_computer::stwo_backend::{
     STWO_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE26,
     STWO_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE25,
     STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE,
+    STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31,
+    STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31,
     STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29,
     STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29,
     STWO_SHARED_LOOKUP_ARTIFACT_SCOPE_PHASE12, STWO_SHARED_LOOKUP_ARTIFACT_VERSION_PHASE12,
@@ -186,6 +188,37 @@ fn sample_phase29_recursive_compression_input_contract() -> Phase29RecursiveComp
         aggregated_chained_folded_interval_accumulator_commitment: "accumulator".to_string(),
         input_contract_commitment: String::new(),
     };
+    contract.input_contract_commitment =
+        commit_phase29_recursive_compression_input_contract(&contract).expect("commit contract");
+    contract
+}
+
+#[cfg(feature = "stwo-backend")]
+fn sample_phase29_contract_matched_to_phase30_manifest(
+    manifest_json: &serde_json::Value,
+) -> Phase29RecursiveCompressionInputContract {
+    let mut contract = sample_phase29_recursive_compression_input_contract();
+    contract.phase28_proof_backend_version = manifest_json["proof_backend_version"]
+        .as_str()
+        .expect("phase30 proof_backend_version")
+        .to_string();
+    contract.statement_version = manifest_json["statement_version"]
+        .as_str()
+        .expect("phase30 statement_version")
+        .to_string();
+    contract.total_steps = manifest_json["total_steps"]
+        .as_u64()
+        .expect("phase30 total_steps") as usize;
+    contract.source_template_commitment = "a".repeat(64);
+    contract.aggregation_template_commitment = "b".repeat(64);
+    contract.global_start_state_commitment = manifest_json["chain_start_boundary_commitment"]
+        .as_str()
+        .expect("phase30 chain_start_boundary_commitment")
+        .to_string();
+    contract.global_end_state_commitment = manifest_json["chain_end_boundary_commitment"]
+        .as_str()
+        .expect("phase30 chain_end_boundary_commitment")
+        .to_string();
     contract.input_contract_commitment =
         commit_phase29_recursive_compression_input_contract(&contract).expect("commit contract");
     contract
@@ -4382,6 +4415,388 @@ fn cli_prepare_stwo_recursive_compression_input_contract_rejects_synthetic_phase
 
     let _ = std::fs::remove_file(phase28_path);
     let _ = std::fs::remove_file(contract_path);
+}
+
+#[test]
+#[cfg(feature = "stwo-backend")]
+fn cli_can_prepare_and_verify_stwo_recursive_compression_decode_boundary_manifest() {
+    let proof_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-proof")
+            .with_extension("json");
+    let phase30_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase30")
+            .with_extension("json");
+    let phase29_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase29")
+            .with_extension("json");
+    let phase31_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase31")
+            .with_extension("json");
+
+    let mut prove = tvm_command();
+    prove
+        .arg("prove-stwo-decoding-family-demo")
+        .arg("-o")
+        .arg(&proof_path)
+        .assert()
+        .success();
+
+    let mut prepare_phase30 = tvm_command();
+    prepare_phase30
+        .arg("prepare-stwo-decoding-step-envelope-manifest")
+        .arg("--proof")
+        .arg(&proof_path)
+        .arg("-o")
+        .arg(&phase30_path)
+        .assert()
+        .success();
+
+    let phase30_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&phase30_path).expect("phase30 json"))
+            .expect("phase30 value");
+    validate_json_against_schema(
+        &phase30_json,
+        "spec/stwo-phase30-decoding-step-envelope-manifest.schema.json",
+    );
+
+    let phase29 = sample_phase29_contract_matched_to_phase30_manifest(&phase30_json);
+    std::fs::write(
+        &phase29_path,
+        serde_json::to_vec_pretty(&phase29).expect("serialize phase29"),
+    )
+    .expect("write phase29");
+
+    let mut prepare_phase31 = tvm_command();
+    prepare_phase31
+        .arg("prepare-stwo-recursive-compression-decode-boundary-manifest")
+        .arg("--contract")
+        .arg(&phase29_path)
+        .arg("--manifest")
+        .arg(&phase30_path)
+        .arg("-o")
+        .arg(&phase31_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "manifest_version: {STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31}",
+        )))
+        .stdout(predicate::str::contains(format!(
+            "semantic_scope: {STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31}",
+        )))
+        .stdout(predicate::str::contains("verified_phase29_contract: true"))
+        .stdout(predicate::str::contains("verified_phase30_manifest: true"));
+
+    let phase31_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&phase31_path).expect("phase31 json"))
+            .expect("phase31 value");
+    validate_json_against_schema(
+        &phase31_json,
+        "spec/stwo-phase31-recursive-compression-decode-boundary-manifest.schema.json",
+    );
+    assert_eq!(
+        phase31_json
+            .get("manifest_version")
+            .and_then(serde_json::Value::as_str),
+        Some(STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_VERSION_PHASE31)
+    );
+    assert_eq!(
+        phase31_json
+            .get("semantic_scope")
+            .and_then(serde_json::Value::as_str),
+        Some(STWO_RECURSIVE_COMPRESSION_DECODE_BOUNDARY_MANIFEST_SCOPE_PHASE31)
+    );
+
+    let mut verify_standalone = tvm_command();
+    verify_standalone
+        .arg("verify-stwo-recursive-compression-decode-boundary-manifest")
+        .arg("--input")
+        .arg(&phase31_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("verified_manifest: true"));
+
+    let mut verify_sources = tvm_command();
+    verify_sources
+        .arg("verify-stwo-recursive-compression-decode-boundary-manifest")
+        .arg("--input")
+        .arg(&phase31_path)
+        .arg("--contract")
+        .arg(&phase29_path)
+        .arg("--manifest")
+        .arg(&phase30_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("verified_against_sources: true"));
+
+    let _ = std::fs::remove_file(proof_path);
+    let _ = std::fs::remove_file(phase30_path);
+    let _ = std::fs::remove_file(phase29_path);
+    let _ = std::fs::remove_file(phase31_path);
+}
+
+#[test]
+#[cfg(feature = "stwo-backend")]
+fn cli_verify_stwo_recursive_compression_decode_boundary_manifest_rejects_tampered_commitment() {
+    let proof_path = unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-proof-tamper")
+        .with_extension("json");
+    let phase30_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase30-tamper")
+            .with_extension("json");
+    let phase29_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase29-tamper")
+            .with_extension("json");
+    let phase31_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase31-tamper")
+            .with_extension("json");
+    let tampered_path = unique_temp_dir(
+        "cli-stwo-recursive-compression-decode-boundary-phase31-commitment-drift",
+    )
+    .with_extension("json");
+
+    let mut prove = tvm_command();
+    prove
+        .arg("prove-stwo-decoding-family-demo")
+        .arg("-o")
+        .arg(&proof_path)
+        .assert()
+        .success();
+
+    let mut prepare_phase30 = tvm_command();
+    prepare_phase30
+        .arg("prepare-stwo-decoding-step-envelope-manifest")
+        .arg("--proof")
+        .arg(&proof_path)
+        .arg("-o")
+        .arg(&phase30_path)
+        .assert()
+        .success();
+
+    let phase30_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&phase30_path).expect("phase30 json"))
+            .expect("phase30 value");
+    let phase29 = sample_phase29_contract_matched_to_phase30_manifest(&phase30_json);
+    std::fs::write(
+        &phase29_path,
+        serde_json::to_vec_pretty(&phase29).expect("serialize phase29"),
+    )
+    .expect("write phase29");
+
+    let mut prepare_phase31 = tvm_command();
+    prepare_phase31
+        .arg("prepare-stwo-recursive-compression-decode-boundary-manifest")
+        .arg("--contract")
+        .arg(&phase29_path)
+        .arg("--manifest")
+        .arg(&phase30_path)
+        .arg("-o")
+        .arg(&phase31_path)
+        .assert()
+        .success();
+
+    let mut phase31_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&phase31_path).expect("phase31 json"))
+            .expect("phase31 value");
+    phase31_json["decode_boundary_bridge_commitment"] =
+        serde_json::Value::String("0".repeat(64));
+    std::fs::write(
+        &tampered_path,
+        serde_json::to_vec(&phase31_json).expect("serialize tampered phase31"),
+    )
+    .expect("write tampered phase31");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-stwo-recursive-compression-decode-boundary-manifest")
+        .arg("--input")
+        .arg(&tampered_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("does not match recomputed"));
+
+    let _ = std::fs::remove_file(proof_path);
+    let _ = std::fs::remove_file(phase30_path);
+    let _ = std::fs::remove_file(phase29_path);
+    let _ = std::fs::remove_file(phase31_path);
+    let _ = std::fs::remove_file(tampered_path);
+}
+
+#[test]
+#[cfg(feature = "stwo-backend")]
+fn cli_verify_stwo_recursive_compression_decode_boundary_manifest_rejects_source_drift() {
+    let proof_path = unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-proof-drift")
+        .with_extension("json");
+    let phase30_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase30-drift")
+            .with_extension("json");
+    let phase29_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase29-drift")
+            .with_extension("json");
+    let tampered_phase29_path = unique_temp_dir(
+        "cli-stwo-recursive-compression-decode-boundary-phase29-start-drift",
+    )
+    .with_extension("json");
+    let phase31_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase31-drift")
+            .with_extension("json");
+
+    let mut prove = tvm_command();
+    prove
+        .arg("prove-stwo-decoding-family-demo")
+        .arg("-o")
+        .arg(&proof_path)
+        .assert()
+        .success();
+
+    let mut prepare_phase30 = tvm_command();
+    prepare_phase30
+        .arg("prepare-stwo-decoding-step-envelope-manifest")
+        .arg("--proof")
+        .arg(&proof_path)
+        .arg("-o")
+        .arg(&phase30_path)
+        .assert()
+        .success();
+
+    let phase30_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&phase30_path).expect("phase30 json"))
+            .expect("phase30 value");
+    let phase29 = sample_phase29_contract_matched_to_phase30_manifest(&phase30_json);
+    std::fs::write(
+        &phase29_path,
+        serde_json::to_vec_pretty(&phase29).expect("serialize phase29"),
+    )
+    .expect("write phase29");
+
+    let mut prepare_phase31 = tvm_command();
+    prepare_phase31
+        .arg("prepare-stwo-recursive-compression-decode-boundary-manifest")
+        .arg("--contract")
+        .arg(&phase29_path)
+        .arg("--manifest")
+        .arg(&phase30_path)
+        .arg("-o")
+        .arg(&phase31_path)
+        .assert()
+        .success();
+
+    let mut tampered_phase29 = phase29.clone();
+    tampered_phase29.global_start_state_commitment = "tampered-start-boundary".to_string();
+    tampered_phase29.input_contract_commitment =
+        commit_phase29_recursive_compression_input_contract(&tampered_phase29)
+            .expect("commit tampered phase29");
+    std::fs::write(
+        &tampered_phase29_path,
+        serde_json::to_vec_pretty(&tampered_phase29).expect("serialize tampered phase29"),
+    )
+    .expect("write tampered phase29");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-stwo-recursive-compression-decode-boundary-manifest")
+        .arg("--input")
+        .arg(&phase31_path)
+        .arg("--contract")
+        .arg(&tampered_phase29_path)
+        .arg("--manifest")
+        .arg(&phase30_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "requires Phase 29 global_start_state_commitment to match the Phase 30 chain_start_boundary_commitment",
+        ));
+
+    let _ = std::fs::remove_file(proof_path);
+    let _ = std::fs::remove_file(phase30_path);
+    let _ = std::fs::remove_file(phase29_path);
+    let _ = std::fs::remove_file(tampered_phase29_path);
+    let _ = std::fs::remove_file(phase31_path);
+}
+
+#[test]
+#[cfg(feature = "stwo-backend")]
+fn cli_verify_stwo_recursive_compression_decode_boundary_manifest_rejects_partial_source_pair() {
+    let proof_path = unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-proof-pair")
+        .with_extension("json");
+    let phase30_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase30-pair")
+            .with_extension("json");
+    let phase29_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase29-pair")
+            .with_extension("json");
+    let phase31_path =
+        unique_temp_dir("cli-stwo-recursive-compression-decode-boundary-phase31-pair")
+            .with_extension("json");
+
+    let mut prove = tvm_command();
+    prove
+        .arg("prove-stwo-decoding-family-demo")
+        .arg("-o")
+        .arg(&proof_path)
+        .assert()
+        .success();
+
+    let mut prepare_phase30 = tvm_command();
+    prepare_phase30
+        .arg("prepare-stwo-decoding-step-envelope-manifest")
+        .arg("--proof")
+        .arg(&proof_path)
+        .arg("-o")
+        .arg(&phase30_path)
+        .assert()
+        .success();
+
+    let phase30_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&phase30_path).expect("phase30 json"))
+            .expect("phase30 value");
+    let phase29 = sample_phase29_contract_matched_to_phase30_manifest(&phase30_json);
+    std::fs::write(
+        &phase29_path,
+        serde_json::to_vec_pretty(&phase29).expect("serialize phase29"),
+    )
+    .expect("write phase29");
+
+    let mut prepare_phase31 = tvm_command();
+    prepare_phase31
+        .arg("prepare-stwo-recursive-compression-decode-boundary-manifest")
+        .arg("--contract")
+        .arg(&phase29_path)
+        .arg("--manifest")
+        .arg(&phase30_path)
+        .arg("-o")
+        .arg(&phase31_path)
+        .assert()
+        .success();
+
+    let mut verify_contract_only = tvm_command();
+    verify_contract_only
+        .arg("verify-stwo-recursive-compression-decode-boundary-manifest")
+        .arg("--input")
+        .arg(&phase31_path)
+        .arg("--contract")
+        .arg(&phase29_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "requires both `--contract` and `--manifest`",
+        ));
+
+    let mut verify_manifest_only = tvm_command();
+    verify_manifest_only
+        .arg("verify-stwo-recursive-compression-decode-boundary-manifest")
+        .arg("--input")
+        .arg(&phase31_path)
+        .arg("--manifest")
+        .arg(&phase30_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "requires both `--contract` and `--manifest`",
+        ));
+
+    let _ = std::fs::remove_file(proof_path);
+    let _ = std::fs::remove_file(phase30_path);
+    let _ = std::fs::remove_file(phase29_path);
+    let _ = std::fs::remove_file(phase31_path);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a Phase 31 manifest that binds the published Phase 29 recursive-compression input contract to the Phase 30 decode-step envelope manifest
- expose prepare/verify CLI commands, schema, and exact CLI coverage for the new bridge surface
- update paper-2 engineering docs to describe the bridge as recursive-adjacent, not recursive closure

## Local validation
- cargo +nightly-2025-07-14 build -q --features full,stwo-backend --bin tvm -j 2
- cargo +nightly-2025-07-14 test -q --features full,stwo-backend --lib stwo_backend::recursion::tests::phase31_decode_boundary_manifest_accepts_matching_phase29_and_phase30_sources -- --exact
- cargo +nightly-2025-07-14 test -q --features full,stwo-backend --lib stwo_backend::recursion::tests::phase31_decode_boundary_manifest_rejects_step_count_mismatch -- --exact
- cargo +nightly-2025-07-14 test -q --features full,stwo-backend --lib stwo_backend::recursion::tests::phase31_decode_boundary_manifest_rejects_boundary_mismatch -- --exact
- cargo +nightly-2025-07-14 test -q --features full,stwo-backend --lib stwo_backend::recursion::tests::phase31_decode_boundary_manifest_rejects_tampered_commitment -- --exact
- cargo +nightly-2025-07-14 test -q --features full,stwo-backend --lib stwo_backend::recursion::tests::phase31_decode_boundary_manifest_deserialization_verifies_manifest -- --exact
- cargo +nightly-2025-07-14 test -q --features full,stwo-backend --lib stwo_backend::recursion::tests::phase31_decode_boundary_manifest_parse_rejects_unknown_fields -- --exact
- TVM_TEST_BINARY=/Users/espejelomar/.codex-targets/ptv-paper-next/debug/tvm cargo +nightly-2025-07-14 test -q --features full,stwo-backend --test cli cli_can_prepare_and_verify_stwo_recursive_compression_decode_boundary_manifest -- --exact
- TVM_TEST_BINARY=/Users/espejelomar/.codex-targets/ptv-paper-next/debug/tvm cargo +nightly-2025-07-14 test -q --features full,stwo-backend --test cli cli_verify_stwo_recursive_compression_decode_boundary_manifest_rejects_tampered_commitment -- --exact
- TVM_TEST_BINARY=/Users/espejelomar/.codex-targets/ptv-paper-next/debug/tvm cargo +nightly-2025-07-14 test -q --features full,stwo-backend --test cli cli_verify_stwo_recursive_compression_decode_boundary_manifest_rejects_source_drift -- --exact
- TVM_TEST_BINARY=/Users/espejelomar/.codex-targets/ptv-paper-next/debug/tvm cargo +nightly-2025-07-14 test -q --features full,stwo-backend --test cli cli_verify_stwo_recursive_compression_decode_boundary_manifest_rejects_partial_source_pair -- --exact
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Phase 31 decode-boundary bridge manifest support for recursive proof verification.
  * New CLI commands to prepare and verify Phase 31 manifests from existing proof components.

* **Documentation**
  * Updated roadmap and engineering guidance to reflect Phase 31 in the proof architecture.
  * Extended artifact specifications and recursive closure documentation.

* **Tests**
  * Added comprehensive test coverage for Phase 31 manifest preparation, verification, and tamper detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->