### PR TITLE
[codex] Add known-bad phase artifact corpus

### DIFF
--- a/docs/engineering/hardening-policy.md
+++ b/docs/engineering/hardening-policy.md
@@ -36,7 +36,7 @@ change requires.
   validation notes and use `workflow_dispatch` intentionally.
 - Merge trusted-core PRs through `scripts/local_merge_gate.sh` so the final
   merge decision is tied to the exact PR head SHA, local evidence logs, a clean
-  GitHub check rollup, zero unresolved review threads, and a five-minute quiet
+  GitHub check rollup, zero unresolved review threads, and a seven-minute quiet
   window after the last CodeRabbit, Greptile, or Qodo event.
 
 ## Local Commands
@@ -58,6 +58,7 @@ scripts/run_workflow_audit_suite.sh
 scripts/run_dependency_audit_suite.sh
 python3 scripts/fuzz/generate_decoding_fuzz_corpus.py
 FUZZ_TIME_PER_TARGET=20 scripts/run_fuzz_smoke_suite.sh
+scripts/run_known_bad_phase_artifact_corpus.sh
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_asan_suite.sh
@@ -68,6 +69,11 @@ scripts/run_formal_contract_suite.sh
 corpus. `scripts/run_fuzz_smoke_suite.sh` generates its own temporary corpus
 under `target/fuzz-smoke/generated-corpus` so the hardening gate does not
 rewrite tracked fuzz seeds as a side effect.
+
+`scripts/run_known_bad_phase_artifact_corpus.sh` runs the manifest-driven Phase
+29-37 known-bad artifact corpus. It derives valid artifacts in memory, mutates
+them, and checks that public parsers and source-bound verifiers reject both
+stale-root and self-consistent bad artifacts.
 
 The sanitizer and UB hardening scripts use the curated exact test lists in
 `scripts/hardening_test_names.sh`; update that file when adding new trusted-core
@@ -133,11 +139,14 @@ Available local command tiers:
   those surfaces, the statement-spec contract, allowlisted integration smoke
   targets, and exact pinned-nightly `stwo-backend` smokes for the Phase 28
   aggregation verifier, Phase 29 recursive-compression input contract, and
-  non-heavy Phase 29 CLI artifact verification paths.
+  non-heavy Phase 29 CLI artifact verification paths. It also runs the
+  Phase 29-37 known-bad artifact corpus when the PR changes those artifact
+  surfaces or corpus files.
 - `--mode full`: runs the same PR-range whitespace and formatting hygiene, full
   library tests, integration tests, doctests, the same conditional workflow
   auditing, dependency auditing, and shellcheck, and the exact pinned-nightly
-  `stwo-backend` smokes.
+  `stwo-backend` smokes, plus the Phase 29-37 known-bad artifact corpus when
+  relevant files change.
 - `--mode hardening`: runs the `full` tier, including the same conditional
   workflow auditing for `.github/workflows/**` and `zizmor.yml`, the same
   conditional dependency auditing for `Cargo.toml`, `Cargo.lock`,
@@ -145,11 +154,13 @@ Available local command tiers:
   `scripts/run_dependency_audit_suite.sh`, and `vendor/onnx-protobuf/**`, and
   the same conditional shellcheck for `scripts/*.sh` and `scripts/**/*.sh`,
   plus diff-scoped mutation testing when the trusted-core prover files change,
-  curated fuzz smoke, UB checks, ASAN, Miri, and the formal contract suite. The
-  inherited whitespace gate is still scoped to the committed PR delta, not the
-  whole worktree. Prefer running this tier inside Lima for Linux parity.
+  curated fuzz smoke, UB checks, ASAN, Miri, and the formal contract suite. It
+  also runs the Phase 29-37 known-bad artifact corpus when relevant files
+  change. The inherited whitespace gate is still scoped to the committed PR
+  delta, not the whole worktree. Prefer running this tier inside Lima for Linux
+  parity.
 - `--mode none`: only checks GitHub status, review-thread state, and the
-  five-minute AI-review quiet window. Use this only after a prior evidence run
+  seven-minute AI-review quiet window. Use this only after a prior evidence run
   for the same PR head SHA.
 
 The GitHub side of the merge gate is intentionally narrow:
@@ -166,7 +177,7 @@ The GitHub side of the merge gate is intentionally narrow:
   fails closed if any individual review thread has more than 100 comments,
   because the gate cannot safely inspect that nested comment stream.
 - No CodeRabbit, Greptile, or Qodo review/comment event may have occurred in the
-  previous 300 seconds. If no AI review/comment event exists yet, the gate
+  previous 420 seconds. If no AI review/comment event exists yet, the gate
   refuses to merge. Passing `--wait` sleeps through the remaining quiet window
   and then rechecks without rerunning local tests; any PR head change causes the
   recheck to fail.

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -8,7 +8,7 @@ cd "$ROOT_DIR"
 
 REPO="${MERGE_GATE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)}"
 PR_NUMBER="${MERGE_GATE_PR:-}"
-QUIET_SECONDS="${MERGE_GATE_QUIET_SECONDS:-300}"
+QUIET_SECONDS="${MERGE_GATE_QUIET_SECONDS:-420}"
 MAX_WAIT_SECONDS="${MERGE_GATE_MAX_WAIT_SECONDS:-1800}"
 WAIT_STARTED_AT="${MERGE_GATE_WAIT_STARTED_AT:-}"
 EVIDENCE_DIR="${MERGE_GATE_EVIDENCE_DIR:-target/local-hardening}"
@@ -31,7 +31,7 @@ Options:
   --pr NUMBER            Pull request number. Can also be positional.
   --mode smoke|full|hardening|none
                           Local command tier. Default: smoke.
-  --quiet-seconds N      AI-review quiet window. Default: 300.
+  --quiet-seconds N      AI-review quiet window. Default: 420.
   --max-wait-seconds N   Maximum total --wait wall time. Default: 1800; 0 disables.
   --evidence-dir DIR     Evidence output directory. Default: target/local-hardening.
   --wait                 Wait until the quiet window is satisfied.
@@ -467,6 +467,15 @@ changed_path_is_research_v3_surface() {
     changed_path_has_prefix "scripts/run_ub_checks_suite.sh"
 }
 
+changed_path_is_phase_artifact_corpus_surface() {
+  changed_path_has_prefix "src/stwo_backend/decoding.rs" ||
+    changed_path_has_prefix "src/stwo_backend/recursion.rs" ||
+    changed_path_has_prefix "tests/known_bad_phase_artifacts.rs" ||
+    changed_path_has_prefix "tests/fixtures/known_bad/phase29_to_phase37/" ||
+    changed_path_has_prefix "scripts/run_known_bad_phase_artifact_corpus.sh" ||
+    changed_path_has_prefix "scripts/local_merge_gate.sh"
+}
+
 changed_path_is_dependency_audit_input() {
   local path
 
@@ -546,6 +555,10 @@ run_stwo_cli_smoke_targets() {
       -- \
       --exact
   done
+}
+
+run_phase_artifact_corpus_smoke() {
+  run_logged known-bad-phase-artifact-corpus scripts/run_known_bad_phase_artifact_corpus.sh
 }
 
 run_research_v3_smoke_targets() {
@@ -632,6 +645,9 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
+  if changed_path_is_phase_artifact_corpus_surface; then
+    run_phase_artifact_corpus_smoke
+  fi
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -652,6 +668,9 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
+  if changed_path_is_phase_artifact_corpus_surface; then
+    run_phase_artifact_corpus_smoke
+  fi
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -672,6 +691,9 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   fi
   run_stwo_smoke_targets
   run_stwo_cli_smoke_targets
+  if changed_path_is_phase_artifact_corpus_surface; then
+    run_phase_artifact_corpus_smoke
+  fi
   run_conditional_mutation_check
   run_logged fuzz-smoke env FUZZ_TIME_PER_TARGET=20 scripts/run_fuzz_smoke_suite.sh
   run_logged ub-checks env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh

--- a/scripts/run_known_bad_phase_artifact_corpus.sh
+++ b/scripts/run_known_bad_phase_artifact_corpus.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+HARDENING_TOOLCHAIN="${HARDENING_TOOLCHAIN:-nightly-2025-07-14}"
+
+cargo +"${HARDENING_TOOLCHAIN}" test -q \
+  --features stwo-backend \
+  --test known_bad_phase_artifacts \
+  phase29_to_phase37_known_bad_corpus_rejects_expected_failures \
+  -- \
+  --exact

--- a/tests/fixtures/known_bad/phase29_to_phase37/README.md
+++ b/tests/fixtures/known_bad/phase29_to_phase37/README.md
@@ -1,0 +1,10 @@
+# Known-Bad Phase 29-37 Corpus
+
+This corpus is manifest-driven. The runner in `tests/known_bad_phase_artifacts.rs`
+builds a valid Phase 29 through Phase 37 artifact chain in memory, applies each
+mutation listed in `manifest.json`, and checks that the public parser or
+source-bound verifier rejects the result.
+
+The important class here is the self-consistent bad artifact: the runner often
+recomputes the outer commitment after mutation. That catches verifiers that only
+notice a stale root commitment while missing a false inner statement.

--- a/tests/fixtures/known_bad/phase29_to_phase37/manifest.json
+++ b/tests/fixtures/known_bad/phase29_to_phase37/manifest.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "known-bad-phase29-to-phase37-v1",
+  "description": "Manifest-driven known-bad corpus for paper-facing Phase 29 through Phase 37 public artifact surfaces. The Rust runner derives valid artifacts in memory, applies these mutations, and checks that the public parser/verifier rejects each result.",
+  "cases": [
+    {
+      "name": "phase29_recursive_claim_recommitted",
+      "phase": "phase29",
+      "verifier": "parse",
+      "mutation": "recursive_claim_recommitted",
+      "expected_error_contains": "must not claim recursive verification"
+    },
+    {
+      "name": "phase30_malformed_json",
+      "phase": "phase30",
+      "verifier": "parse",
+      "mutation": "malformed_json",
+      "expected_error_contains": "EOF"
+    },
+    {
+      "name": "phase30_step_index_drift",
+      "phase": "phase30",
+      "verifier": "parse",
+      "mutation": "step_index_drift",
+      "expected_error_contains": "records step_index"
+    },
+    {
+      "name": "phase31_total_steps_recommitted_against_sources",
+      "phase": "phase31",
+      "verifier": "against_sources",
+      "mutation": "total_steps_recommitted",
+      "expected_error_contains": "recomputed Phase 29 + Phase 30 source artifacts"
+    },
+    {
+      "name": "phase32_phase31_commitment_recommitted_against_source",
+      "phase": "phase32",
+      "verifier": "against_sources",
+      "mutation": "phase31_commitment_recommitted",
+      "expected_error_contains": "recomputed Phase 31 source manifest"
+    },
+    {
+      "name": "phase33_phase32_commitment_recommitted_against_source",
+      "phase": "phase33",
+      "verifier": "against_sources",
+      "mutation": "phase32_commitment_recommitted",
+      "expected_error_contains": "recomputed Phase 32 source contract"
+    },
+    {
+      "name": "phase34_lookup_commitment_recommitted_against_sources",
+      "phase": "phase34",
+      "verifier": "against_sources",
+      "mutation": "lookup_commitment_recommitted",
+      "expected_error_contains": "recomputed Phase 33 + Phase 30 source artifacts"
+    },
+    {
+      "name": "phase35_phase33_commitment_recommitted_against_sources",
+      "phase": "phase35",
+      "verifier": "against_sources",
+      "mutation": "phase33_commitment_recommitted",
+      "expected_error_contains": "recomputed Phase 32 + Phase 33 + Phase 34 source artifacts"
+    },
+    {
+      "name": "phase36_source_binding_false_recommitted",
+      "phase": "phase36",
+      "verifier": "parse",
+      "mutation": "source_binding_false_recommitted",
+      "expected_error_contains": "must record source_binding_verified=true"
+    },
+    {
+      "name": "phase37_phase35_malformed_hash_recommitted",
+      "phase": "phase37",
+      "verifier": "parse",
+      "mutation": "phase35_malformed_hash_recommitted",
+      "expected_error_contains": "32-byte lowercase hex"
+    },
+    {
+      "name": "phase37_phase36_commitment_recommitted_against_sources",
+      "phase": "phase37",
+      "verifier": "against_sources",
+      "mutation": "phase36_commitment_recommitted",
+      "expected_error_contains": "recomputed Phase 29 + Phase 30 source artifacts"
+    }
+  ]
+}

--- a/tests/known_bad_phase_artifacts.rs
+++ b/tests/known_bad_phase_artifacts.rs
@@ -1,0 +1,346 @@
+#![cfg(feature = "stwo-backend")]
+
+use llm_provable_computer::stwo_backend::parse_phase30_decoding_step_proof_envelope_manifest_json;
+use llm_provable_computer::{
+    commit_phase29_recursive_compression_input_contract,
+    commit_phase31_recursive_compression_decode_boundary_manifest,
+    commit_phase32_recursive_compression_statement_contract,
+    commit_phase33_recursive_compression_public_input_manifest,
+    commit_phase34_recursive_compression_shared_lookup_manifest,
+    commit_phase35_recursive_compression_target_manifest,
+    commit_phase36_recursive_verifier_harness_receipt,
+    commit_phase37_recursive_artifact_chain_harness_receipt,
+    parse_phase29_recursive_compression_input_contract_json,
+    parse_phase36_recursive_verifier_harness_receipt_json,
+    parse_phase37_recursive_artifact_chain_harness_receipt_json, phase12_default_decoding_layout,
+    phase30_prepare_decoding_step_proof_envelope_manifest,
+    phase31_prepare_recursive_compression_decode_boundary_manifest,
+    phase32_prepare_recursive_compression_statement_contract,
+    phase33_prepare_recursive_compression_public_input_manifest,
+    phase34_prepare_recursive_compression_shared_lookup_manifest,
+    phase35_prepare_recursive_compression_target_manifest,
+    phase36_prepare_recursive_verifier_harness_receipt,
+    phase37_prepare_recursive_artifact_chain_harness_receipt,
+    prove_phase12_decoding_demo_for_layout,
+    verify_phase31_recursive_compression_decode_boundary_manifest_against_sources,
+    verify_phase32_recursive_compression_statement_contract_against_phase31,
+    verify_phase33_recursive_compression_public_input_manifest_against_phase32,
+    verify_phase34_recursive_compression_shared_lookup_manifest_against_sources,
+    verify_phase35_recursive_compression_target_manifest_against_sources,
+    verify_phase37_recursive_artifact_chain_harness_receipt_against_sources,
+    Phase29RecursiveCompressionInputContract, Phase30DecodingStepProofEnvelopeManifest,
+    Phase31RecursiveCompressionDecodeBoundaryManifest,
+    Phase32RecursiveCompressionStatementContract, Phase33RecursiveCompressionPublicInputManifest,
+    Phase34RecursiveCompressionSharedLookupManifest, Phase35RecursiveCompressionTargetManifest,
+    Phase36RecursiveVerifierHarnessReceipt, Phase37RecursiveArtifactChainHarnessReceipt,
+    StarkProofBackend, VmError, CLAIM_STATEMENT_VERSION_V1,
+    STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28,
+    STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE28,
+    STWO_BACKEND_VERSION_PHASE12, STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE,
+    STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29,
+    STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29,
+};
+use serde::Deserialize;
+
+const CORPUS_MANIFEST_JSON: &str =
+    include_str!("fixtures/known_bad/phase29_to_phase37/manifest.json");
+
+#[derive(Debug, Deserialize)]
+struct KnownBadManifest {
+    schema_version: String,
+    cases: Vec<KnownBadCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KnownBadCase {
+    name: String,
+    phase: String,
+    verifier: String,
+    mutation: String,
+    expected_error_contains: String,
+}
+
+struct ValidArtifacts {
+    phase29: Phase29RecursiveCompressionInputContract,
+    phase30: Phase30DecodingStepProofEnvelopeManifest,
+    phase31: Phase31RecursiveCompressionDecodeBoundaryManifest,
+    phase32: Phase32RecursiveCompressionStatementContract,
+    phase33: Phase33RecursiveCompressionPublicInputManifest,
+    phase34: Phase34RecursiveCompressionSharedLookupManifest,
+    phase35: Phase35RecursiveCompressionTargetManifest,
+    phase36: Phase36RecursiveVerifierHarnessReceipt,
+    phase37: Phase37RecursiveArtifactChainHarnessReceipt,
+}
+
+#[test]
+fn phase29_to_phase37_known_bad_corpus_rejects_expected_failures() {
+    let manifest: KnownBadManifest =
+        serde_json::from_str(CORPUS_MANIFEST_JSON).expect("parse known-bad manifest");
+    assert_eq!(manifest.schema_version, "known-bad-phase29-to-phase37-v1");
+    assert!(
+        !manifest.cases.is_empty(),
+        "known-bad corpus must not be empty"
+    );
+
+    let valid = valid_artifacts();
+    for case in &manifest.cases {
+        run_known_bad_case(&valid, case);
+    }
+}
+
+fn valid_artifacts() -> ValidArtifacts {
+    let layout = phase12_default_decoding_layout();
+    let chain = prove_phase12_decoding_demo_for_layout(&layout).expect("phase12 demo");
+    let phase30 =
+        phase30_prepare_decoding_step_proof_envelope_manifest(&chain).expect("phase30 manifest");
+    let phase29 = phase29_contract_for_phase30(&phase30);
+    let phase31 =
+        phase31_prepare_recursive_compression_decode_boundary_manifest(&phase29, &phase30)
+            .expect("phase31 manifest");
+    let phase32 = phase32_prepare_recursive_compression_statement_contract(&phase31)
+        .expect("phase32 contract");
+    let phase33 = phase33_prepare_recursive_compression_public_input_manifest(&phase32)
+        .expect("phase33 manifest");
+    let phase34 = phase34_prepare_recursive_compression_shared_lookup_manifest(&phase33, &phase30)
+        .expect("phase34 manifest");
+    let phase35 =
+        phase35_prepare_recursive_compression_target_manifest(&phase32, &phase33, &phase34)
+            .expect("phase35 manifest");
+    let phase36 =
+        phase36_prepare_recursive_verifier_harness_receipt(&phase35, &phase32, &phase33, &phase34)
+            .expect("phase36 receipt");
+    let phase37 = phase37_prepare_recursive_artifact_chain_harness_receipt(&phase29, &phase30)
+        .expect("phase37 receipt");
+
+    ValidArtifacts {
+        phase29,
+        phase30,
+        phase31,
+        phase32,
+        phase33,
+        phase34,
+        phase35,
+        phase36,
+        phase37,
+    }
+}
+
+fn phase29_contract_for_phase30(
+    phase30: &Phase30DecodingStepProofEnvelopeManifest,
+) -> Phase29RecursiveCompressionInputContract {
+    let mut contract = Phase29RecursiveCompressionInputContract {
+        proof_backend: StarkProofBackend::Stwo,
+        contract_version: STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_VERSION_PHASE29.to_string(),
+        semantic_scope: STWO_RECURSIVE_COMPRESSION_INPUT_CONTRACT_SCOPE_PHASE29.to_string(),
+        phase28_artifact_version:
+            STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_VERSION_PHASE28
+                .to_string(),
+        phase28_semantic_scope:
+            STWO_AGGREGATED_CHAINED_FOLDED_INTERVALIZED_DECODING_STATE_RELATION_SCOPE_PHASE28
+                .to_string(),
+        phase28_proof_backend_version: STWO_BACKEND_VERSION_PHASE12.to_string(),
+        statement_version: CLAIM_STATEMENT_VERSION_V1.to_string(),
+        required_recursion_posture: STWO_PHASE28_RECURSION_POSTURE_PRE_RECURSIVE.to_string(),
+        recursive_verification_claimed: false,
+        cryptographic_compression_claimed: false,
+        phase28_bounded_aggregation_arity: 2,
+        phase28_member_count: 2,
+        phase28_member_summaries: 2,
+        phase28_nested_members: 2,
+        total_phase26_members: 4,
+        total_phase25_members: 8,
+        max_nested_chain_arity: 2,
+        max_nested_fold_arity: 2,
+        total_matrices: 16,
+        total_layouts: 16,
+        total_rollups: 8,
+        total_segments: 8,
+        total_steps: phase30.total_steps,
+        lookup_delta_entries: 12,
+        max_lookup_frontier_entries: 4,
+        source_template_commitment: "a".repeat(64),
+        global_start_state_commitment: phase30.chain_start_boundary_commitment.clone(),
+        global_end_state_commitment: phase30.chain_end_boundary_commitment.clone(),
+        aggregation_template_commitment: "b".repeat(64),
+        aggregated_chained_folded_interval_accumulator_commitment: "c".repeat(64),
+        input_contract_commitment: String::new(),
+    };
+    contract.input_contract_commitment =
+        commit_phase29_recursive_compression_input_contract(&contract)
+            .expect("commit phase29 contract");
+    contract
+}
+
+fn run_known_bad_case(valid: &ValidArtifacts, case: &KnownBadCase) {
+    match (
+        case.phase.as_str(),
+        case.verifier.as_str(),
+        case.mutation.as_str(),
+    ) {
+        ("phase29", "parse", "recursive_claim_recommitted") => {
+            let mut contract = valid.phase29.clone();
+            contract.recursive_verification_claimed = true;
+            contract.input_contract_commitment =
+                commit_phase29_recursive_compression_input_contract(&contract)
+                    .expect("recommit phase29 contract");
+            let json = serde_json::to_string(&contract).expect("serialize phase29 contract");
+            assert_err_contains(
+                &case.name,
+                parse_phase29_recursive_compression_input_contract_json(&json),
+                &case.expected_error_contains,
+            );
+        }
+        ("phase30", "parse", "malformed_json") => {
+            assert_err_contains(
+                &case.name,
+                parse_phase30_decoding_step_proof_envelope_manifest_json("{"),
+                &case.expected_error_contains,
+            );
+        }
+        ("phase30", "parse", "step_index_drift") => {
+            let mut manifest = valid.phase30.clone();
+            manifest.envelopes[0].step_index += 1;
+            let json = serde_json::to_string(&manifest).expect("serialize phase30 manifest");
+            assert_err_contains(
+                &case.name,
+                parse_phase30_decoding_step_proof_envelope_manifest_json(&json),
+                &case.expected_error_contains,
+            );
+        }
+        ("phase31", "against_sources", "total_steps_recommitted") => {
+            let mut manifest = valid.phase31.clone();
+            manifest.total_steps += 1;
+            manifest.decode_boundary_bridge_commitment =
+                commit_phase31_recursive_compression_decode_boundary_manifest(&manifest)
+                    .expect("recommit phase31 manifest");
+            assert_err_contains(
+                &case.name,
+                verify_phase31_recursive_compression_decode_boundary_manifest_against_sources(
+                    &manifest,
+                    &valid.phase29,
+                    &valid.phase30,
+                ),
+                &case.expected_error_contains,
+            );
+        }
+        ("phase32", "against_sources", "phase31_commitment_recommitted") => {
+            let mut contract = valid.phase32.clone();
+            contract.phase31_decode_boundary_bridge_commitment = "d".repeat(64);
+            contract.recursive_statement_contract_commitment =
+                commit_phase32_recursive_compression_statement_contract(&contract)
+                    .expect("recommit phase32 contract");
+            assert_err_contains(
+                &case.name,
+                verify_phase32_recursive_compression_statement_contract_against_phase31(
+                    &contract,
+                    &valid.phase31,
+                ),
+                &case.expected_error_contains,
+            );
+        }
+        ("phase33", "against_sources", "phase32_commitment_recommitted") => {
+            let mut manifest = valid.phase33.clone();
+            manifest.phase32_recursive_statement_contract_commitment = "e".repeat(64);
+            manifest.recursive_public_inputs_commitment =
+                commit_phase33_recursive_compression_public_input_manifest(&manifest)
+                    .expect("recommit phase33 manifest");
+            assert_err_contains(
+                &case.name,
+                verify_phase33_recursive_compression_public_input_manifest_against_phase32(
+                    &manifest,
+                    &valid.phase32,
+                ),
+                &case.expected_error_contains,
+            );
+        }
+        ("phase34", "against_sources", "lookup_commitment_recommitted") => {
+            let mut manifest = valid.phase34.clone();
+            manifest.input_lookup_rows_commitments_commitment = "f".repeat(64);
+            manifest.shared_lookup_public_inputs_commitment =
+                commit_phase34_recursive_compression_shared_lookup_manifest(&manifest)
+                    .expect("recommit phase34 manifest");
+            assert_err_contains(
+                &case.name,
+                verify_phase34_recursive_compression_shared_lookup_manifest_against_sources(
+                    &manifest,
+                    &valid.phase33,
+                    &valid.phase30,
+                ),
+                &case.expected_error_contains,
+            );
+        }
+        ("phase35", "against_sources", "phase33_commitment_recommitted") => {
+            let mut manifest = valid.phase35.clone();
+            manifest.phase33_recursive_public_inputs_commitment = "1".repeat(64);
+            manifest.recursive_target_manifest_commitment =
+                commit_phase35_recursive_compression_target_manifest(&manifest)
+                    .expect("recommit phase35 manifest");
+            assert_err_contains(
+                &case.name,
+                verify_phase35_recursive_compression_target_manifest_against_sources(
+                    &manifest,
+                    &valid.phase32,
+                    &valid.phase33,
+                    &valid.phase34,
+                ),
+                &case.expected_error_contains,
+            );
+        }
+        ("phase36", "parse", "source_binding_false_recommitted") => {
+            let mut receipt = valid.phase36.clone();
+            receipt.source_binding_verified = false;
+            receipt.recursive_verifier_harness_receipt_commitment =
+                commit_phase36_recursive_verifier_harness_receipt(&receipt)
+                    .expect("recommit phase36 receipt");
+            let json = serde_json::to_string(&receipt).expect("serialize phase36 receipt");
+            assert_err_contains(
+                &case.name,
+                parse_phase36_recursive_verifier_harness_receipt_json(&json),
+                &case.expected_error_contains,
+            );
+        }
+        ("phase37", "parse", "phase35_malformed_hash_recommitted") => {
+            let mut receipt = valid.phase37.clone();
+            receipt.phase35_recursive_target_manifest_commitment = "not-a-hash".to_string();
+            receipt.recursive_artifact_chain_harness_receipt_commitment =
+                commit_phase37_recursive_artifact_chain_harness_receipt(&receipt)
+                    .expect("recommit phase37 receipt");
+            let json = serde_json::to_string(&receipt).expect("serialize phase37 receipt");
+            assert_err_contains(
+                &case.name,
+                parse_phase37_recursive_artifact_chain_harness_receipt_json(&json),
+                &case.expected_error_contains,
+            );
+        }
+        ("phase37", "against_sources", "phase36_commitment_recommitted") => {
+            let mut receipt = valid.phase37.clone();
+            receipt.phase36_recursive_verifier_harness_receipt_commitment = "2".repeat(64);
+            receipt.recursive_artifact_chain_harness_receipt_commitment =
+                commit_phase37_recursive_artifact_chain_harness_receipt(&receipt)
+                    .expect("recommit phase37 receipt");
+            assert_err_contains(
+                &case.name,
+                verify_phase37_recursive_artifact_chain_harness_receipt_against_sources(
+                    &receipt,
+                    &valid.phase29,
+                    &valid.phase30,
+                ),
+                &case.expected_error_contains,
+            );
+        }
+        _ => panic!("unhandled known-bad corpus case: {case:?}"),
+    }
+}
+
+fn assert_err_contains<T>(case_name: &str, result: Result<T, VmError>, expected: &str) {
+    match result {
+        Ok(_) => panic!("known-bad case `{case_name}` unexpectedly passed"),
+        Err(err) => {
+            let message = err.to_string();
+            assert!(
+                message.contains(expected),
+                "known-bad case `{case_name}` failed with `{message}`, expected substring `{expected}`"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a manifest-driven known-bad corpus for Phase 29 through Phase 37 public artifact surfaces
- exercise parser and source-bound verifier failures, including self-consistent bad artifacts with recomputed outer commitments
- wire the corpus into `scripts/local_merge_gate.sh` when Phase 29-37 artifact surfaces or corpus files change
- raise the default AI-review quiet window from 5 minutes to 7 minutes

## Why
We need stronger evidence that the phase artifact chain rejects bad statements for the right reason, not only stale root commitments. The new corpus gives us a cheap, repeatable local guard for the paper-facing artifact surfaces.

## Validation
- [x] `cargo fmt --check`
- [x] `bash -n scripts/local_merge_gate.sh scripts/run_known_bad_phase_artifact_corpus.sh && git diff --check`
- [x] `scripts/run_shellcheck_suite.sh`
- [x] `scripts/run_known_bad_phase_artifact_corpus.sh`

## Hardening
- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

## Hardening notes
- Targeted regression coverage is the new Phase 29-37 known-bad corpus.
- Oracle/differential coverage is source-bound verification against recomputed valid artifacts plus mutated artifacts with recomputed outer commitments.
- Resource-bound impact is limited to one exact integration test and a conditional merge-gate hook.
- Kani/formal-kernel impact is not applicable; this PR adds artifact-surface regression coverage and does not change the formal kernel.
- The merge gate now waits 420 seconds after the latest CodeRabbit, Greptile, or Qodo event before merge.
