### PR TITLE
Add release evidence bundle gate [skip ci]

### DIFF
--- a/docs/engineering/release-evidence-bundle.md
+++ b/docs/engineering/release-evidence-bundle.md
@@ -1,0 +1,61 @@
+# Release Evidence Bundle
+
+The release evidence bundle is the local checkpoint record for paper or release claims.
+
+It does not run the proof system again. It binds evidence that already exists:
+
+- the exact git `HEAD`, branch, remote, and dirty/clean status,
+- local toolchain and host metadata,
+- schema hashes,
+- selected artifact hashes,
+- benchmark result JSON hashes and validator status,
+- local merge-gate `evidence.json`,
+- and every command log hash referenced by that merge-gate evidence.
+
+The goal is to avoid a common failure mode: a release note says "tests passed" or
+"benchmarks were run," but the exact logs, hashes, and local gate evidence are no
+longer connected to the released commit.
+
+## Collect a Bundle
+
+For a real PR/release checkpoint, collect after the local merge gate has produced
+its evidence directory:
+
+```bash
+python3 scripts/collect_release_evidence.py collect \
+  --output target/release-evidence/release-evidence.json \
+  --checkpoint paper2-candidate \
+  --checkpoint-kind paper-release \
+  --merge-gate-evidence target/local-hardening/pr-<PR>-<HEAD>/evidence.json \
+  --schema-artifact spec/benchmark-result.schema.json \
+  --benchmark-result target/local-validation/benchmark-reproducibility/example-run.json \
+  --require-clean
+```
+
+Then validate it:
+
+```bash
+python3 scripts/collect_release_evidence.py validate target/release-evidence/release-evidence.json
+```
+
+The local merge gate now also emits `release-evidence.json` next to its normal
+`evidence.json` after all local checks and review quiet-window checks pass.
+
+## Local Suite
+
+```bash
+bash scripts/run_release_evidence_bundle_suite.sh
+```
+
+The suite creates synthetic local merge-gate evidence, binds it into a release
+evidence bundle, validates the bundle, and runs unit tests that catch tampered
+command logs and stale bundle digests.
+
+## What This Does Not Claim
+
+- It does not verify external attestation signatures or trust chains.
+- It does not replace local testing, fuzzing, benchmark validation, or the merge gate.
+- It does not make benchmark numbers admissible unless the benchmark result JSON
+  and sidecar logs also validate.
+- It does not prove a paper claim by itself; it only binds the evidence used to
+  support that claim.

--- a/docs/engineering/reproducibility.md
+++ b/docs/engineering/reproducibility.md
@@ -7,6 +7,7 @@ For the publication-facing paper package, start with:
 - `docs/paper/README.md`
 - `docs/paper/PUBLICATION_RELEASE.md`
 - `docs/paper/submission-v4-2026-04-11/REPRODUCIBILITY_NOTE.md`
+- `docs/engineering/release-evidence-bundle.md`
 
 ## Tooling notes
 

--- a/scripts/collect_release_evidence.py
+++ b/scripts/collect_release_evidence.py
@@ -594,7 +594,18 @@ def validate_release_evidence(path: Path, *, check_live_repo: bool = False) -> l
     bundle_root = path.resolve().parent
     repo_root_raw = payload.get("repo_root")
     repo_root = Path(repo_root_raw) if isinstance(repo_root_raw, str) and repo_root_raw else None
-    trusted_repo_root = default_repo_root().resolve() if check_live_repo else None
+    live_repo_root: Path | None = None
+    trusted_repo_root: Path | None = None
+    if check_live_repo:
+        if repo_root is None:
+            errors.append("repo_root must be a non-empty string for --check-live-repo")
+        elif not repo_root.exists() or not repo_root.is_dir():
+            errors.append("repo_root must be an existing directory for --check-live-repo")
+        else:
+            live_repo_root = repo_root.resolve()
+            current_repo_root = default_repo_root().resolve()
+            if live_repo_root == current_repo_root:
+                trusted_repo_root = live_repo_root
     if payload.get("schema_version") != SCHEMA_VERSION:
         errors.append("schema_version must be 1")
     generated_at = payload.get("generated_at")
@@ -633,9 +644,9 @@ def validate_release_evidence(path: Path, *, check_live_repo: bool = False) -> l
             errors.append("git.dirty must be boolean")
         if not is_hex64(git.get("status_sha256")):
             errors.append("git.status_sha256 must be lowercase 64-char hex")
-        if check_live_repo and repo_root is not None and repo_root.exists():
-            live_head = run_capture(["git", "rev-parse", "HEAD"], repo_root)
-            live_status = run_capture(["git", "status", "--porcelain"], repo_root)
+        if live_repo_root is not None:
+            live_head = run_capture(["git", "rev-parse", "HEAD"], live_repo_root)
+            live_status = run_capture(["git", "status", "--porcelain"], live_repo_root)
             if live_head is not None and live_head != git.get("head_sha"):
                 errors.append("git.head_sha does not match current repo HEAD")
             if live_status is not None:
@@ -667,6 +678,11 @@ def validate_release_evidence(path: Path, *, check_live_repo: bool = False) -> l
     if not isinstance(benchmarks, list):
         errors.append("benchmark_results must be a list")
     else:
+        if check_live_repo and benchmarks and trusted_repo_root is None and live_repo_root is not None:
+            errors.append(
+                "benchmark_results cannot be live-validated safely unless repo_root "
+                "matches the current trusted checkout"
+            )
         for index, record in enumerate(benchmarks):
             validate_benchmark_record(
                 record,

--- a/scripts/collect_release_evidence.py
+++ b/scripts/collect_release_evidence.py
@@ -537,6 +537,9 @@ def validate_merge_gate_record(
         if not path.exists():
             errors.append(f"{command_field}.path does not exist: {path}")
             continue
+        if not path.is_file():
+            errors.append(f"{command_field}.path is not a regular file: {path}")
+            continue
         if sha256_file(path) != command["sha256"]:
             errors.append(f"{command_field}.sha256 does not match log bytes: {path}")
 

--- a/scripts/collect_release_evidence.py
+++ b/scripts/collect_release_evidence.py
@@ -20,6 +20,7 @@ import tempfile
 import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 
 SCHEMA_VERSION = 1
@@ -27,6 +28,7 @@ RELEASE_EVIDENCE_SCHEMA = "spec/release-evidence.schema.json"
 CHUNK_SIZE = 1024 * 1024
 HEX_40_RE = re.compile(r"^[0-9a-f]{40}$")
 HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+UTC_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
 
 class ReleaseEvidenceError(RuntimeError):
@@ -76,6 +78,23 @@ def run_capture(args: list[str], cwd: Path) -> str | None:
         return None
 
 
+def sanitize_remote_url(value: str | None) -> tuple[str | None, bool]:
+    if not value:
+        return None, False
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None, True
+    if parsed.scheme and parsed.netloc:
+        had_credentials = bool(parsed.username or parsed.password)
+        host = parsed.hostname or ""
+        if parsed.port is not None:
+            host = f"{host}:{parsed.port}"
+        sanitized = urlunsplit((parsed.scheme, host, parsed.path, parsed.query, parsed.fragment))
+        return sanitized, had_credentials
+    return value, False
+
+
 def path_for_json(path: Path, repo_root: Path) -> str:
     resolved = path.resolve()
     try:
@@ -121,7 +140,10 @@ def file_record(path: Path, repo_root: Path, *, role: str, label: str | None = N
 def git_metadata(repo_root: Path, *, require_clean: bool) -> dict[str, Any]:
     head = run_capture(["git", "rev-parse", "HEAD"], repo_root)
     branch = run_capture(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo_root)
-    remote = run_capture(["git", "config", "--get", "remote.origin.url"], repo_root)
+    remote_raw = run_capture(["git", "config", "--get", "remote.origin.url"], repo_root)
+    remote, remote_had_credentials = sanitize_remote_url(remote_raw)
+    if not is_hex40(head):
+        raise ReleaseEvidenceError("git rev-parse HEAD did not return a lowercase 40-char SHA")
     status = run_capture(["git", "status", "--porcelain"], repo_root) or ""
     dirty = bool(status.strip())
     if require_clean and dirty:
@@ -130,6 +152,7 @@ def git_metadata(repo_root: Path, *, require_clean: bool) -> dict[str, Any]:
         "head_sha": head,
         "branch": branch,
         "remote_origin": remote,
+        "remote_origin_had_credentials": remote_had_credentials,
         "dirty": dirty,
         "status_sha256": sha256_bytes(status.encode("utf-8")),
     }
@@ -209,6 +232,9 @@ def collect_merge_gate_evidence(path: Path, repo_root: Path) -> dict[str, Any]:
     evidence = load_json(resolved, "merge-gate evidence")
     if not isinstance(evidence, dict):
         raise ReleaseEvidenceError(f"{resolved}: merge-gate evidence must be a JSON object")
+    for key in ("base_sha", "head_sha"):
+        if not is_hex40(evidence.get(key)):
+            raise ReleaseEvidenceError(f"{resolved}: {key} must be a lowercase 40-char SHA")
     command_logs = merge_gate_command_logs(evidence, repo_root, resolved)
     return {
         "evidence_file": record,
@@ -279,6 +305,8 @@ def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
 
 def collect_release_evidence(args: argparse.Namespace) -> dict[str, Any]:
     repo_root = Path(args.repo_root).resolve()
+    if not args.merge_gate_evidence:
+        raise ReleaseEvidenceError("at least one --merge-gate-evidence file is required")
     schema_path = repo_root / RELEASE_EVIDENCE_SCHEMA
     schema = file_record(schema_path, repo_root, role="release_evidence_schema")
     git = git_metadata(repo_root, require_clean=args.require_clean)
@@ -418,6 +446,10 @@ def validate_merge_gate_record(
             evidence_commands = evidence.get("local_commands")
             if isinstance(evidence_commands, list) and len(evidence_commands) != len(command_logs):
                 errors.append(f"{field}.command_logs length does not match evidence local_commands")
+        else:
+            evidence_commands = None
+    else:
+        evidence_commands = None
     for command_index, command in enumerate(command_logs):
         command_field = f"{field}.command_logs[{command_index}]"
         if not isinstance(command, dict):
@@ -435,6 +467,21 @@ def validate_merge_gate_record(
         if command.get("recorded_sha256") != command.get("sha256"):
             errors.append(f"{command_field}.recorded_sha256 must match sha256")
         path = resolve_path(raw_path, bundle_root, repo_root)
+        if isinstance(evidence_commands, list) and command_index < len(evidence_commands):
+            evidence_command = evidence_commands[command_index]
+            if not isinstance(evidence_command, dict):
+                errors.append(f"{command_field} evidence local_commands entry must be an object")
+            else:
+                evidence_log_file = evidence_command.get("log_file")
+                evidence_log_sha = evidence_command.get("log_sha256")
+                if not isinstance(evidence_log_file, str) or not evidence_log_file:
+                    errors.append(f"{command_field} evidence log_file is missing")
+                else:
+                    evidence_log_path = resolve_path(evidence_log_file, bundle_root, repo_root)
+                    if evidence_log_path.resolve() != path.resolve():
+                        errors.append(f"{command_field}.path does not match evidence local_commands log_file")
+                if evidence_log_sha != command.get("sha256"):
+                    errors.append(f"{command_field}.sha256 does not match evidence local_commands log_sha256")
         if not path.exists():
             errors.append(f"{command_field}.path does not exist: {path}")
             continue
@@ -492,6 +539,9 @@ def validate_release_evidence(path: Path) -> list[str]:
     repo_root = Path(repo_root_raw) if isinstance(repo_root_raw, str) and repo_root_raw else None
     if payload.get("schema_version") != SCHEMA_VERSION:
         errors.append("schema_version must be 1")
+    generated_at = payload.get("generated_at")
+    if not isinstance(generated_at, str) or not UTC_TIMESTAMP_RE.fullmatch(generated_at):
+        errors.append("generated_at must be a UTC timestamp like 2026-04-18T00:00:00Z")
     validate_bundle_digest(payload, errors)
     validate_file_record(payload.get("bundle_schema"), "bundle_schema", errors, bundle_root, repo_root)
     checkpoint = payload.get("checkpoint")
@@ -510,16 +560,36 @@ def validate_release_evidence(path: Path) -> list[str]:
         repo_head = git.get("head_sha") if is_hex40(git.get("head_sha")) else None
         if repo_head is None:
             errors.append("git.head_sha must be lowercase 40-char hex")
+        if not isinstance(git.get("branch"), str) and git.get("branch") is not None:
+            errors.append("git.branch must be string or null")
+        if not isinstance(git.get("remote_origin"), str) and git.get("remote_origin") is not None:
+            errors.append("git.remote_origin must be string or null")
+        if not isinstance(git.get("remote_origin_had_credentials"), bool):
+            errors.append("git.remote_origin_had_credentials must be boolean")
         if not isinstance(git.get("dirty"), bool):
             errors.append("git.dirty must be boolean")
         if not is_hex64(git.get("status_sha256")):
             errors.append("git.status_sha256 must be lowercase 64-char hex")
+        if repo_root is not None and repo_root.exists():
+            live_head = run_capture(["git", "rev-parse", "HEAD"], repo_root)
+            live_status = run_capture(["git", "status", "--porcelain"], repo_root)
+            if live_head is not None and live_head != git.get("head_sha"):
+                errors.append("git.head_sha does not match current repo HEAD")
+            if live_status is not None:
+                live_dirty = bool(live_status.strip())
+                if isinstance(git.get("dirty"), bool) and live_dirty != git["dirty"]:
+                    errors.append("git.dirty does not match current repo state")
+                live_status_sha = sha256_bytes(live_status.encode("utf-8"))
+                if is_hex64(git.get("status_sha256")) and live_status_sha != git["status_sha256"]:
+                    errors.append("git.status_sha256 does not match current repo status")
     for key in ("toolchain", "host"):
         if not isinstance(payload.get(key), dict):
             errors.append(f"{key} must be an object")
     merge_gates = payload.get("merge_gate_evidence")
     if not isinstance(merge_gates, list):
         errors.append("merge_gate_evidence must be a list")
+    elif not merge_gates:
+        errors.append("merge_gate_evidence must contain at least one evidence record")
     else:
         for index, record in enumerate(merge_gates):
             validate_merge_gate_record(record, index, errors, bundle_root, repo_root, repo_head)

--- a/scripts/collect_release_evidence.py
+++ b/scripts/collect_release_evidence.py
@@ -481,6 +481,9 @@ def validate_merge_gate_record(
         errors.append(f"{field}.head_sha must be lowercase 40-char hex")
     elif repo_head and head_sha != repo_head:
         errors.append(f"{field}.head_sha does not match bundle git.head_sha")
+    base_sha = record.get("base_sha")
+    if not is_hex40(base_sha):
+        errors.append(f"{field}.base_sha must be lowercase 40-char hex")
     if evidence_path and evidence_path.exists():
         try:
             evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
@@ -488,6 +491,8 @@ def validate_merge_gate_record(
             errors.append(f"{field}.evidence_file failed to parse: {exc}")
             evidence = None
         if isinstance(evidence, dict):
+            if evidence.get("base_sha") != base_sha:
+                errors.append(f"{field}.base_sha does not match evidence file")
             if evidence.get("head_sha") != head_sha:
                 errors.append(f"{field}.head_sha does not match evidence file")
             evidence_commands = evidence.get("local_commands")
@@ -542,6 +547,7 @@ def validate_benchmark_record(
     errors: list[str],
     bundle_root: Path,
     repo_root: Path | None,
+    trusted_repo_root: Path | None,
 ) -> None:
     field = f"benchmark_results[{index}]"
     if not isinstance(record, dict):
@@ -557,27 +563,24 @@ def validate_benchmark_record(
     validator = record.get("validator")
     if not isinstance(validator, dict):
         errors.append(f"{field}.validator must be an object")
-    elif validator.get("passed") is not True or validator.get("exit_code") != 0:
-        errors.append(f"{field}.validator must have passed with exit_code 0")
-    if result_path and result_path.exists() and repo_root is not None:
-        validator_path = repo_root / "benchmarks" / "validate_benchmark_result.py"
+    else:
+        if validator.get("passed") is not True or validator.get("exit_code") != 0:
+            errors.append(f"{field}.validator must have passed with exit_code 0")
+        if not is_hex64(validator.get("stdout_sha256")):
+            errors.append(f"{field}.validator.stdout_sha256 must be lowercase 64-char hex")
+        if not is_hex64(validator.get("stderr_sha256")):
+            errors.append(f"{field}.validator.stderr_sha256 must be lowercase 64-char hex")
+    if result_path and result_path.exists() and trusted_repo_root is not None:
+        validator_path = trusted_repo_root / "benchmarks" / "validate_benchmark_result.py"
         completed = subprocess.run(
             [sys.executable, str(validator_path), str(result_path)],
-            cwd=repo_root,
+            cwd=trusted_repo_root,
             text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             check=False,
         )
         if completed.returncode != 0:
             errors.append(f"{field}.result_file no longer passes benchmark validator")
-        elif isinstance(validator, dict):
-            stdout_sha = sha256_bytes(completed.stdout.encode("utf-8"))
-            stderr_sha = sha256_bytes(completed.stderr.encode("utf-8"))
-            if validator.get("stdout_sha256") != stdout_sha:
-                errors.append(f"{field}.validator.stdout_sha256 does not match current validator output")
-            if validator.get("stderr_sha256") != stderr_sha:
-                errors.append(f"{field}.validator.stderr_sha256 does not match current validator output")
 
 
 def validate_release_evidence(path: Path, *, check_live_repo: bool = False) -> list[str]:
@@ -591,6 +594,7 @@ def validate_release_evidence(path: Path, *, check_live_repo: bool = False) -> l
     bundle_root = path.resolve().parent
     repo_root_raw = payload.get("repo_root")
     repo_root = Path(repo_root_raw) if isinstance(repo_root_raw, str) and repo_root_raw else None
+    trusted_repo_root = default_repo_root().resolve() if check_live_repo else None
     if payload.get("schema_version") != SCHEMA_VERSION:
         errors.append("schema_version must be 1")
     generated_at = payload.get("generated_at")
@@ -664,7 +668,14 @@ def validate_release_evidence(path: Path, *, check_live_repo: bool = False) -> l
         errors.append("benchmark_results must be a list")
     else:
         for index, record in enumerate(benchmarks):
-            validate_benchmark_record(record, index, errors, bundle_root, repo_root)
+            validate_benchmark_record(
+                record,
+                index,
+                errors,
+                bundle_root,
+                repo_root,
+                trusted_repo_root,
+            )
     for list_key in ("artifacts", "schema_artifacts"):
         records = payload.get(list_key)
         if not isinstance(records, list):

--- a/scripts/collect_release_evidence.py
+++ b/scripts/collect_release_evidence.py
@@ -78,6 +78,35 @@ def run_capture(args: list[str], cwd: Path) -> str | None:
         return None
 
 
+def normalize_repo_prefix(value: str, repo_root: Path) -> str:
+    path = Path(value)
+    resolved = path if path.is_absolute() else repo_root / path
+    try:
+        rel = str(resolved.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        return ""
+    return rel.rstrip("/") + "/"
+
+
+def status_entry_path(line: str) -> str:
+    path = line[3:] if len(line) > 3 else ""
+    if " -> " in path:
+        path = path.rsplit(" -> ", 1)[1]
+    return path.strip()
+
+
+def filter_status_porcelain(status: str, ignored_prefixes: list[str]) -> str:
+    if not ignored_prefixes:
+        return status
+    kept = []
+    for line in status.splitlines():
+        path = status_entry_path(line)
+        if path and any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in ignored_prefixes):
+            continue
+        kept.append(line)
+    return "\n".join(kept) + ("\n" if kept else "")
+
+
 def sanitize_remote_url(value: str | None) -> tuple[str | None, bool]:
     if not value:
         return None, False
@@ -137,14 +166,27 @@ def file_record(path: Path, repo_root: Path, *, role: str, label: str | None = N
     return record
 
 
-def git_metadata(repo_root: Path, *, require_clean: bool) -> dict[str, Any]:
+def git_metadata(
+    repo_root: Path,
+    *,
+    require_clean: bool,
+    clean_ignore_prefixes: list[str] | None = None,
+) -> dict[str, Any]:
     head = run_capture(["git", "rev-parse", "HEAD"], repo_root)
     branch = run_capture(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo_root)
     remote_raw = run_capture(["git", "config", "--get", "remote.origin.url"], repo_root)
     remote, remote_had_credentials = sanitize_remote_url(remote_raw)
     if not is_hex40(head):
         raise ReleaseEvidenceError("git rev-parse HEAD did not return a lowercase 40-char SHA")
-    status = run_capture(["git", "status", "--porcelain"], repo_root) or ""
+    ignored_prefixes = [
+        prefix
+        for prefix in (
+            normalize_repo_prefix(value, repo_root) for value in (clean_ignore_prefixes or [])
+        )
+        if prefix
+    ]
+    raw_status = run_capture(["git", "status", "--porcelain"], repo_root) or ""
+    status = filter_status_porcelain(raw_status, ignored_prefixes)
     dirty = bool(status.strip())
     if require_clean and dirty:
         raise ReleaseEvidenceError("worktree is dirty; release evidence must bind a clean checkout")
@@ -155,6 +197,7 @@ def git_metadata(repo_root: Path, *, require_clean: bool) -> dict[str, Any]:
         "remote_origin_had_credentials": remote_had_credentials,
         "dirty": dirty,
         "status_sha256": sha256_bytes(status.encode("utf-8")),
+        "clean_ignored_prefixes": ignored_prefixes,
     }
 
 
@@ -309,7 +352,11 @@ def collect_release_evidence(args: argparse.Namespace) -> dict[str, Any]:
         raise ReleaseEvidenceError("at least one --merge-gate-evidence file is required")
     schema_path = repo_root / RELEASE_EVIDENCE_SCHEMA
     schema = file_record(schema_path, repo_root, role="release_evidence_schema")
-    git = git_metadata(repo_root, require_clean=args.require_clean)
+    git = git_metadata(
+        repo_root,
+        require_clean=args.require_clean,
+        clean_ignore_prefixes=args.clean_ignore_prefix,
+    )
     artifacts = [
         file_record(Path(path), repo_root, role="release_artifact")
         for path in args.artifact
@@ -524,9 +571,16 @@ def validate_benchmark_record(
         )
         if completed.returncode != 0:
             errors.append(f"{field}.result_file no longer passes benchmark validator")
+        elif isinstance(validator, dict):
+            stdout_sha = sha256_bytes(completed.stdout.encode("utf-8"))
+            stderr_sha = sha256_bytes(completed.stderr.encode("utf-8"))
+            if validator.get("stdout_sha256") != stdout_sha:
+                errors.append(f"{field}.validator.stdout_sha256 does not match current validator output")
+            if validator.get("stderr_sha256") != stderr_sha:
+                errors.append(f"{field}.validator.stderr_sha256 does not match current validator output")
 
 
-def validate_release_evidence(path: Path) -> list[str]:
+def validate_release_evidence(path: Path, *, check_live_repo: bool = False) -> list[str]:
     errors: list[str] = []
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -566,16 +620,28 @@ def validate_release_evidence(path: Path) -> list[str]:
             errors.append("git.remote_origin must be string or null")
         if not isinstance(git.get("remote_origin_had_credentials"), bool):
             errors.append("git.remote_origin_had_credentials must be boolean")
+        ignored_prefixes = git.get("clean_ignored_prefixes")
+        if not isinstance(ignored_prefixes, list) or not all(
+            isinstance(prefix, str) for prefix in ignored_prefixes
+        ):
+            errors.append("git.clean_ignored_prefixes must be a string list")
         if not isinstance(git.get("dirty"), bool):
             errors.append("git.dirty must be boolean")
         if not is_hex64(git.get("status_sha256")):
             errors.append("git.status_sha256 must be lowercase 64-char hex")
-        if repo_root is not None and repo_root.exists():
+        if check_live_repo and repo_root is not None and repo_root.exists():
             live_head = run_capture(["git", "rev-parse", "HEAD"], repo_root)
             live_status = run_capture(["git", "status", "--porcelain"], repo_root)
             if live_head is not None and live_head != git.get("head_sha"):
                 errors.append("git.head_sha does not match current repo HEAD")
             if live_status is not None:
+                ignored_prefixes = (
+                    git["clean_ignored_prefixes"]
+                    if isinstance(git.get("clean_ignored_prefixes"), list)
+                    and all(isinstance(prefix, str) for prefix in git["clean_ignored_prefixes"])
+                    else []
+                )
+                live_status = filter_status_porcelain(live_status, ignored_prefixes)
                 live_dirty = bool(live_status.strip())
                 if isinstance(git.get("dirty"), bool) and live_dirty != git["dirty"]:
                     errors.append("git.dirty does not match current repo state")
@@ -628,9 +694,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     collect.add_argument("--artifact", action="append", default=[], help="release artifact to hash")
     collect.add_argument("--schema-artifact", action="append", default=[], help="schema artifact to hash")
     collect.add_argument("--require-clean", action="store_true", help="fail when git status is dirty")
+    collect.add_argument("--clean-ignore-prefix", action="append", default=[], help="repo-relative prefix ignored only for clean-status checks")
 
     validate = subparsers.add_parser("validate", help="validate a release evidence bundle")
     validate.add_argument("bundle", help="release evidence JSON")
+    validate.add_argument("--check-live-repo", action="store_true", help="also compare recorded git state to the current repo_root checkout")
     return parser
 
 
@@ -641,7 +709,7 @@ def main(argv: list[str] | None = None) -> int:
             payload = collect_release_evidence(args)
             output = Path(args.output)
             write_json_atomic(output, payload)
-            errors = validate_release_evidence(output)
+            errors = validate_release_evidence(output, check_live_repo=True)
         except ReleaseEvidenceError as exc:
             print(f"release evidence collection failed: {exc}", file=sys.stderr)
             return 1
@@ -652,7 +720,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"release evidence bundle written: {output}")
         return 0
     if args.command == "validate":
-        errors = validate_release_evidence(Path(args.bundle))
+        errors = validate_release_evidence(Path(args.bundle), check_live_repo=args.check_live_repo)
         if errors:
             for error in errors:
                 print(error, file=sys.stderr)

--- a/scripts/collect_release_evidence.py
+++ b/scripts/collect_release_evidence.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python3
+"""Collect and validate local release evidence bundles.
+
+The bundle is intentionally local-first. It records the exact git checkout,
+toolchain metadata, selected artifact hashes, benchmark result hashes, merge-gate
+evidence hashes, and the command-log hashes referenced by merge-gate evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+RELEASE_EVIDENCE_SCHEMA = "spec/release-evidence.schema.json"
+CHUNK_SIZE = 1024 * 1024
+HEX_40_RE = re.compile(r"^[0-9a-f]{40}$")
+HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ReleaseEvidenceError(RuntimeError):
+    pass
+
+
+def default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def canonical_json_bytes(payload: Any) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def sha256_canonical_json(payload: Any) -> str:
+    return sha256_bytes(canonical_json_bytes(payload))
+
+
+def sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(CHUNK_SIZE), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def is_hex40(value: Any) -> bool:
+    return isinstance(value, str) and bool(HEX_40_RE.fullmatch(value))
+
+
+def is_hex64(value: Any) -> bool:
+    return isinstance(value, str) and bool(HEX_64_RE.fullmatch(value))
+
+
+def run_capture(args: list[str], cwd: Path) -> str | None:
+    try:
+        return subprocess.check_output(args, cwd=cwd, text=True, stderr=subprocess.DEVNULL).strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+
+def path_for_json(path: Path, repo_root: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(repo_root.resolve()))
+    except ValueError:
+        return str(resolved)
+
+
+def resolve_path(raw_path: str, bundle_root: Path, repo_root: Path | None) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    candidates = [bundle_root / path]
+    if repo_root is not None:
+        candidates.append(repo_root / path)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[-1]
+
+
+def require_file(path: Path, label: str) -> Path:
+    if not path.exists():
+        raise ReleaseEvidenceError(f"{label} does not exist: {path}")
+    if not path.is_file():
+        raise ReleaseEvidenceError(f"{label} is not a regular file: {path}")
+    return path
+
+
+def file_record(path: Path, repo_root: Path, *, role: str, label: str | None = None) -> dict[str, Any]:
+    resolved = require_file(path if path.is_absolute() else repo_root / path, role).resolve()
+    record: dict[str, Any] = {
+        "role": role,
+        "path": path_for_json(resolved, repo_root),
+        "size_bytes": resolved.stat().st_size,
+        "sha256": sha256_file(resolved),
+    }
+    if label:
+        record["label"] = label
+    return record
+
+
+def git_metadata(repo_root: Path, *, require_clean: bool) -> dict[str, Any]:
+    head = run_capture(["git", "rev-parse", "HEAD"], repo_root)
+    branch = run_capture(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo_root)
+    remote = run_capture(["git", "config", "--get", "remote.origin.url"], repo_root)
+    status = run_capture(["git", "status", "--porcelain"], repo_root) or ""
+    dirty = bool(status.strip())
+    if require_clean and dirty:
+        raise ReleaseEvidenceError("worktree is dirty; release evidence must bind a clean checkout")
+    return {
+        "head_sha": head,
+        "branch": branch,
+        "remote_origin": remote,
+        "dirty": dirty,
+        "status_sha256": sha256_bytes(status.encode("utf-8")),
+    }
+
+
+def toolchain_metadata(repo_root: Path) -> dict[str, Any]:
+    return {
+        "python": sys.version.split()[0],
+        "python_executable": sys.executable,
+        "rustc": run_capture(["rustc", "--version"], repo_root),
+        "cargo": run_capture(["cargo", "--version"], repo_root),
+        "rustup_active_toolchain": run_capture(["rustup", "show", "active-toolchain"], repo_root),
+    }
+
+
+def host_metadata() -> dict[str, Any]:
+    return {
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "platform": platform.platform(),
+        "processor": platform.processor(),
+    }
+
+
+def load_json(path: Path, label: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - exact parser error varies
+        raise ReleaseEvidenceError(f"failed to parse {label} as JSON: {exc}") from exc
+
+
+def merge_gate_command_logs(
+    evidence: dict[str, Any],
+    repo_root: Path,
+    evidence_path: Path,
+) -> list[dict[str, Any]]:
+    commands = evidence.get("local_commands")
+    if not isinstance(commands, list):
+        raise ReleaseEvidenceError(f"{evidence_path}: local_commands must be a list")
+    records: list[dict[str, Any]] = []
+    for index, command in enumerate(commands):
+        if not isinstance(command, dict):
+            raise ReleaseEvidenceError(f"{evidence_path}: local_commands[{index}] must be an object")
+        log_file = command.get("log_file")
+        recorded_hash = command.get("log_sha256")
+        if not isinstance(log_file, str) or not log_file:
+            raise ReleaseEvidenceError(f"{evidence_path}: local_commands[{index}].log_file is missing")
+        if not is_hex64(recorded_hash):
+            raise ReleaseEvidenceError(f"{evidence_path}: local_commands[{index}].log_sha256 is not lowercase hex")
+        resolved = Path(log_file)
+        if not resolved.is_absolute():
+            resolved = repo_root / resolved
+        resolved = require_file(resolved, f"merge-gate command log {index}").resolve()
+        actual_hash = sha256_file(resolved)
+        if actual_hash != recorded_hash:
+            raise ReleaseEvidenceError(
+                f"{evidence_path}: local_commands[{index}] log hash mismatch for {resolved}"
+            )
+        records.append(
+            {
+                "name": command.get("name"),
+                "command": command.get("command"),
+                "exit_code": command.get("exit_code"),
+                "path": path_for_json(resolved, repo_root),
+                "sha256": actual_hash,
+                "recorded_sha256": recorded_hash,
+                "matches_recorded": True,
+            }
+        )
+    return records
+
+
+def collect_merge_gate_evidence(path: Path, repo_root: Path) -> dict[str, Any]:
+    resolved = path if path.is_absolute() else repo_root / path
+    record = file_record(resolved, repo_root, role="merge_gate_evidence")
+    evidence = load_json(resolved, "merge-gate evidence")
+    if not isinstance(evidence, dict):
+        raise ReleaseEvidenceError(f"{resolved}: merge-gate evidence must be a JSON object")
+    command_logs = merge_gate_command_logs(evidence, repo_root, resolved)
+    return {
+        "evidence_file": record,
+        "pr_number": evidence.get("pr_number"),
+        "pr_url": evidence.get("pr_url"),
+        "base_sha": evidence.get("base_sha"),
+        "head_sha": evidence.get("head_sha"),
+        "run_mode": evidence.get("run_mode"),
+        "quiet_seconds": evidence.get("quiet_seconds"),
+        "review_gate": evidence.get("review_gate"),
+        "local_command_count": len(command_logs),
+        "command_logs": command_logs,
+    }
+
+
+def benchmark_record(path: Path, repo_root: Path) -> dict[str, Any]:
+    resolved = path if path.is_absolute() else repo_root / path
+    record = file_record(resolved, repo_root, role="benchmark_result")
+    validator = repo_root / "benchmarks" / "validate_benchmark_result.py"
+    completed = subprocess.run(
+        [sys.executable, str(validator), str(resolved)],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return {
+        "result_file": record,
+        "validator": {
+            "command": [sys.executable, str(validator), str(resolved)],
+            "exit_code": completed.returncode,
+            "stdout_sha256": sha256_bytes(completed.stdout.encode("utf-8")),
+            "stderr_sha256": sha256_bytes(completed.stderr.encode("utf-8")),
+            "passed": completed.returncode == 0,
+        },
+    }
+
+
+def add_bundle_digest(payload: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(payload)
+    payload.pop("bundle_digest", None)
+    payload["bundle_digest"] = {
+        "algorithm": "sha256-canonical-json-without-bundle_digest",
+        "sha256": sha256_canonical_json(payload),
+    }
+    return payload
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = -1
+    tmp_path: Path | None = None
+    try:
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+        tmp_path = Path(tmp_name)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        tmp_path.replace(path)
+    finally:
+        if fd != -1:
+            os.close(fd)
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()
+
+
+def collect_release_evidence(args: argparse.Namespace) -> dict[str, Any]:
+    repo_root = Path(args.repo_root).resolve()
+    schema_path = repo_root / RELEASE_EVIDENCE_SCHEMA
+    schema = file_record(schema_path, repo_root, role="release_evidence_schema")
+    git = git_metadata(repo_root, require_clean=args.require_clean)
+    artifacts = [
+        file_record(Path(path), repo_root, role="release_artifact")
+        for path in args.artifact
+    ]
+    schema_artifacts = [
+        file_record(Path(path), repo_root, role="schema_artifact")
+        for path in args.schema_artifact
+    ]
+    merge_gates = [collect_merge_gate_evidence(Path(path), repo_root) for path in args.merge_gate_evidence]
+    benchmarks = [benchmark_record(Path(path), repo_root) for path in args.benchmark_result]
+    failed_benchmarks = [item for item in benchmarks if not item["validator"]["passed"]]
+    if failed_benchmarks:
+        failed = ", ".join(item["result_file"]["path"] for item in failed_benchmarks)
+        raise ReleaseEvidenceError(f"benchmark validation failed for: {failed}")
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": utc_now(),
+        "checkpoint": {
+            "name": args.checkpoint,
+            "kind": args.checkpoint_kind,
+        },
+        "repo_root": str(repo_root),
+        "bundle_schema": schema,
+        "git": git,
+        "toolchain": toolchain_metadata(repo_root),
+        "host": host_metadata(),
+        "merge_gate_evidence": merge_gates,
+        "benchmark_results": benchmarks,
+        "artifacts": artifacts,
+        "schema_artifacts": schema_artifacts,
+        "non_claims": [
+            "Does not verify external attestation signatures or trust chains.",
+            "Does not replace the local merge gate; it records local evidence after it exists.",
+            "Does not turn benchmark evidence into a performance claim without the benchmark result schema and logs.",
+        ],
+    }
+    return add_bundle_digest(payload)
+
+
+def validate_file_record(
+    record: Any,
+    field: str,
+    errors: list[str],
+    bundle_root: Path,
+    repo_root: Path | None,
+) -> Path | None:
+    if not isinstance(record, dict):
+        errors.append(f"{field} must be an object")
+        return None
+    raw_path = record.get("path")
+    if not isinstance(raw_path, str) or not raw_path:
+        errors.append(f"{field}.path must be a non-empty string")
+        return None
+    if not is_hex64(record.get("sha256")):
+        errors.append(f"{field}.sha256 must be lowercase 64-char hex")
+        return None
+    if not isinstance(record.get("size_bytes"), int) or record["size_bytes"] < 0:
+        errors.append(f"{field}.size_bytes must be a non-negative integer")
+    path = resolve_path(raw_path, bundle_root, repo_root)
+    if not path.exists():
+        errors.append(f"{field}.path does not exist: {path}")
+        return path
+    if not path.is_file():
+        errors.append(f"{field}.path is not a regular file: {path}")
+        return path
+    actual_hash = sha256_file(path)
+    if actual_hash != record.get("sha256"):
+        errors.append(f"{field}.sha256 does not match file bytes: {path}")
+    if isinstance(record.get("size_bytes"), int) and path.stat().st_size != record["size_bytes"]:
+        errors.append(f"{field}.size_bytes does not match file bytes: {path}")
+    return path
+
+
+def validate_bundle_digest(payload: dict[str, Any], errors: list[str]) -> None:
+    digest = payload.get("bundle_digest")
+    if not isinstance(digest, dict):
+        errors.append("bundle_digest must be an object")
+        return
+    if digest.get("algorithm") != "sha256-canonical-json-without-bundle_digest":
+        errors.append("bundle_digest.algorithm is unsupported")
+    recorded = digest.get("sha256")
+    if not is_hex64(recorded):
+        errors.append("bundle_digest.sha256 must be lowercase 64-char hex")
+        return
+    payload_without_digest = dict(payload)
+    payload_without_digest.pop("bundle_digest", None)
+    actual = sha256_canonical_json(payload_without_digest)
+    if actual != recorded:
+        errors.append("bundle_digest.sha256 does not match canonical payload")
+
+
+def validate_merge_gate_record(
+    record: Any,
+    index: int,
+    errors: list[str],
+    bundle_root: Path,
+    repo_root: Path | None,
+    repo_head: str | None,
+) -> None:
+    field = f"merge_gate_evidence[{index}]"
+    if not isinstance(record, dict):
+        errors.append(f"{field} must be an object")
+        return
+    evidence_path = validate_file_record(
+        record.get("evidence_file"),
+        f"{field}.evidence_file",
+        errors,
+        bundle_root,
+        repo_root,
+    )
+    command_logs = record.get("command_logs")
+    if not isinstance(command_logs, list):
+        errors.append(f"{field}.command_logs must be a list")
+        command_logs = []
+    if not isinstance(record.get("local_command_count"), int):
+        errors.append(f"{field}.local_command_count must be an integer")
+    elif record.get("local_command_count") != len(command_logs):
+        errors.append(f"{field}.local_command_count does not match command_logs length")
+    head_sha = record.get("head_sha")
+    if not is_hex40(head_sha):
+        errors.append(f"{field}.head_sha must be lowercase 40-char hex")
+    elif repo_head and head_sha != repo_head:
+        errors.append(f"{field}.head_sha does not match bundle git.head_sha")
+    if evidence_path and evidence_path.exists():
+        try:
+            evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            errors.append(f"{field}.evidence_file failed to parse: {exc}")
+            evidence = None
+        if isinstance(evidence, dict):
+            if evidence.get("head_sha") != head_sha:
+                errors.append(f"{field}.head_sha does not match evidence file")
+            evidence_commands = evidence.get("local_commands")
+            if isinstance(evidence_commands, list) and len(evidence_commands) != len(command_logs):
+                errors.append(f"{field}.command_logs length does not match evidence local_commands")
+    for command_index, command in enumerate(command_logs):
+        command_field = f"{field}.command_logs[{command_index}]"
+        if not isinstance(command, dict):
+            errors.append(f"{command_field} must be an object")
+            continue
+        raw_path = command.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            errors.append(f"{command_field}.path must be a non-empty string")
+            continue
+        if command.get("matches_recorded") is not True:
+            errors.append(f"{command_field}.matches_recorded must be true")
+        if not is_hex64(command.get("sha256")):
+            errors.append(f"{command_field}.sha256 must be lowercase 64-char hex")
+            continue
+        if command.get("recorded_sha256") != command.get("sha256"):
+            errors.append(f"{command_field}.recorded_sha256 must match sha256")
+        path = resolve_path(raw_path, bundle_root, repo_root)
+        if not path.exists():
+            errors.append(f"{command_field}.path does not exist: {path}")
+            continue
+        if sha256_file(path) != command["sha256"]:
+            errors.append(f"{command_field}.sha256 does not match log bytes: {path}")
+
+
+def validate_benchmark_record(
+    record: Any,
+    index: int,
+    errors: list[str],
+    bundle_root: Path,
+    repo_root: Path | None,
+) -> None:
+    field = f"benchmark_results[{index}]"
+    if not isinstance(record, dict):
+        errors.append(f"{field} must be an object")
+        return
+    result_path = validate_file_record(
+        record.get("result_file"),
+        f"{field}.result_file",
+        errors,
+        bundle_root,
+        repo_root,
+    )
+    validator = record.get("validator")
+    if not isinstance(validator, dict):
+        errors.append(f"{field}.validator must be an object")
+    elif validator.get("passed") is not True or validator.get("exit_code") != 0:
+        errors.append(f"{field}.validator must have passed with exit_code 0")
+    if result_path and result_path.exists() and repo_root is not None:
+        validator_path = repo_root / "benchmarks" / "validate_benchmark_result.py"
+        completed = subprocess.run(
+            [sys.executable, str(validator_path), str(result_path)],
+            cwd=repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if completed.returncode != 0:
+            errors.append(f"{field}.result_file no longer passes benchmark validator")
+
+
+def validate_release_evidence(path: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return [f"failed to parse JSON: {exc}"]
+    if not isinstance(payload, dict):
+        return ["release evidence must be a JSON object"]
+    bundle_root = path.resolve().parent
+    repo_root_raw = payload.get("repo_root")
+    repo_root = Path(repo_root_raw) if isinstance(repo_root_raw, str) and repo_root_raw else None
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        errors.append("schema_version must be 1")
+    validate_bundle_digest(payload, errors)
+    validate_file_record(payload.get("bundle_schema"), "bundle_schema", errors, bundle_root, repo_root)
+    checkpoint = payload.get("checkpoint")
+    if not isinstance(checkpoint, dict):
+        errors.append("checkpoint must be an object")
+    else:
+        if not isinstance(checkpoint.get("name"), str) or not checkpoint["name"]:
+            errors.append("checkpoint.name must be a non-empty string")
+        if not isinstance(checkpoint.get("kind"), str) or not checkpoint["kind"]:
+            errors.append("checkpoint.kind must be a non-empty string")
+    git = payload.get("git")
+    repo_head = None
+    if not isinstance(git, dict):
+        errors.append("git must be an object")
+    else:
+        repo_head = git.get("head_sha") if is_hex40(git.get("head_sha")) else None
+        if repo_head is None:
+            errors.append("git.head_sha must be lowercase 40-char hex")
+        if not isinstance(git.get("dirty"), bool):
+            errors.append("git.dirty must be boolean")
+        if not is_hex64(git.get("status_sha256")):
+            errors.append("git.status_sha256 must be lowercase 64-char hex")
+    for key in ("toolchain", "host"):
+        if not isinstance(payload.get(key), dict):
+            errors.append(f"{key} must be an object")
+    merge_gates = payload.get("merge_gate_evidence")
+    if not isinstance(merge_gates, list):
+        errors.append("merge_gate_evidence must be a list")
+    else:
+        for index, record in enumerate(merge_gates):
+            validate_merge_gate_record(record, index, errors, bundle_root, repo_root, repo_head)
+    benchmarks = payload.get("benchmark_results")
+    if not isinstance(benchmarks, list):
+        errors.append("benchmark_results must be a list")
+    else:
+        for index, record in enumerate(benchmarks):
+            validate_benchmark_record(record, index, errors, bundle_root, repo_root)
+    for list_key in ("artifacts", "schema_artifacts"):
+        records = payload.get(list_key)
+        if not isinstance(records, list):
+            errors.append(f"{list_key} must be a list")
+        else:
+            for index, record in enumerate(records):
+                validate_file_record(record, f"{list_key}[{index}]", errors, bundle_root, repo_root)
+    non_claims = payload.get("non_claims")
+    if not isinstance(non_claims, list) or not non_claims:
+        errors.append("non_claims must be a non-empty list")
+    elif not all(isinstance(item, str) and "not" in item.lower() for item in non_claims):
+        errors.append("non_claims entries must explicitly state non-claims")
+    return errors
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    collect = subparsers.add_parser("collect", help="collect a release evidence bundle")
+    collect.add_argument("--repo-root", default=str(default_repo_root()), help="repository root")
+    collect.add_argument("--output", required=True, help="output JSON path")
+    collect.add_argument("--checkpoint", required=True, help="checkpoint name")
+    collect.add_argument("--checkpoint-kind", default="paper-release", help="checkpoint kind")
+    collect.add_argument("--merge-gate-evidence", action="append", default=[], help="local merge-gate evidence.json to bind")
+    collect.add_argument("--benchmark-result", action="append", default=[], help="benchmark result JSON to bind")
+    collect.add_argument("--artifact", action="append", default=[], help="release artifact to hash")
+    collect.add_argument("--schema-artifact", action="append", default=[], help="schema artifact to hash")
+    collect.add_argument("--require-clean", action="store_true", help="fail when git status is dirty")
+
+    validate = subparsers.add_parser("validate", help="validate a release evidence bundle")
+    validate.add_argument("bundle", help="release evidence JSON")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    if args.command == "collect":
+        try:
+            payload = collect_release_evidence(args)
+            output = Path(args.output)
+            write_json_atomic(output, payload)
+            errors = validate_release_evidence(output)
+        except ReleaseEvidenceError as exc:
+            print(f"release evidence collection failed: {exc}", file=sys.stderr)
+            return 1
+        if errors:
+            for error in errors:
+                print(f"release evidence validation error: {error}", file=sys.stderr)
+            return 1
+        print(f"release evidence bundle written: {output}")
+        return 0
+    if args.command == "validate":
+        errors = validate_release_evidence(Path(args.bundle))
+        if errors:
+            for error in errors:
+                print(error, file=sys.stderr)
+            return 1
+        print(f"release evidence bundle valid: {args.bundle}")
+        return 0
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -1039,7 +1039,7 @@ python3 scripts/collect_release_evidence.py collect \
   --checkpoint-kind local-merge-gate \
   --merge-gate-evidence "$evidence_file" \
   --require-clean \
-  --clean-ignore-prefix "$EVIDENCE_DIR" \
+  --clean-ignore-prefix "$run_evidence_dir" \
   --schema-artifact spec/benchmark-result.schema.json >/dev/null
 python3 scripts/collect_release_evidence.py validate "$release_evidence_file" >/dev/null
 

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -512,6 +512,7 @@ changed_path_is_release_evidence_surface() {
     changed_path_has_prefix "scripts/tests/test_collect_release_evidence.py" ||
     changed_path_has_prefix "scripts/run_release_evidence_bundle_suite.sh" ||
     changed_path_has_prefix "spec/release-evidence.schema.json" ||
+    changed_path_has_prefix "spec/benchmark-result.schema.json" ||
     changed_path_has_prefix "docs/engineering/release-evidence-bundle.md" ||
     changed_path_has_prefix "docs/engineering/reproducibility.md" ||
     changed_path_has_prefix "scripts/local_merge_gate.sh"
@@ -1037,6 +1038,8 @@ python3 scripts/collect_release_evidence.py collect \
   --checkpoint "pr-${PR_NUMBER}-local-merge-gate" \
   --checkpoint-kind local-merge-gate \
   --merge-gate-evidence "$evidence_file" \
+  --require-clean \
+  --clean-ignore-prefix "$EVIDENCE_DIR" \
   --schema-artifact spec/benchmark-result.schema.json >/dev/null
 python3 scripts/collect_release_evidence.py validate "$release_evidence_file" >/dev/null
 

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -1032,20 +1032,27 @@ jq -n \
     local_commands:$commands[0]
   }' >"$evidence_file"
 
-release_evidence_file="$run_evidence_dir/release-evidence.json"
-python3 scripts/collect_release_evidence.py collect \
-  --output "$release_evidence_file" \
-  --checkpoint "pr-${PR_NUMBER}-local-merge-gate" \
-  --checkpoint-kind local-merge-gate \
-  --merge-gate-evidence "$evidence_file" \
-  --require-clean \
-  --clean-ignore-prefix "$run_evidence_dir" \
-  --schema-artifact spec/benchmark-result.schema.json >/dev/null
-python3 scripts/collect_release_evidence.py validate "$release_evidence_file" >/dev/null
+release_evidence_file=""
+if [[ -f "$local_evidence_marker" ]]; then
+  release_evidence_file="$run_evidence_dir/release-evidence.json"
+  python3 scripts/collect_release_evidence.py collect \
+    --output "$release_evidence_file" \
+    --checkpoint "pr-${PR_NUMBER}-local-merge-gate" \
+    --checkpoint-kind local-merge-gate \
+    --merge-gate-evidence "$evidence_file" \
+    --require-clean \
+    --clean-ignore-prefix "$run_evidence_dir" \
+    --schema-artifact spec/benchmark-result.schema.json >/dev/null
+  python3 scripts/collect_release_evidence.py validate "$release_evidence_file" >/dev/null
+else
+  log "skipping release evidence; no completed local evidence marker for this PR head"
+fi
 
 log "gate passed for ${pr_url}"
 log "evidence: ${evidence_file}"
-log "release evidence: ${release_evidence_file}"
+if [[ -n "$release_evidence_file" ]]; then
+  log "release evidence: ${release_evidence_file}"
+fi
 
 if (( MERGE )); then
   merge_args=(gh pr merge "$PR_NUMBER" --repo "$REPO" --match-head-commit "$head_sha")

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -1037,8 +1037,7 @@ python3 scripts/collect_release_evidence.py collect \
   --checkpoint "pr-${PR_NUMBER}-local-merge-gate" \
   --checkpoint-kind local-merge-gate \
   --merge-gate-evidence "$evidence_file" \
-  --schema-artifact spec/benchmark-result.schema.json \
-  --require-clean >/dev/null
+  --schema-artifact spec/benchmark-result.schema.json >/dev/null
 python3 scripts/collect_release_evidence.py validate "$release_evidence_file" >/dev/null
 
 log "gate passed for ${pr_url}"

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -507,6 +507,16 @@ changed_path_is_benchmark_reproducibility_surface() {
     changed_path_has_prefix "scripts/local_merge_gate.sh"
 }
 
+changed_path_is_release_evidence_surface() {
+  changed_path_has_prefix "scripts/collect_release_evidence.py" ||
+    changed_path_has_prefix "scripts/tests/test_collect_release_evidence.py" ||
+    changed_path_has_prefix "scripts/run_release_evidence_bundle_suite.sh" ||
+    changed_path_has_prefix "spec/release-evidence.schema.json" ||
+    changed_path_has_prefix "docs/engineering/release-evidence-bundle.md" ||
+    changed_path_has_prefix "docs/engineering/reproducibility.md" ||
+    changed_path_has_prefix "scripts/local_merge_gate.sh"
+}
+
 changed_path_is_dependency_audit_input() {
   local path
 
@@ -626,6 +636,12 @@ run_benchmark_reproducibility_if_needed() {
   fi
 }
 
+run_release_evidence_if_needed() {
+  if changed_path_is_release_evidence_surface; then
+    run_logged release-evidence-bundle bash scripts/run_release_evidence_bundle_suite.sh
+  fi
+}
+
 run_research_v3_smoke_targets() {
   local research_v3_smoke label
   for research_v3_smoke in "${research_v3_smoke_targets[@]}"; do
@@ -717,6 +733,7 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   run_phase37_mutation_generator_if_needed
   run_fuzz_smoke_if_needed
   run_benchmark_reproducibility_if_needed
+  run_release_evidence_if_needed
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -744,6 +761,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_phase37_mutation_generator_if_needed
   run_fuzz_smoke_if_needed
   run_benchmark_reproducibility_if_needed
+  run_release_evidence_if_needed
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -770,6 +788,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_reference_verifier_if_needed
   run_phase37_mutation_generator_if_needed
   run_benchmark_reproducibility_if_needed
+  run_release_evidence_if_needed
   run_conditional_mutation_check
   run_logged fuzz-smoke env FUZZ_TIME_PER_TARGET=20 scripts/run_fuzz_smoke_suite.sh
   run_logged ub-checks env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh
@@ -1012,8 +1031,19 @@ jq -n \
     local_commands:$commands[0]
   }' >"$evidence_file"
 
+release_evidence_file="$run_evidence_dir/release-evidence.json"
+python3 scripts/collect_release_evidence.py collect \
+  --output "$release_evidence_file" \
+  --checkpoint "pr-${PR_NUMBER}-local-merge-gate" \
+  --checkpoint-kind local-merge-gate \
+  --merge-gate-evidence "$evidence_file" \
+  --schema-artifact spec/benchmark-result.schema.json \
+  --require-clean >/dev/null
+python3 scripts/collect_release_evidence.py validate "$release_evidence_file" >/dev/null
+
 log "gate passed for ${pr_url}"
 log "evidence: ${evidence_file}"
+log "release evidence: ${release_evidence_file}"
 
 if (( MERGE )); then
   merge_args=(gh pr merge "$PR_NUMBER" --repo "$REPO" --match-head-commit "$head_sha")

--- a/scripts/run_release_evidence_bundle_suite.sh
+++ b/scripts/run_release_evidence_bundle_suite.sh
@@ -24,7 +24,14 @@ print(out_dir.resolve())
 PY
 )"
 mkdir -p "$repo_root/target"
-target_root="$(cd "$repo_root/target" && pwd)"
+target_root="$(
+  python3 - "$repo_root/target" <<'PY'
+import sys
+from pathlib import Path
+
+print(Path(sys.argv[1]).resolve())
+PY
+)"
 case "$out_dir" in
   "$target_root"/*) ;;
   *)

--- a/scripts/run_release_evidence_bundle_suite.sh
+++ b/scripts/run_release_evidence_bundle_suite.sh
@@ -5,7 +5,34 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 out_dir="${RELEASE_EVIDENCE_OUT_DIR:-target/local-validation/release-evidence}"
-rm -rf "$out_dir"
+case "$out_dir" in
+  ""|"/"|"."|"..")
+    echo "unsafe RELEASE_EVIDENCE_OUT_DIR: $out_dir" >&2
+    exit 1
+    ;;
+esac
+out_dir="$(
+  python3 - "$repo_root" "$out_dir" <<'PY'
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1]).resolve()
+out_dir = Path(sys.argv[2])
+if not out_dir.is_absolute():
+    out_dir = repo_root / out_dir
+print(out_dir.resolve())
+PY
+)"
+mkdir -p "$repo_root/target"
+target_root="$(cd "$repo_root/target" && pwd)"
+case "$out_dir" in
+  "$target_root"/*) ;;
+  *)
+    echo "RELEASE_EVIDENCE_OUT_DIR must stay under target/: $out_dir" >&2
+    exit 1
+    ;;
+esac
+rm -rf -- "$out_dir"
 mkdir -p "$out_dir/gate/logs"
 
 python3 -B -m unittest scripts.tests.test_collect_release_evidence

--- a/scripts/run_release_evidence_bundle_suite.sh
+++ b/scripts/run_release_evidence_bundle_suite.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+out_dir="${RELEASE_EVIDENCE_OUT_DIR:-target/local-validation/release-evidence}"
+rm -rf "$out_dir"
+mkdir -p "$out_dir/gate/logs"
+
+python3 -B -m unittest scripts.tests.test_collect_release_evidence
+
+head_sha="$(git rev-parse HEAD)"
+base_sha="$(git rev-parse HEAD^)"
+log_file="$out_dir/gate/logs/smoke.log"
+printf 'release evidence smoke log\n' >"$log_file"
+
+gate_json="$out_dir/gate/evidence.json"
+python3 - "$gate_json" "$log_file" "$head_sha" "$base_sha" <<'PY'
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+gate_json = Path(sys.argv[1])
+log_file = Path(sys.argv[2])
+head_sha = sys.argv[3]
+base_sha = sys.argv[4]
+repo_root = Path.cwd()
+log_sha = hashlib.sha256(log_file.read_bytes()).hexdigest()
+payload = {
+    "repo": "omarespejel/provable-transformer-vm",
+    "pr_number": 0,
+    "pr_url": "local-release-evidence-suite",
+    "base_sha": base_sha,
+    "head_sha": head_sha,
+    "run_mode": "smoke",
+    "quiet_seconds": 360,
+    "review_gate": {"active_threads": 0, "source": "synthetic-local-suite"},
+    "local_commands": [
+        {
+            "name": "release-evidence-smoke",
+            "command": "printf release evidence smoke log",
+            "exit_code": 0,
+            "log_file": str(log_file.resolve().relative_to(repo_root.resolve())),
+            "log_sha256": log_sha,
+        }
+    ],
+}
+gate_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+bundle_json="$out_dir/release-evidence.json"
+python3 scripts/collect_release_evidence.py collect \
+  --output "$bundle_json" \
+  --checkpoint release-evidence-suite \
+  --checkpoint-kind local-validation \
+  --merge-gate-evidence "$gate_json" \
+  --schema-artifact spec/benchmark-result.schema.json \
+  --artifact docs/engineering/reproducibility.md
+
+python3 scripts/collect_release_evidence.py validate "$bundle_json"
+[[ -s "$bundle_json" ]] || { echo "missing release evidence bundle: $bundle_json" >&2; exit 1; }
+
+echo "release evidence bundle suite passed: $bundle_json"

--- a/scripts/tests/test_collect_release_evidence.py
+++ b/scripts/tests/test_collect_release_evidence.py
@@ -122,6 +122,16 @@ class ReleaseEvidenceTests(unittest.TestCase):
 
         self.assertTrue(any("sha256 does not match log bytes" in error for error in errors))
 
+    def test_rejects_command_log_directory_path_without_crashing(self) -> None:
+        payload = self.valid_payload()
+        payload["merge_gate_evidence"][0]["command_logs"][0]["path"] = "target/local-hardening/pr-1/logs"
+        payload = release.add_bundle_digest(payload)
+        path = self.write_bundle(payload)
+
+        errors = release.validate_release_evidence(path)
+
+        self.assertTrue(any("path is not a regular file" in error for error in errors))
+
     def test_rejects_bundle_digest_drift(self) -> None:
         payload = self.valid_payload()
         payload["checkpoint"]["name"] = "changed-after-digest"

--- a/scripts/tests/test_collect_release_evidence.py
+++ b/scripts/tests/test_collect_release_evidence.py
@@ -143,6 +143,16 @@ class ReleaseEvidenceTests(unittest.TestCase):
             any("does not match evidence local_commands log_file" in error for error in errors)
         )
 
+    def test_rejects_base_sha_drift_from_evidence_json(self) -> None:
+        payload = self.valid_payload()
+        payload["merge_gate_evidence"][0]["base_sha"] = "c" * 40
+        payload = release.add_bundle_digest(payload)
+        path = self.write_bundle(payload)
+
+        errors = release.validate_release_evidence(path)
+
+        self.assertTrue(any("base_sha does not match evidence file" in error for error in errors))
+
     def test_collect_merge_gate_rejects_bad_recorded_log_hash(self) -> None:
         gate_path = self.write_gate_evidence()
         payload = json.loads(gate_path.read_text(encoding="utf-8"))
@@ -180,6 +190,41 @@ class ReleaseEvidenceTests(unittest.TestCase):
 
         self.assertEqual(sanitized, "https://example.com/org/repo.git")
         self.assertTrue(had_credentials)
+
+    def test_live_benchmark_validation_does_not_execute_bundle_repo_root(self) -> None:
+        payload = self.valid_payload()
+        benchmark_path = self.root / "benchmark.json"
+        benchmark_path.write_text('{"not": "a benchmark result"}\n', encoding="utf-8")
+        marker_path = self.root / "validator-was-run"
+        malicious_validator = self.root / "benchmarks" / "validate_benchmark_result.py"
+        malicious_validator.parent.mkdir()
+        malicious_validator.write_text(
+            f"from pathlib import Path\nPath({str(marker_path)!r}).write_text('ran')\n",
+            encoding="utf-8",
+        )
+        payload["benchmark_results"] = [
+            {
+                "result_file": release.file_record(
+                    benchmark_path,
+                    self.root,
+                    role="benchmark_result",
+                ),
+                "validator": {
+                    "command": [sys.executable, str(malicious_validator), str(benchmark_path)],
+                    "exit_code": 0,
+                    "stdout_sha256": "0" * 64,
+                    "stderr_sha256": "0" * 64,
+                    "passed": True,
+                },
+            }
+        ]
+        payload = release.add_bundle_digest(payload)
+        path = self.write_bundle(payload)
+
+        errors = release.validate_release_evidence(path, check_live_repo=True)
+
+        self.assertTrue(any("benchmark validator" in error for error in errors))
+        self.assertFalse(marker_path.exists())
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_collect_release_evidence.py
+++ b/scripts/tests/test_collect_release_evidence.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "collect_release_evidence.py"
+SPEC = importlib.util.spec_from_file_location("collect_release_evidence", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load release evidence module from {MODULE_PATH}")
+release = importlib.util.module_from_spec(SPEC)
+sys.modules["collect_release_evidence"] = release
+SPEC.loader.exec_module(release)
+
+
+class ReleaseEvidenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        (self.root / "spec").mkdir()
+        (self.root / "spec" / "release-evidence.schema.json").write_text(
+            '{"schema_version": 1}\n', encoding="utf-8"
+        )
+        (self.root / "target" / "local-hardening" / "pr-1").mkdir(parents=True)
+        (self.root / "target" / "local-hardening" / "pr-1" / "logs").mkdir()
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write_gate_evidence(self, *, head_sha: str = "a" * 40) -> Path:
+        log_path = self.root / "target" / "local-hardening" / "pr-1" / "logs" / "smoke.log"
+        log_path.write_text("smoke passed\n", encoding="utf-8")
+        log_hash = release.sha256_file(log_path)
+        evidence_path = self.root / "target" / "local-hardening" / "pr-1" / "evidence.json"
+        payload = {
+            "repo": "omarespejel/provable-transformer-vm",
+            "pr_number": 1,
+            "pr_url": "https://example.invalid/pr/1",
+            "base_sha": "b" * 40,
+            "head_sha": head_sha,
+            "run_mode": "smoke",
+            "quiet_seconds": 360,
+            "review_gate": {"active_threads": 0},
+            "local_commands": [
+                {
+                    "name": "smoke",
+                    "command": "true",
+                    "exit_code": 0,
+                    "log_file": str(log_path.relative_to(self.root)),
+                    "log_sha256": log_hash,
+                }
+            ],
+        }
+        evidence_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+        return evidence_path
+
+    def valid_payload(self) -> dict:
+        gate_path = self.write_gate_evidence()
+        merge_gate = release.collect_merge_gate_evidence(gate_path, self.root)
+        payload = {
+            "schema_version": 1,
+            "generated_at": "2026-04-18T00:00:00Z",
+            "checkpoint": {"name": "unit", "kind": "paper-release"},
+            "repo_root": str(self.root),
+            "bundle_schema": release.file_record(
+                self.root / "spec" / "release-evidence.schema.json",
+                self.root,
+                role="release_evidence_schema",
+            ),
+            "git": {
+                "head_sha": "a" * 40,
+                "branch": "test",
+                "remote_origin": None,
+                "dirty": False,
+                "status_sha256": release.sha256_bytes(b""),
+            },
+            "toolchain": {
+                "python": "3.test",
+                "python_executable": sys.executable,
+                "rustc": None,
+                "cargo": None,
+                "rustup_active_toolchain": None,
+            },
+            "host": {
+                "system": "test",
+                "release": "test",
+                "machine": "test",
+                "platform": "test",
+                "processor": "test",
+            },
+            "merge_gate_evidence": [merge_gate],
+            "benchmark_results": [],
+            "artifacts": [],
+            "schema_artifacts": [],
+            "non_claims": ["Does not claim external attestation verification."],
+        }
+        return release.add_bundle_digest(payload)
+
+    def write_bundle(self, payload: dict) -> Path:
+        path = self.root / "release-evidence.json"
+        path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+        return path
+
+    def test_valid_bundle_passes_validation(self) -> None:
+        path = self.write_bundle(self.valid_payload())
+
+        self.assertEqual(release.validate_release_evidence(path), [])
+
+    def test_rejects_tampered_command_log(self) -> None:
+        path = self.write_bundle(self.valid_payload())
+        log_path = self.root / "target" / "local-hardening" / "pr-1" / "logs" / "smoke.log"
+        log_path.write_text("tampered\n", encoding="utf-8")
+
+        errors = release.validate_release_evidence(path)
+
+        self.assertTrue(any("sha256 does not match log bytes" in error for error in errors))
+
+    def test_rejects_bundle_digest_drift(self) -> None:
+        payload = self.valid_payload()
+        payload["checkpoint"]["name"] = "changed-after-digest"
+        path = self.write_bundle(payload)
+
+        errors = release.validate_release_evidence(path)
+
+        self.assertTrue(any("bundle_digest.sha256" in error for error in errors))
+
+    def test_collect_merge_gate_rejects_bad_recorded_log_hash(self) -> None:
+        gate_path = self.write_gate_evidence()
+        payload = json.loads(gate_path.read_text(encoding="utf-8"))
+        payload["local_commands"][0]["log_sha256"] = "0" * 64
+        gate_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with self.assertRaisesRegex(release.ReleaseEvidenceError, "log hash mismatch"):
+            release.collect_merge_gate_evidence(gate_path, self.root)
+
+    def test_rejects_relocated_bundle_without_evidence_sidecars(self) -> None:
+        path = self.write_bundle(self.valid_payload())
+        relocated = self.root / "relocated" / "release-evidence.json"
+        relocated.parent.mkdir()
+        shutil.copy2(path, relocated)
+        shutil.rmtree(self.root / "target")
+
+        errors = release.validate_release_evidence(relocated)
+
+        self.assertTrue(any("path does not exist" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_collect_release_evidence.py
+++ b/scripts/tests/test_collect_release_evidence.py
@@ -79,6 +79,7 @@ class ReleaseEvidenceTests(unittest.TestCase):
                 "remote_origin_had_credentials": False,
                 "dirty": False,
                 "status_sha256": release.sha256_bytes(b""),
+                "clean_ignored_prefixes": [],
             },
             "toolchain": {
                 "python": "3.test",

--- a/scripts/tests/test_collect_release_evidence.py
+++ b/scripts/tests/test_collect_release_evidence.py
@@ -76,6 +76,7 @@ class ReleaseEvidenceTests(unittest.TestCase):
                 "head_sha": "a" * 40,
                 "branch": "test",
                 "remote_origin": None,
+                "remote_origin_had_credentials": False,
                 "dirty": False,
                 "status_sha256": release.sha256_bytes(b""),
             },
@@ -129,6 +130,18 @@ class ReleaseEvidenceTests(unittest.TestCase):
 
         self.assertTrue(any("bundle_digest.sha256" in error for error in errors))
 
+    def test_rejects_command_log_drift_from_evidence_json(self) -> None:
+        payload = self.valid_payload()
+        payload["merge_gate_evidence"][0]["command_logs"][0]["path"] = "different.log"
+        payload = release.add_bundle_digest(payload)
+        path = self.write_bundle(payload)
+
+        errors = release.validate_release_evidence(path)
+
+        self.assertTrue(
+            any("does not match evidence local_commands log_file" in error for error in errors)
+        )
+
     def test_collect_merge_gate_rejects_bad_recorded_log_hash(self) -> None:
         gate_path = self.write_gate_evidence()
         payload = json.loads(gate_path.read_text(encoding="utf-8"))
@@ -148,6 +161,24 @@ class ReleaseEvidenceTests(unittest.TestCase):
         errors = release.validate_release_evidence(relocated)
 
         self.assertTrue(any("path does not exist" in error for error in errors))
+
+    def test_rejects_bundle_with_no_merge_gate_evidence(self) -> None:
+        payload = self.valid_payload()
+        payload["merge_gate_evidence"] = []
+        payload = release.add_bundle_digest(payload)
+        path = self.write_bundle(payload)
+
+        errors = release.validate_release_evidence(path)
+
+        self.assertTrue(any("merge_gate_evidence" in error for error in errors))
+
+    def test_sanitizes_remote_url_credentials(self) -> None:
+        sanitized, had_credentials = release.sanitize_remote_url(
+            "https://token@example.com/org/repo.git"
+        )
+
+        self.assertEqual(sanitized, "https://example.com/org/repo.git")
+        self.assertTrue(had_credentials)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_collect_release_evidence.py
+++ b/scripts/tests/test_collect_release_evidence.py
@@ -223,8 +223,20 @@ class ReleaseEvidenceTests(unittest.TestCase):
 
         errors = release.validate_release_evidence(path, check_live_repo=True)
 
-        self.assertTrue(any("benchmark validator" in error for error in errors))
+        self.assertTrue(any("cannot be live-validated safely" in error for error in errors))
         self.assertFalse(marker_path.exists())
+
+    def test_live_repo_check_rejects_regular_file_repo_root(self) -> None:
+        payload = self.valid_payload()
+        fake_repo_root = self.root / "not-a-directory"
+        fake_repo_root.write_text("not a directory\n", encoding="utf-8")
+        payload["repo_root"] = str(fake_repo_root)
+        payload = release.add_bundle_digest(payload)
+        path = self.write_bundle(payload)
+
+        errors = release.validate_release_evidence(path, check_live_repo=True)
+
+        self.assertTrue(any("repo_root must be an existing directory" in error for error in errors))
 
 
 if __name__ == "__main__":

--- a/spec/release-evidence.schema.json
+++ b/spec/release-evidence.schema.json
@@ -37,14 +37,15 @@
     "git": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["head_sha", "branch", "remote_origin", "remote_origin_had_credentials", "dirty", "status_sha256"],
+      "required": ["head_sha", "branch", "remote_origin", "remote_origin_had_credentials", "dirty", "status_sha256", "clean_ignored_prefixes"],
       "properties": {
         "head_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
         "branch": {"type": ["string", "null"]},
         "remote_origin": {"type": ["string", "null"]},
         "remote_origin_had_credentials": {"type": "boolean"},
         "dirty": {"type": "boolean"},
-        "status_sha256": {"$ref": "#/$defs/sha256"}
+        "status_sha256": {"$ref": "#/$defs/sha256"},
+        "clean_ignored_prefixes": {"type": "array", "items": {"type": "string"}}
       }
     },
     "toolchain": {

--- a/spec/release-evidence.schema.json
+++ b/spec/release-evidence.schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/omarespejel/provable-transformer-vm/spec/release-evidence.schema.json",
+  "title": "Provable Transformer VM Release Evidence Bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "checkpoint",
+    "repo_root",
+    "bundle_schema",
+    "git",
+    "toolchain",
+    "host",
+    "merge_gate_evidence",
+    "benchmark_results",
+    "artifacts",
+    "schema_artifacts",
+    "non_claims",
+    "bundle_digest"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "generated_at": {"type": "string"},
+    "checkpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "kind"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "kind": {"type": "string", "minLength": 1}
+      }
+    },
+    "repo_root": {"type": "string", "minLength": 1},
+    "bundle_schema": {"$ref": "#/$defs/file_record"},
+    "git": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["head_sha", "branch", "remote_origin", "dirty", "status_sha256"],
+      "properties": {
+        "head_sha": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"},
+        "branch": {"type": ["string", "null"]},
+        "remote_origin": {"type": ["string", "null"]},
+        "dirty": {"type": "boolean"},
+        "status_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "toolchain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["python", "python_executable", "rustc", "cargo", "rustup_active_toolchain"],
+      "properties": {
+        "python": {"type": "string"},
+        "python_executable": {"type": "string"},
+        "rustc": {"type": ["string", "null"]},
+        "cargo": {"type": ["string", "null"]},
+        "rustup_active_toolchain": {"type": ["string", "null"]}
+      }
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["system", "release", "machine", "platform", "processor"],
+      "properties": {
+        "system": {"type": "string"},
+        "release": {"type": "string"},
+        "machine": {"type": "string"},
+        "platform": {"type": "string"},
+        "processor": {"type": "string"}
+      }
+    },
+    "merge_gate_evidence": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/merge_gate_evidence"}
+    },
+    "benchmark_results": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/benchmark_result"}
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/file_record"}
+    },
+    "schema_artifacts": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/file_record"}
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "bundle_digest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "sha256"],
+      "properties": {
+        "algorithm": {"const": "sha256-canonical-json-without-bundle_digest"},
+        "sha256": {"$ref": "#/$defs/sha256"}
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "sha40": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"},
+    "file_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "path", "size_bytes", "sha256"],
+      "properties": {
+        "role": {"type": "string", "minLength": 1},
+        "path": {"type": "string", "minLength": 1},
+        "size_bytes": {"type": "integer", "minimum": 0},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "label": {"type": "string"}
+      }
+    },
+    "command_log": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "command", "exit_code", "path", "sha256", "recorded_sha256", "matches_recorded"],
+      "properties": {
+        "name": {"type": ["string", "null"]},
+        "command": {"type": ["string", "null"]},
+        "exit_code": {"type": ["integer", "null"]},
+        "path": {"type": "string", "minLength": 1},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "recorded_sha256": {"$ref": "#/$defs/sha256"},
+        "matches_recorded": {"const": true}
+      }
+    },
+    "merge_gate_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_file",
+        "pr_number",
+        "pr_url",
+        "base_sha",
+        "head_sha",
+        "run_mode",
+        "quiet_seconds",
+        "review_gate",
+        "local_command_count",
+        "command_logs"
+      ],
+      "properties": {
+        "evidence_file": {"$ref": "#/$defs/file_record"},
+        "pr_number": {"type": ["integer", "null"]},
+        "pr_url": {"type": ["string", "null"]},
+        "base_sha": {"$ref": "#/$defs/sha40"},
+        "head_sha": {"$ref": "#/$defs/sha40"},
+        "run_mode": {"type": ["string", "null"]},
+        "quiet_seconds": {"type": ["integer", "null"]},
+        "review_gate": {"type": ["object", "null"]},
+        "local_command_count": {"type": "integer", "minimum": 0},
+        "command_logs": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/command_log"}
+        }
+      }
+    },
+    "benchmark_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["result_file", "validator"],
+      "properties": {
+        "result_file": {"$ref": "#/$defs/file_record"},
+        "validator": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["command", "exit_code", "stdout_sha256", "stderr_sha256", "passed"],
+          "properties": {
+            "command": {"type": "array", "items": {"type": "string"}},
+            "exit_code": {"type": "integer"},
+            "stdout_sha256": {"$ref": "#/$defs/sha256"},
+            "stderr_sha256": {"$ref": "#/$defs/sha256"},
+            "passed": {"type": "boolean"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/release-evidence.schema.json
+++ b/spec/release-evidence.schema.json
@@ -37,11 +37,12 @@
     "git": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["head_sha", "branch", "remote_origin", "dirty", "status_sha256"],
+      "required": ["head_sha", "branch", "remote_origin", "remote_origin_had_credentials", "dirty", "status_sha256"],
       "properties": {
-        "head_sha": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"},
+        "head_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
         "branch": {"type": ["string", "null"]},
         "remote_origin": {"type": ["string", "null"]},
+        "remote_origin_had_credentials": {"type": "boolean"},
         "dirty": {"type": "boolean"},
         "status_sha256": {"$ref": "#/$defs/sha256"}
       }
@@ -103,7 +104,7 @@
   },
   "$defs": {
     "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
-    "sha40": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"},
+    "sha40": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
     "file_record": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

PR 8 from issue #161: add a local-first release evidence bundle.

This adds:

- release evidence schema at spec/release-evidence.schema.json
- collector and validator at scripts/collect_release_evidence.py
- local suite at scripts/run_release_evidence_bundle_suite.sh
- unit coverage for tampered logs, stale bundle digests, bad merge-gate log hashes, and missing relocated sidecars
- merge-gate integration that writes release-evidence.json next to evidence.json after local gate evidence exists
- docs for how to collect and validate a release checkpoint bundle

The bundle binds git HEAD, dirty/clean status, toolchain/host metadata, schema hashes, selected artifact hashes, benchmark result validation, local merge-gate evidence, and command log hashes referenced by that gate evidence.

## Local validation

- python3 -m py_compile scripts/collect_release_evidence.py scripts/tests/test_collect_release_evidence.py
- python3 -B -m unittest scripts.tests.test_collect_release_evidence
- bash scripts/run_release_evidence_bundle_suite.sh
- python3 -B -m unittest discover -s scripts/tests
- bash scripts/run_shellcheck_suite.sh
- python3 scripts/paper/paper_preflight.py
- python3 -m json.tool spec/release-evidence.schema.json
- git diff --check

GitHub Actions are intentionally not used as the confidence source. Local merge-gate evidence remains required before merge.

Advances #161 PR 8.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Release Evidence Bundle guide describing bundle contents, failure modes, CLI examples, local verification workflow, and explicit non-claims.

* **New Features**
  * Added CLI tooling to collect and validate local release-evidence bundles, integrated bundle generation/validation into the local merge gate, and added a smoke runner to exercise end-to-end collection/validation.

* **Tests**
  * Added tests exercising successful collection/validation and multiple tamper/live-validation failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->