### PR TITLE
[codex] Add paper 2 claim evidence preflight

### DIFF
--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -7,6 +7,7 @@ Contents:
 - `design/`: implementation and artifact-line design notes
 - `design/engineering-timeline.md`: detailed internal phase chronology moved out of the public README
 - `hardening-policy.md`: local CI, hardening, and merge-gate policy
+- `paper2-claim-evidence.yml`: machine-readable claim-to-evidence ledger enforced by paper preflight
 - `paper2-roadmap.md`: engineering roadmap for bounded paper-2 implementation hardening and provenance/reproducibility work
 - `reproducibility.md`: broader engineering reproducibility guidance, including non-paper artifact flows
 

--- a/docs/engineering/paper2-claim-evidence.yml
+++ b/docs/engineering/paper2-claim-evidence.yml
@@ -1,0 +1,242 @@
+# Machine-readable evidence ledger for the bounded paper-2 claim surface.
+# This file is intentionally small and strict. `scripts/paper/paper_preflight.py`
+# validates that each paper-facing claim has implementation, spec/schema,
+# positive-test, negative-test, evidence-command, and non-claim anchors.
+
+- id: phase29_recursive_input_contract
+  claim: "Phase 29 defines a recursive-adjacent input contract derived from a verified pre-recursive aggregate."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+  implementation:
+    - src/stwo_backend/recursion.rs:phase29_prepare_recursive_compression_input_contract
+    - src/stwo_backend/recursion.rs:verify_phase29_recursive_compression_input_contract
+  specs:
+    - docs/engineering/design/phase29-recursive-compression-input-contract-spec.md
+  positive_tests:
+    - phase29_recursive_compression_input_contract_accepts_committed_shape
+  negative_tests:
+    - phase29_recursive_compression_input_contract_rejects_recursive_claim
+    - phase29_recursive_compression_input_contract_rejects_tampered_commitment
+    - phase29_recursive_compression_input_contract_parse_rejects_unknown_fields
+  evidence_commands:
+    - cargo +nightly-2025-07-14 test -q --features stwo-backend phase29_recursive_compression_input_contract
+  non_claims:
+    - "Does not claim recursive proof verification."
+    - "Does not claim cryptographic compression."
+
+- id: phase30_step_envelope_manifest
+  claim: "Phase 30 binds ordered decode-step envelopes, source-chain commitment, and chain boundary commitments."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+  implementation:
+    - src/stwo_backend/decoding.rs:phase30_prepare_decoding_step_proof_envelope_manifest
+    - src/stwo_backend/decoding.rs:verify_phase30_decoding_step_proof_envelope_manifest
+  specs:
+    - spec/stwo-phase30-decoding-step-envelope-manifest.schema.json
+  positive_tests:
+    - phase30_step_envelope_manifest_binds_phase12_chain_boundaries
+  negative_tests:
+    - phase30_step_envelope_manifest_rejects_tampered_start_boundary
+    - phase30_step_envelope_manifest_rejects_step_index_drift
+    - phase30_parse_manifest_rejects_unknown_top_level_fields
+  evidence_commands:
+    - cargo +nightly-2025-07-14 test -q --features stwo-backend phase30_step_envelope_manifest
+  non_claims:
+    - "Does not claim recursive proof closure."
+    - "Does not claim full model-inference proving."
+
+- id: phase31_decode_boundary_bridge
+  claim: "Phase 31 bridges the Phase 29 input contract and Phase 30 envelope manifest without changing the public decode statement."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+  implementation:
+    - src/stwo_backend/recursion.rs:phase31_prepare_recursive_compression_decode_boundary_manifest
+    - src/stwo_backend/recursion.rs:verify_phase31_recursive_compression_decode_boundary_manifest_against_sources
+  specs:
+    - spec/stwo-phase31-recursive-compression-decode-boundary-manifest.schema.json
+  positive_tests:
+    - phase31_decode_boundary_manifest_accepts_matching_phase29_and_phase30_sources
+  negative_tests:
+    - phase31_decode_boundary_manifest_rejects_step_count_mismatch
+    - phase31_decode_boundary_manifest_rejects_boundary_mismatch
+    - phase31_decode_boundary_manifest_parse_rejects_unknown_fields
+  evidence_commands:
+    - cargo +nightly-2025-07-14 test -q --features stwo-backend phase31
+  non_claims:
+    - "Does not claim recursive proof closure."
+    - "Does not invent a new recursive statement surface."
+
+- id: phase32_recursive_statement_contract
+  claim: "Phase 32 restates the bridged decode boundary as a future recursive target statement contract."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+  implementation:
+    - src/stwo_backend/recursion.rs:phase32_prepare_recursive_compression_statement_contract
+    - src/stwo_backend/recursion.rs:verify_phase32_recursive_compression_statement_contract_against_phase31
+  specs:
+    - spec/stwo-phase32-recursive-compression-statement-contract.schema.json
+  positive_tests:
+    - phase32_recursive_statement_contract_accepts_matching_phase31_source
+  negative_tests:
+    - phase32_recursive_statement_contract_rejects_tampered_commitment
+    - phase32_recursive_statement_contract_parse_rejects_unknown_fields
+  evidence_commands:
+    - cargo +nightly-2025-07-14 test -q --features stwo-backend phase32
+  non_claims:
+    - "Does not claim recursive proof closure."
+    - "Does not prove semantic equivalence across runtimes."
+
+- id: phase33_public_input_manifest
+  claim: "Phase 33 freezes the ordered public-input surface that future recursion must preserve."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+  implementation:
+    - src/stwo_backend/recursion.rs:phase33_prepare_recursive_compression_public_input_manifest
+    - src/stwo_backend/recursion.rs:verify_phase33_recursive_compression_public_input_manifest_against_phase32
+  specs:
+    - spec/stwo-phase33-recursive-compression-public-input-manifest.schema.json
+  positive_tests:
+    - phase33_recursive_public_input_manifest_accepts_matching_phase32_source
+  negative_tests:
+    - phase33_recursive_public_input_manifest_rejects_tampered_commitment
+    - phase33_recursive_public_input_manifest_parse_rejects_unknown_fields
+  evidence_commands:
+    - cargo +nightly-2025-07-14 test -q --features stwo-backend phase33
+  non_claims:
+    - "Does not claim recursive proof closure."
+    - "Does not claim a complete recursive verifier."
+
+- id: phase34_shared_lookup_manifest
+  claim: "Phase 34 freezes the ordered lookup-facing public inputs derived from Phase 33 and Phase 30."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+  implementation:
+    - src/stwo_backend/recursion.rs:phase34_prepare_recursive_compression_shared_lookup_manifest
+    - src/stwo_backend/recursion.rs:verify_phase34_recursive_compression_shared_lookup_manifest_against_sources
+  specs:
+    - spec/stwo-phase34-recursive-compression-shared-lookup-manifest.schema.json
+  positive_tests:
+    - phase34_recursive_shared_lookup_manifest_accepts_matching_phase33_and_phase30_sources
+  negative_tests:
+    - phase34_recursive_shared_lookup_manifest_rejects_tampered_commitment
+    - phase34_recursive_shared_lookup_manifest_parse_rejects_unknown_fields
+  evidence_commands:
+    - cargo +nightly-2025-07-14 test -q --features stwo-backend phase34
+  non_claims:
+    - "Does not claim recursive shared-table accumulation as a compressed proof."
+    - "Does not claim recursive proof closure."
+
+- id: phase35_recursive_target_manifest
+  claim: "Phase 35 binds the Phase 32 statement, Phase 33 public inputs, and Phase 34 lookup inputs into one canonical recursive target manifest."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+  implementation:
+    - src/stwo_backend/recursion.rs:phase35_prepare_recursive_compression_target_manifest
+    - src/stwo_backend/recursion.rs:verify_phase35_recursive_compression_target_manifest_against_sources
+  specs:
+    - spec/stwo-phase35-recursive-compression-target-manifest.schema.json
+  positive_tests:
+    - phase35_recursive_target_manifest_accepts_matching_sources
+  negative_tests:
+    - phase35_recursive_target_manifest_rejects_tampered_commitment
+    - phase35_recursive_target_manifest_parse_rejects_unknown_fields
+  evidence_commands:
+    - cargo +nightly-2025-07-14 test -q --features stwo-backend phase35
+  non_claims:
+    - "Does not claim recursive proof closure."
+    - "Does not claim cryptographic compression."
+
+- id: phase36_verifier_harness_receipt
+  claim: "Phase 36 records source-bound verifier-harness checking of the Phase 35 target and source artifacts."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+  implementation:
+    - src/stwo_backend/recursion.rs:phase36_prepare_recursive_verifier_harness_receipt
+    - src/stwo_backend/recursion.rs:verify_phase36_recursive_verifier_harness_receipt_against_sources
+  specs:
+    - spec/stwo-phase36-recursive-verifier-harness-receipt.schema.json
+  positive_tests:
+    - phase36_recursive_verifier_harness_receipt_accepts_matching_sources
+  negative_tests:
+    - phase36_recursive_verifier_harness_receipt_rejects_recursive_claim
+    - phase36_recursive_verifier_harness_receipt_rejects_tampered_commitment
+    - phase36_recursive_verifier_harness_receipt_parse_rejects_unknown_fields
+  evidence_commands:
+    - cargo +nightly-2025-07-14 test -q --features stwo-backend phase36
+  non_claims:
+    - "Does not claim recursive proof verification."
+    - "Does not claim cryptographic compression."
+
+- id: phase37_artifact_chain_harness_receipt
+  claim: "Phase 37 recomputes the full Phase 29 + Phase 30 through Phase 36 source-bound artifact chain as heavier operational evidence."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+  implementation:
+    - src/stwo_backend/recursion.rs:phase37_prepare_recursive_artifact_chain_harness_receipt
+    - src/stwo_backend/recursion.rs:verify_phase37_recursive_artifact_chain_harness_receipt_against_sources
+  specs:
+    - spec/stwo-phase37-recursive-artifact-chain-harness-receipt.schema.json
+  positive_tests:
+    - phase37_recursive_artifact_chain_harness_receipt_accepts_matching_sources
+  negative_tests:
+    - phase37_recursive_artifact_chain_harness_receipt_rejects_recursive_claim
+    - phase37_recursive_artifact_chain_harness_receipt_rejects_tampered_commitment
+    - phase37_recursive_artifact_chain_harness_receipt_rejects_malformed_commitment_field
+  evidence_commands:
+    - cargo +nightly-2025-07-14 test -q --features stwo-backend phase37
+    - TVM_TEST_BINARY=/Users/espejelomar/.codex-targets/ptv-paper-next/debug/tvm cargo +nightly-2025-07-14 test -q --features 'full stwo-backend' --test cli stwo_recursive_artifact_chain
+  non_claims:
+    - "Does not claim recursive proof verification."
+    - "Does not claim cryptographic compression."
+    - "Does not claim a recursively verifiable compressed proof object."
+
+- id: bounded_runtime_semantic_agreement
+  claim: "The research-v3 artifacts provide bounded semantic-agreement evidence, not a general runtime equivalence theorem."
+  paper_locations:
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+    - docs/paper/paper2/appendix-engineering-gaps.md
+  implementation:
+    - src/bin/tvm.rs:verify_research_v3_equivalence_artifact
+  specs:
+    - spec/statement-v3-equivalence-kernel.schema.json
+    - spec/statement-v3-equivalence-kernel-research.json
+  positive_tests:
+    - cli_supports_research_v3_equivalence_command
+  negative_tests:
+    - research_v3_rule_witnesses_rejects_event_length_mismatch
+  evidence_commands:
+    - cargo test -q research_v3
+  non_claims:
+    - "Does not claim full semantic equivalence across compilers, frontends, or graph rewrites."
+    - "Does not enlarge the proof statement."
+
+- id: release_provenance_boundary
+  claim: "HF provenance manifests bind release and artifact identity as reproducibility guardrails."
+  paper_locations:
+    - docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+    - docs/paper/paper2/appendix-engineering-gaps.md
+  implementation:
+    - src/bin/tvm.rs:prepare_hf_provenance_manifest_command
+    - src/bin/tvm.rs:verify_hf_provenance_manifest_command
+  specs:
+    - spec/hf-provenance-manifest.schema.json
+    - docs/engineering/reproducibility.md
+  positive_tests:
+    - cli_can_prepare_and_verify_hf_provenance_manifest
+  negative_tests:
+    - cli_verifier_rejects_tampered_hf_attestation_hash
+    - cli_verifier_rejects_tampered_hf_external_attestation_statement
+  evidence_commands:
+    - cargo test -q --features full --test cli hf_provenance
+  non_claims:
+    - "Does not claim a complete supply-chain attestation theorem."
+    - "Does not claim verified external builder trust unless attestations are actually verified."

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -7,7 +7,8 @@ Checks:
 3) figure/link cross-reference existence for local file links,
 4) source-note presence in appendix-system-comparison,
 5) backend appendix timing/size consistency against frozen artifact indices,
-6) unresolved publication snapshot placeholder detection.
+6) unresolved publication snapshot placeholder detection,
+7) paper-2 claim evidence matrix completeness.
 """
 
 from __future__ import annotations
@@ -52,6 +53,33 @@ LOCAL_REPOS = {
     ("omarespejel", "provable-transformer-vm"),
 }
 
+CLAIM_EVIDENCE_FILE = "docs/engineering/paper2-claim-evidence.yml"
+
+REQUIRED_CLAIM_IDS = {
+    "phase29_recursive_input_contract",
+    "phase30_step_envelope_manifest",
+    "phase31_decode_boundary_bridge",
+    "phase32_recursive_statement_contract",
+    "phase33_public_input_manifest",
+    "phase34_shared_lookup_manifest",
+    "phase35_recursive_target_manifest",
+    "phase36_verifier_harness_receipt",
+    "phase37_artifact_chain_harness_receipt",
+    "bounded_runtime_semantic_agreement",
+    "release_provenance_boundary",
+}
+
+CLAIM_EVIDENCE_REQUIRED_SCALARS = ("id", "claim")
+CLAIM_EVIDENCE_REQUIRED_LISTS = (
+    "paper_locations",
+    "implementation",
+    "specs",
+    "positive_tests",
+    "negative_tests",
+    "evidence_commands",
+    "non_claims",
+)
+
 
 @dataclass
 class Findings:
@@ -94,7 +122,7 @@ def expand_citation_token(token: str) -> list[int]:
     out: list[int] = []
     for part in re.split(r"\s*,\s*", token):
         if "-" in part:
-            a, b = re.split(r"\s*-\s*", part, 1)
+            a, b = re.split(r"\s*-\s*", part, maxsplit=1)
             if a.isdigit() and b.isdigit():
                 ai, bi = int(a), int(b)
                 if ai <= bi:
@@ -257,6 +285,219 @@ def check_publication_snapshot_placeholders(
                     f"{path}: unresolved publication snapshot placeholder {token!r}; "
                     "replace it before paper preflight."
                 )
+
+
+def unquote_claim_evidence_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def parse_claim_evidence_records(
+    path: pathlib.Path, findings: Findings
+) -> list[dict[str, object]]:
+    """Parse the restricted YAML shape used by paper2-claim-evidence.yml.
+
+    This is intentionally not a general YAML parser. The evidence ledger uses a
+    small stdlib-friendly subset so preflight does not grow a PyYAML dependency.
+    """
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        findings.error(f"{path}: failed to read claim evidence matrix: {exc}")
+        return []
+
+    records: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+    current_list_key: str | None = None
+
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- id:"):
+            value = unquote_claim_evidence_scalar(stripped.split(":", 1)[1])
+            current = {"id": value}
+            records.append(current)
+            current_list_key = None
+            continue
+        if current is None:
+            findings.error(
+                f"{path}:{line_number}: claim evidence content must start with `- id:`"
+            )
+            continue
+        if stripped.startswith("- "):
+            if current_list_key is None:
+                findings.error(
+                    f"{path}:{line_number}: list item has no active claim evidence key"
+                )
+                continue
+            items = current.setdefault(current_list_key, [])
+            if not isinstance(items, list):
+                findings.error(
+                    f"{path}:{line_number}: `{current_list_key}` cannot mix scalar and list values"
+                )
+                continue
+            items.append(unquote_claim_evidence_scalar(stripped[2:]))
+            continue
+        match = re.match(r"^([a-z_]+):\s*(.*)$", stripped)
+        if not match:
+            findings.error(
+                f"{path}:{line_number}: unsupported claim evidence syntax: {stripped}"
+            )
+            continue
+        key, value = match.groups()
+        if value:
+            current[key] = unquote_claim_evidence_scalar(value)
+            current_list_key = None
+        else:
+            current[key] = []
+            current_list_key = key
+
+    return records
+
+
+def iter_code_and_test_files(repo_root: pathlib.Path):
+    for rel_root in ("src", "tests", "scripts", "fuzz"):
+        root = repo_root / rel_root
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if path.is_file() and path.suffix in {".rs", ".py", ".md", ".sh", ".yml", ".json"}:
+                yield path
+
+
+def repo_contains_token(repo_root: pathlib.Path, token: str) -> bool:
+    for path in iter_code_and_test_files(repo_root):
+        try:
+            if token in path.read_text(encoding="utf-8", errors="ignore"):
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def split_evidence_path_anchor(entry: str) -> tuple[str, str | None]:
+    path_part = entry.split("#", 1)[0]
+    if ":" not in path_part:
+        return path_part, None
+    rel_path, anchor = path_part.rsplit(":", 1)
+    if "/" not in rel_path and not rel_path.endswith((".rs", ".py", ".md", ".json", ".yml")):
+        return path_part, None
+    return rel_path, anchor or None
+
+
+def check_claim_evidence_path_anchor(
+    repo_root: pathlib.Path,
+    evidence_path: pathlib.Path,
+    claim_id: str,
+    key: str,
+    entry: str,
+    findings: Findings,
+) -> None:
+    rel_path, anchor = split_evidence_path_anchor(entry)
+    target = repo_root / rel_path
+    if not target.exists():
+        findings.error(
+            f"{evidence_path}: claim `{claim_id}` `{key}` references missing path: {entry}"
+        )
+        return
+    if anchor is None:
+        return
+    try:
+        text = target.read_text(encoding="utf-8", errors="ignore")
+    except OSError as exc:
+        findings.error(
+            f"{evidence_path}: claim `{claim_id}` `{key}` failed to read anchor path {target}: {exc}"
+        )
+        return
+    if anchor not in text:
+        findings.error(
+            f"{evidence_path}: claim `{claim_id}` `{key}` anchor `{anchor}` not found in {rel_path}"
+        )
+
+
+def list_field(record: dict[str, object], key: str) -> list[str]:
+    value = record.get(key)
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return []
+
+
+def check_claim_evidence_matrix(repo_root: pathlib.Path, findings: Findings) -> None:
+    evidence_path = repo_root / CLAIM_EVIDENCE_FILE
+    if not evidence_path.exists():
+        findings.error(f"{evidence_path}: missing paper-2 claim evidence matrix.")
+        return
+
+    parse_findings = Findings()
+    records = parse_claim_evidence_records(evidence_path, parse_findings)
+    findings.errors.extend(parse_findings.errors)
+    findings.warnings.extend(parse_findings.warnings)
+    if parse_findings.errors:
+        return
+
+    seen_ids: set[str] = set()
+    for record in records:
+        claim_id = str(record.get("id", "")).strip()
+        if not claim_id:
+            findings.error(f"{evidence_path}: claim evidence record has empty `id`.")
+            continue
+        if claim_id in seen_ids:
+            findings.error(f"{evidence_path}: duplicate claim evidence id `{claim_id}`.")
+        seen_ids.add(claim_id)
+
+        for key in CLAIM_EVIDENCE_REQUIRED_SCALARS:
+            value = record.get(key)
+            if not isinstance(value, str) or not value.strip():
+                findings.error(
+                    f"{evidence_path}: claim `{claim_id}` requires non-empty scalar `{key}`."
+                )
+
+        for key in CLAIM_EVIDENCE_REQUIRED_LISTS:
+            values = list_field(record, key)
+            if not values:
+                findings.error(
+                    f"{evidence_path}: claim `{claim_id}` requires at least one `{key}` entry."
+                )
+                continue
+            if any("TODO" in value or "TBD" in value for value in values):
+                findings.error(
+                    f"{evidence_path}: claim `{claim_id}` `{key}` contains unresolved placeholder text."
+                )
+
+        for key in ("paper_locations", "implementation", "specs"):
+            for entry in list_field(record, key):
+                check_claim_evidence_path_anchor(
+                    repo_root, evidence_path, claim_id, key, entry, findings
+                )
+
+        for key in ("positive_tests", "negative_tests"):
+            for test_name in list_field(record, key):
+                if not repo_contains_token(repo_root, test_name):
+                    findings.error(
+                        f"{evidence_path}: claim `{claim_id}` `{key}` references missing test token: {test_name}"
+                    )
+
+        for non_claim in list_field(record, "non_claims"):
+            lowered = non_claim.lower()
+            if "not " not in lowered and "does not" not in lowered:
+                findings.error(
+                    f"{evidence_path}: claim `{claim_id}` non-claim must explicitly negate an overclaim: {non_claim}"
+                )
+
+    missing_ids = sorted(REQUIRED_CLAIM_IDS - seen_ids)
+    extra_ids = sorted(seen_ids - REQUIRED_CLAIM_IDS)
+    if missing_ids:
+        findings.error(
+            f"{evidence_path}: missing required paper-2 claim evidence ids: {missing_ids}"
+        )
+    if extra_ids:
+        findings.warn(
+            f"{evidence_path}: extra paper-2 claim evidence ids not in required set: {extra_ids}"
+        )
 
 
 def iter_snapshot_field_lines(text: str):
@@ -591,6 +832,7 @@ def main() -> int:
     check_appendix_source_note(repo_root, findings)
     check_backend_appendix_consistency(repo_root, findings)
     check_publication_snapshot_placeholders(repo_root, findings)
+    check_claim_evidence_matrix(repo_root, findings)
 
     if findings.warnings:
         print("Warnings:")

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -365,6 +365,117 @@ class PaperPreflightTests(unittest.TestCase):
                 findings.errors,
             )
 
+    def test_claim_evidence_matrix_accepts_complete_record_set(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            for rel_path in (
+                "docs/paper/paper2/appendix-artifact-map.md",
+                "docs/paper/paper2/proof-carrying-decode-surfaces-2026.md",
+                "src/stwo_backend/recursion.rs",
+                "spec/stwo-phase37-recursive-artifact-chain-harness-receipt.schema.json",
+                "tests/phase37.rs",
+            ):
+                write_text(repo / rel_path, "")
+            write_text(
+                repo / "src/stwo_backend/recursion.rs",
+                (
+                    "fn phase37_prepare_recursive_artifact_chain_harness_receipt() {}\n"
+                    "fn verify_phase37_recursive_artifact_chain_harness_receipt_against_sources() {}\n"
+                ),
+            )
+            write_text(
+                repo / "tests/phase37.rs",
+                (
+                    "fn phase37_recursive_artifact_chain_harness_receipt_accepts_matching_sources() {}\n"
+                    "fn phase37_recursive_artifact_chain_harness_receipt_rejects_tampered_commitment() {}\n"
+                ),
+            )
+            records = []
+            for claim_id in sorted(MOD.REQUIRED_CLAIM_IDS):
+                records.append(
+                    f"""- id: {claim_id}
+  claim: "Bounded claim for {claim_id}."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+  implementation:
+    - src/stwo_backend/recursion.rs:phase37_prepare_recursive_artifact_chain_harness_receipt
+    - src/stwo_backend/recursion.rs:verify_phase37_recursive_artifact_chain_harness_receipt_against_sources
+  specs:
+    - spec/stwo-phase37-recursive-artifact-chain-harness-receipt.schema.json
+  positive_tests:
+    - phase37_recursive_artifact_chain_harness_receipt_accepts_matching_sources
+  negative_tests:
+    - phase37_recursive_artifact_chain_harness_receipt_rejects_tampered_commitment
+  evidence_commands:
+    - cargo test -q phase37
+  non_claims:
+    - "Does not claim recursive proof closure."
+"""
+                )
+            write_text(
+                repo / MOD.CLAIM_EVIDENCE_FILE,
+                "\n".join(records),
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_evidence_matrix(repo, findings)
+            self.assertEqual(findings.errors, [])
+
+    def test_claim_evidence_matrix_rejects_missing_required_claim_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(repo / MOD.CLAIM_EVIDENCE_FILE, "")
+
+            findings = MOD.Findings()
+            MOD.check_claim_evidence_matrix(repo, findings)
+            self.assertTrue(
+                any("missing required paper-2 claim evidence ids" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
+    def test_claim_evidence_matrix_rejects_missing_anchor_and_test_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(repo / "docs/paper/paper2/appendix-artifact-map.md", "")
+            write_text(repo / "src/stwo_backend/recursion.rs", "fn other_symbol() {}\n")
+            write_text(
+                repo / "spec/stwo-phase37-recursive-artifact-chain-harness-receipt.schema.json",
+                "{}\n",
+            )
+            records = []
+            for claim_id in sorted(MOD.REQUIRED_CLAIM_IDS):
+                records.append(
+                    f"""- id: {claim_id}
+  claim: "Bounded claim for {claim_id}."
+  paper_locations:
+    - docs/paper/paper2/appendix-artifact-map.md
+  implementation:
+    - src/stwo_backend/recursion.rs:missing_symbol
+  specs:
+    - spec/stwo-phase37-recursive-artifact-chain-harness-receipt.schema.json
+  positive_tests:
+    - missing_positive_test
+  negative_tests:
+    - missing_negative_test
+  evidence_commands:
+    - cargo test -q phase37
+  non_claims:
+    - "Does not claim recursive proof closure."
+"""
+                )
+            write_text(repo / MOD.CLAIM_EVIDENCE_FILE, "\n".join(records))
+
+            findings = MOD.Findings()
+            MOD.check_claim_evidence_matrix(repo, findings)
+            self.assertTrue(
+                any("anchor `missing_symbol` not found" in msg for msg in findings.errors),
+                findings.errors,
+            )
+            self.assertTrue(
+                any("references missing test token: missing_positive_test" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a machine-readable Paper 2 claim-evidence ledger and makes `scripts/paper/paper_preflight.py` enforce it.

The goal is to reduce overclaim risk before publication: every paper-facing Phase 29-37 / semantic-agreement / provenance claim now needs implementation anchors, spec/schema anchors, positive and negative test tokens, evidence commands, and explicit non-claims.

## Hardening checklist

- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

## Hardening notes

- Targeted coverage: added preflight tests for a complete evidence matrix, missing required claim IDs, and missing implementation/test-token anchors.
- Oracle/differential: this PR adds paper-claim preflight enforcement; the independent verifier/oracle work remains tracked in issue #153.
- Resource/untrusted input: no runtime parser or proof path changed. The new parser is stdlib-only and restricted to the local evidence-ledger shape.
- Kani/formal kernel: not applicable; no formal kernel or proof verifier code changed.

## Validation

- `python3 -m unittest scripts.paper.tests.test_paper_preflight`
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `python3 -m py_compile scripts/paper/paper_preflight.py scripts/paper/tests/test_paper_preflight.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated engineering documentation with new claim-to-evidence ledger resource.

* **New Features**
  * Added validation system for claim evidence records, including verification of file paths, anchor references, and test token existence.

* **Tests**
  * Added test coverage for claim evidence validation scenarios, including complete record verification, missing identifiers, and invalid references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->