### PR TITLE
Add Phase 37 adversarial mutation generator [skip ci]

### DIFF
--- a/docs/engineering/paper2-claim-evidence.yml
+++ b/docs/engineering/paper2-claim-evidence.yml
@@ -185,6 +185,7 @@
     - src/stwo_backend/recursion.rs:verify_phase37_recursive_artifact_chain_harness_receipt_against_sources
     - tools/reference_verifier/reference_verifier.py:verify_phase37_receipt
     - tools/reference_verifier/reference_verifier.py:commit_phase37_receipt
+    - scripts/generate_bad_phase37_artifacts.py:generate
   specs:
     - spec/stwo-phase37-recursive-artifact-chain-harness-receipt.schema.json
   positive_tests:
@@ -196,10 +197,12 @@
     - phase37_recursive_artifact_chain_harness_receipt_rejects_malformed_commitment_field
     - test_deterministic_parser_mutation_corpus_rejects_invalid_receipts
     - test_rejects_total_steps_that_exceed_u128_encoding
+    - test_generated_artifacts_match_expected_reference_verifier_outcomes
   evidence_commands:
     - cargo +nightly-2025-07-14 test -q --features stwo-backend phase37
     - cargo +nightly-2025-07-14 build -q --features 'full stwo-backend' --bin tvm && TVM_TEST_BINARY=target/debug/tvm cargo +nightly-2025-07-14 test -q --features 'full stwo-backend' --test cli stwo_recursive_artifact_chain
     - scripts/run_reference_verifier_suite.sh
+    - scripts/run_phase37_mutation_generator_suite.sh
   non_claims:
     - "Does not claim recursive proof verification."
     - "Does not claim cryptographic compression."

--- a/docs/engineering/phase37-adversarial-mutation-generator.md
+++ b/docs/engineering/phase37-adversarial-mutation-generator.md
@@ -23,4 +23,7 @@ python3 -B scripts/generate_bad_phase37_artifacts.py \
   target/phase37-adversarial-artifacts
 ```
 
+The output directory must be absent or empty. This avoids silently mixing old
+mutation files with a fresh manifest when the mutation set changes.
+
 The output directory contains one JSON file per mutation plus `phase37-adversarial-manifest.json`, including the expected and actual reference-verifier outcome for each mutation.

--- a/docs/engineering/phase37-adversarial-mutation-generator.md
+++ b/docs/engineering/phase37-adversarial-mutation-generator.md
@@ -1,0 +1,26 @@
+# Phase 37 Adversarial Mutation Generator
+
+`scripts/generate_bad_phase37_artifacts.py` creates deterministic mutations of a valid Phase 37 recursive artifact-chain harness receipt.
+
+The generator is not another verifier. It is an evidence producer for adversarial review:
+
+- most generated artifacts must fail the independent Phase 37 reference verifier;
+- one generated artifact is a boundary probe that drifts a source commitment and recomputes the Phase 37 receipt commitment;
+- that boundary probe is expected to pass the standalone reference verifier because the reference verifier checks receipt self-consistency, not source recomputation;
+- source-bound Rust verification must remain responsible for catching that recommitted source drift.
+
+Run the local suite with:
+
+```bash
+scripts/run_phase37_mutation_generator_suite.sh
+```
+
+Generate artifacts manually with:
+
+```bash
+python3 -B scripts/generate_bad_phase37_artifacts.py \
+  tools/reference_verifier/fixtures/phase37-reference-receipt.json \
+  target/phase37-adversarial-artifacts
+```
+
+The output directory contains one JSON file per mutation plus `phase37-adversarial-manifest.json`, including the expected and actual reference-verifier outcome for each mutation.

--- a/scripts/generate_bad_phase37_artifacts.py
+++ b/scripts/generate_bad_phase37_artifacts.py
@@ -60,7 +60,7 @@ def manifest_display_path(path: pathlib.Path) -> str:
     try:
         return path.resolve().relative_to(ROOT).as_posix()
     except ValueError:
-        return path.name
+        return path.as_posix()
 
 
 def load_receipt(path: pathlib.Path) -> dict[str, Any]:

--- a/scripts/generate_bad_phase37_artifacts.py
+++ b/scripts/generate_bad_phase37_artifacts.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Generate deterministic adversarial Phase 37 receipt artifacts.
+
+The generator targets the Phase 37 reference receipt surface. Most emitted
+artifacts are expected to fail the independent reference verifier. One artifact
+is intentionally a boundary probe: it drifts a source commitment and recomputes
+the Phase 37 receipt commitment, so the standalone reference verifier should
+pass it while source-bound recomputation must catch it.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import pathlib
+import sys
+from collections.abc import Callable
+from typing import Any
+
+sys.dont_write_bytecode = True
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+REFERENCE_VERIFIER_PATH = ROOT / "tools" / "reference_verifier" / "reference_verifier.py"
+MANIFEST_NAME = "phase37-adversarial-manifest.json"
+GENERATOR_VERSION = "phase37-adversarial-mutation-generator-v1"
+
+
+class MutationGeneratorError(RuntimeError):
+    pass
+
+
+def _load_reference_verifier() -> Any:
+    spec = importlib.util.spec_from_file_location("phase37_reference_verifier", REFERENCE_VERIFIER_PATH)
+    if spec is None or spec.loader is None:
+        raise MutationGeneratorError(f"failed to load reference verifier from {REFERENCE_VERIFIER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["phase37_reference_verifier"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+REF = _load_reference_verifier()
+
+
+def stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, indent=2, ensure_ascii=False) + "\n"
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def load_receipt(path: pathlib.Path) -> dict[str, Any]:
+    receipt = REF.load_json_object(path)
+    REF.verify_phase37_receipt(receipt)
+    return receipt
+
+
+def write_json(path: pathlib.Path, value: Any) -> None:
+    path.write_text(stable_json(value), encoding="utf-8")
+
+
+def recommit(receipt: dict[str, Any]) -> None:
+    receipt["recursive_artifact_chain_harness_receipt_commitment"] = REF.commit_phase37_receipt(
+        receipt
+    )
+
+
+def flip_recursive_claim(receipt: dict[str, Any]) -> None:
+    receipt["recursive_verification_claimed"] = True
+    recommit(receipt)
+
+
+def flip_compression_claim(receipt: dict[str, Any]) -> None:
+    receipt["cryptographic_compression_claimed"] = True
+    recommit(receipt)
+
+
+def flip_source_binding(receipt: dict[str, Any]) -> None:
+    receipt["source_binding_verified"] = False
+    recommit(receipt)
+
+
+def uppercase_phase33_commitment(receipt: dict[str, Any]) -> None:
+    receipt["phase33_recursive_public_inputs_commitment"] = receipt[
+        "phase33_recursive_public_inputs_commitment"
+    ].upper()
+    recommit(receipt)
+
+
+def remove_phase30_source_chain(receipt: dict[str, Any]) -> None:
+    del receipt["phase30_source_chain_commitment"]
+
+
+def add_unknown_field(receipt: dict[str, Any]) -> None:
+    receipt["unexpected_phase37_debug_field"] = {
+        "reason": "unknown fields must not survive artifact parsing"
+    }
+
+
+def zero_total_steps(receipt: dict[str, Any]) -> None:
+    receipt["total_steps"] = 0
+
+
+def overflow_total_steps(receipt: dict[str, Any]) -> None:
+    receipt["total_steps"] = 2**128
+
+
+def tamper_final_commitment(receipt: dict[str, Any]) -> None:
+    receipt["recursive_artifact_chain_harness_receipt_commitment"] = "0" * 64
+
+
+def drift_source_chain_recommitted(receipt: dict[str, Any]) -> None:
+    receipt["phase30_source_chain_commitment"] = "1" * 64
+    recommit(receipt)
+
+
+MutationFn = Callable[[dict[str, Any]], None]
+
+MUTATIONS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "flip_recursive_verification_claim",
+        "description": "Recommit a receipt that falsely claims recursive verification.",
+        "changed_paths": ["recursive_verification_claimed", "recursive_artifact_chain_harness_receipt_commitment"],
+        "expected_reference_verifier": "fail",
+        "expected_error": "recursive_verification_claimed",
+        "apply": flip_recursive_claim,
+    },
+    {
+        "name": "flip_cryptographic_compression_claim",
+        "description": "Recommit a receipt that falsely claims cryptographic compression.",
+        "changed_paths": ["cryptographic_compression_claimed", "recursive_artifact_chain_harness_receipt_commitment"],
+        "expected_reference_verifier": "fail",
+        "expected_error": "cryptographic_compression_claimed",
+        "apply": flip_compression_claim,
+    },
+    {
+        "name": "flip_source_binding_flag",
+        "description": "Recommit a receipt with the source-binding verification flag disabled.",
+        "changed_paths": ["source_binding_verified", "recursive_artifact_chain_harness_receipt_commitment"],
+        "expected_reference_verifier": "fail",
+        "expected_error": "source_binding_verified",
+        "apply": flip_source_binding,
+    },
+    {
+        "name": "uppercase_phase33_commitment",
+        "description": "Recommit a receipt whose Phase 33 commitment is uppercase hex.",
+        "changed_paths": ["phase33_recursive_public_inputs_commitment", "recursive_artifact_chain_harness_receipt_commitment"],
+        "expected_reference_verifier": "fail",
+        "expected_error": "lowercase 64-character hex",
+        "apply": uppercase_phase33_commitment,
+    },
+    {
+        "name": "remove_phase30_source_chain_commitment",
+        "description": "Remove a required source-chain commitment field.",
+        "changed_paths": ["phase30_source_chain_commitment"],
+        "expected_reference_verifier": "fail",
+        "expected_error": "missing Phase 37 fields",
+        "apply": remove_phase30_source_chain,
+    },
+    {
+        "name": "add_unknown_field",
+        "description": "Add an unknown field that must not survive strict parsing.",
+        "changed_paths": ["unexpected_phase37_debug_field"],
+        "expected_reference_verifier": "fail",
+        "expected_error": "unknown Phase 37 fields",
+        "apply": add_unknown_field,
+    },
+    {
+        "name": "zero_total_steps",
+        "description": "Set total_steps to zero.",
+        "changed_paths": ["total_steps"],
+        "expected_reference_verifier": "fail",
+        "expected_error": "total_steps must be positive",
+        "apply": zero_total_steps,
+    },
+    {
+        "name": "overflow_total_steps",
+        "description": "Set total_steps beyond the 128-bit transcript encoding range.",
+        "changed_paths": ["total_steps"],
+        "expected_reference_verifier": "fail",
+        "expected_error": "exceeds 128-bit encoding",
+        "apply": overflow_total_steps,
+    },
+    {
+        "name": "tamper_final_commitment",
+        "description": "Overwrite the final Phase 37 receipt commitment without updating transcript fields.",
+        "changed_paths": ["recursive_artifact_chain_harness_receipt_commitment"],
+        "expected_reference_verifier": "fail",
+        "expected_error": "commitment mismatch",
+        "apply": tamper_final_commitment,
+    },
+    {
+        "name": "drift_source_chain_recommitted_boundary_probe",
+        "description": "Drift a source commitment and recompute the Phase 37 receipt commitment; this should pass the standalone reference verifier and remain a source-recompute boundary probe.",
+        "changed_paths": ["phase30_source_chain_commitment", "recursive_artifact_chain_harness_receipt_commitment"],
+        "expected_reference_verifier": "pass_reference_only",
+        "expected_error": "",
+        "apply": drift_source_chain_recommitted,
+    },
+)
+
+
+def evaluate_reference_verifier(receipt: dict[str, Any]) -> tuple[str, str]:
+    try:
+        REF.verify_phase37_receipt(receipt)
+    except REF.ReferenceVerifierError as exc:
+        return "fail", str(exc)
+    return "pass_reference_only", ""
+
+
+def mutation_file_name(index: int, name: str) -> str:
+    return f"phase37_adversarial_{index:02d}_{name}.json"
+
+
+def generate(receipt_path: pathlib.Path, output_dir: pathlib.Path) -> pathlib.Path:
+    source = load_receipt(receipt_path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest: dict[str, Any] = {
+        "schema": "phase37-adversarial-mutation-manifest-v1",
+        "generator_version": GENERATOR_VERSION,
+        "source_receipt": {
+            "path": str(receipt_path.resolve()),
+            "sha256": sha256_file(receipt_path),
+        },
+        "output_dir": str(output_dir.resolve()),
+        "mutation_count": len(MUTATIONS),
+        "mutations": [],
+    }
+
+    for index, spec in enumerate(MUTATIONS, start=1):
+        mutated = copy.deepcopy(source)
+        apply = spec["apply"]
+        apply(mutated)
+        result, error = evaluate_reference_verifier(mutated)
+        expected = str(spec["expected_reference_verifier"])
+        if result != expected:
+            raise MutationGeneratorError(
+                f"mutation {spec['name']} expected reference verifier {expected}, got {result}: {error}"
+            )
+        expected_error = str(spec["expected_error"])
+        if expected_error and expected_error not in error:
+            raise MutationGeneratorError(
+                f"mutation {spec['name']} expected error containing {expected_error!r}, got {error!r}"
+            )
+
+        file_name = mutation_file_name(index, str(spec["name"]))
+        artifact_path = output_dir / file_name
+        write_json(artifact_path, mutated)
+        manifest["mutations"].append(
+            {
+                "name": spec["name"],
+                "file_name": file_name,
+                "sha256": sha256_file(artifact_path),
+                "description": spec["description"],
+                "changed_paths": spec["changed_paths"],
+                "expected_reference_verifier": expected,
+                "actual_reference_verifier": result,
+                "actual_error": error,
+            }
+        )
+
+    manifest_path = output_dir / MANIFEST_NAME
+    write_json(manifest_path, manifest)
+    return manifest_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("receipt", type=pathlib.Path, help="valid Phase 37 receipt JSON")
+    parser.add_argument("output_dir", type=pathlib.Path, help="directory for generated artifacts")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        manifest_path = generate(args.receipt, args.output_dir)
+    except (OSError, json.JSONDecodeError, MutationGeneratorError, REF.ReferenceVerifierError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(manifest_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_bad_phase37_artifacts.py
+++ b/scripts/generate_bad_phase37_artifacts.py
@@ -56,6 +56,13 @@ def sha256_file(path: pathlib.Path) -> str:
     return hasher.hexdigest()
 
 
+def manifest_display_path(path: pathlib.Path) -> str:
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return path.name
+
+
 def load_receipt(path: pathlib.Path) -> dict[str, Any]:
     receipt = REF.load_json_object(path)
     REF.verify_phase37_receipt(receipt)
@@ -221,16 +228,20 @@ def mutation_file_name(index: int, name: str) -> str:
 
 def generate(receipt_path: pathlib.Path, output_dir: pathlib.Path) -> pathlib.Path:
     source = load_receipt(receipt_path)
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            raise MutationGeneratorError(f"output path is not a directory: {output_dir}")
+        if any(output_dir.iterdir()):
+            raise MutationGeneratorError(f"output directory must be empty: {output_dir}")
     output_dir.mkdir(parents=True, exist_ok=True)
 
     manifest: dict[str, Any] = {
         "schema": "phase37-adversarial-mutation-manifest-v1",
         "generator_version": GENERATOR_VERSION,
         "source_receipt": {
-            "path": str(receipt_path.resolve()),
+            "path": manifest_display_path(receipt_path),
             "sha256": sha256_file(receipt_path),
         },
-        "output_dir": str(output_dir.resolve()),
         "mutation_count": len(MUTATIONS),
         "mutations": [],
     }

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -483,6 +483,15 @@ changed_path_is_reference_verifier_surface() {
     changed_path_has_prefix "scripts/local_merge_gate.sh"
 }
 
+changed_path_is_phase37_mutation_generator_surface() {
+  changed_path_has_prefix "scripts/generate_bad_phase37_artifacts.py" ||
+    changed_path_has_prefix "scripts/run_phase37_mutation_generator_suite.sh" ||
+    changed_path_has_prefix "scripts/tests/test_generate_bad_phase37_artifacts.py" ||
+    changed_path_has_prefix "tools/reference_verifier/" ||
+    changed_path_has_prefix "docs/engineering/paper2-claim-evidence.yml" ||
+    changed_path_has_prefix "scripts/local_merge_gate.sh"
+}
+
 changed_path_is_dependency_audit_input() {
   local path
 
@@ -578,6 +587,16 @@ run_reference_verifier_if_needed() {
   fi
 }
 
+run_phase37_mutation_generator_smoke() {
+  run_logged phase37-mutation-generator bash scripts/run_phase37_mutation_generator_suite.sh
+}
+
+run_phase37_mutation_generator_if_needed() {
+  if changed_path_is_phase37_mutation_generator_surface; then
+    run_phase37_mutation_generator_smoke
+  fi
+}
+
 run_research_v3_smoke_targets() {
   local research_v3_smoke label
   for research_v3_smoke in "${research_v3_smoke_targets[@]}"; do
@@ -666,6 +685,7 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
     run_phase_artifact_corpus_smoke
   fi
   run_reference_verifier_if_needed
+  run_phase37_mutation_generator_if_needed
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -690,6 +710,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
     run_phase_artifact_corpus_smoke
   fi
   run_reference_verifier_if_needed
+  run_phase37_mutation_generator_if_needed
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -714,6 +735,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
     run_phase_artifact_corpus_smoke
   fi
   run_reference_verifier_if_needed
+  run_phase37_mutation_generator_if_needed
   run_conditional_mutation_check
   run_logged fuzz-smoke env FUZZ_TIME_PER_TARGET=20 scripts/run_fuzz_smoke_suite.sh
   run_logged ub-checks env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh

--- a/scripts/run_phase37_mutation_generator_suite.sh
+++ b/scripts/run_phase37_mutation_generator_suite.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONDONTWRITEBYTECODE=1
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  printf 'error: python3 is required for the Phase 37 mutation generator suite\n' >&2
+  exit 127
+fi
+python3 - <<'PY'
+import sys
+
+if sys.version_info < (3, 10):
+    version = ".".join(str(part) for part in sys.version_info[:3])
+    raise SystemExit(f"error: python3 >= 3.10 is required, found {version}")
+PY
+
+python3 -B -m unittest discover -s scripts/tests -p 'test_generate_bad_phase37_artifacts.py'

--- a/scripts/tests/test_generate_bad_phase37_artifacts.py
+++ b/scripts/tests/test_generate_bad_phase37_artifacts.py
@@ -69,13 +69,18 @@ class Phase37AdversarialMutationGeneratorTests(unittest.TestCase):
             ]
             self.assertEqual(first["schema"], "phase37-adversarial-mutation-manifest-v1")
             self.assertEqual(first["mutation_count"], len(expected_names))
+            self.assertEqual(
+                first["source_receipt"]["path"],
+                "tools/reference_verifier/fixtures/phase37-reference-receipt.json",
+            )
+            self.assertEqual(first["source_receipt"], second["source_receipt"])
+            self.assertNotIn("output_dir", first)
             self.assertEqual([item["name"] for item in first["mutations"]], expected_names)
             self.assertEqual([item["name"] for item in second["mutations"]], expected_names)
             self.assertEqual(
                 [item["file_name"] for item in first["mutations"]],
                 [item["file_name"] for item in second["mutations"]],
             )
-            self.assertEqual(first["source_receipt"]["sha256"], second["source_receipt"]["sha256"])
 
     def test_generated_artifacts_match_expected_reference_verifier_outcomes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -123,6 +128,20 @@ class Phase37AdversarialMutationGeneratorTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             run_generator(pathlib.Path(tempdir) / "mutations")
         self.assertEqual(pycache_dirs(), [])
+
+    def test_generator_rejects_populated_output_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            output_dir = pathlib.Path(tempdir) / "mutations"
+            output_dir.mkdir()
+            (output_dir / "stale.json").write_text("{}", encoding="utf-8")
+            completed = subprocess.run(
+                [sys.executable, "-B", str(GENERATOR), str(FIXTURE), str(output_dir)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertIn("output directory must be empty", completed.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_generate_bad_phase37_artifacts.py
+++ b/scripts/tests/test_generate_bad_phase37_artifacts.py
@@ -36,9 +36,9 @@ def pycache_dirs() -> list[pathlib.Path]:
     ]
 
 
-def run_generator(output_dir: pathlib.Path) -> pathlib.Path:
+def run_generator(output_dir: pathlib.Path, receipt: pathlib.Path = FIXTURE) -> pathlib.Path:
     completed = subprocess.run(
-        [sys.executable, "-B", str(GENERATOR), str(FIXTURE), str(output_dir)],
+        [sys.executable, "-B", str(GENERATOR), str(receipt), str(output_dir)],
         check=True,
         capture_output=True,
         text=True,
@@ -142,6 +142,16 @@ class Phase37AdversarialMutationGeneratorTests(unittest.TestCase):
             )
             self.assertNotEqual(completed.returncode, 0)
             self.assertIn("output directory must be empty", completed.stderr)
+
+    def test_external_receipt_path_is_not_collapsed_to_basename(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp = pathlib.Path(tempdir)
+            external_receipt = temp / "nested" / "phase37-reference-receipt.json"
+            external_receipt.parent.mkdir()
+            shutil.copy2(FIXTURE, external_receipt)
+
+            manifest = load_json(run_generator(temp / "mutations", external_receipt))
+            self.assertEqual(manifest["source_receipt"]["path"], str(external_receipt))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_generate_bad_phase37_artifacts.py
+++ b/scripts/tests/test_generate_bad_phase37_artifacts.py
@@ -27,10 +27,9 @@ def load_json(path: pathlib.Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def pycache_dirs() -> list[pathlib.Path]:
+def pycache_dirs(root: pathlib.Path) -> list[pathlib.Path]:
     return [
         path
-        for root in (ROOT / "scripts", ROOT / "tools")
         for path in root.glob("**/__pycache__")
         if path.is_dir()
     ]
@@ -91,7 +90,7 @@ class Phase37AdversarialMutationGeneratorTests(unittest.TestCase):
             for item in manifest["mutations"]:
                 artifact = load_json(output_dir / item["file_name"])
                 if item["expected_reference_verifier"] == "fail":
-                    with self.assertRaisesRegex(REF.ReferenceVerifierError, re.escape(item["actual_error"][:40])):
+                    with self.assertRaisesRegex(REF.ReferenceVerifierError, re.escape(item["actual_error"])):
                         REF.verify_phase37_receipt(artifact)
                 else:
                     REF.verify_phase37_receipt(artifact)
@@ -123,11 +122,10 @@ class Phase37AdversarialMutationGeneratorTests(unittest.TestCase):
             )
 
     def test_generator_does_not_write_python_cache_files(self) -> None:
-        for cache in pycache_dirs():
-            shutil.rmtree(cache)
         with tempfile.TemporaryDirectory() as tempdir:
-            run_generator(pathlib.Path(tempdir) / "mutations")
-        self.assertEqual(pycache_dirs(), [])
+            temp = pathlib.Path(tempdir)
+            run_generator(temp / "mutations")
+            self.assertEqual(pycache_dirs(temp), [])
 
     def test_generator_rejects_populated_output_directory(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -151,7 +149,7 @@ class Phase37AdversarialMutationGeneratorTests(unittest.TestCase):
             shutil.copy2(FIXTURE, external_receipt)
 
             manifest = load_json(run_generator(temp / "mutations", external_receipt))
-            self.assertEqual(manifest["source_receipt"]["path"], str(external_receipt))
+            self.assertEqual(manifest["source_receipt"]["path"], external_receipt.as_posix())
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_generate_bad_phase37_artifacts.py
+++ b/scripts/tests/test_generate_bad_phase37_artifacts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import pathlib
 import re
@@ -80,6 +81,7 @@ class Phase37AdversarialMutationGeneratorTests(unittest.TestCase):
                 [item["file_name"] for item in first["mutations"]],
                 [item["file_name"] for item in second["mutations"]],
             )
+            self.assertEqual(first, second)
 
     def test_generated_artifacts_match_expected_reference_verifier_outcomes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -88,7 +90,12 @@ class Phase37AdversarialMutationGeneratorTests(unittest.TestCase):
             by_name = {item["name"]: item for item in manifest["mutations"]}
 
             for item in manifest["mutations"]:
-                artifact = load_json(output_dir / item["file_name"])
+                artifact_path = output_dir / item["file_name"]
+                artifact = load_json(artifact_path)
+                self.assertEqual(
+                    item["sha256"],
+                    hashlib.sha256(artifact_path.read_bytes()).hexdigest(),
+                )
                 if item["expected_reference_verifier"] == "fail":
                     with self.assertRaisesRegex(REF.ReferenceVerifierError, re.escape(item["actual_error"])):
                         REF.verify_phase37_receipt(artifact)
@@ -140,6 +147,8 @@ class Phase37AdversarialMutationGeneratorTests(unittest.TestCase):
             )
             self.assertNotEqual(completed.returncode, 0)
             self.assertIn("output directory must be empty", completed.stderr)
+            self.assertEqual(sorted(path.name for path in output_dir.iterdir()), ["stale.json"])
+            self.assertFalse((output_dir / "phase37-adversarial-manifest.json").exists())
 
     def test_external_receipt_path_is_not_collapsed_to_basename(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/scripts/tests/test_generate_bad_phase37_artifacts.py
+++ b/scripts/tests/test_generate_bad_phase37_artifacts.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+GENERATOR = ROOT / "scripts" / "generate_bad_phase37_artifacts.py"
+FIXTURE = ROOT / "tools" / "reference_verifier" / "fixtures" / "phase37-reference-receipt.json"
+REFERENCE_VERIFIER = ROOT / "tools" / "reference_verifier" / "reference_verifier.py"
+
+SPEC = importlib.util.spec_from_file_location("reference_verifier", REFERENCE_VERIFIER)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load reference verifier from {REFERENCE_VERIFIER}")
+REF = importlib.util.module_from_spec(SPEC)
+sys.modules["reference_verifier"] = REF
+SPEC.loader.exec_module(REF)
+
+
+def load_json(path: pathlib.Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def pycache_dirs() -> list[pathlib.Path]:
+    return [
+        path
+        for root in (ROOT / "scripts", ROOT / "tools")
+        for path in root.glob("**/__pycache__")
+        if path.is_dir()
+    ]
+
+
+def run_generator(output_dir: pathlib.Path) -> pathlib.Path:
+    completed = subprocess.run(
+        [sys.executable, "-B", str(GENERATOR), str(FIXTURE), str(output_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return pathlib.Path(completed.stdout.strip())
+
+
+class Phase37AdversarialMutationGeneratorTests(unittest.TestCase):
+    def test_manifest_and_file_names_are_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp = pathlib.Path(tempdir)
+            first_manifest = run_generator(temp / "first")
+            second_manifest = run_generator(temp / "second")
+            first = load_json(first_manifest)
+            second = load_json(second_manifest)
+
+            expected_names = [
+                "flip_recursive_verification_claim",
+                "flip_cryptographic_compression_claim",
+                "flip_source_binding_flag",
+                "uppercase_phase33_commitment",
+                "remove_phase30_source_chain_commitment",
+                "add_unknown_field",
+                "zero_total_steps",
+                "overflow_total_steps",
+                "tamper_final_commitment",
+                "drift_source_chain_recommitted_boundary_probe",
+            ]
+            self.assertEqual(first["schema"], "phase37-adversarial-mutation-manifest-v1")
+            self.assertEqual(first["mutation_count"], len(expected_names))
+            self.assertEqual([item["name"] for item in first["mutations"]], expected_names)
+            self.assertEqual([item["name"] for item in second["mutations"]], expected_names)
+            self.assertEqual(
+                [item["file_name"] for item in first["mutations"]],
+                [item["file_name"] for item in second["mutations"]],
+            )
+            self.assertEqual(first["source_receipt"]["sha256"], second["source_receipt"]["sha256"])
+
+    def test_generated_artifacts_match_expected_reference_verifier_outcomes(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            output_dir = pathlib.Path(tempdir) / "mutations"
+            manifest = load_json(run_generator(output_dir))
+            by_name = {item["name"]: item for item in manifest["mutations"]}
+
+            for item in manifest["mutations"]:
+                artifact = load_json(output_dir / item["file_name"])
+                if item["expected_reference_verifier"] == "fail":
+                    with self.assertRaisesRegex(REF.ReferenceVerifierError, re.escape(item["actual_error"][:40])):
+                        REF.verify_phase37_receipt(artifact)
+                else:
+                    REF.verify_phase37_receipt(artifact)
+
+            recursive = load_json(output_dir / by_name["flip_recursive_verification_claim"]["file_name"])
+            self.assertTrue(recursive["recursive_verification_claimed"])
+            self.assertEqual(
+                recursive["recursive_artifact_chain_harness_receipt_commitment"],
+                REF.commit_phase37_receipt(recursive),
+            )
+
+            uppercased = load_json(output_dir / by_name["uppercase_phase33_commitment"]["file_name"])
+            self.assertTrue(uppercased["phase33_recursive_public_inputs_commitment"].isupper())
+
+            tampered = load_json(output_dir / by_name["tamper_final_commitment"]["file_name"])
+            self.assertEqual(tampered["recursive_artifact_chain_harness_receipt_commitment"], "0" * 64)
+
+            boundary_probe = load_json(
+                output_dir / by_name["drift_source_chain_recommitted_boundary_probe"]["file_name"]
+            )
+            self.assertEqual(boundary_probe["phase30_source_chain_commitment"], "1" * 64)
+            self.assertEqual(
+                boundary_probe["recursive_artifact_chain_harness_receipt_commitment"],
+                REF.commit_phase37_receipt(boundary_probe),
+            )
+            self.assertEqual(
+                by_name["drift_source_chain_recommitted_boundary_probe"]["actual_reference_verifier"],
+                "pass_reference_only",
+            )
+
+    def test_generator_does_not_write_python_cache_files(self) -> None:
+        for cache in pycache_dirs():
+            shutil.rmtree(cache)
+        with tempfile.TemporaryDirectory() as tempdir:
+            run_generator(pathlib.Path(tempdir) / "mutations")
+        self.assertEqual(pycache_dirs(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #161.

Adds a deterministic Phase 37 adversarial mutation generator for the recursive artifact-chain harness receipt surface.

What changed:
- generate invalid Phase 37 receipt artifacts from the valid reference fixture;
- record a manifest with expected and actual independent reference-verifier outcomes;
- include one recommitted source-drift boundary probe that should pass the standalone reference verifier but remain catchable by source-bound recomputation;
- wire the suite into the local merge gate and paper evidence ledger.

Local validation only, GitHub CI intentionally skipped:
- `scripts/run_phase37_mutation_generator_suite.sh`
- `scripts/run_reference_verifier_suite.sh`
- `bash scripts/run_shellcheck_suite.sh`
- `python3 scripts/paper/paper_preflight.py`
- `python3 -B -m unittest discover -s scripts/paper/tests`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide describing the Phase 37 adversarial mutation generator, usage, outputs, and expected verifier behaviors.

* **New Features**
  * Added a CLI to produce deterministic adversarial Phase 37 receipt mutations and a manifest of expected vs actual verifier results.
  * Added a script to run the generator test suite and wired the smoke run into the local merge gate.

* **Tests**
  * Added end-to-end tests for determinism, verifier outcome checks, output/caching guardrails, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->