### PR TITLE
[codex] Fix paper evidence path validation and token discovery

### DIFF
--- a/docs/engineering/paper2-claim-evidence.yml
+++ b/docs/engineering/paper2-claim-evidence.yml
@@ -193,7 +193,7 @@
     - phase37_recursive_artifact_chain_harness_receipt_rejects_malformed_commitment_field
   evidence_commands:
     - cargo +nightly-2025-07-14 test -q --features stwo-backend phase37
-    - TVM_TEST_BINARY=/Users/espejelomar/.codex-targets/ptv-paper-next/debug/tvm cargo +nightly-2025-07-14 test -q --features 'full stwo-backend' --test cli stwo_recursive_artifact_chain
+    - cargo +nightly-2025-07-14 build -q --features 'full stwo-backend' --bin tvm && TVM_TEST_BINARY=target/debug/tvm cargo +nightly-2025-07-14 test -q --features 'full stwo-backend' --test cli stwo_recursive_artifact_chain
   non_claims:
     - "Does not claim recursive proof verification."
     - "Does not claim cryptographic compression."

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -305,7 +305,7 @@ def parse_claim_evidence_records(
 
     try:
         text = path.read_text(encoding="utf-8")
-    except OSError as exc:
+    except (OSError, UnicodeError) as exc:
         findings.error(f"{path}: failed to read claim evidence matrix: {exc}")
         return []
 
@@ -369,14 +369,24 @@ def iter_code_and_test_files(repo_root: pathlib.Path):
                 yield path
 
 
-def repo_contains_token(repo_root: pathlib.Path, token: str) -> bool:
+def find_repo_tokens(repo_root: pathlib.Path, tokens: set[str]) -> set[str]:
+    remaining = {token for token in tokens if token}
+    found: set[str] = set()
+    if not remaining:
+        return found
+
     for path in iter_code_and_test_files(repo_root):
         try:
-            if token in path.read_text(encoding="utf-8", errors="ignore"):
-                return True
-        except OSError:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except (OSError, UnicodeError):
             continue
-    return False
+        present = {token for token in remaining if token in text}
+        if present:
+            found.update(present)
+            remaining.difference_update(present)
+            if not remaining:
+                break
+    return found
 
 
 def split_evidence_path_anchor(entry: str) -> tuple[str, str | None]:
@@ -398,7 +408,24 @@ def check_claim_evidence_path_anchor(
     findings: Findings,
 ) -> None:
     rel_path, anchor = split_evidence_path_anchor(entry)
-    target = repo_root / rel_path
+    relative_path = pathlib.Path(rel_path)
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        findings.error(
+            f"{evidence_path}: claim `{claim_id}` `{key}` path must be repo-relative "
+            f"and must not contain `..`: {entry}"
+        )
+        return
+
+    root = repo_root.resolve()
+    target = (root / relative_path).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError:
+        findings.error(
+            f"{evidence_path}: claim `{claim_id}` `{key}` path escapes repo root: {entry}"
+        )
+        return
+
     if not target.exists():
         findings.error(
             f"{evidence_path}: claim `{claim_id}` `{key}` references missing path: {entry}"
@@ -439,6 +466,14 @@ def check_claim_evidence_matrix(repo_root: pathlib.Path, findings: Findings) -> 
     if parse_findings.errors:
         return
 
+    test_tokens = {
+        test_name
+        for record in records
+        for key in ("positive_tests", "negative_tests")
+        for test_name in list_field(record, key)
+    }
+    found_test_tokens = find_repo_tokens(repo_root, test_tokens)
+
     seen_ids: set[str] = set()
     for record in records:
         claim_id = str(record.get("id", "")).strip()
@@ -476,7 +511,7 @@ def check_claim_evidence_matrix(repo_root: pathlib.Path, findings: Findings) -> 
 
         for key in ("positive_tests", "negative_tests"):
             for test_name in list_field(record, key):
-                if not repo_contains_token(repo_root, test_name):
+                if test_name not in found_test_tokens:
                     findings.error(
                         f"{evidence_path}: claim `{claim_id}` `{key}` references missing test token: {test_name}"
                     )

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -416,8 +416,14 @@ def check_claim_evidence_path_anchor(
         )
         return
 
-    root = repo_root.resolve()
-    target = (root / relative_path).resolve()
+    try:
+        root = repo_root.resolve()
+        target = (root / relative_path).resolve()
+    except (OSError, RuntimeError) as exc:
+        findings.error(
+            f"{evidence_path}: claim `{claim_id}` `{key}` failed to resolve path {entry}: {exc}"
+        )
+        return
     try:
         target.relative_to(root)
     except ValueError:

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -409,7 +409,13 @@ def check_claim_evidence_path_anchor(
 ) -> None:
     rel_path, anchor = split_evidence_path_anchor(entry)
     relative_path = pathlib.Path(rel_path)
-    if relative_path.is_absolute() or ".." in relative_path.parts:
+    windows_path = pathlib.PureWindowsPath(rel_path)
+    if (
+        relative_path.is_absolute()
+        or windows_path.is_absolute()
+        or ".." in relative_path.parts
+        or ".." in windows_path.parts
+    ):
         findings.error(
             f"{evidence_path}: claim `{claim_id}` `{key}` path must be repo-relative "
             f"and must not contain `..`: {entry}"

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -531,6 +531,26 @@ class PaperPreflightTests(unittest.TestCase):
                 findings.errors,
             )
 
+    def test_claim_evidence_path_anchor_reports_resolution_failures(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            findings = MOD.Findings()
+
+            with mock.patch.object(pathlib.Path, "resolve", side_effect=OSError("loop")):
+                MOD.check_claim_evidence_path_anchor(
+                    repo,
+                    repo / MOD.CLAIM_EVIDENCE_FILE,
+                    "phase37_artifact_chain_harness_receipt",
+                    "implementation",
+                    "src/lib.rs:anchor",
+                    findings,
+                )
+
+            self.assertTrue(
+                any("failed to resolve path" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
     def test_find_repo_tokens_scans_for_all_tokens_in_one_pass_result(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo = pathlib.Path(tmp)

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -511,6 +511,24 @@ class PaperPreflightTests(unittest.TestCase):
                 findings.errors,
             )
 
+            for windows_entry in (
+                r"C:\tmp\outside.rs:escaped_anchor",
+                r"\\server\share\file.txt:escaped_anchor",
+            ):
+                findings = MOD.Findings()
+                MOD.check_claim_evidence_path_anchor(
+                    repo,
+                    repo / MOD.CLAIM_EVIDENCE_FILE,
+                    "phase37_artifact_chain_harness_receipt",
+                    "implementation",
+                    windows_entry,
+                    findings,
+                )
+                self.assertTrue(
+                    any("path must be repo-relative" in msg for msg in findings.errors),
+                    findings.errors,
+                )
+
             link = repo / "inside-link.rs"
             try:
                 link.symlink_to(outside)

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -476,6 +476,86 @@ class PaperPreflightTests(unittest.TestCase):
                 findings.errors,
             )
 
+    def test_claim_evidence_path_anchor_rejects_paths_outside_repo(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp) / "repo"
+            repo.mkdir()
+            outside = pathlib.Path(tmp) / "outside.rs"
+            write_text(outside, "fn escaped_anchor() {}\n")
+
+            findings = MOD.Findings()
+            MOD.check_claim_evidence_path_anchor(
+                repo,
+                repo / MOD.CLAIM_EVIDENCE_FILE,
+                "phase37_artifact_chain_harness_receipt",
+                "implementation",
+                f"{outside}:escaped_anchor",
+                findings,
+            )
+            self.assertTrue(
+                any("path must be repo-relative" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_evidence_path_anchor(
+                repo,
+                repo / MOD.CLAIM_EVIDENCE_FILE,
+                "phase37_artifact_chain_harness_receipt",
+                "implementation",
+                "../outside.rs:escaped_anchor",
+                findings,
+            )
+            self.assertTrue(
+                any("path must be repo-relative" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
+            link = repo / "inside-link.rs"
+            try:
+                link.symlink_to(outside)
+            except OSError as exc:
+                self.skipTest(f"symlink creation is unavailable: {exc}")
+
+            findings = MOD.Findings()
+            MOD.check_claim_evidence_path_anchor(
+                repo,
+                repo / MOD.CLAIM_EVIDENCE_FILE,
+                "phase37_artifact_chain_harness_receipt",
+                "implementation",
+                "inside-link.rs:escaped_anchor",
+                findings,
+            )
+            self.assertTrue(
+                any("path escapes repo root" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
+    def test_find_repo_tokens_scans_for_all_tokens_in_one_pass_result(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(repo / "src/lib.rs", "fn alpha_token() {}\n")
+            write_text(repo / "tests/smoke.rs", "fn beta_token() {}\n")
+
+            found = MOD.find_repo_tokens(
+                repo, {"alpha_token", "beta_token", "missing_token"}
+            )
+            self.assertEqual(found, {"alpha_token", "beta_token"})
+
+    def test_parse_claim_evidence_records_reports_invalid_utf8(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / MOD.CLAIM_EVIDENCE_FILE
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"\xff")
+
+            findings = MOD.Findings()
+            records = MOD.parse_claim_evidence_records(path, findings)
+            self.assertEqual(records, [])
+            self.assertTrue(
+                any("failed to read claim evidence matrix" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes the post-merge Qodo findings on PR #154.

Changes:
- removes the local `/Users/...` path from the evidence command and replaces it with a repo-relative `target/debug/tvm` workflow
- rejects absolute, `..`, and symlink-escaped evidence paths before checking anchors
- changes test-token validation from repeated repo scans to one pass over code/test files
- reports invalid UTF-8 in the evidence ledger as a structured preflight finding

## Hardening checklist

- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

## Hardening notes

- Targeted coverage: added tests for repo-escape evidence paths, one-pass token discovery results, and invalid UTF-8 ledger reads.
- Oracle/differential: not applicable; this is preflight hardening, not a verifier semantic change.
- Resource/untrusted input: improved bounded local preflight behavior and avoids repeated file-tree scans per token.
- Kani/formal kernel: not applicable; no Rust verifier/formal kernel code changed.

## Validation

- `python3 -m unittest scripts.paper.tests.test_paper_preflight`
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `python3 -m py_compile scripts/paper/paper_preflight.py scripts/paper/tests/test_paper_preflight.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened path validation for evidence entries: reject absolute paths, reject .. traversal (including Windows-style), and prevent repo-escape via resolved paths; improved error reporting when resolution fails
  * Treated Unicode/encoding read errors like other read failures, returning empty records and recording an error

* **Performance Improvements**
  * Optimized token scanning to locate all candidate tokens in one repository pass

* **Tests**
  * Added tests for path validation, token-scanning, resolution failure handling, and encoding error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->