### PR TITLE
Issue 161: fuzz public recursive artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5768,9 +5768,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6470,7 +6470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.59.0",

--- a/docs/engineering/paper2-claim-evidence.yml
+++ b/docs/engineering/paper2-claim-evidence.yml
@@ -140,6 +140,7 @@
   implementation:
     - src/stwo_backend/recursion.rs:phase35_prepare_recursive_compression_target_manifest
     - src/stwo_backend/recursion.rs:verify_phase35_recursive_compression_target_manifest_against_sources
+    - fuzz/fuzz_targets/phase35_recursive_compression_target_manifest.rs
   specs:
     - spec/stwo-phase35-recursive-compression-target-manifest.schema.json
   positive_tests:
@@ -149,6 +150,7 @@
     - phase35_recursive_target_manifest_parse_rejects_unknown_fields
   evidence_commands:
     - cargo +nightly-2025-07-14 test -q --features stwo-backend phase35
+    - FUZZ_TIME_PER_TARGET=5 scripts/run_fuzz_smoke_suite.sh
   non_claims:
     - "Does not claim recursive proof closure."
     - "Does not claim cryptographic compression."
@@ -161,6 +163,7 @@
   implementation:
     - src/stwo_backend/recursion.rs:phase36_prepare_recursive_verifier_harness_receipt
     - src/stwo_backend/recursion.rs:verify_phase36_recursive_verifier_harness_receipt_against_sources
+    - fuzz/fuzz_targets/phase36_recursive_verifier_harness_receipt.rs
   specs:
     - spec/stwo-phase36-recursive-verifier-harness-receipt.schema.json
   positive_tests:
@@ -171,6 +174,7 @@
     - phase36_recursive_verifier_harness_receipt_parse_rejects_unknown_fields
   evidence_commands:
     - cargo +nightly-2025-07-14 test -q --features stwo-backend phase36
+    - FUZZ_TIME_PER_TARGET=5 scripts/run_fuzz_smoke_suite.sh
   non_claims:
     - "Does not claim recursive proof verification."
     - "Does not claim cryptographic compression."
@@ -186,6 +190,7 @@
     - tools/reference_verifier/reference_verifier.py:verify_phase37_receipt
     - tools/reference_verifier/reference_verifier.py:commit_phase37_receipt
     - scripts/generate_bad_phase37_artifacts.py:generate
+    - fuzz/fuzz_targets/phase37_recursive_artifact_chain_harness_receipt.rs
   specs:
     - spec/stwo-phase37-recursive-artifact-chain-harness-receipt.schema.json
   positive_tests:
@@ -203,6 +208,7 @@
     - cargo +nightly-2025-07-14 build -q --features 'full stwo-backend' --bin tvm && TVM_TEST_BINARY=target/debug/tvm cargo +nightly-2025-07-14 test -q --features 'full stwo-backend' --test cli stwo_recursive_artifact_chain
     - scripts/run_reference_verifier_suite.sh
     - scripts/run_phase37_mutation_generator_suite.sh
+    - FUZZ_TIME_PER_TARGET=5 scripts/run_fuzz_smoke_suite.sh
   non_claims:
     - "Does not claim recursive proof verification."
     - "Does not claim cryptographic compression."

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,3 +1,4 @@
 target
 artifacts
 coverage
+corpus/_support

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -83,5 +83,26 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "phase35_recursive_compression_target_manifest"
+path = "fuzz_targets/phase35_recursive_compression_target_manifest.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "phase36_recursive_verifier_harness_receipt"
+path = "fuzz_targets/phase36_recursive_verifier_harness_receipt.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "phase37_recursive_artifact_chain_harness_receipt"
+path = "fuzz_targets/phase37_recursive_artifact_chain_harness_receipt.rs"
+test = false
+doc = false
+bench = false
+
 [workspace]
 members = ["."]

--- a/fuzz/fuzz_targets/phase35_recursive_compression_target_manifest.rs
+++ b/fuzz/fuzz_targets/phase35_recursive_compression_target_manifest.rs
@@ -1,0 +1,20 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use llm_provable_computer::{
+    parse_phase35_recursive_compression_target_manifest_json,
+    verify_phase35_recursive_compression_target_manifest,
+};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 1024 * 1024 {
+        return;
+    }
+    let Ok(json) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(manifest) = parse_phase35_recursive_compression_target_manifest_json(json) else {
+        return;
+    };
+    let _ = verify_phase35_recursive_compression_target_manifest(&manifest);
+});

--- a/fuzz/fuzz_targets/phase36_recursive_verifier_harness_receipt.rs
+++ b/fuzz/fuzz_targets/phase36_recursive_verifier_harness_receipt.rs
@@ -1,0 +1,20 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use llm_provable_computer::{
+    parse_phase36_recursive_verifier_harness_receipt_json,
+    verify_phase36_recursive_verifier_harness_receipt,
+};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 1024 * 1024 {
+        return;
+    }
+    let Ok(json) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(receipt) = parse_phase36_recursive_verifier_harness_receipt_json(json) else {
+        return;
+    };
+    let _ = verify_phase36_recursive_verifier_harness_receipt(&receipt);
+});

--- a/fuzz/fuzz_targets/phase37_recursive_artifact_chain_harness_receipt.rs
+++ b/fuzz/fuzz_targets/phase37_recursive_artifact_chain_harness_receipt.rs
@@ -1,0 +1,20 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use llm_provable_computer::{
+    parse_phase37_recursive_artifact_chain_harness_receipt_json,
+    verify_phase37_recursive_artifact_chain_harness_receipt,
+};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 1024 * 1024 {
+        return;
+    }
+    let Ok(json) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(receipt) = parse_phase37_recursive_artifact_chain_harness_receipt_json(json) else {
+        return;
+    };
+    let _ = verify_phase37_recursive_artifact_chain_harness_receipt(&receipt);
+});

--- a/scripts/fuzz/generate_decoding_fuzz_corpus.py
+++ b/scripts/fuzz/generate_decoding_fuzz_corpus.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import hashlib
 import json
 import os
 import pathlib
@@ -10,9 +11,6 @@ import tomllib
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 CORPUS = ROOT / "fuzz" / "corpus"
 FUZZ_TOOLCHAIN_TOML = ROOT / "fuzz" / "rust-toolchain.toml"
-PHASE29_CURATED_CORPUS = (
-    CORPUS / "phase29_recursive_compression_input_contract" / "valid_phase29.json"
-)
 RUN_TIMEOUT_SECONDS = 300
 DEFAULT_RUST_TOOLCHAIN = "nightly-2025-07-14"
 
@@ -91,6 +89,137 @@ def write_json(path: pathlib.Path, value: object) -> None:
     json.loads(path.read_text())
 
 
+def phase29_update_usize(hasher, value: int) -> None:
+    hasher.update(int(value).to_bytes(16, byteorder="little", signed=False))
+
+
+def phase29_update_bool(hasher, value: bool) -> None:
+    hasher.update(bytes([1 if value else 0]))
+
+
+def phase29_update_len_prefixed(hasher, value: str) -> None:
+    encoded = value.encode()
+    phase29_update_usize(hasher, len(encoded))
+    hasher.update(encoded)
+
+
+def commit_phase29_contract(contract: dict[str, object]) -> str:
+    hasher = hashlib.blake2b(digest_size=32)
+    phase29_update_len_prefixed(hasher, "phase29-contract")
+    for field in (
+        "proof_backend",
+        "contract_version",
+        "semantic_scope",
+        "phase28_artifact_version",
+        "phase28_semantic_scope",
+        "phase28_proof_backend_version",
+        "statement_version",
+        "required_recursion_posture",
+    ):
+        value = contract[field]
+        if not isinstance(value, str):
+            raise SystemExit(f"Phase 29 `{field}` must be a string")
+        phase29_update_len_prefixed(hasher, value)
+    for field in ("recursive_verification_claimed", "cryptographic_compression_claimed"):
+        value = contract[field]
+        if not isinstance(value, bool):
+            raise SystemExit(f"Phase 29 `{field}` must be a bool")
+        phase29_update_bool(hasher, value)
+    for field in (
+        "phase28_bounded_aggregation_arity",
+        "phase28_member_count",
+        "phase28_member_summaries",
+        "phase28_nested_members",
+        "total_phase26_members",
+        "total_phase25_members",
+        "max_nested_chain_arity",
+        "max_nested_fold_arity",
+        "total_matrices",
+        "total_layouts",
+        "total_rollups",
+        "total_segments",
+        "total_steps",
+        "lookup_delta_entries",
+        "max_lookup_frontier_entries",
+    ):
+        value = contract[field]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise SystemExit(f"Phase 29 `{field}` must be a non-negative integer")
+        phase29_update_usize(hasher, value)
+    for field in (
+        "source_template_commitment",
+        "global_start_state_commitment",
+        "global_end_state_commitment",
+        "aggregation_template_commitment",
+        "aggregated_chained_folded_interval_accumulator_commitment",
+    ):
+        value = contract[field]
+        if not isinstance(value, str):
+            raise SystemExit(f"Phase 29 `{field}` must be a string")
+        phase29_update_len_prefixed(hasher, value)
+    return hasher.hexdigest()
+
+
+def phase29_contract_for_phase30(phase30: dict[str, object]) -> dict[str, object]:
+    total_steps = phase30.get("total_steps")
+    start_commitment = phase30.get("chain_start_boundary_commitment")
+    end_commitment = phase30.get("chain_end_boundary_commitment")
+    proof_backend_version = phase30.get("proof_backend_version")
+    statement_version = phase30.get("statement_version")
+    if not isinstance(total_steps, int) or total_steps <= 0:
+        raise SystemExit("Phase 30 seed must declare a positive integer total_steps")
+    for label, value in (
+        ("chain_start_boundary_commitment", start_commitment),
+        ("chain_end_boundary_commitment", end_commitment),
+        ("proof_backend_version", proof_backend_version),
+        ("statement_version", statement_version),
+    ):
+        if not isinstance(value, str) or not value:
+            raise SystemExit(f"Phase 30 seed is missing `{label}`")
+
+    contract: dict[str, object] = {
+        "proof_backend": "stwo",
+        "contract_version": "stwo-phase29-recursive-compression-input-contract-v1",
+        "semantic_scope": "stwo_phase29_recursive_compression_input_contract",
+        "phase28_artifact_version": (
+            "stwo-phase28-aggregated-chained-folded-intervalized-"
+            "decoding-state-relation-v1"
+        ),
+        "phase28_semantic_scope": (
+            "stwo_execution_parameterized_aggregated_chained_folded_intervalized_"
+            "proof_carrying_decoding_state_relation"
+        ),
+        "phase28_proof_backend_version": proof_backend_version,
+        "statement_version": statement_version,
+        "required_recursion_posture": "pre-recursive-proof-carrying-aggregation",
+        "recursive_verification_claimed": False,
+        "cryptographic_compression_claimed": False,
+        "phase28_bounded_aggregation_arity": 2,
+        "phase28_member_count": 2,
+        "phase28_member_summaries": 2,
+        "phase28_nested_members": 2,
+        "total_phase26_members": 4,
+        "total_phase25_members": 8,
+        "max_nested_chain_arity": 2,
+        "max_nested_fold_arity": 2,
+        "total_matrices": 16,
+        "total_layouts": 16,
+        "total_rollups": 8,
+        "total_segments": 8,
+        "total_steps": total_steps,
+        "lookup_delta_entries": 12,
+        "max_lookup_frontier_entries": 4,
+        "source_template_commitment": "a" * 64,
+        "global_start_state_commitment": start_commitment,
+        "global_end_state_commitment": end_commitment,
+        "aggregation_template_commitment": "b" * 64,
+        "aggregated_chained_folded_interval_accumulator_commitment": "c" * 64,
+        "input_contract_commitment": "",
+    }
+    contract["input_contract_commitment"] = commit_phase29_contract(contract)
+    return contract
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Generate curated fuzz corpus inputs for decoding-related targets."
@@ -117,12 +246,31 @@ def main() -> int:
     phase30_path = (
         corpus_root / "phase30_decoding_step_proof_envelope_manifest" / "valid_phase30.json"
     )
+    support_root = corpus_root / "_support"
+    phase30_raw_path = support_root / "phase30_raw.json"
+    phase31_path = support_root / "phase31_decode_boundary_manifest.json"
+    phase32_path = support_root / "phase32_statement_contract.json"
+    phase33_path = support_root / "phase33_public_input_manifest.json"
+    phase34_path = support_root / "phase34_shared_lookup_manifest.json"
+    phase35_path = (
+        corpus_root / "phase35_recursive_compression_target_manifest" / "valid_phase35.json"
+    )
+    phase36_path = (
+        corpus_root / "phase36_recursive_verifier_harness_receipt" / "valid_phase36.json"
+    )
+    phase37_path = (
+        corpus_root / "phase37_recursive_artifact_chain_harness_receipt" / "valid_phase37.json"
+    )
 
     phase12_path.parent.mkdir(parents=True, exist_ok=True)
     phase14_path.parent.mkdir(parents=True, exist_ok=True)
     artifact_path.parent.mkdir(parents=True, exist_ok=True)
     phase29_path.parent.mkdir(parents=True, exist_ok=True)
     phase30_path.parent.mkdir(parents=True, exist_ok=True)
+    support_root.mkdir(parents=True, exist_ok=True)
+    phase35_path.parent.mkdir(parents=True, exist_ok=True)
+    phase36_path.parent.mkdir(parents=True, exist_ok=True)
+    phase37_path.parent.mkdir(parents=True, exist_ok=True)
 
     run(
         "cargo",
@@ -216,15 +364,15 @@ def main() -> int:
         str(phase30_path),
     )
     phase30 = json.loads(phase30_path.read_text())
+    write_json(phase30_raw_path, phase30)
     phase30_input = {
         "manifest": phase30,
         "chain": phase12,
     }
     write_json(phase30_path, phase30_input)
 
-    if not PHASE29_CURATED_CORPUS.is_file():
-        raise SystemExit(f"missing checked-in Phase 29 corpus seed: {PHASE29_CURATED_CORPUS}")
-
+    phase29 = phase29_contract_for_phase30(phase30)
+    write_json(phase29_path, phase29)
     run(
         "cargo",
         f"+{RUST_TOOLCHAIN}",
@@ -237,11 +385,146 @@ def main() -> int:
         "--",
         "verify-stwo-recursive-compression-input-contract",
         "--input",
-        str(PHASE29_CURATED_CORPUS),
+        str(phase29_path),
     )
-
-    phase29 = json.loads(PHASE29_CURATED_CORPUS.read_text())
-    write_json(phase29_path, phase29)
+    run(
+        "cargo",
+        f"+{RUST_TOOLCHAIN}",
+        "run",
+        "--quiet",
+        "--features",
+        "stwo-backend",
+        "--bin",
+        "tvm",
+        "--",
+        "prepare-stwo-recursive-compression-decode-boundary-manifest",
+        "--contract",
+        str(phase29_path),
+        "--manifest",
+        str(phase30_raw_path),
+        "-o",
+        str(phase31_path),
+    )
+    run(
+        "cargo",
+        f"+{RUST_TOOLCHAIN}",
+        "run",
+        "--quiet",
+        "--features",
+        "stwo-backend",
+        "--bin",
+        "tvm",
+        "--",
+        "prepare-stwo-recursive-compression-statement-contract",
+        "--manifest",
+        str(phase31_path),
+        "-o",
+        str(phase32_path),
+    )
+    run(
+        "cargo",
+        f"+{RUST_TOOLCHAIN}",
+        "run",
+        "--quiet",
+        "--features",
+        "stwo-backend",
+        "--bin",
+        "tvm",
+        "--",
+        "prepare-stwo-recursive-compression-public-input-manifest",
+        "--contract",
+        str(phase32_path),
+        "-o",
+        str(phase33_path),
+    )
+    run(
+        "cargo",
+        f"+{RUST_TOOLCHAIN}",
+        "run",
+        "--quiet",
+        "--features",
+        "stwo-backend",
+        "--bin",
+        "tvm",
+        "--",
+        "prepare-stwo-recursive-compression-shared-lookup-manifest",
+        "--public-inputs",
+        str(phase33_path),
+        "--envelopes",
+        str(phase30_raw_path),
+        "-o",
+        str(phase34_path),
+    )
+    run(
+        "cargo",
+        f"+{RUST_TOOLCHAIN}",
+        "run",
+        "--quiet",
+        "--features",
+        "stwo-backend",
+        "--bin",
+        "tvm",
+        "--",
+        "prepare-stwo-recursive-compression-target-manifest",
+        "--statement-contract",
+        str(phase32_path),
+        "--public-inputs",
+        str(phase33_path),
+        "--shared-lookup",
+        str(phase34_path),
+        "-o",
+        str(phase35_path),
+    )
+    run(
+        "cargo",
+        f"+{RUST_TOOLCHAIN}",
+        "run",
+        "--quiet",
+        "--features",
+        "stwo-backend",
+        "--bin",
+        "tvm",
+        "--",
+        "prepare-stwo-recursive-verifier-harness-receipt",
+        "--target",
+        str(phase35_path),
+        "--statement-contract",
+        str(phase32_path),
+        "--public-inputs",
+        str(phase33_path),
+        "--shared-lookup",
+        str(phase34_path),
+        "-o",
+        str(phase36_path),
+    )
+    run(
+        "cargo",
+        f"+{RUST_TOOLCHAIN}",
+        "run",
+        "--quiet",
+        "--features",
+        "stwo-backend",
+        "--bin",
+        "tvm",
+        "--",
+        "prepare-stwo-recursive-artifact-chain-harness-receipt",
+        "--contract",
+        str(phase29_path),
+        "--manifest",
+        str(phase30_raw_path),
+        "-o",
+        str(phase37_path),
+    )
+    for generated_path in (
+        phase31_path,
+        phase32_path,
+        phase33_path,
+        phase34_path,
+        phase35_path,
+        phase36_path,
+        phase37_path,
+    ):
+        write_json(generated_path, json.loads(generated_path.read_text()))
     return 0
 
 

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -492,6 +492,13 @@ changed_path_is_phase37_mutation_generator_surface() {
     changed_path_has_prefix "scripts/local_merge_gate.sh"
 }
 
+changed_path_is_fuzz_surface() {
+  changed_path_has_prefix "fuzz/" ||
+    changed_path_has_prefix "scripts/fuzz/" ||
+    changed_path_has_prefix "scripts/run_fuzz_smoke_suite.sh" ||
+    changed_path_has_prefix "scripts/local_merge_gate.sh"
+}
+
 changed_path_is_dependency_audit_input() {
   local path
 
@@ -597,6 +604,14 @@ run_phase37_mutation_generator_if_needed() {
   fi
 }
 
+run_fuzz_smoke_if_needed() {
+  local fuzz_time
+  if changed_path_is_fuzz_surface; then
+    fuzz_time="${FUZZ_TIME_PER_TARGET:-5}"
+    run_logged fuzz-smoke env FUZZ_TIME_PER_TARGET="$fuzz_time" scripts/run_fuzz_smoke_suite.sh
+  fi
+}
+
 run_research_v3_smoke_targets() {
   local research_v3_smoke label
   for research_v3_smoke in "${research_v3_smoke_targets[@]}"; do
@@ -686,6 +701,7 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   fi
   run_reference_verifier_if_needed
   run_phase37_mutation_generator_if_needed
+  run_fuzz_smoke_if_needed
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -711,6 +727,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   fi
   run_reference_verifier_if_needed
   run_phase37_mutation_generator_if_needed
+  run_fuzz_smoke_if_needed
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"

--- a/scripts/run_fuzz_smoke_suite.sh
+++ b/scripts/run_fuzz_smoke_suite.sh
@@ -13,6 +13,9 @@ FUZZ_TARGETS=(
   phase12_shared_lookup_artifact
   phase29_recursive_compression_input_contract
   phase30_decoding_step_proof_envelope_manifest
+  phase35_recursive_compression_target_manifest
+  phase36_recursive_verifier_harness_receipt
+  phase37_recursive_artifact_chain_harness_receipt
 )
 
 if ! command -v cargo-fuzz >/dev/null 2>&1 && ! cargo fuzz --version >/dev/null 2>&1; then

--- a/scripts/tests/test_generate_decoding_fuzz_corpus.py
+++ b/scripts/tests/test_generate_decoding_fuzz_corpus.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+GENERATOR = ROOT / "scripts" / "fuzz" / "generate_decoding_fuzz_corpus.py"
+PHASE29_FIXTURE = (
+    ROOT / "fuzz" / "corpus" / "phase29_recursive_compression_input_contract" / "valid_phase29.json"
+)
+PHASE30_FIXTURE = (
+    ROOT / "fuzz" / "corpus" / "phase30_decoding_step_proof_envelope_manifest" / "valid_phase30.json"
+)
+
+SPEC = importlib.util.spec_from_file_location("generate_decoding_fuzz_corpus", GENERATOR)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load fuzz corpus generator from {GENERATOR}")
+GEN = importlib.util.module_from_spec(SPEC)
+sys.modules["generate_decoding_fuzz_corpus"] = GEN
+SPEC.loader.exec_module(GEN)
+
+
+def load_json(path: pathlib.Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class DecodingFuzzCorpusGeneratorTests(unittest.TestCase):
+    def test_phase29_commitment_mirror_matches_checked_in_fixture(self) -> None:
+        contract = load_json(PHASE29_FIXTURE)
+        self.assertEqual(
+            GEN.commit_phase29_contract(contract),
+            contract["input_contract_commitment"],
+        )
+
+    def test_generated_phase29_contract_is_bound_to_phase30_boundaries(self) -> None:
+        phase30 = load_json(PHASE30_FIXTURE)["manifest"]
+        contract = GEN.phase29_contract_for_phase30(phase30)
+
+        self.assertEqual(contract["total_steps"], phase30["total_steps"])
+        self.assertEqual(
+            contract["global_start_state_commitment"],
+            phase30["chain_start_boundary_commitment"],
+        )
+        self.assertEqual(
+            contract["global_end_state_commitment"],
+            phase30["chain_end_boundary_commitment"],
+        )
+        self.assertEqual(
+            contract["input_contract_commitment"],
+            GEN.commit_phase29_contract(contract),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Implements issue #161 PR-5: public artifact loader fuzzing for the recursive artifact surface.

- Add libFuzzer targets for Phase35 recursive compression target manifests, Phase36 verifier harness receipts, and Phase37 artifact-chain harness receipts.
- Generate coherent Phase29->Phase37 corpus seeds from the same Phase30 decoding chain instead of mixing stale Phase29 fixtures.
- Wire fuzz smoke into the local merge gate for fuzz-surface changes.
- Extend the claim-evidence matrix with the new fuzz targets and local fuzz smoke command.
- Add a Python drift test for the Phase29 commitment mirror used by the corpus generator.

## Local validation

GitHub CI is intentionally skipped; all validation was run locally.

- `python3 -B -m unittest discover -s scripts/tests`
- `cargo fmt --check`
- `bash scripts/run_shellcheck_suite.sh`
- `python3 scripts/paper/paper_preflight.py`
- `git diff --check`
- `FUZZ_TIME_PER_TARGET=1 scripts/run_fuzz_smoke_suite.sh`
- `FUZZ_TIME_PER_TARGET=5 scripts/run_fuzz_smoke_suite.sh`

[skip ci]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for fuzz corpus generation logic.

* **Chores**
  * Enhanced fuzz testing pipeline with dynamic corpus generation.
  * Expanded fuzz test suite with three new targets for advanced phases.
  * Improved fuzz smoke test automation to run conditionally on relevant code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->