### PR TITLE
[codex] Harden Phase 36 verifier harness boundaries

### DIFF
--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -4505,4 +4505,70 @@ mod tests {
         assert!(matches!(err, VmError::InvalidConfig(_)));
         assert!(err.to_string().contains("unknown field"));
     }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase36_parse_recursive_verifier_harness_receipt_reports_malformed_json_as_invalid_config() {
+        let err = parse_phase36_recursive_verifier_harness_receipt_json("{")
+            .expect_err("malformed Phase 36 receipt JSON must fail");
+        assert!(
+            matches!(err, VmError::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase36_parse_recursive_verifier_harness_receipt_rejects_oversized_json() {
+        let json = " ".repeat(MAX_PHASE36_RECURSIVE_VERIFIER_HARNESS_RECEIPT_JSON_BYTES + 1);
+        let err = parse_phase36_recursive_verifier_harness_receipt_json(&json)
+            .expect_err("oversized Phase 36 receipt JSON must fail before serde parsing");
+        assert!(
+            matches!(err, VmError::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+        assert!(err.to_string().contains("exceeding the limit"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase36_load_recursive_verifier_harness_receipt_rejects_oversized_file() {
+        let path = std::env::temp_dir().join(format!(
+            "phase36-recursive-verifier-harness-receipt-oversized-{}.json",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            vec![b'x'; MAX_PHASE36_RECURSIVE_VERIFIER_HARNESS_RECEIPT_JSON_BYTES + 1],
+        )
+        .expect("write oversized Phase 36 receipt");
+
+        let err = load_phase36_recursive_verifier_harness_receipt(&path)
+            .expect_err("oversized Phase 36 receipt should fail");
+        assert!(
+            matches!(err, VmError::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+        assert!(err.to_string().contains("exceeding the limit"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase36_load_recursive_verifier_harness_receipt_rejects_non_regular_file() {
+        let path = std::env::temp_dir().join(format!(
+            "phase36-recursive-verifier-harness-receipt-dir-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&path).expect("create Phase 36 receipt test dir");
+
+        let err = load_phase36_recursive_verifier_harness_receipt(&path)
+            .expect_err("directory path should fail");
+        assert!(
+            matches!(err, VmError::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+        assert!(err.to_string().contains("is not a regular file"));
+        let _ = std::fs::remove_dir_all(path);
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6793,6 +6793,86 @@ fn cli_verify_stwo_recursive_verifier_harness_receipt_rejects_source_drift() {
 
 #[test]
 #[cfg(feature = "stwo-backend")]
+fn cli_prepare_stwo_recursive_verifier_harness_receipt_rejects_gzip_output_path() {
+    let target_path = unique_temp_dir("cli-stwo-recursive-verifier-harness-receipt-gzip-target")
+        .with_extension("json");
+    let statement_contract_path =
+        unique_temp_dir("cli-stwo-recursive-verifier-harness-receipt-gzip-statement")
+            .with_extension("json");
+    let public_inputs_path =
+        unique_temp_dir("cli-stwo-recursive-verifier-harness-receipt-gzip-public")
+            .with_extension("json");
+    let shared_lookup_path =
+        unique_temp_dir("cli-stwo-recursive-verifier-harness-receipt-gzip-shared")
+            .with_extension("json");
+    let output_path = unique_temp_dir("cli-stwo-recursive-verifier-harness-receipt-gzip-output")
+        .with_extension("json.gz");
+
+    let mut prepare = tvm_command();
+    prepare
+        .arg("prepare-stwo-recursive-verifier-harness-receipt")
+        .arg("--target")
+        .arg(&target_path)
+        .arg("--statement-contract")
+        .arg(&statement_contract_path)
+        .arg("--public-inputs")
+        .arg(&public_inputs_path)
+        .arg("--shared-lookup")
+        .arg(&shared_lookup_path)
+        .arg("-o")
+        .arg(&output_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "writes plain JSON; use a `.json` output path",
+        ));
+}
+
+#[test]
+#[cfg(feature = "stwo-backend")]
+fn cli_verify_stwo_recursive_verifier_harness_receipt_requires_all_source_args() {
+    let fixture = prepare_phase35_recursive_compression_cli_fixture(
+        "cli-stwo-recursive-verifier-harness-receipt-partial-source",
+    );
+    let phase36_path =
+        unique_temp_dir("cli-stwo-recursive-verifier-harness-receipt-partial-phase36")
+            .with_extension("json");
+
+    let mut prepare_phase36 = tvm_command();
+    prepare_phase36
+        .arg("prepare-stwo-recursive-verifier-harness-receipt")
+        .arg("--target")
+        .arg(&fixture.phase35_path)
+        .arg("--statement-contract")
+        .arg(&fixture.phase32_path)
+        .arg("--public-inputs")
+        .arg(&fixture.phase33_path)
+        .arg("--shared-lookup")
+        .arg(&fixture.phase34_path)
+        .arg("-o")
+        .arg(&phase36_path)
+        .assert()
+        .success();
+
+    let mut verify = tvm_command();
+    verify
+        .arg("verify-stwo-recursive-verifier-harness-receipt")
+        .arg("--input")
+        .arg(&phase36_path)
+        .arg("--target")
+        .arg(&fixture.phase35_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "requires either all of --target, --statement-contract, --public-inputs, and --shared-lookup or none",
+        ));
+
+    fixture.cleanup();
+    let _ = std::fs::remove_file(phase36_path);
+}
+
+#[test]
+#[cfg(feature = "stwo-backend")]
 fn cli_prepare_stwo_recursive_compression_input_contract_rejects_gzip_output_path() {
     let phase28_path = unique_temp_dir("cli-stwo-recursive-compression-input-missing-phase28")
         .with_extension("json");


### PR DESCRIPTION
## Summary
- add focused Phase 36 verifier harness receipt parser/load hardening tests
- add CLI tests for `.json.gz` output rejection and all-or-none source binding args
- keep the change scoped to boundary coverage only; no new proof claims or runtime behavior changes

## Validation
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/Users/espejelomar/.codex-targets/ptv-paper-next CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' cargo +nightly-2025-07-14 test -q --features stwo-backend phase36`
- `TVM_TEST_BINARY=/Users/espejelomar/.codex-targets/ptv-paper-next/debug/tvm CARGO_TARGET_DIR=/Users/espejelomar/.codex-targets/ptv-paper-next CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' cargo +nightly-2025-07-14 test -q --features 'full stwo-backend' --test cli cli_prepare_stwo_recursive_verifier_harness_receipt_rejects_gzip_output_path -- --exact`
- `TVM_TEST_BINARY=/Users/espejelomar/.codex-targets/ptv-paper-next/debug/tvm CARGO_TARGET_DIR=/Users/espejelomar/.codex-targets/ptv-paper-next CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' cargo +nightly-2025-07-14 test -q --features 'full stwo-backend' --test cli cli_verify_stwo_recursive_verifier_harness_receipt_requires_all_source_args -- --exact`
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `git diff --check`

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Notes:
- Oracle/differential: not applicable beyond existing source-bound recomputation path; this PR adds boundary tests around it.
- Resource-bound: oversized JSON and non-regular-file rejection are now covered for Phase 36 receipt loading.
- Kani/formal kernel: no formal-kernel changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added comprehensive test coverage for Phase 36 recursive verifier receipt validation, including handling of malformed JSON inputs, detection of oversized data exceeding system limits, and validation of proper file paths.
* Introduced new CLI tests to verify correct behavior of receipt preparation and verification command pairs, with emphasis on argument validation and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->