### PR TITLE
Add HF external attestation statement binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,7 +837,8 @@ cargo run --bin tvm -- prepare-hf-provenance-manifest \
   --onnx-model path/to/model.onnx \
   --onnx-metadata path/to/metadata.json \
   --onnx-external-data path/to/model.onnx_data \
-  --model-card path/to/README.md
+  --model-card path/to/README.md \
+  --external-attestation-statement path/to/release.attestation.json
 cargo run --bin tvm -- verify-hf-provenance-manifest compiled/hf-provenance.json
 ```
 
@@ -852,17 +853,22 @@ algorithm correctness, safetensors architectural semantics, ONNX exporter semant
 equivalence, ONNX metadata semantic correctness, live Hub availability, DOI
 validity, or GitHub/Sigstore/in-toto/SLSA attestation validity. The current wire
 format also carries `sha256` digests for bound files so release assets can be
-matched against attestation subject digests without turning the manifest into an
-attestation verifier. When an ONNX metadata sidecar is bound, the manifest now
-also carries a versioned metadata-identity projection over the exporter-facing
-format/opset/shape/encoding surface and instruction-table cardinality.
+matched against attestation subject digests. When an external in-toto/SLSA-style
+statement file is supplied, the manifest can also bind that statement file plus a
+narrow identity projection over its statement type, predicate type, builder id,
+build invocation id, and subject inventory. This still does not turn the
+manifest into a signed-attestation verifier. When an ONNX metadata sidecar is
+bound, the manifest also carries a versioned metadata-identity projection over
+the exporter-facing format/opset/shape/encoding surface and instruction-table
+cardinality.
 
-The current manifest wire format is `hf-provenance-manifest-v5`. Older
+The current manifest wire format is `hf-provenance-manifest-v7`. Older
 `hf-provenance-manifest-v1`, `hf-provenance-manifest-v2`,
-`hf-provenance-manifest-v3`, and `hf-provenance-manifest-v4` files must be
+`hf-provenance-manifest-v3`, `hf-provenance-manifest-v4`,
+`hf-provenance-manifest-v5`, and `hf-provenance-manifest-v6` files must be
 regenerated before verification because the ONNX sidecar surface, hub-binding
-commitment, metadata-identity projection, and attestation-digest inventory now
-have explicit versioned format boundaries.
+commitment, metadata-identity projection, attestation-digest inventory, and
+external-statement binding now have explicit versioned format boundaries.
 
 Canonical HF provenance spec file:
 

--- a/docs/engineering/paper2-roadmap.md
+++ b/docs/engineering/paper2-roadmap.md
@@ -28,6 +28,8 @@ The repository is already strong enough for the bounded paper-2 claim:
   declared external-data side files,
 - attestation-friendly subject digests plus optional builder/source release
   metadata now exist on the HF provenance surface,
+- the HF provenance surface can now also bind an external in-toto/SLSA-style
+  statement file as a narrow release-layer identity projection,
 - ONNX-facing provenance now also binds exporter identity and graph-constraint
   identity where metadata exposes those constraints,
 - parser/verifier hardening has materially improved the trust boundary around
@@ -61,8 +63,10 @@ Concrete targets:
 - preserve external-file identity where ONNX layout requires it,
 - keep the new builder/source metadata aligned with signed attestation subjects
   rather than proof semantics,
-- add externally signed provenance only as a release-layer extension, not as a
-  proof-semantics claim,
+- keep external statement binding narrow and machine-checkable at the release
+  layer,
+- add full external signature/trust-chain verification only as a release-layer
+  extension, not as a proof-semantics claim,
 - keep the claim phrased as provenance/reproducibility, not proof semantics.
 
 ### 3. Keep semantic-agreement artifacts bounded
@@ -115,8 +119,8 @@ exists to sequence the implementation work that keeps those boundaries honest.
 The next concrete engineering slice should be:
 
 1. keep the expanded HF provenance verifier narrow and explicit about what is
-   local identity binding versus what would require external signed
-   attestations,
+   local identity binding and external statement binding versus what would still
+   require external signed attestation verification,
 2. keep the Phase 31 decode-boundary bridge narrow and explicit about what is
    bound from Phase 29 and Phase 30 versus what would require actual recursive
    verification,

--- a/docs/engineering/reproducibility.md
+++ b/docs/engineering/reproducibility.md
@@ -120,10 +120,11 @@ bundle-looking directory unless that override is set. Its outputs are:
 - HF provenance manifests are release/provenance artifacts only. They bind
   pinned Hub and tokenizer identifiers plus local tokenizer, safetensors, ONNX,
   model-card, DOI, dataset, attestation-subject, exporter-identity,
-  graph-constraint-identity, and optional builder/source metadata where
-  supplied, but they do not prove tokenizer algorithm correctness, model-weight
-  semantics, Optimum export equivalence, live Hub availability, or DOI
-  validity.
+  graph-constraint-identity, optional builder/source metadata, and an optional
+  external attestation statement projection where supplied, but they do not
+  prove tokenizer algorithm correctness, model-weight semantics, Optimum export
+  equivalence, live Hub availability, DOI validity, or external attestation
+  signature/trust-chain validity.
 
 ## Paper figure regeneration
 

--- a/docs/paper/paper2/appendix-engineering-gaps.md
+++ b/docs/paper/paper2/appendix-engineering-gaps.md
@@ -23,12 +23,13 @@ compressed proof object.
 
 The Hugging Face provenance line is strong as a bounded reproducibility surface,
 but it is not yet a complete supply-chain attestation story. In particular,
-externally signed attestations remain a live engineering gap. Today the
-repository binds the produced ONNX-facing graph, metadata, external-file
-identities, exporter identity, and metadata-derived graph-constraint identity
-together with local file hashes, attestation-friendly subject digests, and
-optional builder/source release metadata, but it does not yet expose a verified
-external attestation layer for builder trust or supply-chain signing.
+verified external signatures and trust chains remain a live engineering gap.
+Today the repository binds the produced ONNX-facing graph, metadata,
+external-file identities, exporter identity, metadata-derived graph-constraint
+identity, local file hashes, attestation-friendly subject digests, optional
+builder/source release metadata, and an optional external statement projection,
+but it does not yet expose a verified external attestation layer for builder
+trust or supply-chain signing.
 
 ### Runtime-consistency scope
 

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -305,6 +305,13 @@ confused with a proof relation or a verified attestation pipeline. It is a
 release boundary, not a theorem that exporter or supply-chain semantics are
 preserved.
 
+The current release layer can also bind an external in-toto/SLSA-style
+statement file through a narrow identity projection over its statement type,
+predicate type, builder id, build invocation id, and subject inventory. That
+still does not verify the statement's signature or trust chain. It keeps the
+provenance surface aligned with existing release workflows without turning the
+manifest into a supply-chain theorem.
+
 ______________________________________________________________________
 
 ## 6. Negative Results and Non-Claims

--- a/spec/hf-provenance-manifest.schema.json
+++ b/spec/hf-provenance-manifest.schema.json
@@ -13,11 +13,12 @@
     "safetensors",
     "onnx_export",
     "release",
+    "external_attestation",
     "limitations",
     "commitments"
   ],
   "properties": {
-    "manifest_version": { "const": "hf-provenance-manifest-v6" },
+    "manifest_version": { "const": "hf-provenance-manifest-v7" },
     "semantic_scope": { "const": "hf-release-provenance-boundary-v1" },
     "commitment_hash_function": { "const": "blake2b-256" },
     "hub_repo": { "type": "string", "minLength": 1 },
@@ -37,6 +38,12 @@
     "attestation": {
       "anyOf": [
         { "$ref": "#/$defs/attestation" },
+        { "type": "null" }
+      ]
+    },
+    "external_attestation": {
+      "anyOf": [
+        { "$ref": "#/$defs/external_attestation" },
         { "type": "null" }
       ]
     },
@@ -324,6 +331,45 @@
       },
       "additionalProperties": false
     },
+    "external_attestation_identity": {
+      "type": "object",
+      "required": [
+        "identity_version",
+        "statement_type",
+        "predicate_type",
+        "builder_id",
+        "build_invocation_id",
+        "subject_count"
+      ],
+      "properties": {
+        "identity_version": { "const": "hf-external-attestation-identity-v1" },
+        "statement_type": { "type": "string", "minLength": 1 },
+        "predicate_type": { "type": "string", "minLength": 1 },
+        "builder_id": {
+          "anyOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
+        },
+        "build_invocation_id": {
+          "anyOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
+        },
+        "subject_count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "external_attestation": {
+      "type": "object",
+      "required": ["statement", "identity"],
+      "properties": {
+        "statement": { "$ref": "#/$defs/file_commitment" },
+        "identity": { "$ref": "#/$defs/external_attestation_identity" }
+      },
+      "additionalProperties": false
+    },
     "commitments": {
       "type": "object",
       "required": [
@@ -335,6 +381,8 @@
         "onnx_metadata_identity_hash",
         "onnx_graph_constraint_identity_hash",
         "release_metadata_hash",
+        "attestation_hash",
+        "external_attestation_hash",
         "limitations_hash"
       ],
       "properties": {
@@ -347,6 +395,7 @@
         "onnx_graph_constraint_identity_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "release_metadata_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "attestation_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
+        "external_attestation_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" },
         "limitations_hash": { "$ref": "#/$defs/hash_blake2b_256_hex" }
       },
       "additionalProperties": false

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -761,6 +761,9 @@ enum Command {
         /// Optional pinned source revision for build provenance metadata.
         #[arg(long = "attestation-source-revision")]
         attestation_source_revision: Option<String>,
+        /// Optional external in-toto/SLSA-style attestation statement to bind at the release layer.
+        #[arg(long = "external-attestation-statement")]
+        external_attestation_statement: Option<PathBuf>,
     },
     /// Verify a Hugging Face release/provenance manifest and local file bindings.
     VerifyHfProvenanceManifest {
@@ -953,7 +956,8 @@ const HF_PROVENANCE_MANIFEST_VERSION_V2_LEGACY: &str = "hf-provenance-manifest-v
 const HF_PROVENANCE_MANIFEST_VERSION_V3_LEGACY: &str = "hf-provenance-manifest-v3";
 const HF_PROVENANCE_MANIFEST_VERSION_V4_LEGACY: &str = "hf-provenance-manifest-v4";
 const HF_PROVENANCE_MANIFEST_VERSION_V5_LEGACY: &str = "hf-provenance-manifest-v5";
-const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v6";
+const HF_PROVENANCE_MANIFEST_VERSION_V6_LEGACY: &str = "hf-provenance-manifest-v6";
+const HF_PROVENANCE_MANIFEST_VERSION: &str = "hf-provenance-manifest-v7";
 const HF_PROVENANCE_SEMANTIC_SCOPE: &str = "hf-release-provenance-boundary-v1";
 const HF_PROVENANCE_HASH_FUNCTION: &str = "blake2b-256";
 const HF_ONNX_METADATA_IDENTITY_VERSION: &str = "onnx-program-metadata-identity-v1";
@@ -961,6 +965,7 @@ const HF_ONNX_EXPORTER_IDENTITY_VERSION: &str = "onnx-exporter-identity-v1";
 const HF_ONNX_GRAPH_CONSTRAINT_IDENTITY_VERSION: &str =
     "onnx-graph-constraint-identity-v1";
 const HF_ATTESTATION_METADATA_VERSION: &str = "hf-attestation-metadata-v1";
+const HF_EXTERNAL_ATTESTATION_IDENTITY_VERSION: &str = "hf-external-attestation-identity-v1";
 
 struct HfProvenanceManifestCommand {
     output: PathBuf,
@@ -985,6 +990,7 @@ struct HfProvenanceManifestCommand {
     attestation_build_invocation_id: Option<String>,
     attestation_source_repository: Option<String>,
     attestation_source_revision: Option<String>,
+    external_attestation_statement: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1094,6 +1100,24 @@ struct HfAttestationMetadata {
     subjects: Vec<HfAttestationSubject>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HfExternalAttestationIdentity {
+    identity_version: String,
+    statement_type: String,
+    predicate_type: String,
+    builder_id: Option<String>,
+    build_invocation_id: Option<String>,
+    subject_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HfExternalAttestationProvenance {
+    statement: HfFileCommitment,
+    identity: HfExternalAttestationIdentity,
+}
+
 #[derive(Debug, Serialize)]
 struct HfHubBinding<'a> {
     hub_repo: &'a str,
@@ -1113,6 +1137,8 @@ struct HfProvenanceCommitments {
     release_metadata_hash: String,
     #[serde(default = "default_hf_attestation_hash")]
     attestation_hash: String,
+    #[serde(default = "default_hf_external_attestation_hash")]
+    external_attestation_hash: String,
     limitations_hash: String,
 }
 
@@ -1130,6 +1156,8 @@ struct HfProvenanceManifest {
     release: HfReleaseMetadata,
     #[serde(default)]
     attestation: Option<HfAttestationMetadata>,
+    #[serde(default)]
+    external_attestation: Option<HfExternalAttestationProvenance>,
     limitations: Vec<String>,
     commitments: HfProvenanceCommitments,
 }
@@ -1137,6 +1165,11 @@ struct HfProvenanceManifest {
 fn default_hf_attestation_hash() -> String {
     hash_json_projection_hex(&Option::<HfAttestationMetadata>::None)
         .expect("default HF attestation hash")
+}
+
+fn default_hf_external_attestation_hash() -> String {
+    hash_json_projection_hex(&Option::<HfExternalAttestationProvenance>::None)
+        .expect("default HF external attestation hash")
 }
 
 #[cfg(feature = "onnx-export")]
@@ -1760,6 +1793,7 @@ fn run() -> llm_provable_computer::Result<()> {
             attestation_build_invocation_id,
             attestation_source_repository,
             attestation_source_revision,
+            external_attestation_statement,
         } => prepare_hf_provenance_manifest_command(HfProvenanceManifestCommand {
             output,
             hub_repo,
@@ -1783,6 +1817,7 @@ fn run() -> llm_provable_computer::Result<()> {
             attestation_build_invocation_id,
             attestation_source_repository,
             attestation_source_revision,
+            external_attestation_statement,
         })?,
         Command::VerifyHfProvenanceManifest { manifest } => {
             verify_hf_provenance_manifest_command(&manifest)?
@@ -4607,18 +4642,69 @@ fn prepare_hf_provenance_manifest_command(
         datasets: command.datasets,
         notes: command.notes,
     };
+    let expected_attestation_subjects =
+        derive_hf_attestation_subjects(&tokenizer, &safetensors, onnx_export.as_ref(), &release);
+    let external_attestation = command
+        .external_attestation_statement
+        .as_deref()
+        .map(|path| {
+            let (statement_identity, statement_commitment, identity, statement_subjects) =
+                inspect_hf_external_attestation_statement(path)?;
+            let expected_statement_subjects =
+                derive_hf_external_attestation_statement_subjects(&expected_attestation_subjects);
+            if statement_subjects != expected_statement_subjects {
+                return Err(VmError::InvalidConfig(
+                    "HF provenance external attestation subjects do not match the bound local-file surface".to_string(),
+                ));
+            }
+            if let (Some(expected), Some(observed)) = (
+                command.attestation_builder_id.as_deref(),
+                identity.builder_id.as_deref(),
+            ) {
+                expect_eq(
+                    "hf external_attestation.identity.builder_id",
+                    observed,
+                    expected,
+                )?;
+            }
+            if let (Some(expected), Some(observed)) = (
+                command.attestation_build_invocation_id.as_deref(),
+                identity.build_invocation_id.as_deref(),
+            ) {
+                expect_eq(
+                    "hf external_attestation.identity.build_invocation_id",
+                    observed,
+                    expected,
+                )?;
+            }
+            let mut bound_paths = std::collections::BTreeSet::new();
+            ensure_unique_hf_identity(
+                "HF provenance external_attestation.statement",
+                &statement_commitment.path,
+                statement_identity,
+                &mut bound_paths,
+            )?;
+            Ok::<HfExternalAttestationProvenance, VmError>(HfExternalAttestationProvenance {
+                statement: statement_commitment,
+                identity,
+            })
+        })
+        .transpose()?;
     let attestation = Some(HfAttestationMetadata {
         attestation_version: HF_ATTESTATION_METADATA_VERSION.to_string(),
-        builder_id: command.attestation_builder_id,
-        build_invocation_id: command.attestation_build_invocation_id,
+        builder_id: command.attestation_builder_id.clone().or_else(|| {
+            external_attestation
+                .as_ref()
+                .and_then(|binding| binding.identity.builder_id.clone())
+        }),
+        build_invocation_id: command.attestation_build_invocation_id.clone().or_else(|| {
+            external_attestation
+                .as_ref()
+                .and_then(|binding| binding.identity.build_invocation_id.clone())
+        }),
         source_repository: command.attestation_source_repository,
         source_revision: command.attestation_source_revision,
-        subjects: derive_hf_attestation_subjects(
-            &tokenizer,
-            &safetensors,
-            onnx_export.as_ref(),
-            &release,
-        ),
+        subjects: expected_attestation_subjects,
     });
     let limitations = hf_provenance_limitations();
     let hub_binding_hash = hash_json_projection_hex(&HfHubBinding {
@@ -4653,6 +4739,7 @@ fn prepare_hf_provenance_manifest_command(
             )?,
             release_metadata_hash: hash_json_projection_hex(&release)?,
             attestation_hash: hash_json_projection_hex(&attestation)?,
+            external_attestation_hash: hash_json_projection_hex(&external_attestation)?,
             limitations_hash: hash_json_projection_hex(&limitations)?,
         },
         tokenizer,
@@ -4660,6 +4747,7 @@ fn prepare_hf_provenance_manifest_command(
         onnx_export,
         release,
         attestation,
+        external_attestation,
         limitations,
     };
     verify_hf_provenance_manifest(&manifest)?;
@@ -4989,8 +5077,14 @@ fn load_hf_provenance_manifest(
             HF_PROVENANCE_MANIFEST_VERSION_V5_LEGACY,
             HF_PROVENANCE_MANIFEST_VERSION
         ))),
+        HF_PROVENANCE_MANIFEST_VERSION_V6_LEGACY => Err(VmError::Serialization(format!(
+            "failed to parse HF provenance manifest {}: legacy manifest_version `{}` is no longer accepted after the external attestation binding update; regenerate the manifest as {}",
+            manifest_path.display(),
+            HF_PROVENANCE_MANIFEST_VERSION_V6_LEGACY,
+            HF_PROVENANCE_MANIFEST_VERSION
+        ))),
         HF_PROVENANCE_MANIFEST_VERSION => {
-            ensure_hf_provenance_manifest_v6_required_fields(manifest_path, &manifest_value)?;
+            ensure_hf_provenance_manifest_v7_required_fields(manifest_path, &manifest_value)?;
             serde_json::from_value(manifest_value).map_err(|err| {
                 VmError::Serialization(format!(
                     "failed to parse HF provenance manifest {}: {err}",
@@ -5005,10 +5099,21 @@ fn load_hf_provenance_manifest(
     }
 }
 
-fn ensure_hf_provenance_manifest_v6_required_fields(
+fn ensure_hf_provenance_manifest_v7_required_fields(
     manifest_path: &Path,
     manifest_value: &serde_json::Value,
 ) -> llm_provable_computer::Result<()> {
+    let manifest_label = HF_PROVENANCE_MANIFEST_VERSION;
+    if !manifest_value
+        .as_object()
+        .is_some_and(|object| object.contains_key("external_attestation"))
+    {
+        return Err(VmError::Serialization(format!(
+            "failed to parse HF provenance manifest {}: missing field `external_attestation` for {}",
+            manifest_path.display(),
+            manifest_label
+        )));
+    }
     if let Some(commitments_obj) = manifest_value
         .get("commitments")
         .and_then(|v| v.as_object())
@@ -5017,28 +5122,42 @@ fn ensure_hf_provenance_manifest_v6_required_fields(
             return Err(VmError::Serialization(format!(
                 "failed to parse HF provenance manifest {}: missing field `hub_binding_hash` in `commitments` for {}",
                 manifest_path.display(),
-                HF_PROVENANCE_MANIFEST_VERSION
+                manifest_label
             )));
         }
         if !commitments_obj.contains_key("onnx_metadata_identity_hash") {
             return Err(VmError::Serialization(format!(
                 "failed to parse HF provenance manifest {}: missing field `onnx_metadata_identity_hash` in `commitments` for {}",
                 manifest_path.display(),
-                HF_PROVENANCE_MANIFEST_VERSION
+                manifest_label
             )));
         }
         if !commitments_obj.contains_key("onnx_exporter_identity_hash") {
             return Err(VmError::Serialization(format!(
                 "failed to parse HF provenance manifest {}: missing field `onnx_exporter_identity_hash` in `commitments` for {}",
                 manifest_path.display(),
-                HF_PROVENANCE_MANIFEST_VERSION
+                manifest_label
             )));
         }
         if !commitments_obj.contains_key("onnx_graph_constraint_identity_hash") {
             return Err(VmError::Serialization(format!(
                 "failed to parse HF provenance manifest {}: missing field `onnx_graph_constraint_identity_hash` in `commitments` for {}",
                 manifest_path.display(),
-                HF_PROVENANCE_MANIFEST_VERSION
+                manifest_label
+            )));
+        }
+        if !commitments_obj.contains_key("attestation_hash") {
+            return Err(VmError::Serialization(format!(
+                "failed to parse HF provenance manifest {}: missing field `attestation_hash` in `commitments` for {}",
+                manifest_path.display(),
+                manifest_label
+            )));
+        }
+        if !commitments_obj.contains_key("external_attestation_hash") {
+            return Err(VmError::Serialization(format!(
+                "failed to parse HF provenance manifest {}: missing field `external_attestation_hash` in `commitments` for {}",
+                manifest_path.display(),
+                manifest_label
             )));
         }
     }
@@ -5060,7 +5179,7 @@ fn ensure_hf_provenance_manifest_v6_required_fields(
             return Err(VmError::Serialization(format!(
                 "failed to parse HF provenance manifest {}: missing field `{field}` in `onnx_export` for {}",
                 manifest_path.display(),
-                HF_PROVENANCE_MANIFEST_VERSION
+                manifest_label
             )));
         }
     }
@@ -5168,6 +5287,11 @@ fn verify_hf_provenance_manifest(
         "hf attestation_hash",
         &manifest.commitments.attestation_hash,
         &hash_json_projection_hex(&manifest.attestation)?,
+    )?;
+    verify_hash_commitment(
+        "hf external_attestation_hash",
+        &manifest.commitments.external_attestation_hash,
+        &hash_json_projection_hex(&manifest.external_attestation)?,
     )?;
     verify_hash_commitment(
         "hf limitations_hash",
@@ -5377,6 +5501,61 @@ fn verify_hf_provenance_manifest(
             ));
         }
     }
+    if let Some(external_attestation) = &manifest.external_attestation {
+        let attestation = manifest.attestation.as_ref().ok_or_else(|| {
+            VmError::InvalidConfig(
+                "HF provenance external_attestation requires attestation metadata".to_string(),
+            )
+        })?;
+        let (
+            statement_identity,
+            computed_statement,
+            computed_identity,
+            statement_subjects,
+        ) = inspect_hf_external_attestation_statement(Path::new(
+            &external_attestation.statement.path,
+        ))?;
+        ensure_hf_file_commitment_matches(
+            "external_attestation.statement",
+            &external_attestation.statement,
+            &computed_statement,
+            statement_identity,
+            &mut bound_paths,
+        )?;
+        if external_attestation.identity != computed_identity {
+            return Err(VmError::InvalidConfig(format!(
+                "hf external_attestation.identity mismatch: expected {:?}, got {:?}",
+                external_attestation.identity, computed_identity
+            )));
+        }
+        let expected_subjects =
+            derive_hf_external_attestation_statement_subjects(&attestation.subjects);
+        if statement_subjects != expected_subjects {
+            return Err(VmError::InvalidConfig(
+                "HF provenance external attestation subjects do not match the bound local-file surface".to_string(),
+            ));
+        }
+        if let (Some(attested), Some(external)) = (
+            attestation.builder_id.as_deref(),
+            external_attestation.identity.builder_id.as_deref(),
+        ) {
+            expect_eq(
+                "hf attestation.builder_id",
+                attested,
+                external,
+            )?;
+        }
+        if let (Some(attested), Some(external)) = (
+            attestation.build_invocation_id.as_deref(),
+            external_attestation.identity.build_invocation_id.as_deref(),
+        ) {
+            expect_eq(
+                "hf attestation.build_invocation_id",
+                attested,
+                external,
+            )?;
+        }
+    }
 
     Ok(())
 }
@@ -5384,7 +5563,7 @@ fn verify_hf_provenance_manifest(
 fn hf_provenance_limitations() -> Vec<String> {
     [
         "HF provenance manifests pin artifact identity and local file hashes only",
-        "attestation-friendly SHA-256 digests do not by themselves verify GitHub, Sigstore, in-toto, or SLSA attestations",
+        "attestation-friendly SHA-256 digests and optional external statement binding do not by themselves verify GitHub, Sigstore, in-toto, or SLSA attestations",
         "the manifest does not prove tokenizer algorithm correctness",
         "the manifest does not prove safetensors weights implement a model architecture",
         "the manifest does not prove Optimum or ONNX exporter semantic equivalence even when exporter identity is pinned",
@@ -5472,6 +5651,187 @@ fn push_hf_attestation_file_subject(
             sha256: commitment.sha256.clone(),
         });
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct HfExternalAttestationStatementSubject {
+    path: String,
+    sha256: String,
+}
+
+fn derive_hf_external_attestation_statement_subjects(
+    subjects: &[HfAttestationSubject],
+) -> Vec<HfExternalAttestationStatementSubject> {
+    let mut projected = subjects
+        .iter()
+        .map(|subject| HfExternalAttestationStatementSubject {
+            path: subject.path.clone(),
+            sha256: subject.sha256.clone(),
+        })
+        .collect::<Vec<_>>();
+    projected.sort();
+    projected
+}
+
+fn inspect_hf_external_attestation_statement(
+    path: &Path,
+) -> llm_provable_computer::Result<(
+    HfFileIdentity,
+    HfFileCommitment,
+    HfExternalAttestationIdentity,
+    Vec<HfExternalAttestationStatementSubject>,
+)> {
+    let label = "HF external attestation statement";
+    let max_bytes = MAX_HF_ONNX_METADATA_JSON_BYTES as u64;
+    let (file, size_bytes) = open_checked_regular_file(path, label, Some(max_bytes))?;
+    let identity = hf_file_identity_from_open_file(path, label, &file)?;
+    let bytes = read_checked_bounded_file_bytes(file, path, label, size_bytes, max_bytes)?;
+    let (blake2b_256, sha256) = hash_hf_commitment_bytes(&bytes)?;
+    let statement = parse_hf_external_attestation_statement_json(path, &bytes)?;
+    let (projection, subjects) =
+        derive_hf_external_attestation_identity_from_value(path, &statement)?;
+    Ok((
+        identity,
+        HfFileCommitment {
+            path: path.display().to_string(),
+            size_bytes,
+            blake2b_256,
+            sha256,
+        },
+        projection,
+        subjects,
+    ))
+}
+
+fn parse_hf_external_attestation_statement_json(
+    path: &Path,
+    bytes: &[u8],
+) -> llm_provable_computer::Result<serde_json::Value> {
+    serde_json::from_slice(bytes).map_err(|err| {
+        VmError::Serialization(format!(
+            "failed to parse HF external attestation statement {}: {err}",
+            path.display()
+        ))
+    })
+}
+
+fn derive_hf_external_attestation_identity_from_value(
+    path: &Path,
+    statement: &serde_json::Value,
+) -> llm_provable_computer::Result<(
+    HfExternalAttestationIdentity,
+    Vec<HfExternalAttestationStatementSubject>,
+)> {
+    let statement_type = statement
+        .get("_type")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            VmError::InvalidConfig(format!(
+                "HF external attestation statement {} missing non-empty string field `_type`",
+                path.display()
+            ))
+        })?
+        .to_string();
+    let predicate_type = statement
+        .get("predicateType")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            VmError::InvalidConfig(format!(
+                "HF external attestation statement {} missing non-empty string field `predicateType`",
+                path.display()
+            ))
+        })?
+        .to_string();
+    let subject_values = statement
+        .get("subject")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            VmError::InvalidConfig(format!(
+                "HF external attestation statement {} missing subject array",
+                path.display()
+            ))
+        })?;
+    if subject_values.is_empty() {
+        return Err(VmError::InvalidConfig(format!(
+            "HF external attestation statement {} subject array must be non-empty",
+            path.display()
+        )));
+    }
+    let mut seen_subjects = std::collections::BTreeSet::new();
+    let mut subjects = Vec::with_capacity(subject_values.len());
+    for (idx, subject) in subject_values.iter().enumerate() {
+        let path_value = subject
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                VmError::InvalidConfig(format!(
+                    "HF external attestation statement {} subject[{idx}] missing non-empty string field `name`",
+                    path.display()
+                ))
+            })?;
+        let sha256 = subject
+            .get("digest")
+            .and_then(|digest| digest.get("sha256"))
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                VmError::InvalidConfig(format!(
+                    "HF external attestation statement {} subject[{idx}] missing string field `digest.sha256`",
+                    path.display()
+                ))
+            })?;
+        expect_hash_hex(
+            &format!(
+                "HF external attestation statement {} subject[{idx}] digest.sha256",
+                path.display()
+            ),
+            sha256,
+        )?;
+        let projected = HfExternalAttestationStatementSubject {
+            path: path_value.to_string(),
+            sha256: sha256.to_string(),
+        };
+        if !seen_subjects.insert(projected.clone()) {
+            return Err(VmError::InvalidConfig(format!(
+                "HF external attestation statement {} repeats subject `{}` with the same SHA-256 digest",
+                path.display(),
+                projected.path
+            )));
+        }
+        subjects.push(projected);
+    }
+    subjects.sort();
+    let builder_id = statement
+        .pointer("/predicate/runDetails/builder/id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string);
+    let build_invocation_id = statement
+        .pointer("/predicate/runDetails/metadata/invocationId")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string);
+    validate_hf_optional_identifier(
+        "external_attestation.identity.builder_id",
+        builder_id.as_deref(),
+    )?;
+    validate_hf_optional_identifier(
+        "external_attestation.identity.build_invocation_id",
+        build_invocation_id.as_deref(),
+    )?;
+    Ok((
+        HfExternalAttestationIdentity {
+            identity_version: HF_EXTERNAL_ATTESTATION_IDENTITY_VERSION.to_string(),
+            statement_type,
+            predicate_type,
+            builder_id,
+            build_invocation_id,
+            subject_count: subjects.len(),
+        },
+        subjects,
+    ))
 }
 
 fn validate_hf_identifier(label: &str, value: &str) -> llm_provable_computer::Result<()> {
@@ -8690,6 +9050,7 @@ mod hf_provenance_manifest_tests {
                 "notes": []
             },
             "attestation": null,
+            "external_attestation": null,
             "limitations": hf_provenance_limitations(),
             "commitments": {
                 "hub_binding_hash": "f".repeat(64),
@@ -8701,6 +9062,7 @@ mod hf_provenance_manifest_tests {
                 "onnx_graph_constraint_identity_hash": "8".repeat(64),
                 "release_metadata_hash": "5".repeat(64),
                 "attestation_hash": default_hf_attestation_hash(),
+                "external_attestation_hash": default_hf_external_attestation_hash(),
                 "limitations_hash": "4".repeat(64)
             }
         })
@@ -8754,6 +9116,7 @@ mod hf_provenance_manifest_tests {
                     &release,
                 ),
             }),
+            external_attestation: None,
             limitations: limitations.clone(),
             commitments: HfProvenanceCommitments {
                 hub_binding_hash: hash_json_projection_hex(&HfHubBinding {
@@ -8800,6 +9163,7 @@ mod hf_provenance_manifest_tests {
                     ),
                 }))
                 .expect("attestation hash"),
+                external_attestation_hash: default_hf_external_attestation_hash(),
                 limitations_hash: hash_json_projection_hex(&limitations).expect("limitations hash"),
             },
         }
@@ -8852,7 +9216,7 @@ mod hf_provenance_manifest_tests {
     }
 
     #[test]
-    fn load_hf_provenance_manifest_rejects_v6_missing_onnx_exporter_identity_field() {
+    fn load_hf_provenance_manifest_rejects_v7_missing_onnx_exporter_identity_field() {
         let file = hf_provenance_test_manifest_file("missing-onnx-exporter-identity");
         let mut value = sample_hf_provenance_manifest_value();
         value["onnx_export"] = serde_json::json!({
@@ -8872,14 +9236,14 @@ mod hf_provenance_manifest_tests {
         write_hf_provenance_test_manifest(file.path(), &value);
 
         let err = load_hf_provenance_manifest(file.path())
-            .expect_err("v6 manifest missing onnx exporter_identity field should fail");
+            .expect_err("v7 manifest missing onnx exporter_identity field should fail");
         assert!(err
             .to_string()
             .contains("missing field `exporter_identity`"));
     }
 
     #[test]
-    fn load_hf_provenance_manifest_rejects_v6_missing_onnx_metadata_identity_field() {
+    fn load_hf_provenance_manifest_rejects_v7_missing_onnx_metadata_identity_field() {
         let file = hf_provenance_test_manifest_file("missing-onnx-metadata");
         let mut value = sample_hf_provenance_manifest_value();
         value["onnx_export"] = serde_json::json!({
@@ -8903,14 +9267,14 @@ mod hf_provenance_manifest_tests {
         write_hf_provenance_test_manifest(file.path(), &value);
 
         let err = load_hf_provenance_manifest(file.path())
-            .expect_err("v6 manifest missing onnx metadata_identity field should fail");
+            .expect_err("v7 manifest missing onnx metadata_identity field should fail");
         assert!(err
             .to_string()
             .contains("missing field `metadata_identity`"));
     }
 
     #[test]
-    fn load_hf_provenance_manifest_rejects_v6_missing_onnx_graph_constraint_identity_field() {
+    fn load_hf_provenance_manifest_rejects_v7_missing_onnx_graph_constraint_identity_field() {
         let file = hf_provenance_test_manifest_file("missing-onnx-graph-constraint-identity");
         let mut value = sample_hf_provenance_manifest_value();
         value["onnx_export"] = serde_json::json!({
@@ -8934,14 +9298,14 @@ mod hf_provenance_manifest_tests {
         write_hf_provenance_test_manifest(file.path(), &value);
 
         let err = load_hf_provenance_manifest(file.path())
-            .expect_err("v6 manifest missing onnx graph_constraint_identity field should fail");
+            .expect_err("v7 manifest missing onnx graph_constraint_identity field should fail");
         assert!(err
             .to_string()
             .contains("missing field `graph_constraint_identity`"));
     }
 
     #[test]
-    fn load_hf_provenance_manifest_rejects_v6_missing_onnx_metadata_identity_hash_field() {
+    fn load_hf_provenance_manifest_rejects_v7_missing_onnx_metadata_identity_hash_field() {
         let file = hf_provenance_test_manifest_file("missing-onnx-metadata-identity-hash");
         let mut value = sample_hf_provenance_manifest_value();
         value["onnx_export"] = serde_json::json!({
@@ -8970,14 +9334,14 @@ mod hf_provenance_manifest_tests {
         write_hf_provenance_test_manifest(file.path(), &value);
 
         let err = load_hf_provenance_manifest(file.path())
-            .expect_err("v6 manifest missing onnx_metadata_identity_hash field should fail");
+            .expect_err("v7 manifest missing onnx_metadata_identity_hash field should fail");
         assert!(err
             .to_string()
             .contains("missing field `onnx_metadata_identity_hash`"));
     }
 
     #[test]
-    fn load_hf_provenance_manifest_rejects_v6_missing_onnx_exporter_identity_hash_field() {
+    fn load_hf_provenance_manifest_rejects_v7_missing_onnx_exporter_identity_hash_field() {
         let file = hf_provenance_test_manifest_file("missing-onnx-exporter-identity-hash");
         let mut value = sample_hf_provenance_manifest_value();
         value["onnx_export"] = serde_json::json!({
@@ -9006,14 +9370,14 @@ mod hf_provenance_manifest_tests {
         write_hf_provenance_test_manifest(file.path(), &value);
 
         let err = load_hf_provenance_manifest(file.path())
-            .expect_err("v6 manifest missing onnx_exporter_identity_hash field should fail");
+            .expect_err("v7 manifest missing onnx_exporter_identity_hash field should fail");
         assert!(err
             .to_string()
             .contains("missing field `onnx_exporter_identity_hash`"));
     }
 
     #[test]
-    fn load_hf_provenance_manifest_rejects_v6_missing_onnx_graph_constraint_identity_hash_field() {
+    fn load_hf_provenance_manifest_rejects_v7_missing_onnx_graph_constraint_identity_hash_field() {
         let file =
             hf_provenance_test_manifest_file("missing-onnx-graph-constraint-identity-hash");
         let mut value = sample_hf_provenance_manifest_value();
@@ -9043,10 +9407,44 @@ mod hf_provenance_manifest_tests {
         write_hf_provenance_test_manifest(file.path(), &value);
 
         let err = load_hf_provenance_manifest(file.path())
-            .expect_err("v6 manifest missing onnx_graph_constraint_identity_hash field should fail");
+            .expect_err("v7 manifest missing onnx_graph_constraint_identity_hash field should fail");
         assert!(err
             .to_string()
             .contains("missing field `onnx_graph_constraint_identity_hash`"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_v7_missing_external_attestation_field() {
+        let file = hf_provenance_test_manifest_file("missing-external-attestation");
+        let mut value = sample_hf_provenance_manifest_value();
+        value
+            .as_object_mut()
+            .expect("manifest object")
+            .remove("external_attestation");
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("v7 manifest missing external_attestation field should fail");
+        assert!(err
+            .to_string()
+            .contains("missing field `external_attestation`"));
+    }
+
+    #[test]
+    fn load_hf_provenance_manifest_rejects_v7_missing_external_attestation_hash_field() {
+        let file = hf_provenance_test_manifest_file("missing-external-attestation-hash");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["commitments"]
+            .as_object_mut()
+            .expect("commitments object")
+            .remove("external_attestation_hash");
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("v7 manifest missing external_attestation_hash should fail");
+        assert!(err
+            .to_string()
+            .contains("missing field `external_attestation_hash`"));
     }
 
     #[test]
@@ -9146,6 +9544,20 @@ mod hf_provenance_manifest_tests {
     }
 
     #[test]
+    fn load_hf_provenance_manifest_rejects_legacy_v6_with_upgrade_message() {
+        let file = hf_provenance_test_manifest_file("legacy-v6");
+        let mut value = sample_hf_provenance_manifest_value();
+        value["manifest_version"] = serde_json::json!(HF_PROVENANCE_MANIFEST_VERSION_V6_LEGACY);
+        write_hf_provenance_test_manifest(file.path(), &value);
+
+        let err = load_hf_provenance_manifest(file.path())
+            .expect_err("legacy v6 manifest should require regeneration");
+        assert!(err
+            .to_string()
+            .contains("legacy manifest_version `hf-provenance-manifest-v6` is no longer accepted"));
+    }
+
+    #[test]
     fn load_hf_provenance_manifest_reports_malformed_json_as_serialization() {
         let file = hf_provenance_test_manifest_file("malformed");
         fs::write(file.path(), b"{").expect("write malformed manifest");
@@ -9211,6 +9623,7 @@ mod hf_provenance_manifest_tests {
             attestation_build_invocation_id: None,
             attestation_source_repository: None,
             attestation_source_revision: None,
+            external_attestation_statement: None,
         })
         .expect_err("oversized manifest output should fail");
 
@@ -9297,8 +9710,9 @@ mod hf_provenance_manifest_tests {
                     role: "model_card".to_string(),
                     path: bound_dir.display().to_string(),
                     sha256: "1".repeat(64),
-                }],
-            }),
+                    }],
+                }),
+            external_attestation: None,
             limitations,
             commitments: HfProvenanceCommitments {
                 hub_binding_hash: hash_json_projection_hex(&HfHubBinding {
@@ -9357,6 +9771,7 @@ mod hf_provenance_manifest_tests {
                     }],
                 }))
                 .expect("attestation hash"),
+                external_attestation_hash: default_hf_external_attestation_hash(),
                 limitations_hash: hash_json_projection_hex(&hf_provenance_limitations())
                     .expect("limitations hash"),
             },
@@ -9397,6 +9812,7 @@ mod hf_provenance_manifest_tests {
             attestation_build_invocation_id: None,
             attestation_source_repository: None,
             attestation_source_revision: None,
+            external_attestation_statement: None,
         })
         .expect_err("ONNX sidecars without graph should fail");
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -9,6 +9,7 @@ use flate2::GzBuilder;
 #[cfg(any(feature = "onnx-export", feature = "stwo-backend"))]
 use jsonschema::{Draft, JSONSchema};
 use predicates::prelude::*;
+use sha2::{Digest, Sha256};
 #[cfg(feature = "stwo-backend")]
 use std::io::Write;
 #[cfg(feature = "stwo-backend")]
@@ -552,6 +553,65 @@ fn assert_research_v2_spec_commitments(
 
 fn hash_json_value(value: &serde_json::Value) -> String {
     blake2b_256_hex(&serde_json::to_vec(value).expect("json hash payload"))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    Digest::update(&mut hasher, bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn write_hf_external_attestation_statement(
+    path: &std::path::Path,
+    subject_paths: &[&std::path::Path],
+    builder_id: Option<&str>,
+    build_invocation_id: Option<&str>,
+) {
+    let subjects = subject_paths
+        .iter()
+        .map(|subject_path| {
+            let bytes = std::fs::read(subject_path).expect("read attestation subject");
+            serde_json::json!({
+                "name": subject_path.display().to_string(),
+                "digest": {
+                    "sha256": sha256_hex(&bytes),
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let mut predicate = serde_json::Map::new();
+    let mut run_details = serde_json::Map::new();
+    if let Some(builder_id) = builder_id {
+        run_details.insert(
+            "builder".to_string(),
+            serde_json::json!({ "id": builder_id }),
+        );
+    }
+    if let Some(build_invocation_id) = build_invocation_id {
+        run_details.insert(
+            "metadata".to_string(),
+            serde_json::json!({ "invocationId": build_invocation_id }),
+        );
+    }
+    if !run_details.is_empty() {
+        predicate.insert(
+            "runDetails".to_string(),
+            serde_json::Value::Object(run_details),
+        );
+    }
+
+    let statement = serde_json::json!({
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": subjects,
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "predicate": serde_json::Value::Object(predicate),
+    });
+    std::fs::write(
+        path,
+        serde_json::to_vec_pretty(&statement).expect("serialize attestation statement"),
+    )
+    .expect("write attestation statement");
 }
 
 #[cfg(all(feature = "burn-model", feature = "onnx-export"))]
@@ -5189,6 +5249,7 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
     let safetensors = fixture_dir.join("model.safetensors");
     let onnx_model = fixture_dir.join("model.onnx");
     let model_card = fixture_dir.join("README.md");
+    let attestation_statement = fixture_dir.join("release.attestation.json");
     let manifest = fixture_dir.join("hf-provenance.json");
 
     std::fs::write(
@@ -5215,6 +5276,19 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
         "# HF provenance fixture\n\nPinned for CLI manifest tests.\n",
     )
     .expect("write model card");
+    write_hf_external_attestation_statement(
+        &attestation_statement,
+        &[
+            tokenizer_json.as_path(),
+            tokenizer_config.as_path(),
+            transcript.as_path(),
+            safetensors.as_path(),
+            onnx_model.as_path(),
+            model_card.as_path(),
+        ],
+        Some("https://github.com/example/workflows/release.yml@refs/tags/v1"),
+        Some("build-123"),
+    );
 
     let mut prepare = tvm_command();
     prepare
@@ -5255,6 +5329,8 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
         .arg("omarespejel/provable-transformer-vm")
         .arg("--attestation-source-revision")
         .arg("45706ff0776fd2e5a36b22b4c3cb85533d0676c6")
+        .arg("--external-attestation-statement")
+        .arg(&attestation_statement)
         .assert()
         .success()
         .stdout(predicate::str::contains("hf_provenance_manifest:"))
@@ -5270,7 +5346,7 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
         manifest_json
             .get("manifest_version")
             .and_then(serde_json::Value::as_str),
-        Some("hf-provenance-manifest-v6")
+        Some("hf-provenance-manifest-v7")
     );
     assert_eq!(
         manifest_json["attestation"]["attestation_version"].as_str(),
@@ -5327,6 +5403,26 @@ fn cli_can_prepare_and_verify_hf_provenance_manifest() {
                 digest.len() == 64 && digest.chars().all(|c| c.is_ascii_hexdigit())
             }),
         "commitments.attestation_hash must be hex",
+    );
+    assert!(
+        manifest_json["commitments"]["external_attestation_hash"]
+            .as_str()
+            .is_some_and(|digest| {
+                digest.len() == 64 && digest.chars().all(|c| c.is_ascii_hexdigit())
+            }),
+        "commitments.external_attestation_hash must be hex",
+    );
+    assert_eq!(
+        manifest_json["external_attestation"]["identity"]["identity_version"].as_str(),
+        Some("hf-external-attestation-identity-v1")
+    );
+    assert_eq!(
+        manifest_json["external_attestation"]["identity"]["builder_id"].as_str(),
+        Some("https://github.com/example/workflows/release.yml@refs/tags/v1")
+    );
+    assert_eq!(
+        manifest_json["external_attestation"]["identity"]["build_invocation_id"].as_str(),
+        Some("build-123")
     );
     assert!(manifest_json["onnx_export"]["metadata_identity"].is_null());
     assert_eq!(
@@ -6157,6 +6253,171 @@ fn cli_verifier_rejects_tampered_hf_attestation_subjects() {
         .failure()
         .stderr(predicate::str::contains(
             "HF provenance attestation.subjects do not match the bound local-file surface",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_tampered_hf_external_attestation_hash() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-external-attestation-hash-tamper");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let tokenizer_json = fixture_dir.join("tokenizer.json");
+    let statement = fixture_dir.join("release.attestation.json");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(
+        &tokenizer_json,
+        br#"{"version":"1.0","model":{"type":"WordPiece","unk_token":"[UNK]"}}"#,
+    )
+    .expect("write tokenizer json");
+    write_hf_external_attestation_statement(
+        &statement,
+        &[tokenizer_json.as_path()],
+        Some("https://github.com/example/workflows/release.yml@refs/tags/v1"),
+        Some("build-123"),
+    );
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&tokenizer_json)
+        .arg("--external-attestation-statement")
+        .arg(&statement)
+        .assert()
+        .success();
+
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest).expect("manifest bytes"))
+            .expect("manifest json");
+    manifest_json["commitments"]["external_attestation_hash"] = serde_json::json!("0".repeat(64));
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec_pretty(&manifest_json).expect("serialize tampered manifest"),
+    )
+    .expect("write tampered manifest");
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "hf external_attestation_hash commitment mismatch",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_verifier_rejects_tampered_hf_external_attestation_statement() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-external-attestation-statement-tamper");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let tokenizer_json = fixture_dir.join("tokenizer.json");
+    let statement = fixture_dir.join("release.attestation.json");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(
+        &tokenizer_json,
+        br#"{"version":"1.0","model":{"type":"WordPiece","unk_token":"[UNK]"}}"#,
+    )
+    .expect("write tokenizer json");
+    write_hf_external_attestation_statement(
+        &statement,
+        &[tokenizer_json.as_path()],
+        Some("https://github.com/example/workflows/release.yml@refs/tags/v1"),
+        Some("build-123"),
+    );
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&tokenizer_json)
+        .arg("--external-attestation-statement")
+        .arg(&statement)
+        .assert()
+        .success();
+
+    write_hf_external_attestation_statement(
+        &statement,
+        &[tokenizer_json.as_path()],
+        Some("https://github.com/example/workflows/release.yml@refs/tags/v2"),
+        Some("build-123"),
+    );
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-hf-provenance-manifest")
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "HF provenance external_attestation.statement blake2b_256 commitment mismatch",
+        ));
+
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+#[test]
+fn cli_prepare_rejects_hf_external_attestation_builder_mismatch() {
+    let fixture_dir = unique_temp_dir("cli-hf-provenance-external-attestation-builder-mismatch");
+    std::fs::create_dir_all(&fixture_dir).expect("create HF provenance fixture dir");
+    let tokenizer_json = fixture_dir.join("tokenizer.json");
+    let statement = fixture_dir.join("release.attestation.json");
+    let manifest = fixture_dir.join("hf-provenance.json");
+
+    std::fs::write(
+        &tokenizer_json,
+        br#"{"version":"1.0","model":{"type":"WordPiece","unk_token":"[UNK]"}}"#,
+    )
+    .expect("write tokenizer json");
+    write_hf_external_attestation_statement(
+        &statement,
+        &[tokenizer_json.as_path()],
+        Some("https://github.com/example/workflows/release.yml@refs/tags/v1"),
+        Some("build-123"),
+    );
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-hf-provenance-manifest")
+        .arg("-o")
+        .arg(&manifest)
+        .arg("--hub-repo")
+        .arg("example/test-model")
+        .arg("--hub-revision")
+        .arg("0123456789abcdef")
+        .arg("--tokenizer-id")
+        .arg("example/test-model")
+        .arg("--tokenizer-json")
+        .arg(&tokenizer_json)
+        .arg("--attestation-builder-id")
+        .arg("https://github.com/example/workflows/release.yml@refs/tags/v9")
+        .arg("--external-attestation-statement")
+        .arg(&statement)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "hf external_attestation.identity.builder_id mismatch",
         ));
 
     let _ = std::fs::remove_dir_all(fixture_dir);


### PR DESCRIPTION
## Summary
- bump HF provenance manifests to v7 and add optional external attestation statement binding
- verify a narrow in-toto/SLSA-style statement projection against the bound local file surface
- document that this is still release-layer provenance, not signed attestation verification

## Local validation
- cargo test -q --features full --bin tvm hf_provenance_manifest_tests::
- cargo build -q --features full --bin tvm
- cargo test -q --features full --test cli cli_can_prepare_and_verify_hf_provenance_manifest -- --exact
- cargo test -q --features full --test cli cli_verifier_rejects_tampered_hf_external_attestation_hash -- --exact
- cargo test -q --features full --test cli cli_verifier_rejects_tampered_hf_external_attestation_statement -- --exact
- cargo test -q --features full --test cli cli_prepare_rejects_hf_external_attestation_builder_mismatch -- --exact
- cargo test -q --features full --test cli cli_verifier_rejects_tampered_hf_attestation_subjects -- --exact
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for binding external in-toto/SLSA-style attestation statements to provenance manifests via a new CLI parameter.
  * Narrow identity projection capability for external statements covering statement type, predicate type, builder, build invocation, and subject inventory.

* **Documentation**
  * Updated CLI examples and provenance manifest specifications to reflect new external attestation binding semantics.
  * Clarified that external statement binding does not verify signature or trust-chain validity.

* **Tests**
  * Expanded test coverage for external attestation integration, including tamper detection and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->