### PR TITLE
Track mutation survivors for paper milestones [skip ci]

### DIFF
--- a/docs/engineering/hardening-policy.md
+++ b/docs/engineering/hardening-policy.md
@@ -155,10 +155,12 @@ Available local command tiers:
   the same conditional shellcheck for `scripts/*.sh` and `scripts/**/*.sh`,
   plus diff-scoped mutation testing when the trusted-core prover files change,
   curated fuzz smoke, UB checks, ASAN, Miri, and the formal contract suite. It
-  also runs the Phase 29-37 known-bad artifact corpus when relevant files
-  change. The inherited whitespace gate is still scoped to the committed PR
-  delta, not the whole worktree. Prefer running this tier inside Lima for Linux
-  parity.
+  records mutation survivors through `scripts/collect_mutation_survivors.py`
+  when mutation output exists, and validates the mutation-survivor ledger when
+  that evidence surface changes. It also runs the Phase 29-37 known-bad
+  artifact corpus when relevant files change. The inherited whitespace gate is
+  still scoped to the committed PR delta, not the whole worktree. Prefer running
+  this tier inside Lima for Linux parity.
 - `--mode none`: only checks GitHub status, review-thread state, and the
   seven-minute AI-review quiet window. Use this only after a prior evidence run
   for the same PR head SHA.

--- a/docs/engineering/hardening-strategy.md
+++ b/docs/engineering/hardening-strategy.md
@@ -44,6 +44,9 @@ do not let trusted-core changes merge on smoke alone.
 | scheduled baseline | Detect drift that diff-scoped PR checks cannot see | scheduled or `main`-branch dependency audit, manually dispatched heavy CI baselines when needed |
 
 The merge gate in `scripts/local_merge_gate.sh` enforces the first three tiers.
+Mutation-testing evidence is tracked through
+`docs/engineering/mutation-survivors.md`; survived and timed-out mutants must be
+triaged there or killed with stronger tests before paper milestones.
 
 ## Required Test Types
 

--- a/docs/engineering/mutation-survivors.md
+++ b/docs/engineering/mutation-survivors.md
@@ -1,0 +1,87 @@
+# Mutation Survivor Ledger
+
+This file is the paper-facing mutation-testing control point.
+
+Mutation testing is useful only if survivors are not silently ignored. A killed
+mutant is evidence that at least one test noticed the injected change. A
+surviving mutant is evidence that either the tests are weak, the mutation is
+semantically equivalent, or the target is outside the claim surface. Those cases
+must be separated before a paper milestone.
+
+## Milestone Rule
+
+Before a Paper 2 or Paper 3 evidence checkpoint that depends on the trusted
+`stwo` verifier surface, run the targeted mutation suite locally and keep the
+survivor report with the release evidence bundle.
+
+Use a dedicated output root so the run can be hashed and referenced later:
+
+```bash
+MUTATION_OUTPUT_ROOT=target/mutation/paper2-checkpoint \
+MUTATION_SURVIVOR_REPORT=target/mutation/paper2-checkpoint/survivors.json \
+scripts/run_mutation_suite.sh
+```
+
+The wrapper runs `cargo mutants` on the trusted verifier files and then writes a
+JSON summary containing killed, survived, timed-out, and unviable counts. If a
+run produces a survivor or timeout, do one of two things:
+
+- Add or strengthen a test so the mutant is killed, rerun the mutation slice, and
+  keep the new report.
+- Record the survivor below with a concrete classification, evidence path, next
+  action, and whether it blocks paper claims.
+
+The default is strict: untriaged survivors and untriaged timeouts block paper
+claims. Equivalent mutants are allowed only when the reason is written down and
+kept narrow.
+
+## Checked Ledger
+
+The following JSON block is validated by
+`scripts/collect_mutation_survivors.py check-doc`. Keep it machine-readable; put
+human explanation around it, not inside comments.
+
+```json mutation-survivors-v1
+{
+  "schema": "mutation-survivor-ledger-v1",
+  "updated_at": "2026-04-18T00:00:00Z",
+  "trusted_targets": [
+    "src/stwo_backend/decoding.rs",
+    "src/stwo_backend/shared_lookup_artifact.rs",
+    "src/stwo_backend/arithmetic_subset_prover.rs"
+  ],
+  "milestone_commands": [
+    "MUTATION_OUTPUT_ROOT=target/mutation/<checkpoint> MUTATION_SURVIVOR_REPORT=target/mutation/<checkpoint>/survivors.json scripts/run_mutation_suite.sh",
+    "python3 scripts/collect_mutation_survivors.py check-doc docs/engineering/mutation-survivors.md"
+  ],
+  "current_status": {
+    "surviving_mutants": [],
+    "timed_out_mutants": []
+  },
+  "non_claims": [
+    "Does not claim exhaustive proof of correctness.",
+    "Does not claim mutation testing covers code outside the trusted target list.",
+    "Does not claim a survivor-free run proves the implementation is sound."
+  ]
+}
+```
+
+## Triage Template
+
+When a survivor or timeout exists, add an object to the appropriate list:
+
+```json
+{
+  "mutant": "src/stwo_backend/decoding.rs:123 replace == with !=",
+  "target": "src/stwo_backend/decoding.rs",
+  "outcome": "survived",
+  "classification": "weak-test | equivalent | out-of-scope | tool-limitation",
+  "evidence": "target/mutation/paper2-checkpoint/survivors.json",
+  "next_action": "add rejection test for boundary mismatch",
+  "paper_blocker": true
+}
+```
+
+A `paper_blocker: false` survivor must be justified by `classification` and must
+not support a paper-facing claim. If the classification is `weak-test`, it stays
+a blocker until a new test kills it.

--- a/docs/engineering/paper2-claim-evidence.yml
+++ b/docs/engineering/paper2-claim-evidence.yml
@@ -208,6 +208,7 @@
     - cargo +nightly-2025-07-14 build -q --features 'full stwo-backend' --bin tvm && TVM_TEST_BINARY=target/debug/tvm cargo +nightly-2025-07-14 test -q --features 'full stwo-backend' --test cli stwo_recursive_artifact_chain
     - scripts/run_reference_verifier_suite.sh
     - scripts/run_phase37_mutation_generator_suite.sh
+    - scripts/run_mutation_survivor_tracking_suite.sh
     - FUZZ_TIME_PER_TARGET=5 scripts/run_fuzz_smoke_suite.sh
   non_claims:
     - "Does not claim recursive proof verification."

--- a/scripts/collect_mutation_survivors.py
+++ b/scripts/collect_mutation_survivors.py
@@ -211,8 +211,6 @@ def validate_ledger(payload: Any) -> list[str]:
     require_string_list(payload.get("milestone_commands"), "milestone_commands", errors, non_empty=True)
     non_claims = payload.get("non_claims")
     require_string_list(non_claims, "non_claims", errors, non_empty=True)
-    if isinstance(non_claims, list) and not all("not" in item.lower() for item in non_claims):
-        errors.append("non_claims entries must explicitly state non-claims")
     current_status = payload.get("current_status")
     if not isinstance(current_status, dict):
         errors.append("current_status must be an object")

--- a/scripts/collect_mutation_survivors.py
+++ b/scripts/collect_mutation_survivors.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Collect and validate mutation-survivor evidence.
+
+This script intentionally understands a small, stable surface of cargo-mutants
+output: the text files that list caught, missed, timed-out, and unviable mutants.
+It is used to turn a heavy local mutation run into explicit evidence instead of
+letting survivors disappear into an untracked `mutants.out` directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+REPORT_SCHEMA = "mutation-survivor-report-v1"
+LEDGER_SCHEMA = "mutation-survivor-ledger-v1"
+CHUNK_SIZE = 1024 * 1024
+UTC_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+OUTCOME_FILES = {
+    "caught": ("caught.txt", "caught"),
+    "survived": ("missed.txt", "missed"),
+    "timeout": ("timeout.txt", "timeout"),
+    "unviable": ("unviable.txt", "unviable"),
+}
+
+
+class MutationEvidenceError(RuntimeError):
+    pass
+
+
+def utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(CHUNK_SIZE), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def path_for_json(path: Path, repo_root: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(repo_root.resolve()))
+    except ValueError:
+        return str(resolved)
+
+
+def run_capture(args: list[str], cwd: Path) -> str | None:
+    try:
+        return subprocess.check_output(args, cwd=cwd, text=True, stderr=subprocess.DEVNULL).strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+
+def parse_outcome_file(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    if not path.is_file():
+        raise MutationEvidenceError(f"outcome path is not a regular file: {path}")
+    lines = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        stripped = line.strip()
+        if stripped:
+            lines.append(stripped)
+    return lines
+
+
+def first_existing(root: Path, names: tuple[str, ...]) -> Path | None:
+    for name in names:
+        candidate = root / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def outcome_records(mutants_dir: Path, repo_root: Path) -> tuple[dict[str, list[str]], list[dict[str, Any]]]:
+    outcomes: dict[str, list[str]] = {}
+    source_files: list[dict[str, Any]] = []
+    for outcome, names in OUTCOME_FILES.items():
+        path = first_existing(mutants_dir, names)
+        if path is None:
+            outcomes[outcome] = []
+            continue
+        lines = parse_outcome_file(path)
+        outcomes[outcome] = lines
+        source_files.append(
+            {
+                "role": f"cargo_mutants_{outcome}",
+                "path": path_for_json(path, repo_root),
+                "size_bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+                "entries": len(lines),
+            }
+        )
+    return outcomes, source_files
+
+
+def build_summary(args: argparse.Namespace) -> dict[str, Any]:
+    repo_root = Path(args.repo_root).resolve()
+    mutants_dir = Path(args.mutants_dir).resolve()
+    if not mutants_dir.exists():
+        raise MutationEvidenceError(f"mutants directory does not exist: {mutants_dir}")
+    if not mutants_dir.is_dir():
+        raise MutationEvidenceError(f"mutants directory is not a directory: {mutants_dir}")
+
+    outcomes, source_files = outcome_records(mutants_dir, repo_root)
+    target_files = list(args.target or [])
+    if not target_files:
+        target_output = run_capture(["bash", "scripts/run_mutation_suite.sh", "--print-targets"], repo_root)
+        target_files = target_output.splitlines() if target_output else []
+
+    counts = {name: len(values) for name, values in outcomes.items()}
+    counts["total_classified"] = sum(counts.values())
+
+    return {
+        "schema": REPORT_SCHEMA,
+        "generated_at": utc_now(),
+        "repo_root": str(repo_root),
+        "mutants_dir": path_for_json(mutants_dir, repo_root),
+        "tool": {
+            "cargo_mutants": run_capture(["cargo", "mutants", "--version"], repo_root),
+            "rustc": run_capture(["rustc", "--version"], repo_root),
+            "cargo": run_capture(["cargo", "--version"], repo_root),
+        },
+        "target_files": target_files,
+        "counts": counts,
+        "source_files": source_files,
+        "survived": outcomes["survived"],
+        "timeouts": outcomes["timeout"],
+        "unviable": outcomes["unviable"],
+        "policy": {
+            "survived_or_timeout_requires_triage": True,
+            "paper_milestone_requires_no_untriaged_survivors": True,
+        },
+    }
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def extract_ledger_json(markdown_path: Path) -> Any:
+    text = markdown_path.read_text(encoding="utf-8")
+    marker = "```json mutation-survivors-v1"
+    start = text.find(marker)
+    if start == -1:
+        raise MutationEvidenceError("missing ```json mutation-survivors-v1 ledger block")
+    start = text.find("\n", start)
+    if start == -1:
+        raise MutationEvidenceError("ledger block has no JSON payload")
+    end = text.find("```", start + 1)
+    if end == -1:
+        raise MutationEvidenceError("ledger block is not closed")
+    payload = text[start:end].strip()
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise MutationEvidenceError(f"ledger JSON is malformed: {exc}") from exc
+
+
+def require_string_list(value: Any, field: str, errors: list[str], *, non_empty: bool = False) -> None:
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        errors.append(f"{field} must be a list of non-empty strings")
+    elif non_empty and not value:
+        errors.append(f"{field} must not be empty")
+
+
+def validate_triage_entries(entries: Any, field: str, errors: list[str]) -> None:
+    if not isinstance(entries, list):
+        errors.append(f"{field} must be a list")
+        return
+    for index, entry in enumerate(entries):
+        entry_field = f"{field}[{index}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{entry_field} must be an object")
+            continue
+        for key in ("mutant", "target", "outcome", "classification", "evidence", "next_action"):
+            if not isinstance(entry.get(key), str) or not entry[key].strip():
+                errors.append(f"{entry_field}.{key} must be a non-empty string")
+        if entry.get("classification") == "untriaged":
+            errors.append(f"{entry_field}.classification must not be untriaged")
+        if entry.get("outcome") not in {"survived", "timeout"}:
+            errors.append(f"{entry_field}.outcome must be survived or timeout")
+        if not isinstance(entry.get("paper_blocker"), bool):
+            errors.append(f"{entry_field}.paper_blocker must be boolean")
+
+
+def validate_ledger(payload: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return ["ledger must be a JSON object"]
+    if payload.get("schema") != LEDGER_SCHEMA:
+        errors.append(f"schema must be {LEDGER_SCHEMA}")
+    updated_at = payload.get("updated_at")
+    if not isinstance(updated_at, str) or not UTC_TIMESTAMP_RE.fullmatch(updated_at):
+        errors.append("updated_at must be a UTC timestamp like 2026-04-18T00:00:00Z")
+    require_string_list(payload.get("trusted_targets"), "trusted_targets", errors, non_empty=True)
+    require_string_list(payload.get("milestone_commands"), "milestone_commands", errors, non_empty=True)
+    non_claims = payload.get("non_claims")
+    require_string_list(non_claims, "non_claims", errors, non_empty=True)
+    if isinstance(non_claims, list) and not all("not" in item.lower() for item in non_claims):
+        errors.append("non_claims entries must explicitly state non-claims")
+    current_status = payload.get("current_status")
+    if not isinstance(current_status, dict):
+        errors.append("current_status must be an object")
+    else:
+        validate_triage_entries(current_status.get("surviving_mutants"), "current_status.surviving_mutants", errors)
+        validate_triage_entries(current_status.get("timed_out_mutants"), "current_status.timed_out_mutants", errors)
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    summarize = subparsers.add_parser("summarize", help="summarize a cargo-mutants output directory")
+    summarize.add_argument("--repo-root", default=str(Path(__file__).resolve().parents[1]))
+    summarize.add_argument("--mutants-dir", required=True)
+    summarize.add_argument("--output", required=True)
+    summarize.add_argument("--target", action="append", default=[])
+
+    check_doc = subparsers.add_parser("check-doc", help="validate docs/engineering/mutation-survivors.md")
+    check_doc.add_argument("path", help="mutation survivor ledger markdown")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "summarize":
+            summary = build_summary(args)
+            write_json(Path(args.output), summary)
+            print(f"mutation survivor summary written: {args.output}")
+            if summary["survived"] or summary["timeouts"]:
+                print(
+                    "warning: mutation survivors/timeouts require triage in docs/engineering/mutation-survivors.md",
+                    file=sys.stderr,
+                )
+            return 0
+        if args.command == "check-doc":
+            ledger = extract_ledger_json(Path(args.path))
+            errors = validate_ledger(ledger)
+            if errors:
+                for error in errors:
+                    print(error, file=sys.stderr)
+                return 1
+            print(f"mutation survivor ledger valid: {args.path}")
+            return 0
+    except MutationEvidenceError as exc:
+        print(f"mutation survivor evidence error: {exc}", file=sys.stderr)
+        return 1
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -518,6 +518,15 @@ changed_path_is_release_evidence_surface() {
     changed_path_has_prefix "scripts/local_merge_gate.sh"
 }
 
+changed_path_is_mutation_survivor_tracking_surface() {
+  changed_path_has_prefix "scripts/collect_mutation_survivors.py" ||
+    changed_path_has_prefix "scripts/tests/test_collect_mutation_survivors.py" ||
+    changed_path_has_prefix "scripts/run_mutation_survivor_tracking_suite.sh" ||
+    changed_path_has_prefix "scripts/run_mutation_suite.sh" ||
+    changed_path_has_prefix "docs/engineering/mutation-survivors.md" ||
+    changed_path_has_prefix "scripts/local_merge_gate.sh"
+}
+
 changed_path_is_dependency_audit_input() {
   local path
 
@@ -643,6 +652,12 @@ run_release_evidence_if_needed() {
   fi
 }
 
+run_mutation_survivor_tracking_if_needed() {
+  if changed_path_is_mutation_survivor_tracking_surface; then
+    run_logged mutation-survivor-tracking bash scripts/run_mutation_survivor_tracking_suite.sh
+  fi
+}
+
 run_research_v3_smoke_targets() {
   local research_v3_smoke label
   for research_v3_smoke in "${research_v3_smoke_targets[@]}"; do
@@ -735,6 +750,7 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   run_fuzz_smoke_if_needed
   run_benchmark_reproducibility_if_needed
   run_release_evidence_if_needed
+  run_mutation_survivor_tracking_if_needed
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -763,6 +779,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_fuzz_smoke_if_needed
   run_benchmark_reproducibility_if_needed
   run_release_evidence_if_needed
+  run_mutation_survivor_tracking_if_needed
   completed_local_mode="$RUN_MODE"
 elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_logged git-diff-check git diff --check "$diff_range"
@@ -790,6 +807,7 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   run_phase37_mutation_generator_if_needed
   run_benchmark_reproducibility_if_needed
   run_release_evidence_if_needed
+  run_mutation_survivor_tracking_if_needed
   run_conditional_mutation_check
   run_logged fuzz-smoke env FUZZ_TIME_PER_TARGET=20 scripts/run_fuzz_smoke_suite.sh
   run_logged ub-checks env HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -67,6 +67,32 @@ if [[ -n "${MUTATION_DIFF_FILE:-}" ]]; then
   args+=(--in-diff "${MUTATION_DIFF_FILE}")
 fi
 
+mtime_epoch() {
+  local path="$1"
+  stat -f %m "$path" 2>/dev/null || stat -c %Y "$path" 2>/dev/null
+}
+
+is_fresh_path() {
+  local path="$1"
+  local mtime
+  mtime="$(mtime_epoch "$path" || true)"
+  [[ -n "$mtime" ]] && (( mtime >= mutation_run_started_epoch ))
+}
+
+find_fresh_mutants_dir() {
+  local candidate outcome
+  for candidate in "$@"; do
+    [[ -d "$candidate" ]] || continue
+    for outcome in caught.txt caught missed.txt missed timeout.txt timeout unviable.txt unviable outcomes.json; do
+      if [[ -e "$candidate/$outcome" ]] && is_fresh_path "$candidate/$outcome"; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    done
+  done
+  return 1
+}
+
 mutation_output_root="${MUTATION_OUTPUT_ROOT:-.}"
 if [[ "$mutation_output_root" != "." ]]; then
   mkdir -p "$mutation_output_root"
@@ -77,14 +103,24 @@ else
 fi
 
 mutation_status=0
+mutation_run_started_epoch="$(date +%s)"
 "${args[@]}" "$@" || mutation_status=$?
 
-if [[ -d "$mutation_results_dir" ]]; then
-  survivor_report="${MUTATION_SURVIVOR_REPORT:-$mutation_results_dir/survivors.json}"
+fresh_mutation_results_dir=""
+if [[ "$mutation_output_root" != "." ]]; then
+  fresh_mutation_results_dir="$(find_fresh_mutants_dir "$mutation_results_dir" "$mutation_output_root" || true)"
+else
+  fresh_mutation_results_dir="$(find_fresh_mutants_dir "$mutation_results_dir" || true)"
+fi
+
+if [[ -n "$fresh_mutation_results_dir" ]]; then
+  survivor_report="${MUTATION_SURVIVOR_REPORT:-$fresh_mutation_results_dir/survivors.json}"
   python3 scripts/collect_mutation_survivors.py summarize \
-    --mutants-dir "$mutation_results_dir" \
+    --mutants-dir "$fresh_mutation_results_dir" \
     --output "$survivor_report"
   echo "mutation survivor report: $survivor_report"
+elif [[ -d "$mutation_results_dir" || -d "$mutation_output_root" ]]; then
+  echo "warning: no fresh cargo-mutants output found; skipping mutation survivor report" >&2
 fi
 
 exit "$mutation_status"

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -119,8 +119,16 @@ if [[ -n "$fresh_mutation_results_dir" ]]; then
     --mutants-dir "$fresh_mutation_results_dir" \
     --output "$survivor_report"
   echo "mutation survivor report: $survivor_report"
-elif [[ -d "$mutation_results_dir" || -d "$mutation_output_root" ]]; then
-  echo "warning: no fresh cargo-mutants output found; skipping mutation survivor report" >&2
+else
+  stale_output_seen=0
+  if [[ "$mutation_output_root" == "." ]]; then
+    [[ -d "$mutation_results_dir" ]] && stale_output_seen=1
+  elif [[ -d "$mutation_results_dir" || -d "$mutation_output_root" ]]; then
+    stale_output_seen=1
+  fi
+  if (( stale_output_seen )); then
+    echo "warning: no fresh cargo-mutants output found; skipping mutation survivor report" >&2
+  fi
 fi
 
 exit "$mutation_status"

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -69,7 +69,16 @@ fi
 
 mtime_epoch() {
   local path="$1"
-  stat -f %m "$path" 2>/dev/null || stat -c %Y "$path" 2>/dev/null
+  local mtime
+  if mtime="$(stat -c %Y "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$mtime"
+    return 0
+  fi
+  if mtime="$(stat -f %m "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$mtime"
+    return 0
+  fi
+  return 1
 }
 
 is_fresh_path() {

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -67,4 +67,24 @@ if [[ -n "${MUTATION_DIFF_FILE:-}" ]]; then
   args+=(--in-diff "${MUTATION_DIFF_FILE}")
 fi
 
-"${args[@]}" "$@"
+mutation_output_root="${MUTATION_OUTPUT_ROOT:-.}"
+if [[ "$mutation_output_root" != "." ]]; then
+  mkdir -p "$mutation_output_root"
+  args+=(--output "$mutation_output_root")
+  mutation_results_dir="$mutation_output_root/mutants.out"
+else
+  mutation_results_dir="mutants.out"
+fi
+
+mutation_status=0
+"${args[@]}" "$@" || mutation_status=$?
+
+if [[ -d "$mutation_results_dir" ]]; then
+  survivor_report="${MUTATION_SURVIVOR_REPORT:-$mutation_results_dir/survivors.json}"
+  python3 scripts/collect_mutation_survivors.py summarize \
+    --mutants-dir "$mutation_results_dir" \
+    --output "$survivor_report"
+  echo "mutation survivor report: $survivor_report"
+fi
+
+exit "$mutation_status"

--- a/scripts/run_mutation_suite.sh
+++ b/scripts/run_mutation_suite.sh
@@ -76,19 +76,27 @@ is_fresh_path() {
   local path="$1"
   local mtime
   mtime="$(mtime_epoch "$path" || true)"
-  [[ -n "$mtime" ]] && (( mtime >= mutation_run_started_epoch ))
+  [[ "$mtime" =~ ^[0-9]+$ ]] && (( mtime >= mutation_run_started_epoch ))
 }
 
 find_fresh_mutants_dir() {
-  local candidate outcome
+  local candidate outcome saw_marker all_fresh
   for candidate in "$@"; do
     [[ -d "$candidate" ]] || continue
+    saw_marker=0
+    all_fresh=1
     for outcome in caught.txt caught missed.txt missed timeout.txt timeout unviable.txt unviable outcomes.json; do
-      if [[ -e "$candidate/$outcome" ]] && is_fresh_path "$candidate/$outcome"; then
-        printf '%s\n' "$candidate"
-        return 0
+      [[ -e "$candidate/$outcome" ]] || continue
+      saw_marker=1
+      if ! is_fresh_path "$candidate/$outcome"; then
+        all_fresh=0
+        break
       fi
     done
+    if (( saw_marker && all_fresh )); then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
   done
   return 1
 }
@@ -127,7 +135,14 @@ else
     stale_output_seen=1
   fi
   if (( stale_output_seen )); then
-    echo "warning: no fresh cargo-mutants output found; skipping mutation survivor report" >&2
+    if (( mutation_status == 0 )); then
+      echo "error: cargo-mutants succeeded but no fresh mutation output was found; refusing to skip survivor report" >&2
+      exit 1
+    fi
+    echo "warning: no fresh cargo-mutants output found after failed cargo-mutants run; skipping mutation survivor report" >&2
+  elif (( mutation_status == 0 )); then
+    echo "error: cargo-mutants succeeded but did not produce mutation output; refusing to skip survivor report" >&2
+    exit 1
   fi
 fi
 

--- a/scripts/run_mutation_survivor_tracking_suite.sh
+++ b/scripts/run_mutation_survivor_tracking_suite.sh
@@ -30,6 +30,8 @@ while (($# > 0)); do
   esac
 done
 
+: "${output_root:?fake cargo expected --output}"
+
 if [[ -n "${FAKE_CARGO_NO_OUTPUT:-}" ]]; then
   exit 2
 fi
@@ -38,7 +40,6 @@ if [[ -n "${FAKE_CARGO_SUCCESS_NO_OUTPUT:-}" ]]; then
   exit 0
 fi
 
-: "${output_root:?fake cargo expected --output}"
 if [[ -n "${FAKE_CARGO_DIRECT_OUTPUT:-}" ]]; then
   mkdir -p "$output_root"
   printf '%s\n' 'src/stwo_backend/decoding.rs:1 direct-output survivor' >"$output_root/missed.txt"

--- a/scripts/run_mutation_survivor_tracking_suite.sh
+++ b/scripts/run_mutation_survivor_tracking_suite.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 -m py_compile \
+  scripts/collect_mutation_survivors.py \
+  scripts/tests/test_collect_mutation_survivors.py
+python3 -B -m unittest scripts.tests.test_collect_mutation_survivors
+python3 scripts/collect_mutation_survivors.py check-doc docs/engineering/mutation-survivors.md
+
+echo "mutation survivor tracking suite passed"

--- a/scripts/run_mutation_survivor_tracking_suite.sh
+++ b/scripts/run_mutation_survivor_tracking_suite.sh
@@ -34,6 +34,10 @@ if [[ -n "${FAKE_CARGO_NO_OUTPUT:-}" ]]; then
   exit 2
 fi
 
+if [[ -n "${FAKE_CARGO_SUCCESS_NO_OUTPUT:-}" ]]; then
+  exit 0
+fi
+
 : "${output_root:?fake cargo expected --output}"
 if [[ -n "${FAKE_CARGO_DIRECT_OUTPUT:-}" ]]; then
   mkdir -p "$output_root"
@@ -77,6 +81,45 @@ if [[ -e "$tmp_dir/stale-survivors.json" ]]; then
   echo "stale-output check produced a survivor report" >&2
   exit 1
 fi
-grep -q "no fresh cargo-mutants output found" "$tmp_dir/stale.stderr"
+grep -q "no fresh cargo-mutants output found after failed cargo-mutants run" "$tmp_dir/stale.stderr"
+
+set +e
+PATH="$tmp_dir/bin:$PATH" \
+  FAKE_CARGO_SUCCESS_NO_OUTPUT=1 \
+  MUTATION_OUTPUT_ROOT="$tmp_dir/missing-output" \
+  MUTATION_SURVIVOR_REPORT="$tmp_dir/missing-output-survivors.json" \
+  scripts/run_mutation_suite.sh >/dev/null 2>"$tmp_dir/missing-output.stderr"
+status=$?
+set -e
+if [[ "$status" -eq 0 ]]; then
+  echo "expected successful cargo run without output to fail evidence collection" >&2
+  exit 1
+fi
+if [[ -e "$tmp_dir/missing-output-survivors.json" ]]; then
+  echo "missing-output check produced a survivor report" >&2
+  exit 1
+fi
+grep -q "succeeded but no fresh mutation output was found" "$tmp_dir/missing-output.stderr"
+
+mkdir -p "$tmp_dir/mixed"
+printf '%s\n' 'old killed mutant' >"$tmp_dir/mixed/caught.txt"
+touch -t 200001010000 "$tmp_dir/mixed/caught.txt"
+set +e
+PATH="$tmp_dir/bin:$PATH" \
+  FAKE_CARGO_DIRECT_OUTPUT=1 \
+  MUTATION_OUTPUT_ROOT="$tmp_dir/mixed" \
+  MUTATION_SURVIVOR_REPORT="$tmp_dir/mixed-survivors.json" \
+  scripts/run_mutation_suite.sh >/dev/null 2>"$tmp_dir/mixed.stderr"
+status=$?
+set -e
+if [[ "$status" -eq 0 ]]; then
+  echo "expected mixed stale/fresh mutation output to fail evidence collection" >&2
+  exit 1
+fi
+if [[ -e "$tmp_dir/mixed-survivors.json" ]]; then
+  echo "mixed freshness check produced a survivor report" >&2
+  exit 1
+fi
+grep -q "succeeded but no fresh mutation output was found" "$tmp_dir/mixed.stderr"
 
 echo "mutation survivor tracking suite passed"

--- a/scripts/run_mutation_survivor_tracking_suite.sh
+++ b/scripts/run_mutation_survivor_tracking_suite.sh
@@ -10,4 +10,73 @@ python3 -m py_compile \
 python3 -B -m unittest scripts.tests.test_collect_mutation_survivors
 python3 scripts/collect_mutation_survivors.py check-doc docs/engineering/mutation-survivors.md
 
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin"
+cat >"$tmp_dir/bin/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_root=""
+while (($# > 0)); do
+  case "$1" in
+    --output)
+      output_root="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "${FAKE_CARGO_NO_OUTPUT:-}" ]]; then
+  exit 2
+fi
+
+: "${output_root:?fake cargo expected --output}"
+if [[ -n "${FAKE_CARGO_DIRECT_OUTPUT:-}" ]]; then
+  mkdir -p "$output_root"
+  printf '%s\n' 'src/stwo_backend/decoding.rs:1 direct-output survivor' >"$output_root/missed.txt"
+else
+  mkdir -p "$output_root/mutants.out"
+  printf '%s\n' 'src/stwo_backend/decoding.rs:1 nested-output survivor' >"$output_root/mutants.out/missed.txt"
+fi
+SH
+chmod +x "$tmp_dir/bin/cargo"
+
+PATH="$tmp_dir/bin:$PATH" \
+  MUTATION_OUTPUT_ROOT="$tmp_dir/nested" \
+  MUTATION_SURVIVOR_REPORT="$tmp_dir/nested-survivors.json" \
+  scripts/run_mutation_suite.sh >/dev/null
+test -s "$tmp_dir/nested-survivors.json"
+
+PATH="$tmp_dir/bin:$PATH" \
+  FAKE_CARGO_DIRECT_OUTPUT=1 \
+  MUTATION_OUTPUT_ROOT="$tmp_dir/direct" \
+  MUTATION_SURVIVOR_REPORT="$tmp_dir/direct-survivors.json" \
+  scripts/run_mutation_suite.sh >/dev/null
+test -s "$tmp_dir/direct-survivors.json"
+
+mkdir -p "$tmp_dir/stale/mutants.out"
+printf '%s\n' 'stale survivor' >"$tmp_dir/stale/mutants.out/missed.txt"
+touch -t 200001010000 "$tmp_dir/stale/mutants.out/missed.txt" "$tmp_dir/stale/mutants.out"
+set +e
+PATH="$tmp_dir/bin:$PATH" \
+  FAKE_CARGO_NO_OUTPUT=1 \
+  MUTATION_OUTPUT_ROOT="$tmp_dir/stale" \
+  MUTATION_SURVIVOR_REPORT="$tmp_dir/stale-survivors.json" \
+  scripts/run_mutation_suite.sh >/dev/null 2>"$tmp_dir/stale.stderr"
+status=$?
+set -e
+if [[ "$status" -eq 0 ]]; then
+  echo "expected fake cargo failure in stale-output check" >&2
+  exit 1
+fi
+if [[ -e "$tmp_dir/stale-survivors.json" ]]; then
+  echo "stale-output check produced a survivor report" >&2
+  exit 1
+fi
+grep -q "no fresh cargo-mutants output found" "$tmp_dir/stale.stderr"
+
 echo "mutation survivor tracking suite passed"

--- a/scripts/run_mutation_survivor_tracking_suite.sh
+++ b/scripts/run_mutation_survivor_tracking_suite.sh
@@ -30,6 +30,9 @@ while (($# > 0)); do
   esac
 done
 
+if [[ -z "$output_root" && -n "${FAKE_CARGO_ALLOW_DEFAULT_OUTPUT:-}" ]]; then
+  output_root="."
+fi
 : "${output_root:?fake cargo expected --output}"
 
 if [[ -n "${FAKE_CARGO_NO_OUTPUT:-}" ]]; then
@@ -122,5 +125,21 @@ if [[ -e "$tmp_dir/mixed-survivors.json" ]]; then
   exit 1
 fi
 grep -q "succeeded but no fresh mutation output was found" "$tmp_dir/mixed.stderr"
+
+default_repo="$tmp_dir/default-repo"
+mkdir -p "$default_repo/scripts" "$default_repo/src/stwo_backend"
+cp scripts/run_mutation_suite.sh scripts/collect_mutation_survivors.py "$default_repo/scripts/"
+for target in \
+  src/stwo_backend/decoding.rs \
+  src/stwo_backend/shared_lookup_artifact.rs \
+  src/stwo_backend/arithmetic_subset_prover.rs
+do
+  printf '%s\n' '// fake mutation target' >"$default_repo/$target"
+done
+PATH="$tmp_dir/bin:$PATH" \
+  FAKE_CARGO_ALLOW_DEFAULT_OUTPUT=1 \
+  "$default_repo/scripts/run_mutation_suite.sh" >/dev/null
+test -s "$default_repo/mutants.out/missed.txt"
+test -s "$default_repo/mutants.out/survivors.json"
 
 echo "mutation survivor tracking suite passed"

--- a/scripts/tests/test_collect_mutation_survivors.py
+++ b/scripts/tests/test_collect_mutation_survivors.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "collect_mutation_survivors.py"
+SPEC = importlib.util.spec_from_file_location("collect_mutation_survivors", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load mutation survivor module from {MODULE_PATH}")
+mutation = importlib.util.module_from_spec(SPEC)
+sys.modules["collect_mutation_survivors"] = mutation
+SPEC.loader.exec_module(mutation)
+
+
+class MutationSurvivorTests(unittest.TestCase):
+    def test_summarize_counts_outcome_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            mutants = root / "mutants.out"
+            mutants.mkdir()
+            (mutants / "caught.txt").write_text("src/a.rs:1 replace true with false\n", encoding="utf-8")
+            (mutants / "missed.txt").write_text("src/a.rs:2 delete statement\n", encoding="utf-8")
+            (mutants / "timeout.txt").write_text("src/a.rs:3 replace + with -\n", encoding="utf-8")
+            (mutants / "unviable.txt").write_text("src/a.rs:4 invalid mutant\n", encoding="utf-8")
+
+            summary = mutation.build_summary(
+                SimpleNamespace(
+                    repo_root=str(root),
+                    mutants_dir=str(mutants),
+                    output=str(root / "summary.json"),
+                    target=["src/a.rs"],
+                )
+            )
+
+            self.assertEqual(summary["counts"]["caught"], 1)
+            self.assertEqual(summary["counts"]["survived"], 1)
+            self.assertEqual(summary["counts"]["timeout"], 1)
+            self.assertEqual(summary["counts"]["unviable"], 1)
+            self.assertEqual(summary["counts"]["total_classified"], 4)
+            self.assertEqual(summary["survived"], ["src/a.rs:2 delete statement"])
+            self.assertEqual(summary["target_files"], ["src/a.rs"])
+            self.assertEqual(len(summary["source_files"]), 4)
+
+    def test_summarize_rejects_non_directory_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            not_dir = root / "mutants.out"
+            not_dir.write_text("not a dir", encoding="utf-8")
+
+            with self.assertRaisesRegex(mutation.MutationEvidenceError, "not a directory"):
+                mutation.build_summary(
+                    SimpleNamespace(
+                        repo_root=str(root),
+                        mutants_dir=str(not_dir),
+                        output=str(root / "summary.json"),
+                        target=[],
+                    )
+                )
+
+    def test_ledger_accepts_empty_triage_lists(self) -> None:
+        ledger = {
+            "schema": "mutation-survivor-ledger-v1",
+            "updated_at": "2026-04-18T00:00:00Z",
+            "trusted_targets": ["src/stwo_backend/decoding.rs"],
+            "milestone_commands": ["scripts/run_mutation_suite.sh"],
+            "current_status": {"surviving_mutants": [], "timed_out_mutants": []},
+            "non_claims": ["Does not claim exhaustive proof of correctness."],
+        }
+
+        self.assertEqual(mutation.validate_ledger(ledger), [])
+
+    def test_ledger_rejects_untriaged_survivor(self) -> None:
+        ledger = {
+            "schema": "mutation-survivor-ledger-v1",
+            "updated_at": "2026-04-18T00:00:00Z",
+            "trusted_targets": ["src/stwo_backend/decoding.rs"],
+            "milestone_commands": ["scripts/run_mutation_suite.sh"],
+            "current_status": {
+                "surviving_mutants": [
+                    {
+                        "mutant": "src/a.rs:1 replace true with false",
+                        "target": "src/a.rs",
+                        "outcome": "survived",
+                        "classification": "untriaged",
+                        "evidence": "target/mutation/run/survivors.json",
+                        "next_action": "add a test",
+                        "paper_blocker": True,
+                    }
+                ],
+                "timed_out_mutants": [],
+            },
+            "non_claims": ["Does not claim exhaustive proof of correctness."],
+        }
+
+        errors = mutation.validate_ledger(ledger)
+
+        self.assertTrue(any("classification must not be untriaged" in error for error in errors))
+
+    def test_extract_ledger_json_from_markdown(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = Path(tempdir) / "mutation-survivors.md"
+            payload = {
+                "schema": "mutation-survivor-ledger-v1",
+                "updated_at": "2026-04-18T00:00:00Z",
+                "trusted_targets": ["src/a.rs"],
+                "milestone_commands": ["scripts/run_mutation_suite.sh"],
+                "current_status": {"surviving_mutants": [], "timed_out_mutants": []},
+                "non_claims": ["Does not claim exhaustive proof of correctness."],
+            }
+            path.write_text(
+                "# Ledger\n\n```json mutation-survivors-v1\n"
+                + json.dumps(payload)
+                + "\n```\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(mutation.extract_ledger_json(path), payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements issue #161 PR 9: mutation survivor tracking.

- adds a local mutation-survivor collector for `cargo-mutants` result directories
- records caught/survived/timeout/unviable counts with source-file hashes
- adds a checked `docs/engineering/mutation-survivors.md` ledger for paper milestones
- updates `scripts/run_mutation_suite.sh` to emit survivor reports when mutation output exists
- wires the survivor tracking suite into the local merge gate and Paper 2 evidence matrix

## Local validation

- `python3 -m py_compile scripts/collect_mutation_survivors.py scripts/tests/test_collect_mutation_survivors.py`
- `python3 -B -m unittest scripts.tests.test_collect_mutation_survivors`
- `bash scripts/run_mutation_survivor_tracking_suite.sh`
- `bash scripts/run_shellcheck_suite.sh`
- `python3 scripts/paper/paper_preflight.py`
- `scripts/run_mutation_suite.sh --print-targets`
- `python3 -B -m unittest discover -s scripts/tests`
- `git diff --check`

## Non-claims

- Does not claim mutation testing proves correctness.
- Does not claim the current milestone has run the full heavy mutation suite.
- Does not claim survivors are acceptable unless they are explicitly triaged in the checked ledger.

Closes no issue; advances #161.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Mutation Survivor Ledger docs, triage workflow, milestone rules, reporting format, and required ledger fields.

* **New Features**
  * Tooling to collect, emit, and validate mutation-testing evidence; conditional survivor-tracking runs when relevant files change; survivor report persistence for checkpoint gating and CI/local checks.

* **Tests**
  * New unit and integration tests plus a fast-fail survivor-tracking suite validating collection, validation, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->