### PR TITLE
[codex] Add Phase 37 malformed receipt smoke to local gate

### DIFF
--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -384,6 +384,7 @@ stwo_smoke_targets=(
   "stwo_backend::decoding::tests::phase30_step_envelope_manifest_rejects_step_index_drift"
   "stwo_backend::recursion::tests::phase29_recursive_compression_input_contract_rejects_tampered_commitment"
   "stwo_backend::recursion::tests::phase37_recursive_artifact_chain_harness_receipt_rejects_tampered_commitment"
+  "stwo_backend::recursion::tests::phase37_recursive_artifact_chain_harness_receipt_rejects_malformed_commitment_field"
 )
 onnx_smoke_targets=(
   "onnx_export::tests::load_onnx_program_metadata_rejects_wrong_format_version"


### PR DESCRIPTION
## Summary

- add the Phase 37 malformed-commitment regression to the local merge gate `stwo` smoke target list
- keep the heavy harness gate aligned with the new receipt-boundary hardening from PR #151

## Validation

- `bash -n scripts/local_merge_gate.sh scripts/hardening_test_names.sh`
- `CARGO_TARGET_DIR=/Users/espejelomar/.codex-targets/ptv-paper-next CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' cargo +nightly-2025-07-14 test -q --features stwo-backend phase37_recursive_artifact_chain_harness_receipt_rejects_malformed_commitment_field`
- `git diff --check`

## Hardening

- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Notes:

- Targeted regression: local merge gate now smokes the Phase 37 malformed inner-commitment regression.
- Oracle/differential: not applicable; this is gate wiring only.
- Resource-bound/untrusted input: keeps malformed receipt input coverage in the local trusted-core smoke set.
- Kani/formal-kernel: not applicable; no formal-kernel or Kani surface changed.
- No full CI, benchmarks, or long hardening suite was run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded recursion smoke test coverage to improve quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->