### PR TITLE
[codex] Add paper overclaim preflight linter

### DIFF
--- a/docs/paper/paper2/appendix-ivc-positioning.md
+++ b/docs/paper/paper2/appendix-ivc-positioning.md
@@ -17,8 +17,8 @@ The repository currently provides:
 
 ## B2. What recursive systems additionally provide
 
-Recursive proof-carrying data, IVC, and folding systems aim to provide one or
-more of the following:
+Recursive proof-carrying data, IVC, and folding systems, which this repository
+does not yet claim, aim to provide one or more of the following:
 
 - a verifier whose output becomes the next proof input,
 - asymptotic or practical proof-size compression across many steps,
@@ -39,7 +39,7 @@ The right comparison language is:
 The wrong comparison language is:
 
 - “already an IVC system”
-- “already recursive proof-carrying data”
+- “already recursive proof-carrying data” (not claimed here)
 - “already a folding construction”
 - “already compressed recursive verification”
 

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -339,7 +339,7 @@ The repository does not yet support the following stronger claims:
    HyperNova, NeutronNova, ProtoStar, SnarkFold, or related folding lines,
 3. general implementation-equivalence proofs over runtime/compiler frontends,
 4. full standard-softmax transformer proving on the `stwo` path,
-5. supply-chain attestation theorems comparable to a complete in-toto or SLSA
+5. missing supply-chain attestation theorems comparable to an in-toto or SLSA
    provenance story.
 
 These are not cosmetic disclaimers. They define the boundary that protects the

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -339,8 +339,8 @@ The repository does not yet support the following stronger claims:
    HyperNova, NeutronNova, ProtoStar, SnarkFold, or related folding lines,
 3. general implementation-equivalence proofs over runtime/compiler frontends,
 4. full standard-softmax transformer proving on the `stwo` path,
-5. missing supply-chain attestation theorems comparable to an in-toto or SLSA
-   provenance story.
+5. supply-chain attestation theorems are still a missing gap compared with an
+   in-toto or SLSA provenance story.
 
 These are not cosmetic disclaimers. They define the boundary that protects the
 paper from overclaiming.

--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -461,7 +461,7 @@ For a stronger follow-on paper, the missing milestones are clear:
 - recursive cryptographic compression over the same decode statement,
 - recursive shared-table accumulation as a compressed proof object,
 - stronger exporter/provenance binding for ONNX-facing release artifacts,
-- broader signed supply-chain attestations with verified builder identity,
+- missing broader signed supply-chain attestations with verified builder identity,
 - broader `stwo` transformer coverage beyond the current narrow experimental
   boundary.
 

--- a/docs/paper/stark-transformer-alignment-2026.md
+++ b/docs/paper/stark-transformer-alignment-2026.md
@@ -549,8 +549,9 @@ relation.
 This artifact narrows the gap between analytic and systems claims by showing:
 
 1. transformer-relevant traces can be proved directly,
-2. semantic equivalence can be checked across runtimes before proving and exposed as
-   transition-relation hashes rather than prose-only assertions,
+2. bounded semantic-equivalence evidence can be checked across runtimes before
+   proving and exposed as transition-relation hashes rather than prose-only
+   assertions,
 3. one parameterized decode relation preserves carried state across layouts and
    packaging layers,
 4. carried-state packages can be aggregated as pre-recursive statements without changing

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -95,7 +95,7 @@ CLAIM_LANGUAGE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
         "recursive proof",
         (
             "not",
-            "no ",
+            "no",
             "without",
             "pre-recursive",
             "non-claim",
@@ -117,14 +117,7 @@ CLAIM_LANGUAGE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ),
     (
         "semantic equivalence",
-        (
-            "bounded",
-            "not",
-            "does not",
-            "scope",
-            "boundary",
-            "evidence",
-        ),
+        ("bounded",),
     ),
     (
         "preserves accuracy",
@@ -155,9 +148,23 @@ CLAIM_LANGUAGE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
             "does not",
             "complete",
             "bounded",
-            "verified",
             "gap",
             "boundary",
+            "missing",
+            "non-claim",
+        ),
+    ),
+    (
+        "supply-chain attestations",
+        (
+            "not",
+            "does not",
+            "complete",
+            "bounded",
+            "gap",
+            "boundary",
+            "missing",
+            "non-claim",
         ),
     ),
 )
@@ -655,6 +662,21 @@ def iter_markdown_paragraphs(text: str):
         yield start, "".join(lines)
 
 
+def normalized_claim_tokens(text: str) -> list[str]:
+    return re.sub(r"[^a-z0-9]+", " ", text.lower()).split()
+
+
+def contains_token_sequence(tokens: list[str], phrase: str) -> bool:
+    phrase_tokens = normalized_claim_tokens(phrase)
+    if not phrase_tokens or len(phrase_tokens) > len(tokens):
+        return False
+    width = len(phrase_tokens)
+    return any(
+        tokens[index : index + width] == phrase_tokens
+        for index in range(len(tokens) - width + 1)
+    )
+
+
 def check_claim_language_in_file(path: pathlib.Path, findings: Findings) -> None:
     try:
         text = path.read_text(encoding="utf-8")
@@ -663,11 +685,14 @@ def check_claim_language_in_file(path: pathlib.Path, findings: Findings) -> None
         return
 
     for paragraph_offset, paragraph in iter_markdown_paragraphs(text):
-        lowered = paragraph.lower()
+        paragraph_tokens = normalized_claim_tokens(paragraph)
         for phrase, required_context in CLAIM_LANGUAGE_RULES:
-            if phrase not in lowered:
+            if not contains_token_sequence(paragraph_tokens, phrase):
                 continue
-            if any(token in lowered for token in required_context):
+            if any(
+                contains_token_sequence(paragraph_tokens, token)
+                for token in required_context
+            ):
                 continue
             line_number = paragraph_start_line(text, paragraph_offset)
             findings.error(

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -36,16 +36,6 @@ PAPER_FILES = [
     *PUBLICATION_METADATA_FILES,
 ]
 
-PAPER_CLAIM_LINT_FILES = [
-    "docs/paper/stark-transformer-alignment-2026.md",
-    "docs/paper/paper2/README.md",
-    "docs/paper/paper2/proof-carrying-decode-surfaces-2026.md",
-    "docs/paper/paper2/appendix-artifact-map.md",
-    "docs/paper/paper2/appendix-claim-boundary.md",
-    "docs/paper/paper2/appendix-engineering-gaps.md",
-    "docs/paper/paper2/appendix-ivc-positioning.md",
-]
-
 SNAPSHOT_FIELD_PREFIXES = (
     "Canonical publication snapshot",
     "Canonical repository snapshot",
@@ -146,7 +136,6 @@ CLAIM_LANGUAGE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
         (
             "not",
             "does not",
-            "complete",
             "bounded",
             "gap",
             "boundary",
@@ -159,7 +148,6 @@ CLAIM_LANGUAGE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
         (
             "not",
             "does not",
-            "complete",
             "bounded",
             "gap",
             "boundary",
@@ -701,12 +689,21 @@ def check_claim_language_in_file(path: pathlib.Path, findings: Findings) -> None
             )
 
 
+def discover_paper_claim_lint_files(repo_root: pathlib.Path) -> list[pathlib.Path]:
+    paper_root = repo_root / "docs/paper"
+    if not paper_root.exists():
+        return []
+    return sorted(path for path in paper_root.rglob("*.md") if path.is_file())
+
+
 def check_paper_claim_language(repo_root: pathlib.Path, findings: Findings) -> None:
-    for rel_path in PAPER_CLAIM_LINT_FILES:
-        path = repo_root / rel_path
-        if not path.exists():
-            findings.error(f"{path}: missing expected paper claim-language lint file.")
-            continue
+    paths = discover_paper_claim_lint_files(repo_root)
+    if not paths:
+        findings.error(
+            f"{repo_root / 'docs/paper'}: no markdown files found for claim-language linting."
+        )
+        return
+    for path in paths:
         check_claim_language_in_file(path, findings)
 
 

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -36,6 +36,16 @@ PAPER_FILES = [
     *PUBLICATION_METADATA_FILES,
 ]
 
+PAPER_CLAIM_LINT_FILES = [
+    "docs/paper/stark-transformer-alignment-2026.md",
+    "docs/paper/paper2/README.md",
+    "docs/paper/paper2/proof-carrying-decode-surfaces-2026.md",
+    "docs/paper/paper2/appendix-artifact-map.md",
+    "docs/paper/paper2/appendix-claim-boundary.md",
+    "docs/paper/paper2/appendix-engineering-gaps.md",
+    "docs/paper/paper2/appendix-ivc-positioning.md",
+]
+
 SNAPSHOT_FIELD_PREFIXES = (
     "Canonical publication snapshot",
     "Canonical repository snapshot",
@@ -78,6 +88,78 @@ CLAIM_EVIDENCE_REQUIRED_LISTS = (
     "negative_tests",
     "evidence_commands",
     "non_claims",
+)
+
+CLAIM_LANGUAGE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "recursive proof",
+        (
+            "not",
+            "no ",
+            "without",
+            "pre-recursive",
+            "non-claim",
+            "non-goal",
+            "boundary",
+            "wrong",
+        ),
+    ),
+    (
+        "proves model inference",
+        (
+            "bounded",
+            "specific",
+            "not",
+            "does not",
+            "non-claim",
+            "boundary",
+        ),
+    ),
+    (
+        "semantic equivalence",
+        (
+            "bounded",
+            "not",
+            "does not",
+            "scope",
+            "boundary",
+            "evidence",
+        ),
+    ),
+    (
+        "preserves accuracy",
+        (
+            "bounded",
+            "budget",
+            "evidence",
+            "measured",
+            "not",
+            "does not",
+        ),
+    ),
+    (
+        "same model behavior",
+        (
+            "bounded",
+            "budget",
+            "evidence",
+            "not",
+            "does not",
+            "non-claim",
+        ),
+    ),
+    (
+        "supply-chain attestation",
+        (
+            "not",
+            "does not",
+            "complete",
+            "bounded",
+            "verified",
+            "gap",
+            "boundary",
+        ),
+    ),
 )
 
 
@@ -547,6 +629,62 @@ def check_claim_evidence_matrix(repo_root: pathlib.Path, findings: Findings) -> 
         )
 
 
+def paragraph_start_line(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def iter_markdown_paragraphs(text: str):
+    start = 0
+    lines: list[str] = []
+    offset = 0
+
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if not stripped:
+            if lines:
+                yield start, "".join(lines)
+                lines = []
+            offset += len(line)
+            continue
+        if not lines:
+            start = offset
+        lines.append(line)
+        offset += len(line)
+
+    if lines:
+        yield start, "".join(lines)
+
+
+def check_claim_language_in_file(path: pathlib.Path, findings: Findings) -> None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        findings.error(f"{path}: failed to read paper claim language for linting: {exc}")
+        return
+
+    for paragraph_offset, paragraph in iter_markdown_paragraphs(text):
+        lowered = paragraph.lower()
+        for phrase, required_context in CLAIM_LANGUAGE_RULES:
+            if phrase not in lowered:
+                continue
+            if any(token in lowered for token in required_context):
+                continue
+            line_number = paragraph_start_line(text, paragraph_offset)
+            findings.error(
+                f"{path}:{line_number}: overclaim-prone phrase `{phrase}` lacks nearby "
+                f"bounded/non-claim context. Add one of: {', '.join(required_context)}."
+            )
+
+
+def check_paper_claim_language(repo_root: pathlib.Path, findings: Findings) -> None:
+    for rel_path in PAPER_CLAIM_LINT_FILES:
+        path = repo_root / rel_path
+        if not path.exists():
+            findings.error(f"{path}: missing expected paper claim-language lint file.")
+            continue
+        check_claim_language_in_file(path, findings)
+
+
 def iter_snapshot_field_lines(text: str):
     lines = text.splitlines()
     for index, line in enumerate(lines):
@@ -880,6 +1018,7 @@ def main() -> int:
     check_backend_appendix_consistency(repo_root, findings)
     check_publication_snapshot_placeholders(repo_root, findings)
     check_claim_evidence_matrix(repo_root, findings)
+    check_paper_claim_language(repo_root, findings)
 
     if findings.warnings:
         print("Warnings:")

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -697,10 +697,14 @@ def discover_paper_claim_lint_files(repo_root: pathlib.Path) -> list[pathlib.Pat
 
 
 def check_paper_claim_language(repo_root: pathlib.Path, findings: Findings) -> None:
+    paper_root = repo_root / "docs/paper"
+    if not paper_root.exists():
+        findings.error(f"{paper_root}: missing docs/paper directory for claim-language linting.")
+        return
     paths = discover_paper_claim_lint_files(repo_root)
     if not paths:
         findings.error(
-            f"{repo_root / 'docs/paper'}: no markdown files found for claim-language linting."
+            f"{paper_root}: no markdown files found for claim-language linting."
         )
         return
     for path in paths:

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -641,6 +641,10 @@ def iter_markdown_paragraphs(text: str):
                 lines = []
             offset += len(line)
             continue
+        starts_list_item = bool(re.match(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)", line))
+        if starts_list_item and lines:
+            yield start, "".join(lines)
+            lines = []
         if not lines:
             start = offset
         lines.append(line)

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -594,6 +594,66 @@ class PaperPreflightTests(unittest.TestCase):
                 findings.errors,
             )
 
+    def test_claim_language_linter_rejects_unbounded_semantic_equivalence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "paper.md"
+            write_text(
+                path,
+                "The artifact proves semantic equivalence across runtime frontends.\n",
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_language_in_file(path, findings)
+            self.assertTrue(
+                any("semantic equivalence" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
+    def test_claim_language_linter_accepts_bounded_equivalence_language(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "paper.md"
+            write_text(
+                path,
+                (
+                    "The artifact provides bounded semantic-equivalence evidence "
+                    "inside a stated claim boundary, not a general theorem.\n"
+                ),
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_language_in_file(path, findings)
+            self.assertEqual(findings.errors, [])
+
+    def test_claim_language_linter_rejects_accuracy_claim_without_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "paper.md"
+            write_text(
+                path,
+                "The quantized artifact preserves accuracy across model exports.\n",
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_language_in_file(path, findings)
+            self.assertTrue(
+                any("preserves accuracy" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
+    def test_claim_language_linter_accepts_wrong_comparison_examples(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "paper.md"
+            write_text(
+                path,
+                (
+                    "The wrong comparison language is `already recursive "
+                    "proof-carrying data`; the repository does not claim that.\n"
+                ),
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_language_in_file(path, findings)
+            self.assertEqual(findings.errors, [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -624,6 +624,24 @@ class PaperPreflightTests(unittest.TestCase):
             MOD.check_claim_language_in_file(path, findings)
             self.assertEqual(findings.errors, [])
 
+    def test_claim_language_linter_splits_adjacent_list_items(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "paper.md"
+            write_text(
+                path,
+                (
+                    "- bounded semantic equivalence evidence for a toy case\n"
+                    "- The artifact proves semantic equivalence across runtimes.\n"
+                ),
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_language_in_file(path, findings)
+            self.assertTrue(
+                any(":2:" in msg and "semantic equivalence" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
     def test_claim_language_linter_rejects_hyphenated_unbounded_equivalence(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = pathlib.Path(tmp) / "paper.md"

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -742,6 +742,17 @@ class PaperPreflightTests(unittest.TestCase):
                 findings.errors,
             )
 
+    def test_claim_language_linter_reports_missing_paper_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+
+            findings = MOD.Findings()
+            MOD.check_paper_claim_language(repo, findings)
+            self.assertTrue(
+                any("missing docs/paper directory" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -615,9 +615,36 @@ class PaperPreflightTests(unittest.TestCase):
             write_text(
                 path,
                 (
-                    "The artifact provides bounded semantic-equivalence evidence "
+                    "The artifact provides bounded semantic equivalence evidence "
                     "inside a stated claim boundary, not a general theorem.\n"
                 ),
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_language_in_file(path, findings)
+            self.assertEqual(findings.errors, [])
+
+    def test_claim_language_linter_rejects_hyphenated_unbounded_equivalence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "paper.md"
+            write_text(
+                path,
+                "The artifact proves semantic-equivalence across runtime frontends.\n",
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_language_in_file(path, findings)
+            self.assertTrue(
+                any("semantic equivalence" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
+    def test_claim_language_linter_accepts_hyphenated_bounded_equivalence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "paper.md"
+            write_text(
+                path,
+                "This is bounded semantic-equivalence evidence for one fixture.\n",
             )
 
             findings = MOD.Findings()
@@ -648,6 +675,33 @@ class PaperPreflightTests(unittest.TestCase):
                     "The wrong comparison language is `already recursive "
                     "proof-carrying data`; the repository does not claim that.\n"
                 ),
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_language_in_file(path, findings)
+            self.assertEqual(findings.errors, [])
+
+    def test_claim_language_linter_rejects_attestation_verified_as_context(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "paper.md"
+            write_text(
+                path,
+                "The release provides supply-chain attestation with verified identity.\n",
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_language_in_file(path, findings)
+            self.assertTrue(
+                any("supply-chain attestation" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
+    def test_claim_language_linter_accepts_attestation_gap_language(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "paper.md"
+            write_text(
+                path,
+                "Supply-chain attestations remain a missing gap for future work.\n",
             )
 
             findings = MOD.Findings()

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -696,6 +696,21 @@ class PaperPreflightTests(unittest.TestCase):
                 findings.errors,
             )
 
+    def test_claim_language_linter_rejects_complete_attestation_as_context(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "paper.md"
+            write_text(
+                path,
+                "The release provides complete supply-chain attestation.\n",
+            )
+
+            findings = MOD.Findings()
+            MOD.check_claim_language_in_file(path, findings)
+            self.assertTrue(
+                any("supply-chain attestation" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
     def test_claim_language_linter_accepts_attestation_gap_language(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = pathlib.Path(tmp) / "paper.md"
@@ -707,6 +722,25 @@ class PaperPreflightTests(unittest.TestCase):
             findings = MOD.Findings()
             MOD.check_claim_language_in_file(path, findings)
             self.assertEqual(findings.errors, [])
+
+    def test_claim_language_linter_discovers_new_paper_docs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(repo / "docs/paper/existing.md", "Bounded claims only.\n")
+            write_text(
+                repo / "docs/paper/new-section/new-paper.md",
+                "The artifact proves semantic equivalence across runtimes.\n",
+            )
+
+            findings = MOD.Findings()
+            MOD.check_paper_claim_language(repo, findings)
+            self.assertTrue(
+                any(
+                    "new-paper.md" in msg and "semantic equivalence" in msg
+                    for msg in findings.errors
+                ),
+                findings.errors,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a paper preflight claim-language linter for #153. The linter fails on overclaim-prone phrases unless nearby bounded/non-claim context is present, and it updates two existing paper passages so the current docs pass under the stricter rule.

## Scope

- Adds claim-language lint rules to `scripts/paper/paper_preflight.py`.
- Adds unit coverage for unbounded semantic-equivalence and accuracy claims.
- Tightens existing paper wording around bounded semantic-equivalence evidence and recursive proof-carrying language.

## Validation

- `python3 -m unittest scripts.paper.tests.test_paper_preflight`
- `python3 scripts/paper/paper_preflight.py`
- `git diff --check`

## Merge discipline

This PR should only merge after the review/comment quiet window is satisfied and any useful AI-review comments have been applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation claim-language linting to flag overclaiming and require contextual qualifiers.

* **Documentation**
  * Clarified scope of technical claims, marking certain recursive/IVC statements as not asserted here.
  * Reworded semantics guidance to specify "bounded semantic-equivalence" where appropriate.
  * Adjusted wording to describe supply-chain attestation as a "missing gap" rather than a stated absence.

* **Tests**
  * Added unit tests for the new documentation linting rules and accepted/rejected phrasings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->