### PR TITLE
[codex] Harden Phase 37 receipt commitment formats

### DIFF
--- a/scripts/hardening_test_names.sh
+++ b/scripts/hardening_test_names.sh
@@ -135,6 +135,7 @@ hardening_stwo_test_filters=(
   "stwo_backend::recursion::tests::phase37_recursive_artifact_chain_harness_receipt_accepts_matching_sources"
   "stwo_backend::recursion::tests::phase37_recursive_artifact_chain_harness_receipt_rejects_recursive_claim"
   "stwo_backend::recursion::tests::phase37_recursive_artifact_chain_harness_receipt_rejects_tampered_commitment"
+  "stwo_backend::recursion::tests::phase37_recursive_artifact_chain_harness_receipt_rejects_malformed_commitment_field"
   "stwo_backend::recursion::tests::phase37_recursive_artifact_chain_harness_receipt_deserialization_verifies_receipt"
   "stwo_backend::recursion::tests::phase37_recursive_artifact_chain_harness_receipt_parse_rejects_unknown_fields"
   "stwo_backend::recursion::tests::phase37_parse_recursive_artifact_chain_harness_receipt_reports_malformed_json_as_invalid_config"

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -1454,6 +1454,20 @@ fn phase29_lower_hex(bytes: &[u8]) -> String {
 }
 
 #[cfg(feature = "stwo-backend")]
+fn phase37_require_hash32(label: &str, value: &str) -> Result<()> {
+    let is_hash32 = value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'));
+    if !is_hash32 {
+        return Err(VmError::InvalidConfig(format!(
+            "Phase 37 recursive artifact-chain harness receipt `{label}` must be a 32-byte lowercase hex commitment"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "stwo-backend")]
 pub fn phase31_prepare_recursive_compression_decode_boundary_manifest(
     contract: &Phase29RecursiveCompressionInputContract,
     phase30: &Phase30DecodingStepProofEnvelopeManifest,
@@ -3304,11 +3318,7 @@ pub fn verify_phase37_recursive_artifact_chain_harness_receipt(
                 .as_str(),
         ),
     ] {
-        if value.is_empty() {
-            return Err(VmError::InvalidConfig(format!(
-                "Phase 37 recursive artifact-chain harness receipt `{label}` must be non-empty"
-            )));
-        }
+        phase37_require_hash32(label, value)?;
     }
 
     let expected = commit_phase37_recursive_artifact_chain_harness_receipt(receipt)?;
@@ -4275,10 +4285,10 @@ mod tests {
             total_steps: 32,
             lookup_delta_entries: 12,
             max_lookup_frontier_entries: 4,
-            source_template_commitment: "phase28-source-template".to_string(),
+            source_template_commitment: "a".repeat(64),
             global_start_state_commitment: "phase28-start".to_string(),
             global_end_state_commitment: "phase28-end".to_string(),
-            aggregation_template_commitment: "phase28-aggregation-template".to_string(),
+            aggregation_template_commitment: "b".repeat(64),
             aggregated_chained_folded_interval_accumulator_commitment:
                 "phase28-aggregate-accumulator".to_string(),
             input_contract_commitment: String::new(),
@@ -5340,6 +5350,23 @@ mod tests {
         let err = verify_phase37_recursive_artifact_chain_harness_receipt(&receipt)
             .expect_err("tampered phase37 receipt must fail");
         assert!(err.to_string().contains("does not match recomputed"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase37_recursive_artifact_chain_harness_receipt_rejects_malformed_commitment_field() {
+        let mut receipt = sample_phase37_receipt();
+        receipt.phase35_recursive_target_manifest_commitment = "not-a-hash".to_string();
+        receipt.recursive_artifact_chain_harness_receipt_commitment =
+            commit_phase37_recursive_artifact_chain_harness_receipt(&receipt)
+                .expect("recommit malformed phase37 receipt");
+
+        let err = verify_phase37_recursive_artifact_chain_harness_receipt(&receipt)
+            .expect_err("self-consistent malformed phase37 receipt must fail");
+        assert!(err
+            .to_string()
+            .contains("phase35_recursive_target_manifest_commitment"));
+        assert!(err.to_string().contains("32-byte lowercase hex"));
     }
 
     #[cfg(feature = "stwo-backend")]


### PR DESCRIPTION
## Summary

- tighten the Phase 37 recursive artifact-chain harness receipt verifier so every recorded commitment must be a 32-byte lowercase hex value
- add a regression test proving a self-consistent but malformed receipt is rejected before it can be treated as valid operational evidence
- add that regression to the local hardening test list

## Validation

- `cargo fmt --all`
- `bash -n scripts/hardening_test_names.sh scripts/local_merge_gate.sh`
- `CARGO_TARGET_DIR=/Users/espejelomar/.codex-targets/ptv-paper-next CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' cargo +nightly-2025-07-14 test -q --features stwo-backend phase37`
- `CARGO_TARGET_DIR=/Users/espejelomar/.codex-targets/ptv-paper-next CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' cargo +nightly-2025-07-14 build -q --features 'full stwo-backend' --bin tvm`
- `TVM_TEST_BINARY=/Users/espejelomar/.codex-targets/ptv-paper-next/debug/tvm CARGO_TARGET_DIR=/Users/espejelomar/.codex-targets/ptv-paper-next CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' cargo +nightly-2025-07-14 test -q --features 'full stwo-backend' --test cli stwo_recursive_artifact_chain -- --nocapture`
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `git diff --check`

## Hardening

- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Notes:

- Targeted regression: added a Phase 37 test for a self-consistent receipt with a malformed inner commitment field.
- Oracle/differential: existing source recomputation and schema-backed CLI tests still cover the source-vs-receipt path.
- Resource-bound/untrusted input: this tightens untrusted JSON receipt validation before accepting standalone receipts.
- Kani/formal-kernel: not applicable; no formal-kernel or Kani surface changed.
- No recursive-verification or cryptographic-compression claim is added.
- No full CI, benchmarks, or long hardening suite was run locally.
