### PR TITLE
[codex] Add differential reference evidence harness

### DIFF
--- a/docs/engineering/approximation-budget.md
+++ b/docs/engineering/approximation-budget.md
@@ -1,0 +1,61 @@
+# Approximation Budget
+
+This document defines the bounded approximation budget format used by
+`scripts/check_approximation_budget.py`.
+
+## Purpose
+
+The budget checker exists to make approximation evidence explicit and bounded.
+It is not a benchmark runner.
+It only validates that a recorded evidence bundle stays within declared limits.
+
+## Budget bundle schema
+
+The checker expects a JSON object with a non-empty `cases` array.
+Each case must contain:
+
+- `case_id`
+- `budget`
+- `evidence`
+
+## Budget fields
+
+Supported budget fields are:
+
+- `max_logit_error`
+- `max_mean_logit_error`
+- `max_kl`
+- `require_top1_match`
+- `min_topk_overlap`
+- `max_token_flips` optional
+
+## Evidence fields
+
+Supported evidence fields are:
+
+- `max_logit_error`
+- `mean_logit_error`
+- `kl_divergence`
+- `top1_match`
+- `topk_overlap`
+- `token_flips` optional, required if the budget sets `max_token_flips`
+
+## Example
+
+The tiny fixture at `tests/fixtures/reference_cases/toy_approximation_budget_bundle.json`
+shows the expected shape.
+
+## Failure mode
+
+The checker exits non-zero if:
+
+- the bundle is malformed
+- a case is missing evidence
+- a required metric is missing
+- any evidence value exceeds the declared budget
+
+## Intended use
+
+Use this for small, auditable evidence bundles.
+Do not use it as a substitute for a benchmark harness or a proof of model
+equivalence.

--- a/docs/engineering/differential-reference-plan.md
+++ b/docs/engineering/differential-reference-plan.md
@@ -1,0 +1,66 @@
+# Differential Reference Plan
+
+This plan covers the small reference harness used to validate the pattern for a
+reference decode path without claiming full transformer equivalence.
+
+## Goal
+
+Create a minimal, deterministic decode reference that:
+
+- reads a fixture JSON file
+- computes a toy reference decode
+- emits a comparison JSON report
+- validates the report against the fixture or a golden comparison file
+- fails non-zero if evidence is missing or inconsistent
+
+## Scope
+
+The harness is intentionally narrow.
+It demonstrates the workflow for a future differential-reference setup, but it
+does not claim to validate end-to-end transformer parity.
+
+## Fixture shape
+
+The toy fixture at `tests/fixtures/reference_cases/toy_reference_case.json` uses:
+
+- `case_id`
+- `reference_decode.context_tokens`
+- `reference_decode.logit_bias`
+- `reference_decode.context_scale`
+- `reference_decode.position_slope`
+- `reference_decode.top_k`
+- `candidate.logits`
+- `expected_comparison`
+
+The comparison report includes:
+
+- reference logits
+- candidate logits
+- max and mean logit error
+- KL divergence
+- top-1 match
+- top-k overlap
+- token flip count
+
+## Tooling
+
+Use `scripts/reference/run_reference_decode.py`.
+
+- `emit` writes a comparison JSON report
+- `check` recomputes the report and validates it against the fixture's embedded
+  `expected_comparison`
+
+## Failure mode
+
+The harness exits non-zero if:
+
+- the fixture is malformed
+- candidate data is missing
+- reference and candidate lengths differ
+- the computed report does not match the expected comparison
+
+## Maintenance rule
+
+Keep the harness small and explicit.
+If a future case needs richer structure, add a new fixture and keep the toy
+comparison logic deterministic.

--- a/docs/engineering/differential-reference-plan.md
+++ b/docs/engineering/differential-reference-plan.md
@@ -10,7 +10,7 @@ Create a minimal, deterministic decode reference that:
 - reads a fixture JSON file
 - computes a toy reference decode
 - emits a comparison JSON report
-- validates the report against the fixture or a golden comparison file
+- validates the report against the fixture's embedded expected comparison
 - fails non-zero if evidence is missing or inconsistent
 
 ## Scope

--- a/scripts/check_approximation_budget.py
+++ b/scripts/check_approximation_budget.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 
-def load_json(path: Path) -> Dict[str, Any]:
+def load_json(path: Path) -> Any:
     with path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
 
@@ -118,6 +118,8 @@ def main() -> int:
 
     try:
         payload = load_json(args.budget_json)
+        if not isinstance(payload, dict):
+            return die("budget JSON must be an object with a non-empty cases array")
         cases = payload.get("cases")
         if not isinstance(cases, list) or not cases:
             return die("budget JSON must contain a non-empty cases array")

--- a/scripts/check_approximation_budget.py
+++ b/scripts/check_approximation_budget.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Check bounded approximation budgets from a JSON bundle.
+
+The expected input is a JSON object with a non-empty ``cases`` array. Each case
+must include a ``budget`` object and an ``evidence`` object. Missing evidence or
+budget overruns exit non-zero.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def die(message: str) -> int:
+    print(f"error: {message}", file=sys.stderr)
+    return 1
+
+
+def require_number(mapping: Dict[str, Any], key: str, case_id: str, section: str) -> float:
+    value = mapping.get(key)
+    if not isinstance(value, (int, float)):
+        raise ValueError(f"{case_id}: {section}.{key} must be numeric")
+    return float(value)
+
+
+def require_bool(mapping: Dict[str, Any], key: str, case_id: str, section: str) -> bool:
+    value = mapping.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{case_id}: {section}.{key} must be boolean")
+    return bool(value)
+
+
+def require_int(mapping: Dict[str, Any], key: str, case_id: str, section: str) -> int:
+    value = mapping.get(key)
+    if not isinstance(value, int):
+        raise ValueError(f"{case_id}: {section}.{key} must be an integer")
+    return int(value)
+
+
+def check_case(case: Dict[str, Any]) -> None:
+    case_id = case.get("case_id")
+    if not isinstance(case_id, str) or not case_id:
+        raise ValueError("each case must include a non-empty case_id")
+
+    budget = case.get("budget")
+    evidence = case.get("evidence")
+    if not isinstance(budget, dict):
+        raise ValueError(f"{case_id}: budget must be an object")
+    if not isinstance(evidence, dict):
+        raise ValueError(f"{case_id}: evidence must be an object")
+
+    max_logit_error = require_number(budget, "max_logit_error", case_id, "budget")
+    mean_logit_error = require_number(budget, "max_mean_logit_error", case_id, "budget")
+    max_kl = require_number(budget, "max_kl", case_id, "budget")
+    min_topk_overlap = require_int(budget, "min_topk_overlap", case_id, "budget")
+
+    token_flip_budget = budget.get("max_token_flips")
+    if token_flip_budget is not None and not isinstance(token_flip_budget, int):
+        raise ValueError(f"{case_id}: budget.max_token_flips must be an integer when provided")
+
+    evidence_max_logit_error = require_number(evidence, "max_logit_error", case_id, "evidence")
+    evidence_mean_logit_error = require_number(evidence, "mean_logit_error", case_id, "evidence")
+    evidence_kl = require_number(evidence, "kl_divergence", case_id, "evidence")
+    top1_match = require_bool(evidence, "top1_match", case_id, "evidence")
+    topk_overlap = require_int(evidence, "topk_overlap", case_id, "evidence")
+
+    if evidence_max_logit_error > max_logit_error:
+        raise ValueError(
+            f"{case_id}: max_logit_error {evidence_max_logit_error} exceeds budget {max_logit_error}"
+        )
+    if evidence_mean_logit_error > mean_logit_error:
+        raise ValueError(
+            f"{case_id}: mean_logit_error {evidence_mean_logit_error} exceeds budget {mean_logit_error}"
+        )
+    if evidence_kl > max_kl:
+        raise ValueError(f"{case_id}: kl_divergence {evidence_kl} exceeds budget {max_kl}")
+    if budget.get("require_top1_match", False) and not top1_match:
+        raise ValueError(f"{case_id}: top1_match is required but evidence reports false")
+    if topk_overlap < min_topk_overlap:
+        raise ValueError(
+            f"{case_id}: topk_overlap {topk_overlap} is below budget {min_topk_overlap}"
+        )
+
+    if token_flip_budget is not None:
+        token_flips = require_int(evidence, "token_flips", case_id, "evidence")
+        if token_flips > token_flip_budget:
+            raise ValueError(
+                f"{case_id}: token_flips {token_flips} exceeds budget {token_flip_budget}"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("budget_json", type=Path)
+    args = parser.parse_args()
+
+    try:
+        payload = load_json(args.budget_json)
+        cases = payload.get("cases")
+        if not isinstance(cases, list) or not cases:
+            return die("budget JSON must contain a non-empty cases array")
+        for case in cases:
+            if not isinstance(case, dict):
+                return die("each case must be a JSON object")
+            check_case(case)
+    except (OSError, json.JSONDecodeError) as err:
+        return die(str(err))
+    except ValueError as err:
+        return die(str(err))
+
+    print(f"checked {len(cases)} case(s) from {args.budget_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_approximation_budget.py
+++ b/scripts/check_approximation_budget.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from pathlib import Path
 from typing import Any, Dict
@@ -26,9 +27,12 @@ def die(message: str) -> int:
 
 def require_number(mapping: Dict[str, Any], key: str, case_id: str, section: str) -> float:
     value = mapping.get(key)
-    if not isinstance(value, (int, float)):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ValueError(f"{case_id}: {section}.{key} must be numeric")
-    return float(value)
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{case_id}: {section}.{key} must be finite")
+    return number
 
 
 def require_bool(mapping: Dict[str, Any], key: str, case_id: str, section: str) -> bool:
@@ -40,7 +44,7 @@ def require_bool(mapping: Dict[str, Any], key: str, case_id: str, section: str) 
 
 def require_int(mapping: Dict[str, Any], key: str, case_id: str, section: str) -> int:
     value = mapping.get(key)
-    if not isinstance(value, int):
+    if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError(f"{case_id}: {section}.{key} must be an integer")
     return int(value)
 
@@ -61,10 +65,20 @@ def check_case(case: Dict[str, Any]) -> None:
     mean_logit_error = require_number(budget, "max_mean_logit_error", case_id, "budget")
     max_kl = require_number(budget, "max_kl", case_id, "budget")
     min_topk_overlap = require_int(budget, "min_topk_overlap", case_id, "budget")
+    require_top1_match = require_bool(budget, "require_top1_match", case_id, "budget")
+
+    if max_logit_error < 0 or mean_logit_error < 0 or max_kl < 0:
+        raise ValueError(f"{case_id}: numeric budget maxima must be non-negative")
+    if min_topk_overlap < 0:
+        raise ValueError(f"{case_id}: budget.min_topk_overlap must be non-negative")
 
     token_flip_budget = budget.get("max_token_flips")
-    if token_flip_budget is not None and not isinstance(token_flip_budget, int):
+    if token_flip_budget is not None and (
+        isinstance(token_flip_budget, bool) or not isinstance(token_flip_budget, int)
+    ):
         raise ValueError(f"{case_id}: budget.max_token_flips must be an integer when provided")
+    if isinstance(token_flip_budget, int) and token_flip_budget < 0:
+        raise ValueError(f"{case_id}: budget.max_token_flips must be non-negative")
 
     evidence_max_logit_error = require_number(evidence, "max_logit_error", case_id, "evidence")
     evidence_mean_logit_error = require_number(evidence, "mean_logit_error", case_id, "evidence")
@@ -82,7 +96,7 @@ def check_case(case: Dict[str, Any]) -> None:
         )
     if evidence_kl > max_kl:
         raise ValueError(f"{case_id}: kl_divergence {evidence_kl} exceeds budget {max_kl}")
-    if budget.get("require_top1_match", False) and not top1_match:
+    if require_top1_match and not top1_match:
         raise ValueError(f"{case_id}: top1_match is required but evidence reports false")
     if topk_overlap < min_topk_overlap:
         raise ValueError(

--- a/scripts/reference/README.md
+++ b/scripts/reference/README.md
@@ -1,0 +1,17 @@
+# Reference Harness
+
+Tiny stdlib-only reference tooling for the differential-reference slice.
+
+Files:
+
+- `run_reference_decode.py`: emits or validates a toy comparison JSON report
+
+Example:
+
+```bash
+python3 scripts/reference/run_reference_decode.py emit --fixture tests/fixtures/reference_cases/toy_reference_case.json
+python3 scripts/reference/run_reference_decode.py check --fixture tests/fixtures/reference_cases/toy_reference_case.json
+```
+
+The harness is deliberately narrow and does not claim full transformer
+equivalence.

--- a/scripts/reference/run_reference_decode.py
+++ b/scripts/reference/run_reference_decode.py
@@ -38,9 +38,12 @@ def require_number_list(name: str, value: Any) -> List[float]:
     items = require_list(name, value)
     result: List[float] = []
     for index, item in enumerate(items):
-        if not isinstance(item, (int, float)):
+        if isinstance(item, bool) or not isinstance(item, (int, float)):
             raise ValueError(f"{name}[{index}] must be numeric")
-        result.append(float(item))
+        number = float(item)
+        if not math.isfinite(number):
+            raise ValueError(f"{name}[{index}] must be finite")
+        result.append(number)
     return result
 
 
@@ -48,10 +51,25 @@ def require_int_list(name: str, value: Any) -> List[int]:
     items = require_list(name, value)
     result: List[int] = []
     for index, item in enumerate(items):
-        if not isinstance(item, int):
+        if isinstance(item, bool) or not isinstance(item, int):
             raise ValueError(f"{name}[{index}] must be an integer")
         result.append(int(item))
     return result
+
+
+def require_number(name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be numeric")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite")
+    return number
+
+
+def require_positive_int(name: str, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return int(value)
 
 
 def softmax(logits: Sequence[float]) -> List[float]:
@@ -78,22 +96,19 @@ def reference_logits(case: Dict[str, Any]) -> Dict[str, Any]:
 
     context_tokens = require_int_list("reference_decode.context_tokens", decode.get("context_tokens"))
     logit_bias = require_number_list("reference_decode.logit_bias", decode.get("logit_bias"))
-    context_scale = decode.get("context_scale")
-    position_slope = decode.get("position_slope")
-    top_k = decode.get("top_k")
-
-    if not isinstance(context_scale, (int, float)):
-        raise ValueError("reference_decode.context_scale must be numeric")
-    if not isinstance(position_slope, (int, float)):
-        raise ValueError("reference_decode.position_slope must be numeric")
-    if not isinstance(top_k, int) or top_k <= 0:
-        raise ValueError("reference_decode.top_k must be a positive integer")
+    context_scale = require_number(
+        "reference_decode.context_scale", decode.get("context_scale")
+    )
+    position_slope = require_number(
+        "reference_decode.position_slope", decode.get("position_slope")
+    )
+    top_k = require_positive_int("reference_decode.top_k", decode.get("top_k"))
     if len(logit_bias) == 0:
         raise ValueError("reference_decode.logit_bias must not be empty")
 
     context_score = sum(context_tokens)
     logits = [
-        round(float(context_scale) * context_score + bias + float(position_slope) * index, 12)
+        round(context_scale * context_score + bias + position_slope * index, 12)
         for index, bias in enumerate(logit_bias)
     ]
     ranked = top_indices(logits, min(top_k, len(logits)))
@@ -105,11 +120,17 @@ def reference_logits(case: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def compare_logits(reference: Sequence[float], candidate: Sequence[float]) -> Dict[str, Any]:
+def compare_logits(
+    reference: Sequence[float],
+    candidate: Sequence[float],
+    top_k: int,
+) -> Dict[str, Any]:
     if len(reference) != len(candidate):
         raise ValueError(
             f"reference and candidate logits length mismatch: {len(reference)} != {len(candidate)}"
         )
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
 
     absolute_errors = [abs(ref - cand) for ref, cand in zip(reference, candidate)]
     reference_probs = softmax(reference)
@@ -121,9 +142,9 @@ def compare_logits(reference: Sequence[float], candidate: Sequence[float]) -> Di
 
     reference_top1 = top_indices(reference, 1)[0]
     candidate_top1 = top_indices(candidate, 1)[0]
-    top_k = min(2, len(reference))
-    reference_topk = top_indices(reference, top_k)
-    candidate_topk = top_indices(candidate, top_k)
+    bounded_top_k = min(top_k, len(reference))
+    reference_topk = top_indices(reference, bounded_top_k)
+    candidate_topk = top_indices(candidate, bounded_top_k)
     topk_overlap = len(set(reference_topk).intersection(candidate_topk))
 
     return {
@@ -151,7 +172,9 @@ def build_report(case: Dict[str, Any]) -> Dict[str, Any]:
     candidate_logits = require_number_list("candidate.logits", candidate.get("logits"))
 
     reference = reference_logits(case)
-    metrics = compare_logits(reference["logits"], candidate_logits)
+    metrics = compare_logits(
+        reference["logits"], candidate_logits, top_k=len(reference["topk"])
+    )
 
     return {
         "case_id": case_id,

--- a/scripts/reference/run_reference_decode.py
+++ b/scripts/reference/run_reference_decode.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Tiny reference decode harness for fixture-driven differential checks.
+
+This is intentionally small and model-agnostic. It demonstrates the
+reference-vs-candidate pattern on a toy decoder shape; it does not claim full
+transformer equivalence.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def dump_json(data: Dict[str, Any], path: Path | None) -> None:
+    payload = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    if path is None:
+        sys.stdout.write(payload)
+        return
+    path.write_text(payload, encoding="utf-8")
+
+
+def require_list(name: str, value: Any) -> List[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a JSON array")
+    return value
+
+
+def require_number_list(name: str, value: Any) -> List[float]:
+    items = require_list(name, value)
+    result: List[float] = []
+    for index, item in enumerate(items):
+        if not isinstance(item, (int, float)):
+            raise ValueError(f"{name}[{index}] must be numeric")
+        result.append(float(item))
+    return result
+
+
+def require_int_list(name: str, value: Any) -> List[int]:
+    items = require_list(name, value)
+    result: List[int] = []
+    for index, item in enumerate(items):
+        if not isinstance(item, int):
+            raise ValueError(f"{name}[{index}] must be an integer")
+        result.append(int(item))
+    return result
+
+
+def softmax(logits: Sequence[float]) -> List[float]:
+    if not logits:
+        raise ValueError("logits must not be empty")
+    max_logit = max(logits)
+    exps = [math.exp(logit - max_logit) for logit in logits]
+    total = sum(exps)
+    return [value / total for value in exps]
+
+
+def top_indices(logits: Sequence[float], k: int) -> List[int]:
+    ranked = sorted(
+        enumerate(logits),
+        key=lambda pair: (-pair[1], pair[0]),
+    )
+    return [index for index, _ in ranked[:k]]
+
+
+def reference_logits(case: Dict[str, Any]) -> Dict[str, Any]:
+    decode = case.get("reference_decode")
+    if not isinstance(decode, dict):
+        raise ValueError("fixture must contain reference_decode object")
+
+    context_tokens = require_int_list("reference_decode.context_tokens", decode.get("context_tokens"))
+    logit_bias = require_number_list("reference_decode.logit_bias", decode.get("logit_bias"))
+    context_scale = decode.get("context_scale")
+    position_slope = decode.get("position_slope")
+    top_k = decode.get("top_k")
+
+    if not isinstance(context_scale, (int, float)):
+        raise ValueError("reference_decode.context_scale must be numeric")
+    if not isinstance(position_slope, (int, float)):
+        raise ValueError("reference_decode.position_slope must be numeric")
+    if not isinstance(top_k, int) or top_k <= 0:
+        raise ValueError("reference_decode.top_k must be a positive integer")
+    if len(logit_bias) == 0:
+        raise ValueError("reference_decode.logit_bias must not be empty")
+
+    context_score = sum(context_tokens)
+    logits = [
+        round(float(context_scale) * context_score + bias + float(position_slope) * index, 12)
+        for index, bias in enumerate(logit_bias)
+    ]
+    ranked = top_indices(logits, min(top_k, len(logits)))
+    return {
+        "context_score": context_score,
+        "logits": logits,
+        "top1": ranked[0],
+        "topk": ranked,
+    }
+
+
+def compare_logits(reference: Sequence[float], candidate: Sequence[float]) -> Dict[str, Any]:
+    if len(reference) != len(candidate):
+        raise ValueError(
+            f"reference and candidate logits length mismatch: {len(reference)} != {len(candidate)}"
+        )
+
+    absolute_errors = [abs(ref - cand) for ref, cand in zip(reference, candidate)]
+    reference_probs = softmax(reference)
+    candidate_probs = softmax(candidate)
+    kl_divergence = sum(
+        ref_prob * math.log(ref_prob / cand_prob)
+        for ref_prob, cand_prob in zip(reference_probs, candidate_probs)
+    )
+
+    reference_top1 = top_indices(reference, 1)[0]
+    candidate_top1 = top_indices(candidate, 1)[0]
+    top_k = min(2, len(reference))
+    reference_topk = top_indices(reference, top_k)
+    candidate_topk = top_indices(candidate, top_k)
+    topk_overlap = len(set(reference_topk).intersection(candidate_topk))
+
+    return {
+        "max_logit_error": max(absolute_errors),
+        "mean_logit_error": sum(absolute_errors) / len(absolute_errors),
+        "kl_divergence": kl_divergence,
+        "top1_match": reference_top1 == candidate_top1,
+        "topk_overlap": topk_overlap,
+        "token_flips": 0 if reference_top1 == candidate_top1 else 1,
+        "reference_top1": reference_top1,
+        "candidate_top1": candidate_top1,
+        "reference_topk": reference_topk,
+        "candidate_topk": candidate_topk,
+    }
+
+
+def build_report(case: Dict[str, Any]) -> Dict[str, Any]:
+    case_id = case.get("case_id")
+    if not isinstance(case_id, str) or not case_id:
+        raise ValueError("fixture must contain a non-empty case_id string")
+
+    candidate = case.get("candidate")
+    if not isinstance(candidate, dict):
+        raise ValueError("fixture must contain candidate object")
+    candidate_logits = require_number_list("candidate.logits", candidate.get("logits"))
+
+    reference = reference_logits(case)
+    metrics = compare_logits(reference["logits"], candidate_logits)
+
+    return {
+        "case_id": case_id,
+        "reference": reference,
+        "candidate": {
+            "logits": candidate_logits,
+            "top1": metrics["candidate_top1"],
+            "topk": metrics["candidate_topk"],
+        },
+        "metrics": {
+            "max_logit_error": metrics["max_logit_error"],
+            "mean_logit_error": metrics["mean_logit_error"],
+            "kl_divergence": metrics["kl_divergence"],
+            "top1_match": metrics["top1_match"],
+            "topk_overlap": metrics["topk_overlap"],
+            "token_flips": metrics["token_flips"],
+        },
+        "status": "pass" if metrics["top1_match"] and metrics["max_logit_error"] == 0 else "needs-review",
+    }
+
+
+def check_report(fixture: Dict[str, Any], report: Dict[str, Any]) -> None:
+    expected = fixture.get("expected_comparison")
+    if not isinstance(expected, dict):
+        raise ValueError("fixture must contain expected_comparison object for check mode")
+    if report != expected:
+        raise ValueError(
+            "comparison report did not match expected_comparison in fixture"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    emit = subparsers.add_parser("emit", help="emit a comparison JSON report")
+    emit.add_argument("--fixture", required=True, type=Path)
+    emit.add_argument("--output", type=Path)
+
+    check = subparsers.add_parser("check", help="validate a comparison JSON report")
+    check.add_argument("--fixture", required=True, type=Path)
+    check.add_argument("--output", type=Path)
+
+    args = parser.parse_args()
+    fixture = load_json(args.fixture)
+    report = build_report(fixture)
+
+    if args.command == "emit":
+        dump_json(report, args.output)
+        return 0
+
+    if args.command == "check":
+        check_report(fixture, report)
+        dump_json(report, args.output)
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reference/tests/test_reference_decode.py
+++ b/scripts/reference/tests/test_reference_decode.py
@@ -10,7 +10,8 @@ import unittest
 REPO = pathlib.Path(__file__).resolve().parents[3]
 MODULE_PATH = REPO / "scripts" / "reference" / "run_reference_decode.py"
 SPEC = importlib.util.spec_from_file_location("run_reference_decode", MODULE_PATH)
-assert SPEC and SPEC.loader
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load reference decode module from {MODULE_PATH}")
 MOD = importlib.util.module_from_spec(SPEC)
 sys.modules["run_reference_decode"] = MOD
 SPEC.loader.exec_module(MOD)

--- a/scripts/reference/tests/test_reference_decode.py
+++ b/scripts/reference/tests/test_reference_decode.py
@@ -35,6 +35,13 @@ class ReferenceDecodeTests(unittest.TestCase):
         self.assertEqual(report["candidate"]["topk"], [1, 0, 2])
         self.assertEqual(report["metrics"]["topk_overlap"], 3)
 
+    def test_check_report_rejects_tampered_expected_comparison(self) -> None:
+        fixture = copy.deepcopy(self.load_fixture("toy_reference_case.json"))
+        report = MOD.build_report(fixture)
+        fixture["expected_comparison"]["metrics"]["max_logit_error"] = 0.25
+        with self.assertRaisesRegex(ValueError, "did not match expected_comparison"):
+            MOD.check_report(fixture, report)
+
     def test_rejects_bool_in_numeric_fields(self) -> None:
         fixture = self.load_fixture("toy_reference_case.json")
         fixture = copy.deepcopy(fixture)

--- a/scripts/reference/tests/test_reference_decode.py
+++ b/scripts/reference/tests/test_reference_decode.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO / "scripts" / "reference" / "run_reference_decode.py"
+SPEC = importlib.util.spec_from_file_location("run_reference_decode", MODULE_PATH)
+assert SPEC and SPEC.loader
+MOD = importlib.util.module_from_spec(SPEC)
+sys.modules["run_reference_decode"] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+class ReferenceDecodeTests(unittest.TestCase):
+    def load_fixture(self, name: str) -> dict:
+        return MOD.load_json(REPO / "tests" / "fixtures" / "reference_cases" / name)
+
+    def test_fixture_embedded_expected_comparison_passes(self) -> None:
+        fixture = self.load_fixture("toy_reference_case.json")
+        report = MOD.build_report(fixture)
+        MOD.check_report(fixture, report)
+        self.assertEqual(report, fixture["expected_comparison"])
+
+    def test_top_k_comes_from_fixture(self) -> None:
+        fixture = self.load_fixture("toy_reference_case_topk3.json")
+        report = MOD.build_report(fixture)
+        MOD.check_report(fixture, report)
+        self.assertEqual(report["reference"]["topk"], [1, 0, 2])
+        self.assertEqual(report["candidate"]["topk"], [1, 0, 2])
+        self.assertEqual(report["metrics"]["topk_overlap"], 3)
+
+    def test_rejects_bool_in_numeric_fields(self) -> None:
+        fixture = self.load_fixture("toy_reference_case.json")
+        fixture = copy.deepcopy(fixture)
+        fixture["reference_decode"]["context_scale"] = True
+        with self.assertRaisesRegex(ValueError, "context_scale must be numeric"):
+            MOD.build_report(fixture)
+
+        fixture = self.load_fixture("toy_reference_case.json")
+        fixture = copy.deepcopy(fixture)
+        fixture["reference_decode"]["context_tokens"] = [2, True, 1]
+        with self.assertRaisesRegex(
+            ValueError, r"context_tokens\[1\] must be an integer"
+        ):
+            MOD.build_report(fixture)
+
+    def test_rejects_length_mismatch(self) -> None:
+        fixture = self.load_fixture("toy_reference_case.json")
+        fixture = copy.deepcopy(fixture)
+        fixture["candidate"]["logits"] = [0.95, 0.65]
+        with self.assertRaisesRegex(ValueError, "length mismatch"):
+            MOD.build_report(fixture)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_approximation_budget.py
+++ b/scripts/tests/test_check_approximation_budget.py
@@ -45,7 +45,7 @@ class ApproximationBudgetTests(unittest.TestCase):
         cases = self.load_negative_cases()
         self.assertGreaterEqual(len(cases), 3)
         for case in cases:
-            with self.subTest(case_id=case["case_id"]):
+            with self.subTest(case_id=case.get("case_id", "<missing>")):
                 with self.assertRaises(ValueError):
                     MOD.check_case(case)
 

--- a/scripts/tests/test_check_approximation_budget.py
+++ b/scripts/tests/test_check_approximation_budget.py
@@ -10,7 +10,8 @@ import unittest
 REPO = pathlib.Path(__file__).resolve().parents[2]
 MODULE_PATH = REPO / "scripts" / "check_approximation_budget.py"
 SPEC = importlib.util.spec_from_file_location("check_approximation_budget", MODULE_PATH)
-assert SPEC and SPEC.loader
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load approximation budget module from {MODULE_PATH}")
 MOD = importlib.util.module_from_spec(SPEC)
 sys.modules["check_approximation_budget"] = MOD
 SPEC.loader.exec_module(MOD)

--- a/scripts/tests/test_check_approximation_budget.py
+++ b/scripts/tests/test_check_approximation_budget.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import copy
+import io
 import importlib.util
 import pathlib
 import sys
+import tempfile
 import unittest
+from unittest import mock
 
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
@@ -40,6 +43,17 @@ class ApproximationBudgetTests(unittest.TestCase):
 
     def test_valid_fixture_case_passes(self) -> None:
         MOD.check_case(self.load_case())
+
+    def test_main_rejects_non_object_json_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "bundle.json"
+            path.write_text("[]", encoding="utf-8")
+            with (
+                mock.patch.object(sys, "argv", ["check_approximation_budget.py", str(path)]),
+                mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+            ):
+                self.assertEqual(MOD.main(), 1)
+                self.assertIn("budget JSON must be an object", stderr.getvalue())
 
     def test_negative_fixture_cases_fail_closed(self) -> None:
         cases = self.load_negative_cases()

--- a/scripts/tests/test_check_approximation_budget.py
+++ b/scripts/tests/test_check_approximation_budget.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO / "scripts" / "check_approximation_budget.py"
+SPEC = importlib.util.spec_from_file_location("check_approximation_budget", MODULE_PATH)
+assert SPEC and SPEC.loader
+MOD = importlib.util.module_from_spec(SPEC)
+sys.modules["check_approximation_budget"] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+class ApproximationBudgetTests(unittest.TestCase):
+    def load_case(self) -> dict:
+        payload = MOD.load_json(
+            REPO
+            / "tests"
+            / "fixtures"
+            / "reference_cases"
+            / "toy_approximation_budget_bundle.json"
+        )
+        return copy.deepcopy(payload["cases"][0])
+
+    def test_valid_fixture_case_passes(self) -> None:
+        MOD.check_case(self.load_case())
+
+    def test_rejects_bool_as_number(self) -> None:
+        case = self.load_case()
+        case["evidence"]["max_logit_error"] = True
+        with self.assertRaisesRegex(ValueError, "max_logit_error must be numeric"):
+            MOD.check_case(case)
+
+    def test_rejects_non_finite_number(self) -> None:
+        case = self.load_case()
+        case["evidence"]["kl_divergence"] = float("nan")
+        with self.assertRaisesRegex(ValueError, "kl_divergence must be finite"):
+            MOD.check_case(case)
+
+    def test_rejects_budget_overrun(self) -> None:
+        case = self.load_case()
+        case["evidence"]["max_logit_error"] = 0.2
+        with self.assertRaisesRegex(ValueError, "exceeds budget"):
+            MOD.check_case(case)
+
+    def test_rejects_missing_token_flips_when_budget_requires_it(self) -> None:
+        case = self.load_case()
+        del case["evidence"]["token_flips"]
+        with self.assertRaisesRegex(ValueError, "token_flips must be an integer"):
+            MOD.check_case(case)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_approximation_budget.py
+++ b/scripts/tests/test_check_approximation_budget.py
@@ -28,8 +28,26 @@ class ApproximationBudgetTests(unittest.TestCase):
         )
         return copy.deepcopy(payload["cases"][0])
 
+    def load_negative_cases(self) -> list[dict]:
+        payload = MOD.load_json(
+            REPO
+            / "tests"
+            / "fixtures"
+            / "reference_cases"
+            / "toy_approximation_budget_negative_bundle.json"
+        )
+        return copy.deepcopy(payload["cases"])
+
     def test_valid_fixture_case_passes(self) -> None:
         MOD.check_case(self.load_case())
+
+    def test_negative_fixture_cases_fail_closed(self) -> None:
+        cases = self.load_negative_cases()
+        self.assertGreaterEqual(len(cases), 3)
+        for case in cases:
+            with self.subTest(case_id=case["case_id"]):
+                with self.assertRaises(ValueError):
+                    MOD.check_case(case)
 
     def test_rejects_bool_as_number(self) -> None:
         case = self.load_case()

--- a/tests/fixtures/reference_cases/toy_approximation_budget_bundle.json
+++ b/tests/fixtures/reference_cases/toy_approximation_budget_bundle.json
@@ -1,6 +1,5 @@
 {
   "suite_id": "toy_approximation_budget_v1",
-  "negative_case_bundle": "toy_approximation_budget_negative_bundle.json",
   "cases": [
     {
       "case_id": "toy_reference_case_v1",

--- a/tests/fixtures/reference_cases/toy_approximation_budget_bundle.json
+++ b/tests/fixtures/reference_cases/toy_approximation_budget_bundle.json
@@ -1,5 +1,6 @@
 {
   "suite_id": "toy_approximation_budget_v1",
+  "negative_case_bundle": "toy_approximation_budget_negative_bundle.json",
   "cases": [
     {
       "case_id": "toy_reference_case_v1",

--- a/tests/fixtures/reference_cases/toy_approximation_budget_bundle.json
+++ b/tests/fixtures/reference_cases/toy_approximation_budget_bundle.json
@@ -1,0 +1,24 @@
+{
+  "suite_id": "toy_approximation_budget_v1",
+  "cases": [
+    {
+      "case_id": "toy_reference_case_v1",
+      "budget": {
+        "max_logit_error": 0.01,
+        "max_mean_logit_error": 0.01,
+        "max_kl": 0.01,
+        "require_top1_match": true,
+        "min_topk_overlap": 2,
+        "max_token_flips": 0
+      },
+      "evidence": {
+        "max_logit_error": 0.0,
+        "mean_logit_error": 0.0,
+        "kl_divergence": 0.0,
+        "top1_match": true,
+        "topk_overlap": 2,
+        "token_flips": 0
+      }
+    }
+  ]
+}

--- a/tests/fixtures/reference_cases/toy_approximation_budget_negative_bundle.json
+++ b/tests/fixtures/reference_cases/toy_approximation_budget_negative_bundle.json
@@ -1,0 +1,60 @@
+{
+  "suite_id": "toy_approximation_budget_negative_v1",
+  "cases": [
+    {
+      "case_id": "toy_reference_case_v1_missing_token_flips",
+      "budget": {
+        "max_logit_error": 0.01,
+        "max_mean_logit_error": 0.01,
+        "max_kl": 0.01,
+        "require_top1_match": true,
+        "min_topk_overlap": 2,
+        "max_token_flips": 0
+      },
+      "evidence": {
+        "max_logit_error": 0.0,
+        "mean_logit_error": 0.0,
+        "kl_divergence": 0.0,
+        "top1_match": true,
+        "topk_overlap": 2
+      }
+    },
+    {
+      "case_id": "toy_reference_case_v1_wrong_metric_type",
+      "budget": {
+        "max_logit_error": 0.01,
+        "max_mean_logit_error": 0.01,
+        "max_kl": 0.01,
+        "require_top1_match": true,
+        "min_topk_overlap": 2,
+        "max_token_flips": 0
+      },
+      "evidence": {
+        "max_logit_error": "0.0",
+        "mean_logit_error": 0.0,
+        "kl_divergence": 0.0,
+        "top1_match": true,
+        "topk_overlap": 2,
+        "token_flips": 0
+      }
+    },
+    {
+      "case_id": "toy_reference_case_v1_missing_top1_match",
+      "budget": {
+        "max_logit_error": 0.01,
+        "max_mean_logit_error": 0.01,
+        "max_kl": 0.01,
+        "require_top1_match": true,
+        "min_topk_overlap": 2,
+        "max_token_flips": 0
+      },
+      "evidence": {
+        "max_logit_error": 0.0,
+        "mean_logit_error": 0.0,
+        "kl_divergence": 0.0,
+        "topk_overlap": 2,
+        "token_flips": 0
+      }
+    }
+  ]
+}

--- a/tests/fixtures/reference_cases/toy_reference_case.json
+++ b/tests/fixtures/reference_cases/toy_reference_case.json
@@ -1,0 +1,36 @@
+{
+  "case_id": "toy_reference_case_v1",
+  "reference_decode": {
+    "context_tokens": [2, 0, 1],
+    "logit_bias": [0.35, 0.15, 0.05],
+    "context_scale": 0.2,
+    "position_slope": -0.1,
+    "top_k": 2
+  },
+  "candidate": {
+    "logits": [0.95, 0.65, 0.45]
+  },
+  "expected_comparison": {
+    "case_id": "toy_reference_case_v1",
+    "reference": {
+      "context_score": 3,
+      "logits": [0.95, 0.65, 0.45],
+      "top1": 0,
+      "topk": [0, 1]
+    },
+    "candidate": {
+      "logits": [0.95, 0.65, 0.45],
+      "top1": 0,
+      "topk": [0, 1]
+    },
+    "metrics": {
+      "max_logit_error": 0.0,
+      "mean_logit_error": 0.0,
+      "kl_divergence": 0.0,
+      "top1_match": true,
+      "topk_overlap": 2,
+      "token_flips": 0
+    },
+    "status": "pass"
+  }
+}

--- a/tests/fixtures/reference_cases/toy_reference_case.json
+++ b/tests/fixtures/reference_cases/toy_reference_case.json
@@ -1,6 +1,5 @@
 {
   "case_id": "toy_reference_case_v1",
-  "related_fixtures": ["toy_reference_case_topk3.json"],
   "reference_decode": {
     "context_tokens": [2, 0, 1],
     "logit_bias": [0.35, 0.15, 0.05],

--- a/tests/fixtures/reference_cases/toy_reference_case.json
+++ b/tests/fixtures/reference_cases/toy_reference_case.json
@@ -1,5 +1,6 @@
 {
   "case_id": "toy_reference_case_v1",
+  "related_fixtures": ["toy_reference_case_topk3.json"],
   "reference_decode": {
     "context_tokens": [2, 0, 1],
     "logit_bias": [0.35, 0.15, 0.05],

--- a/tests/fixtures/reference_cases/toy_reference_case_topk3.json
+++ b/tests/fixtures/reference_cases/toy_reference_case_topk3.json
@@ -1,0 +1,36 @@
+{
+  "case_id": "toy_reference_case_topk3_v1",
+  "reference_decode": {
+    "context_tokens": [1, 2],
+    "logit_bias": [0.2, 0.5, 0.1, 0.0],
+    "context_scale": 0.1,
+    "position_slope": 0.05,
+    "top_k": 3
+  },
+  "candidate": {
+    "logits": [0.5, 0.85, 0.5, 0.45]
+  },
+  "expected_comparison": {
+    "case_id": "toy_reference_case_topk3_v1",
+    "reference": {
+      "context_score": 3,
+      "logits": [0.5, 0.85, 0.5, 0.45],
+      "top1": 1,
+      "topk": [1, 0, 2]
+    },
+    "candidate": {
+      "logits": [0.5, 0.85, 0.5, 0.45],
+      "top1": 1,
+      "topk": [1, 0, 2]
+    },
+    "metrics": {
+      "max_logit_error": 0.0,
+      "mean_logit_error": 0.0,
+      "kl_divergence": 0.0,
+      "top1_match": true,
+      "topk_overlap": 3,
+      "token_flips": 0
+    },
+    "status": "pass"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the differential-reference and approximation-budget slice from #153. This introduces a tiny stdlib-only reference harness, fixture-backed comparisons, unit tests, and an explicit budget checker so semantic/approximation evidence fails closed instead of staying narrative-only.

## Scope

- Adds `scripts/reference/run_reference_decode.py` and README.
- Adds toy reference and budget fixtures, including a non-hardcoded top-k fixture.
- Adds `scripts/check_approximation_budget.py`.
- Adds focused Python unit tests for the reference harness and approximation budget checker.
- Adds engineering docs for differential-reference and approximation-budget policy.

## Validation

- `python3 -m py_compile scripts/check_approximation_budget.py scripts/reference/run_reference_decode.py scripts/reference/tests/test_reference_decode.py scripts/tests/test_check_approximation_budget.py`
- `python3 -m unittest discover -s scripts/reference/tests`
- `python3 -m unittest discover -s scripts/tests`
- `python3 scripts/reference/run_reference_decode.py emit --fixture tests/fixtures/reference_cases/toy_reference_case.json --output /tmp/toy-reference-report.json`
- `python3 scripts/reference/run_reference_decode.py check --fixture tests/fixtures/reference_cases/toy_reference_case.json --output /tmp/toy-reference-check.json`
- `python3 scripts/reference/run_reference_decode.py check --fixture tests/fixtures/reference_cases/toy_reference_case_topk3.json --output /tmp/toy-reference-topk3-check.json`
- `python3 scripts/check_approximation_budget.py tests/fixtures/reference_cases/toy_approximation_budget_bundle.json`
- `git diff --check -- scripts/check_approximation_budget.py scripts/reference/run_reference_decode.py scripts/reference/tests scripts/tests docs/engineering/differential-reference-plan.md tests/fixtures/reference_cases`

## Hardening

- [x] targeted regression and tamper-path coverage added or updated
- [x] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below

Hardening notes:

- Regression coverage exercises exact matching, tolerance failure, top-k arity derived from fixtures, non-finite numeric rejection, bool-as-number rejection, and invalid approximation-budget shapes.
- Oracle/differential coverage is the point of this slice: fixtures can now be checked against embedded expected comparisons and emitted as evidence JSON.
- Resource-bound impact is intentionally narrow: stdlib-only scripts read bounded JSON fixtures, reject malformed numeric values, and avoid network or subprocess execution.
- Kani/formal-kernel impact is not applicable for this slice because it adds Python evidence tooling and docs, not Rust verifier/prover kernels.

## Merge discipline

This PR should only merge after the review/comment quiet window is satisfied and any useful AI-review comments have been applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added engineering specifications for approximation budget validation format
  * Added differential reference plan documentation for decode comparisons
  * Added reference harness usage guide

* **New Features**
  * Added validation tool to check approximation budgets against defined constraints
  * Added reference decoding comparison harness with emit and check modes for fixture-driven testing

* **Tests**
  * Added comprehensive test suites and fixtures for budget validation and reference decode workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->