### PR TITLE
Add bounded formal harnesses for recursive receipts [skip ci]

### DIFF
--- a/docs/engineering/design/formal-contract-pilot.md
+++ b/docs/engineering/design/formal-contract-pilot.md
@@ -1,6 +1,8 @@
 # Formal Contract Pilot
 
-This pilot formalizes the narrowest trust-critical decoding bindings we currently rely on in the `stwo` proof-carrying path.
+This pilot machine-checks the small scalar contracts that protect the current `stwo` proof-carrying path from silent drift.
+
+It is deliberately bounded. These harnesses are not a proof of the full verifier, the `stwo` backend, or recursive proof closure. They check the narrow invariants that the implementation and paper currently rely on.
 
 Scope:
 - Phase 12 claim bindings:
@@ -18,18 +20,35 @@ Scope:
   - history length must advance by exactly one
   - lookup transcript entries must advance by exactly one
   - position must advance by exactly one
+- Phase 24 through Phase 30 recursive-composition shape:
+  - interval members must be contiguous
+  - folded and chained artifacts must preserve start/end boundaries
+  - manifests must preserve ordered step indexes and declared counts
+- Phase 33 public-input ordering:
+  - the recursive statement commitment, step count, source chain, step envelopes, decode boundary, chain boundaries, and template commitments must remain in canonical order
+- Phase 36 and Phase 37 receipt posture:
+  - valid receipts must not claim recursive verification
+  - valid receipts must not claim cryptographic compression
+  - source-binding and source-verification flags must be set
+  - receipt surfaces must require at least one decode step
+- Phase 37 commitment syntax:
+  - commitment fields are bounded as 64-character lowercase hex strings
+- Phase 36 and Phase 37 parse/load wrapper classification:
+  - accepting a loaded artifact requires a regular file, byte-limit compliance, well-formed JSON, and verifier acceptance
+  - every other class is an explicit error path in the bounded model
 
 Mechanization:
-- Kani harnesses live in `src/stwo_backend/decoding.rs`
-- the Kani model deliberately reduces string/commitment equality into scalar match predicates so the solver checks the binding logic rather than spending proof budget on `memcmp`
-- the dedicated runner is `scripts/run_formal_contract_suite.sh`
-- CI entrypoint is `.github/workflows/formal-contracts.yml`
+- Kani harnesses live in `src/stwo_backend/decoding.rs` and `src/stwo_backend/recursion.rs`
+- the Kani model deliberately reduces string/commitment equality into scalar predicates so the solver checks binding logic rather than spending proof budget on `memcmp`
+- the dedicated local runner is `scripts/run_formal_contract_suite.sh`
+- local merge evidence should cite the runner output; GitHub Actions are not required for this gate
 
 Non-goals:
 - this does not prove the full decoding verifier
 - this does not prove the `stwo` backend itself
-- this does not replace fuzzing, mutation testing, or oracle checks
+- this does not prove parser memory safety beyond Rust's normal safety model
+- this does not replace runtime negative tests for malformed JSON, oversized files, non-regular files, fuzzing, mutation testing, or oracle checks
 
 Why this exists:
-- the decoding validator is now stable enough that its scalar binding kernel is worth machine-checking
-- these contracts cover the highest-value “do not silently drift” invariants before larger proof-carrying decoding work continues
+- the artifact chain is now stable enough that its scalar binding kernels are worth machine-checking
+- these contracts cover the highest-value "do not silently drift" invariants before larger proof-carrying decoding work continues

--- a/docs/engineering/design/formal-contract-pilot.md
+++ b/docs/engineering/design/formal-contract-pilot.md
@@ -33,9 +33,6 @@ Scope:
   - receipt surfaces must require at least one decode step
 - Phase 37 commitment syntax:
   - commitment fields are bounded as 64-character lowercase hex strings
-- Phase 36 and Phase 37 parse/load wrapper classification:
-  - accepting a loaded artifact requires a regular file, byte-limit compliance, well-formed JSON, and verifier acceptance
-  - every other class is an explicit error path in the bounded model
 
 Mechanization:
 - Kani harnesses live in `src/stwo_backend/decoding.rs` and `src/stwo_backend/recursion.rs`
@@ -47,7 +44,8 @@ Non-goals:
 - this does not prove the full decoding verifier
 - this does not prove the `stwo` backend itself
 - this does not prove parser memory safety beyond Rust's normal safety model
-- this does not replace runtime negative tests for malformed JSON, oversized files, non-regular files, fuzzing, mutation testing, or oracle checks
+- this does not claim formal parser/load coverage; malformed JSON, oversized files, non-regular files, and load wrappers remain covered by runtime negative tests
+- this does not replace fuzzing, mutation testing, or oracle checks
 
 Why this exists:
 - the artifact chain is now stable enough that its scalar binding kernels are worth machine-checking

--- a/docs/engineering/design/formal-contract-pilot.md
+++ b/docs/engineering/design/formal-contract-pilot.md
@@ -26,6 +26,7 @@ Scope:
   - manifests must preserve ordered step indexes and declared counts
 - Phase 33 public-input ordering:
   - the recursive statement commitment, step count, source chain, step envelopes, decode boundary, chain boundaries, and template commitments must remain in canonical order
+  - each canonical lane must remain wired to its intended manifest field
 - Phase 36 and Phase 37 receipt posture:
   - valid receipts must not claim recursive verification
   - valid receipts must not claim cryptographic compression

--- a/docs/engineering/paper2-claim-evidence.yml
+++ b/docs/engineering/paper2-claim-evidence.yml
@@ -205,6 +205,7 @@
     - src/stwo_backend/recursion.rs:verify_phase37_recursive_artifact_chain_harness_receipt_against_sources
     - src/stwo_backend/recursion.rs:kani_phase37_hash32_accepts_lowercase_hex_boundary
     - src/stwo_backend/recursion.rs:kani_phase37_hash32_rejects_any_non_lowercase_hex_byte
+    - src/stwo_backend/recursion.rs:kani_phase37_hash32_requires_exact_length
     - src/stwo_backend/recursion.rs:kani_phase37_receipt_flags_accept_canonical_source_bound_receipt
     - src/stwo_backend/recursion.rs:kani_phase37_receipt_flags_reject_any_claim_or_missing_source_check
     - src/stwo_backend/recursion.rs:kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
@@ -219,6 +220,7 @@
     - phase37_recursive_artifact_chain_harness_receipt_accepts_matching_sources
     - test_reference_fixture_verifies_and_commitment_is_stable
     - kani_phase37_hash32_accepts_lowercase_hex_boundary
+    - kani_phase37_hash32_requires_exact_length
     - kani_phase37_receipt_flags_accept_canonical_source_bound_receipt
     - kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
   negative_tests:
@@ -226,6 +228,7 @@
     - phase37_recursive_artifact_chain_harness_receipt_rejects_tampered_commitment
     - phase37_recursive_artifact_chain_harness_receipt_rejects_malformed_commitment_field
     - kani_phase37_hash32_rejects_any_non_lowercase_hex_byte
+    - kani_phase37_hash32_requires_exact_length
     - kani_phase37_receipt_flags_reject_any_claim_or_missing_source_check
     - kani_phase36_phase37_parser_wrapper_rejects_any_error_class
     - test_deterministic_parser_mutation_corpus_rejects_invalid_receipts

--- a/docs/engineering/paper2-claim-evidence.yml
+++ b/docs/engineering/paper2-claim-evidence.yml
@@ -99,12 +99,14 @@
     - src/stwo_backend/recursion.rs:phase33_prepare_recursive_compression_public_input_manifest
     - src/stwo_backend/recursion.rs:verify_phase33_recursive_compression_public_input_manifest_against_phase32
     - src/stwo_backend/recursion.rs:kani_phase33_public_input_ordering_accepts_canonical_order
+    - src/stwo_backend/recursion.rs:kani_phase33_public_input_lane_payload_wires_canonical_fields
     - src/stwo_backend/recursion.rs:kani_phase33_public_input_ordering_rejects_any_lane_drift
   specs:
     - spec/stwo-phase33-recursive-compression-public-input-manifest.schema.json
   positive_tests:
     - phase33_recursive_public_input_manifest_accepts_matching_phase32_source
     - kani_phase33_public_input_ordering_accepts_canonical_order
+    - kani_phase33_public_input_lane_payload_wires_canonical_fields
   negative_tests:
     - phase33_recursive_public_input_manifest_rejects_tampered_commitment
     - phase33_recursive_public_input_manifest_parse_rejects_unknown_fields
@@ -115,7 +117,7 @@
   non_claims:
     - "Does not claim recursive proof closure."
     - "Does not claim a complete recursive verifier."
-    - "Does not claim formal coverage beyond bounded scalar public-input ordering checks."
+    - "Does not claim formal coverage beyond bounded scalar public-input ordering and lane-to-field wiring checks."
 
 - id: phase34_shared_lookup_manifest
   claim: "Phase 34 freezes the ordered lookup-facing public inputs derived from Phase 33 and Phase 30."

--- a/docs/engineering/paper2-claim-evidence.yml
+++ b/docs/engineering/paper2-claim-evidence.yml
@@ -98,18 +98,24 @@
   implementation:
     - src/stwo_backend/recursion.rs:phase33_prepare_recursive_compression_public_input_manifest
     - src/stwo_backend/recursion.rs:verify_phase33_recursive_compression_public_input_manifest_against_phase32
+    - src/stwo_backend/recursion.rs:kani_phase33_public_input_ordering_accepts_canonical_order
+    - src/stwo_backend/recursion.rs:kani_phase33_public_input_ordering_rejects_any_lane_drift
   specs:
     - spec/stwo-phase33-recursive-compression-public-input-manifest.schema.json
   positive_tests:
     - phase33_recursive_public_input_manifest_accepts_matching_phase32_source
+    - kani_phase33_public_input_ordering_accepts_canonical_order
   negative_tests:
     - phase33_recursive_public_input_manifest_rejects_tampered_commitment
     - phase33_recursive_public_input_manifest_parse_rejects_unknown_fields
+    - kani_phase33_public_input_ordering_rejects_any_lane_drift
   evidence_commands:
     - cargo +nightly-2025-07-14 test -q --features stwo-backend phase33
+    - scripts/run_formal_contract_suite.sh
   non_claims:
     - "Does not claim recursive proof closure."
     - "Does not claim a complete recursive verifier."
+    - "Does not claim formal coverage beyond bounded scalar public-input ordering checks."
 
 - id: phase34_shared_lookup_manifest
   claim: "Phase 34 freezes the ordered lookup-facing public inputs derived from Phase 33 and Phase 30."
@@ -163,21 +169,31 @@
   implementation:
     - src/stwo_backend/recursion.rs:phase36_prepare_recursive_verifier_harness_receipt
     - src/stwo_backend/recursion.rs:verify_phase36_recursive_verifier_harness_receipt_against_sources
+    - src/stwo_backend/recursion.rs:kani_phase36_receipt_flags_accept_canonical_nonclaim_receipt
+    - src/stwo_backend/recursion.rs:kani_phase36_receipt_flags_reject_any_claim_or_missing_source_check
+    - src/stwo_backend/recursion.rs:kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
+    - src/stwo_backend/recursion.rs:kani_phase36_phase37_parser_wrapper_rejects_any_error_class
     - fuzz/fuzz_targets/phase36_recursive_verifier_harness_receipt.rs
   specs:
     - spec/stwo-phase36-recursive-verifier-harness-receipt.schema.json
   positive_tests:
     - phase36_recursive_verifier_harness_receipt_accepts_matching_sources
+    - kani_phase36_receipt_flags_accept_canonical_nonclaim_receipt
+    - kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
   negative_tests:
     - phase36_recursive_verifier_harness_receipt_rejects_recursive_claim
     - phase36_recursive_verifier_harness_receipt_rejects_tampered_commitment
     - phase36_recursive_verifier_harness_receipt_parse_rejects_unknown_fields
+    - kani_phase36_receipt_flags_reject_any_claim_or_missing_source_check
+    - kani_phase36_phase37_parser_wrapper_rejects_any_error_class
   evidence_commands:
     - cargo +nightly-2025-07-14 test -q --features stwo-backend phase36
+    - scripts/run_formal_contract_suite.sh
     - FUZZ_TIME_PER_TARGET=5 scripts/run_fuzz_smoke_suite.sh
   non_claims:
     - "Does not claim recursive proof verification."
     - "Does not claim cryptographic compression."
+    - "Does not claim formal coverage beyond bounded scalar flag and parse/load classification checks."
 
 - id: phase37_artifact_chain_harness_receipt
   claim: "Phase 37 recomputes the full Phase 29 + Phase 30 through Phase 36 source-bound artifact chain as heavier operational evidence."
@@ -187,6 +203,12 @@
   implementation:
     - src/stwo_backend/recursion.rs:phase37_prepare_recursive_artifact_chain_harness_receipt
     - src/stwo_backend/recursion.rs:verify_phase37_recursive_artifact_chain_harness_receipt_against_sources
+    - src/stwo_backend/recursion.rs:kani_phase37_hash32_accepts_lowercase_hex_boundary
+    - src/stwo_backend/recursion.rs:kani_phase37_hash32_rejects_any_non_lowercase_hex_byte
+    - src/stwo_backend/recursion.rs:kani_phase37_receipt_flags_accept_canonical_source_bound_receipt
+    - src/stwo_backend/recursion.rs:kani_phase37_receipt_flags_reject_any_claim_or_missing_source_check
+    - src/stwo_backend/recursion.rs:kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
+    - src/stwo_backend/recursion.rs:kani_phase36_phase37_parser_wrapper_rejects_any_error_class
     - tools/reference_verifier/reference_verifier.py:verify_phase37_receipt
     - tools/reference_verifier/reference_verifier.py:commit_phase37_receipt
     - scripts/generate_bad_phase37_artifacts.py:generate
@@ -196,15 +218,22 @@
   positive_tests:
     - phase37_recursive_artifact_chain_harness_receipt_accepts_matching_sources
     - test_reference_fixture_verifies_and_commitment_is_stable
+    - kani_phase37_hash32_accepts_lowercase_hex_boundary
+    - kani_phase37_receipt_flags_accept_canonical_source_bound_receipt
+    - kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
   negative_tests:
     - phase37_recursive_artifact_chain_harness_receipt_rejects_recursive_claim
     - phase37_recursive_artifact_chain_harness_receipt_rejects_tampered_commitment
     - phase37_recursive_artifact_chain_harness_receipt_rejects_malformed_commitment_field
+    - kani_phase37_hash32_rejects_any_non_lowercase_hex_byte
+    - kani_phase37_receipt_flags_reject_any_claim_or_missing_source_check
+    - kani_phase36_phase37_parser_wrapper_rejects_any_error_class
     - test_deterministic_parser_mutation_corpus_rejects_invalid_receipts
     - test_rejects_total_steps_that_exceed_u128_encoding
     - test_generated_artifacts_match_expected_reference_verifier_outcomes
   evidence_commands:
     - cargo +nightly-2025-07-14 test -q --features stwo-backend phase37
+    - scripts/run_formal_contract_suite.sh
     - cargo +nightly-2025-07-14 build -q --features 'full stwo-backend' --bin tvm && TVM_TEST_BINARY=target/debug/tvm cargo +nightly-2025-07-14 test -q --features 'full stwo-backend' --test cli stwo_recursive_artifact_chain
     - scripts/run_reference_verifier_suite.sh
     - scripts/run_phase37_mutation_generator_suite.sh
@@ -214,6 +243,7 @@
     - "Does not claim recursive proof verification."
     - "Does not claim cryptographic compression."
     - "Does not claim a recursively verifiable compressed proof object."
+    - "Does not claim formal coverage beyond bounded scalar syntax, flag, ordering, and parse/load classification checks."
 
 - id: bounded_runtime_semantic_agreement
   claim: "The research-v3 artifacts provide bounded semantic-agreement evidence, not a general runtime equivalence theorem."

--- a/docs/engineering/paper2-claim-evidence.yml
+++ b/docs/engineering/paper2-claim-evidence.yml
@@ -171,21 +171,17 @@
     - src/stwo_backend/recursion.rs:verify_phase36_recursive_verifier_harness_receipt_against_sources
     - src/stwo_backend/recursion.rs:kani_phase36_receipt_flags_accept_canonical_nonclaim_receipt
     - src/stwo_backend/recursion.rs:kani_phase36_receipt_flags_reject_any_claim_or_missing_source_check
-    - src/stwo_backend/recursion.rs:kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
-    - src/stwo_backend/recursion.rs:kani_phase36_phase37_parser_wrapper_rejects_any_error_class
     - fuzz/fuzz_targets/phase36_recursive_verifier_harness_receipt.rs
   specs:
     - spec/stwo-phase36-recursive-verifier-harness-receipt.schema.json
   positive_tests:
     - phase36_recursive_verifier_harness_receipt_accepts_matching_sources
     - kani_phase36_receipt_flags_accept_canonical_nonclaim_receipt
-    - kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
   negative_tests:
     - phase36_recursive_verifier_harness_receipt_rejects_recursive_claim
     - phase36_recursive_verifier_harness_receipt_rejects_tampered_commitment
     - phase36_recursive_verifier_harness_receipt_parse_rejects_unknown_fields
     - kani_phase36_receipt_flags_reject_any_claim_or_missing_source_check
-    - kani_phase36_phase37_parser_wrapper_rejects_any_error_class
   evidence_commands:
     - cargo +nightly-2025-07-14 test -q --features stwo-backend phase36
     - scripts/run_formal_contract_suite.sh
@@ -193,7 +189,7 @@
   non_claims:
     - "Does not claim recursive proof verification."
     - "Does not claim cryptographic compression."
-    - "Does not claim formal coverage beyond bounded scalar flag and parse/load classification checks."
+    - "Does not claim formal coverage beyond bounded scalar flag-surface checks."
 
 - id: phase37_artifact_chain_harness_receipt
   claim: "Phase 37 recomputes the full Phase 29 + Phase 30 through Phase 36 source-bound artifact chain as heavier operational evidence."
@@ -204,12 +200,10 @@
     - src/stwo_backend/recursion.rs:phase37_prepare_recursive_artifact_chain_harness_receipt
     - src/stwo_backend/recursion.rs:verify_phase37_recursive_artifact_chain_harness_receipt_against_sources
     - src/stwo_backend/recursion.rs:kani_phase37_hash32_accepts_lowercase_hex_boundary
-    - src/stwo_backend/recursion.rs:kani_phase37_hash32_rejects_any_non_lowercase_hex_byte
+    - src/stwo_backend/recursion.rs:kani_phase37_hash32_rejects_non_lowercase_hex_examples
     - src/stwo_backend/recursion.rs:kani_phase37_hash32_requires_exact_length
     - src/stwo_backend/recursion.rs:kani_phase37_receipt_flags_accept_canonical_source_bound_receipt
     - src/stwo_backend/recursion.rs:kani_phase37_receipt_flags_reject_any_claim_or_missing_source_check
-    - src/stwo_backend/recursion.rs:kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
-    - src/stwo_backend/recursion.rs:kani_phase36_phase37_parser_wrapper_rejects_any_error_class
     - tools/reference_verifier/reference_verifier.py:verify_phase37_receipt
     - tools/reference_verifier/reference_verifier.py:commit_phase37_receipt
     - scripts/generate_bad_phase37_artifacts.py:generate
@@ -222,15 +216,13 @@
     - kani_phase37_hash32_accepts_lowercase_hex_boundary
     - kani_phase37_hash32_requires_exact_length
     - kani_phase37_receipt_flags_accept_canonical_source_bound_receipt
-    - kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
   negative_tests:
     - phase37_recursive_artifact_chain_harness_receipt_rejects_recursive_claim
     - phase37_recursive_artifact_chain_harness_receipt_rejects_tampered_commitment
     - phase37_recursive_artifact_chain_harness_receipt_rejects_malformed_commitment_field
-    - kani_phase37_hash32_rejects_any_non_lowercase_hex_byte
+    - kani_phase37_hash32_rejects_non_lowercase_hex_examples
     - kani_phase37_hash32_requires_exact_length
     - kani_phase37_receipt_flags_reject_any_claim_or_missing_source_check
-    - kani_phase36_phase37_parser_wrapper_rejects_any_error_class
     - test_deterministic_parser_mutation_corpus_rejects_invalid_receipts
     - test_rejects_total_steps_that_exceed_u128_encoding
     - test_generated_artifacts_match_expected_reference_verifier_outcomes
@@ -246,7 +238,7 @@
     - "Does not claim recursive proof verification."
     - "Does not claim cryptographic compression."
     - "Does not claim a recursively verifiable compressed proof object."
-    - "Does not claim formal coverage beyond bounded scalar syntax, flag, ordering, and parse/load classification checks."
+    - "Does not claim formal coverage beyond bounded scalar syntax, flag-surface, and ordering checks."
 
 - id: bounded_runtime_semantic_agreement
   claim: "The research-v3 artifacts provide bounded semantic-agreement evidence, not a general runtime equivalence theorem."

--- a/scripts/run_formal_contract_suite.sh
+++ b/scripts/run_formal_contract_suite.sh
@@ -90,6 +90,8 @@ KANI_ARGS=(
   --harness
   kani_phase37_hash32_rejects_any_non_lowercase_hex_byte
   --harness
+  kani_phase37_hash32_requires_exact_length
+  --harness
   kani_phase36_receipt_flags_accept_canonical_nonclaim_receipt
   --harness
   kani_phase36_receipt_flags_reject_any_claim_or_missing_source_check

--- a/scripts/run_formal_contract_suite.sh
+++ b/scripts/run_formal_contract_suite.sh
@@ -88,7 +88,7 @@ KANI_ARGS=(
   --harness
   kani_phase37_hash32_accepts_lowercase_hex_boundary
   --harness
-  kani_phase37_hash32_rejects_any_non_lowercase_hex_byte
+  kani_phase37_hash32_rejects_non_lowercase_hex_examples
   --harness
   kani_phase37_hash32_requires_exact_length
   --harness
@@ -103,10 +103,6 @@ KANI_ARGS=(
   kani_phase33_public_input_ordering_accepts_canonical_order
   --harness
   kani_phase33_public_input_ordering_rejects_any_lane_drift
-  --harness
-  kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
-  --harness
-  kani_phase36_phase37_parser_wrapper_rejects_any_error_class
 )
 
 "${KANI_ARGS[@]}"

--- a/scripts/run_formal_contract_suite.sh
+++ b/scripts/run_formal_contract_suite.sh
@@ -102,6 +102,8 @@ KANI_ARGS=(
   --harness
   kani_phase33_public_input_ordering_accepts_canonical_order
   --harness
+  kani_phase33_public_input_lane_payload_wires_canonical_fields
+  --harness
   kani_phase33_public_input_ordering_rejects_any_lane_drift
 )
 

--- a/scripts/run_formal_contract_suite.sh
+++ b/scripts/run_formal_contract_suite.sh
@@ -85,6 +85,26 @@ KANI_ARGS=(
   kani_phase30_manifest_counts_reject_zero_envelopes
   --harness
   kani_phase30_manifest_counts_reject_mismatched_totals
+  --harness
+  kani_phase37_hash32_accepts_lowercase_hex_boundary
+  --harness
+  kani_phase37_hash32_rejects_any_non_lowercase_hex_byte
+  --harness
+  kani_phase36_receipt_flags_accept_canonical_nonclaim_receipt
+  --harness
+  kani_phase36_receipt_flags_reject_any_claim_or_missing_source_check
+  --harness
+  kani_phase37_receipt_flags_accept_canonical_source_bound_receipt
+  --harness
+  kani_phase37_receipt_flags_reject_any_claim_or_missing_source_check
+  --harness
+  kani_phase33_public_input_ordering_accepts_canonical_order
+  --harness
+  kani_phase33_public_input_ordering_rejects_any_lane_drift
+  --harness
+  kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok
+  --harness
+  kani_phase36_phase37_parser_wrapper_rejects_any_error_class
 )
 
 "${KANI_ARGS[@]}"

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -1454,17 +1454,268 @@ fn phase29_lower_hex(bytes: &[u8]) -> String {
 }
 
 #[cfg(feature = "stwo-backend")]
+fn phase37_is_lower_hex_byte(byte: u8) -> bool {
+    matches!(byte, b'0'..=b'9' | b'a'..=b'f')
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase37_is_hash32_lower_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(phase37_is_lower_hex_byte)
+}
+
+#[cfg(feature = "stwo-backend")]
 fn phase37_require_hash32(label: &str, value: &str) -> Result<()> {
-    let is_hash32 = value.len() == 64
-        && value
-            .bytes()
-            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'));
-    if !is_hash32 {
+    if !phase37_is_hash32_lower_hex(value) {
         return Err(VmError::InvalidConfig(format!(
             "Phase 37 recursive artifact-chain harness receipt `{label}` must be a 32-byte lowercase hex commitment"
         )));
     }
     Ok(())
+}
+
+#[cfg(all(kani, feature = "stwo-backend"))]
+mod kani_phase36_phase37_proofs {
+    use super::phase37_is_lower_hex_byte;
+
+    const PHASE33_PUBLIC_INPUT_FIELD_COUNT: usize = 9;
+    const PHASE37_SOURCE_FLAG_COUNT: usize = 9;
+
+    fn phase37_hash32_bytes_are_lower_hex(bytes: &[u8; 64]) -> bool {
+        for byte in bytes {
+            if !phase37_is_lower_hex_byte(*byte) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn phase36_receipt_flag_surface_is_valid(
+        recursive_verification_claimed: bool,
+        cryptographic_compression_claimed: bool,
+        target_manifest_verified: bool,
+        source_binding_verified: bool,
+        total_steps: usize,
+    ) -> bool {
+        !recursive_verification_claimed
+            && !cryptographic_compression_claimed
+            && target_manifest_verified
+            && source_binding_verified
+            && total_steps > 0
+    }
+
+    fn phase37_source_flags_are_all_set(flags: &[bool; PHASE37_SOURCE_FLAG_COUNT]) -> bool {
+        for flag in flags {
+            if !*flag {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn phase37_receipt_flag_surface_is_valid(
+        recursive_verification_claimed: bool,
+        cryptographic_compression_claimed: bool,
+        source_flags: &[bool; PHASE37_SOURCE_FLAG_COUNT],
+        total_steps: usize,
+    ) -> bool {
+        !recursive_verification_claimed
+            && !cryptographic_compression_claimed
+            && phase37_source_flags_are_all_set(source_flags)
+            && total_steps > 0
+    }
+
+    fn phase33_ordered_public_input_tags(
+        phase32_statement_contract: u8,
+        total_steps: u8,
+        phase30_source_chain: u8,
+        phase30_step_envelopes: u8,
+        phase31_decode_boundary_bridge: u8,
+        chain_start_boundary: u8,
+        chain_end_boundary: u8,
+        source_template: u8,
+        aggregation_template: u8,
+    ) -> [u8; PHASE33_PUBLIC_INPUT_FIELD_COUNT] {
+        [
+            phase32_statement_contract,
+            total_steps,
+            phase30_source_chain,
+            phase30_step_envelopes,
+            phase31_decode_boundary_bridge,
+            chain_start_boundary,
+            chain_end_boundary,
+            source_template,
+            aggregation_template,
+        ]
+    }
+
+    fn phase33_public_input_ordering_is_preserved(
+        expected: &[u8; PHASE33_PUBLIC_INPUT_FIELD_COUNT],
+        observed: &[u8; PHASE33_PUBLIC_INPUT_FIELD_COUNT],
+    ) -> bool {
+        expected == observed
+    }
+
+    fn phase36_phase37_parse_load_surface_accepts(
+        file_is_regular: bool,
+        bytes_within_limit: bool,
+        json_well_formed: bool,
+        verifier_accepts: bool,
+    ) -> bool {
+        file_is_regular && bytes_within_limit && json_well_formed && verifier_accepts
+    }
+
+    #[kani::proof]
+    fn kani_phase37_hash32_accepts_lowercase_hex_boundary() {
+        let byte = kani::any::<u8>();
+        kani::assume(phase37_is_lower_hex_byte(byte));
+
+        assert!(phase37_hash32_bytes_are_lower_hex(&[byte; 64]));
+        assert!(phase37_hash32_bytes_are_lower_hex(&[b'0'; 64]));
+        assert!(phase37_hash32_bytes_are_lower_hex(&[b'f'; 64]));
+    }
+
+    #[kani::proof]
+    fn kani_phase37_hash32_rejects_any_non_lowercase_hex_byte() {
+        let bad_index = kani::any::<usize>();
+        kani::assume(bad_index < 64);
+        let bad_byte = kani::any::<u8>();
+        kani::assume(!phase37_is_lower_hex_byte(bad_byte));
+
+        let mut candidate = [b'a'; 64];
+        candidate[bad_index] = bad_byte;
+
+        assert!(!phase37_hash32_bytes_are_lower_hex(&candidate));
+    }
+
+    #[kani::proof]
+    fn kani_phase36_receipt_flags_accept_canonical_nonclaim_receipt() {
+        assert!(phase36_receipt_flag_surface_is_valid(
+            false, false, true, true, 1
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase36_receipt_flags_reject_any_claim_or_missing_source_check() {
+        let recursive_claimed = kani::any::<bool>();
+        let compression_claimed = kani::any::<bool>();
+        let target_manifest_verified = kani::any::<bool>();
+        let source_binding_verified = kani::any::<bool>();
+        let total_steps = if kani::any::<bool>() { 0 } else { 1 };
+        kani::assume(
+            recursive_claimed
+                || compression_claimed
+                || !target_manifest_verified
+                || !source_binding_verified
+                || total_steps == 0,
+        );
+
+        assert!(!phase36_receipt_flag_surface_is_valid(
+            recursive_claimed,
+            compression_claimed,
+            target_manifest_verified,
+            source_binding_verified,
+            total_steps,
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase37_receipt_flags_accept_canonical_source_bound_receipt() {
+        assert!(phase37_receipt_flag_surface_is_valid(
+            false,
+            false,
+            &[true; PHASE37_SOURCE_FLAG_COUNT],
+            1
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase37_receipt_flags_reject_any_claim_or_missing_source_check() {
+        let mut source_flags = [true; PHASE37_SOURCE_FLAG_COUNT];
+        let bad_flag_index = kani::any::<usize>();
+        kani::assume(bad_flag_index < PHASE37_SOURCE_FLAG_COUNT);
+        source_flags[bad_flag_index] = false;
+
+        assert!(!phase37_receipt_flag_surface_is_valid(
+            false,
+            false,
+            &source_flags,
+            1,
+        ));
+        assert!(!phase37_receipt_flag_surface_is_valid(
+            true,
+            false,
+            &[true; PHASE37_SOURCE_FLAG_COUNT],
+            1,
+        ));
+        assert!(!phase37_receipt_flag_surface_is_valid(
+            false,
+            true,
+            &[true; PHASE37_SOURCE_FLAG_COUNT],
+            1,
+        ));
+        assert!(!phase37_receipt_flag_surface_is_valid(
+            false,
+            false,
+            &[true; PHASE37_SOURCE_FLAG_COUNT],
+            0,
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase33_public_input_ordering_accepts_canonical_order() {
+        let expected = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let observed = phase33_ordered_public_input_tags(1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+        assert!(phase33_public_input_ordering_is_preserved(
+            &expected, &observed
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase33_public_input_ordering_rejects_any_lane_drift() {
+        let expected = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let mut observed = phase33_ordered_public_input_tags(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        let bad_lane = kani::any::<usize>();
+        kani::assume(bad_lane < PHASE33_PUBLIC_INPUT_FIELD_COUNT);
+        observed[bad_lane] = observed[bad_lane].wrapping_add(9);
+        kani::assume(observed[bad_lane] != expected[bad_lane]);
+
+        assert!(!phase33_public_input_ordering_is_preserved(
+            &expected, &observed
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok() {
+        let file_is_regular = kani::any::<bool>();
+        let bytes_within_limit = kani::any::<bool>();
+        let json_well_formed = kani::any::<bool>();
+        let verifier_accepts = kani::any::<bool>();
+
+        if phase36_phase37_parse_load_surface_accepts(
+            file_is_regular,
+            bytes_within_limit,
+            json_well_formed,
+            verifier_accepts,
+        ) {
+            assert!(file_is_regular);
+            assert!(bytes_within_limit);
+            assert!(json_well_formed);
+            assert!(verifier_accepts);
+        }
+    }
+
+    #[kani::proof]
+    fn kani_phase36_phase37_parser_wrapper_rejects_any_error_class() {
+        let mut classes = [true; 4];
+        let bad_class = kani::any::<usize>();
+        kani::assume(bad_class < 4);
+        classes[bad_class] = false;
+
+        assert!(!phase36_phase37_parse_load_surface_accepts(
+            classes[0], classes[1], classes[2], classes[3],
+        ));
+    }
 }
 
 #[cfg(feature = "stwo-backend")]

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -1475,7 +1475,7 @@ fn phase37_require_hash32(label: &str, value: &str) -> Result<()> {
 
 #[cfg(all(kani, feature = "stwo-backend"))]
 mod kani_phase36_phase37_proofs {
-    use super::phase37_is_lower_hex_byte;
+    use super::{phase37_is_hash32_lower_hex, phase37_is_lower_hex_byte};
 
     const PHASE33_PUBLIC_INPUT_FIELD_COUNT: usize = 9;
     const PHASE37_SOURCE_FLAG_COUNT: usize = 9;
@@ -1585,6 +1585,29 @@ mod kani_phase36_phase37_proofs {
         candidate[bad_index] = bad_byte;
 
         assert!(!phase37_hash32_bytes_are_lower_hex(&candidate));
+    }
+
+    #[kani::proof]
+    fn kani_phase37_hash32_requires_exact_length() {
+        const HEX_63: &str = concat!(
+            "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa",
+            "aaaaaaa"
+        );
+        const HEX_64: &str = concat!(
+            "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa",
+            "aaaaaaaa"
+        );
+        const HEX_65: &str = concat!(
+            "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa",
+            "aaaaaaaa", "a"
+        );
+
+        assert!(HEX_63.len() == 63);
+        assert!(HEX_64.len() == 64);
+        assert!(HEX_65.len() == 65);
+        assert!(!phase37_is_hash32_lower_hex(HEX_63));
+        assert!(phase37_is_hash32_lower_hex(HEX_64));
+        assert!(!phase37_is_hash32_lower_hex(HEX_65));
     }
 
     #[kani::proof]

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -1490,6 +1490,13 @@ const PHASE33_PUBLIC_INPUT_LANES: [Phase33PublicInputLane; 9] = [
     Phase33PublicInputLane::AggregationTemplate,
 ];
 
+#[cfg(feature = "stwo-backend")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase33PublicInputLanePayload<'a> {
+    Bytes(&'a str),
+    Usize(usize),
+}
+
 #[cfg(all(kani, feature = "stwo-backend"))]
 fn phase33_public_input_lanes_are_canonical(lanes: &[Phase33PublicInputLane; 9]) -> bool {
     *lanes
@@ -1504,6 +1511,46 @@ fn phase33_public_input_lanes_are_canonical(lanes: &[Phase33PublicInputLane; 9])
             Phase33PublicInputLane::SourceTemplate,
             Phase33PublicInputLane::AggregationTemplate,
         ]
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase33_public_input_lane_payload<'a>(
+    manifest: &'a Phase33RecursiveCompressionPublicInputManifest,
+    lane: Phase33PublicInputLane,
+) -> Phase33PublicInputLanePayload<'a> {
+    match lane {
+        Phase33PublicInputLane::Phase32RecursiveStatementContract => {
+            Phase33PublicInputLanePayload::Bytes(
+                &manifest.phase32_recursive_statement_contract_commitment,
+            )
+        }
+        Phase33PublicInputLane::TotalSteps => {
+            Phase33PublicInputLanePayload::Usize(manifest.total_steps)
+        }
+        Phase33PublicInputLane::Phase30SourceChain => {
+            Phase33PublicInputLanePayload::Bytes(&manifest.phase30_source_chain_commitment)
+        }
+        Phase33PublicInputLane::Phase30StepEnvelopes => {
+            Phase33PublicInputLanePayload::Bytes(&manifest.phase30_step_envelopes_commitment)
+        }
+        Phase33PublicInputLane::Phase31DecodeBoundaryBridge => {
+            Phase33PublicInputLanePayload::Bytes(
+                &manifest.phase31_decode_boundary_bridge_commitment,
+            )
+        }
+        Phase33PublicInputLane::ChainStartBoundary => {
+            Phase33PublicInputLanePayload::Bytes(&manifest.chain_start_boundary_commitment)
+        }
+        Phase33PublicInputLane::ChainEndBoundary => {
+            Phase33PublicInputLanePayload::Bytes(&manifest.chain_end_boundary_commitment)
+        }
+        Phase33PublicInputLane::SourceTemplate => {
+            Phase33PublicInputLanePayload::Bytes(&manifest.source_template_commitment)
+        }
+        Phase33PublicInputLane::AggregationTemplate => {
+            Phase33PublicInputLanePayload::Bytes(&manifest.aggregation_template_commitment)
+        }
+    }
 }
 
 #[cfg(feature = "stwo-backend")]
@@ -1557,10 +1604,13 @@ fn phase37_require_hash32(label: &str, value: &str) -> Result<()> {
 #[cfg(all(kani, feature = "stwo-backend"))]
 mod kani_phase36_phase37_proofs {
     use super::{
-        phase33_public_input_lanes_are_canonical, phase36_receipt_flag_surface_is_valid,
-        phase37_is_hash32_lower_hex, phase37_is_lower_hex_byte,
-        phase37_receipt_flag_surface_is_valid, Phase33PublicInputLane, PHASE33_PUBLIC_INPUT_LANES,
+        phase33_public_input_lane_payload, phase33_public_input_lanes_are_canonical,
+        phase36_receipt_flag_surface_is_valid, phase37_is_hash32_lower_hex,
+        phase37_is_lower_hex_byte, phase37_receipt_flag_surface_is_valid, Phase33PublicInputLane,
+        Phase33PublicInputLanePayload, Phase33RecursiveCompressionPublicInputManifest,
+        PHASE33_PUBLIC_INPUT_LANES,
     };
+    use crate::proof::StarkProofBackend;
 
     const PHASE37_SOURCE_FLAG_COUNT: usize = 9;
 
@@ -1584,8 +1634,8 @@ mod kani_phase36_phase37_proofs {
 
     #[kani::proof]
     fn kani_phase37_hash32_rejects_non_lowercase_hex_examples() {
-        const UPPERCASE: &str = concat!(
-            "G", "aaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa",
+        const UPPERCASE_HEX: &str = concat!(
+            "A", "aaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa",
             "aaaaaaaa"
         );
         const PUNCTUATION: &str = concat!(
@@ -1593,11 +1643,11 @@ mod kani_phase36_phase37_proofs {
             "aaaaaaa", ":"
         );
 
-        assert!(UPPERCASE.len() == 64);
+        assert!(UPPERCASE_HEX.len() == 64);
         assert!(PUNCTUATION.len() == 64);
-        assert!(!phase37_is_lower_hex_byte(b'G'));
+        assert!(!phase37_is_lower_hex_byte(b'A'));
         assert!(!phase37_is_lower_hex_byte(b':'));
-        assert!(!phase37_is_hash32_lower_hex(UPPERCASE));
+        assert!(!phase37_is_hash32_lower_hex(UPPERCASE_HEX));
         assert!(!phase37_is_hash32_lower_hex(PUNCTUATION));
     }
 
@@ -1703,6 +1753,82 @@ mod kani_phase36_phase37_proofs {
         assert!(phase33_public_input_lanes_are_canonical(
             &PHASE33_PUBLIC_INPUT_LANES
         ));
+    }
+
+    #[kani::proof]
+    fn kani_phase33_public_input_lane_payload_wires_canonical_fields() {
+        let manifest = Phase33RecursiveCompressionPublicInputManifest {
+            proof_backend: StarkProofBackend::Stwo,
+            manifest_version: "manifest-version".to_string(),
+            semantic_scope: "semantic-scope".to_string(),
+            proof_backend_version: "proof-backend-version".to_string(),
+            statement_version: "statement-version".to_string(),
+            step_relation: "step-relation".to_string(),
+            required_recursion_posture: "required-recursion-posture".to_string(),
+            recursive_verification_claimed: false,
+            cryptographic_compression_claimed: false,
+            phase32_contract_version: "phase32-contract-version".to_string(),
+            phase32_semantic_scope: "phase32-semantic-scope".to_string(),
+            phase32_recursive_statement_contract_commitment: "lane-phase32-contract".to_string(),
+            total_steps: 73,
+            phase30_source_chain_commitment: "lane-phase30-source-chain".to_string(),
+            phase30_step_envelopes_commitment: "lane-phase30-step-envelopes".to_string(),
+            phase31_decode_boundary_bridge_commitment: "lane-phase31-boundary-bridge".to_string(),
+            chain_start_boundary_commitment: "lane-chain-start".to_string(),
+            chain_end_boundary_commitment: "lane-chain-end".to_string(),
+            source_template_commitment: "lane-source-template".to_string(),
+            aggregation_template_commitment: "lane-aggregation-template".to_string(),
+            recursive_public_inputs_commitment: "not-a-public-input-lane".to_string(),
+        };
+
+        assert!(
+            phase33_public_input_lane_payload(
+                &manifest,
+                Phase33PublicInputLane::Phase32RecursiveStatementContract
+            ) == Phase33PublicInputLanePayload::Bytes("lane-phase32-contract")
+        );
+        assert!(
+            phase33_public_input_lane_payload(&manifest, Phase33PublicInputLane::TotalSteps)
+                == Phase33PublicInputLanePayload::Usize(73)
+        );
+        assert!(
+            phase33_public_input_lane_payload(
+                &manifest,
+                Phase33PublicInputLane::Phase30SourceChain
+            ) == Phase33PublicInputLanePayload::Bytes("lane-phase30-source-chain")
+        );
+        assert!(
+            phase33_public_input_lane_payload(
+                &manifest,
+                Phase33PublicInputLane::Phase30StepEnvelopes
+            ) == Phase33PublicInputLanePayload::Bytes("lane-phase30-step-envelopes")
+        );
+        assert!(
+            phase33_public_input_lane_payload(
+                &manifest,
+                Phase33PublicInputLane::Phase31DecodeBoundaryBridge
+            ) == Phase33PublicInputLanePayload::Bytes("lane-phase31-boundary-bridge")
+        );
+        assert!(
+            phase33_public_input_lane_payload(
+                &manifest,
+                Phase33PublicInputLane::ChainStartBoundary
+            ) == Phase33PublicInputLanePayload::Bytes("lane-chain-start")
+        );
+        assert!(
+            phase33_public_input_lane_payload(&manifest, Phase33PublicInputLane::ChainEndBoundary)
+                == Phase33PublicInputLanePayload::Bytes("lane-chain-end")
+        );
+        assert!(
+            phase33_public_input_lane_payload(&manifest, Phase33PublicInputLane::SourceTemplate)
+                == Phase33PublicInputLanePayload::Bytes("lane-source-template")
+        );
+        assert!(
+            phase33_public_input_lane_payload(
+                &manifest,
+                Phase33PublicInputLane::AggregationTemplate
+            ) == Phase33PublicInputLanePayload::Bytes("lane-aggregation-template")
+        );
     }
 
     #[kani::proof]
@@ -4004,55 +4130,12 @@ fn phase33_update_public_input_lane(
     manifest: &Phase33RecursiveCompressionPublicInputManifest,
     lane: Phase33PublicInputLane,
 ) {
-    match lane {
-        Phase33PublicInputLane::Phase32RecursiveStatementContract => {
-            phase29_update_len_prefixed(
-                hasher,
-                manifest
-                    .phase32_recursive_statement_contract_commitment
-                    .as_bytes(),
-            );
+    match phase33_public_input_lane_payload(manifest, lane) {
+        Phase33PublicInputLanePayload::Bytes(value) => {
+            phase29_update_len_prefixed(hasher, value.as_bytes());
         }
-        Phase33PublicInputLane::TotalSteps => {
-            phase29_update_usize(hasher, manifest.total_steps);
-        }
-        Phase33PublicInputLane::Phase30SourceChain => {
-            phase29_update_len_prefixed(
-                hasher,
-                manifest.phase30_source_chain_commitment.as_bytes(),
-            );
-        }
-        Phase33PublicInputLane::Phase30StepEnvelopes => {
-            phase29_update_len_prefixed(
-                hasher,
-                manifest.phase30_step_envelopes_commitment.as_bytes(),
-            );
-        }
-        Phase33PublicInputLane::Phase31DecodeBoundaryBridge => {
-            phase29_update_len_prefixed(
-                hasher,
-                manifest
-                    .phase31_decode_boundary_bridge_commitment
-                    .as_bytes(),
-            );
-        }
-        Phase33PublicInputLane::ChainStartBoundary => {
-            phase29_update_len_prefixed(
-                hasher,
-                manifest.chain_start_boundary_commitment.as_bytes(),
-            );
-        }
-        Phase33PublicInputLane::ChainEndBoundary => {
-            phase29_update_len_prefixed(hasher, manifest.chain_end_boundary_commitment.as_bytes());
-        }
-        Phase33PublicInputLane::SourceTemplate => {
-            phase29_update_len_prefixed(hasher, manifest.source_template_commitment.as_bytes());
-        }
-        Phase33PublicInputLane::AggregationTemplate => {
-            phase29_update_len_prefixed(
-                hasher,
-                manifest.aggregation_template_commitment.as_bytes(),
-            );
+        Phase33PublicInputLanePayload::Usize(value) => {
+            phase29_update_usize(hasher, value);
         }
     }
 }

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -1464,6 +1464,87 @@ fn phase37_is_hash32_lower_hex(value: &str) -> bool {
 }
 
 #[cfg(feature = "stwo-backend")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase33PublicInputLane {
+    Phase32RecursiveStatementContract,
+    TotalSteps,
+    Phase30SourceChain,
+    Phase30StepEnvelopes,
+    Phase31DecodeBoundaryBridge,
+    ChainStartBoundary,
+    ChainEndBoundary,
+    SourceTemplate,
+    AggregationTemplate,
+}
+
+#[cfg(feature = "stwo-backend")]
+const PHASE33_PUBLIC_INPUT_LANES: [Phase33PublicInputLane; 9] = [
+    Phase33PublicInputLane::Phase32RecursiveStatementContract,
+    Phase33PublicInputLane::TotalSteps,
+    Phase33PublicInputLane::Phase30SourceChain,
+    Phase33PublicInputLane::Phase30StepEnvelopes,
+    Phase33PublicInputLane::Phase31DecodeBoundaryBridge,
+    Phase33PublicInputLane::ChainStartBoundary,
+    Phase33PublicInputLane::ChainEndBoundary,
+    Phase33PublicInputLane::SourceTemplate,
+    Phase33PublicInputLane::AggregationTemplate,
+];
+
+#[cfg(all(kani, feature = "stwo-backend"))]
+fn phase33_public_input_lanes_are_canonical(lanes: &[Phase33PublicInputLane; 9]) -> bool {
+    *lanes
+        == [
+            Phase33PublicInputLane::Phase32RecursiveStatementContract,
+            Phase33PublicInputLane::TotalSteps,
+            Phase33PublicInputLane::Phase30SourceChain,
+            Phase33PublicInputLane::Phase30StepEnvelopes,
+            Phase33PublicInputLane::Phase31DecodeBoundaryBridge,
+            Phase33PublicInputLane::ChainStartBoundary,
+            Phase33PublicInputLane::ChainEndBoundary,
+            Phase33PublicInputLane::SourceTemplate,
+            Phase33PublicInputLane::AggregationTemplate,
+        ]
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase36_receipt_flag_surface_is_valid(
+    recursive_verification_claimed: bool,
+    cryptographic_compression_claimed: bool,
+    target_manifest_verified: bool,
+    source_binding_verified: bool,
+    total_steps: usize,
+) -> bool {
+    !recursive_verification_claimed
+        && !cryptographic_compression_claimed
+        && target_manifest_verified
+        && source_binding_verified
+        && total_steps > 0
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase37_source_flags_are_all_set(flags: &[bool; 9]) -> bool {
+    for flag in flags {
+        if !*flag {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase37_receipt_flag_surface_is_valid(
+    recursive_verification_claimed: bool,
+    cryptographic_compression_claimed: bool,
+    source_flags: &[bool; 9],
+    total_steps: usize,
+) -> bool {
+    !recursive_verification_claimed
+        && !cryptographic_compression_claimed
+        && phase37_source_flags_are_all_set(source_flags)
+        && total_steps > 0
+}
+
+#[cfg(feature = "stwo-backend")]
 fn phase37_require_hash32(label: &str, value: &str) -> Result<()> {
     if !phase37_is_hash32_lower_hex(value) {
         return Err(VmError::InvalidConfig(format!(
@@ -1475,116 +1556,49 @@ fn phase37_require_hash32(label: &str, value: &str) -> Result<()> {
 
 #[cfg(all(kani, feature = "stwo-backend"))]
 mod kani_phase36_phase37_proofs {
-    use super::{phase37_is_hash32_lower_hex, phase37_is_lower_hex_byte};
+    use super::{
+        phase33_public_input_lanes_are_canonical, phase36_receipt_flag_surface_is_valid,
+        phase37_is_hash32_lower_hex, phase37_is_lower_hex_byte,
+        phase37_receipt_flag_surface_is_valid, Phase33PublicInputLane, PHASE33_PUBLIC_INPUT_LANES,
+    };
 
-    const PHASE33_PUBLIC_INPUT_FIELD_COUNT: usize = 9;
     const PHASE37_SOURCE_FLAG_COUNT: usize = 9;
-
-    fn phase37_hash32_bytes_are_lower_hex(bytes: &[u8; 64]) -> bool {
-        for byte in bytes {
-            if !phase37_is_lower_hex_byte(*byte) {
-                return false;
-            }
-        }
-        true
-    }
-
-    fn phase36_receipt_flag_surface_is_valid(
-        recursive_verification_claimed: bool,
-        cryptographic_compression_claimed: bool,
-        target_manifest_verified: bool,
-        source_binding_verified: bool,
-        total_steps: usize,
-    ) -> bool {
-        !recursive_verification_claimed
-            && !cryptographic_compression_claimed
-            && target_manifest_verified
-            && source_binding_verified
-            && total_steps > 0
-    }
-
-    fn phase37_source_flags_are_all_set(flags: &[bool; PHASE37_SOURCE_FLAG_COUNT]) -> bool {
-        for flag in flags {
-            if !*flag {
-                return false;
-            }
-        }
-        true
-    }
-
-    fn phase37_receipt_flag_surface_is_valid(
-        recursive_verification_claimed: bool,
-        cryptographic_compression_claimed: bool,
-        source_flags: &[bool; PHASE37_SOURCE_FLAG_COUNT],
-        total_steps: usize,
-    ) -> bool {
-        !recursive_verification_claimed
-            && !cryptographic_compression_claimed
-            && phase37_source_flags_are_all_set(source_flags)
-            && total_steps > 0
-    }
-
-    fn phase33_ordered_public_input_tags(
-        phase32_statement_contract: u8,
-        total_steps: u8,
-        phase30_source_chain: u8,
-        phase30_step_envelopes: u8,
-        phase31_decode_boundary_bridge: u8,
-        chain_start_boundary: u8,
-        chain_end_boundary: u8,
-        source_template: u8,
-        aggregation_template: u8,
-    ) -> [u8; PHASE33_PUBLIC_INPUT_FIELD_COUNT] {
-        [
-            phase32_statement_contract,
-            total_steps,
-            phase30_source_chain,
-            phase30_step_envelopes,
-            phase31_decode_boundary_bridge,
-            chain_start_boundary,
-            chain_end_boundary,
-            source_template,
-            aggregation_template,
-        ]
-    }
-
-    fn phase33_public_input_ordering_is_preserved(
-        expected: &[u8; PHASE33_PUBLIC_INPUT_FIELD_COUNT],
-        observed: &[u8; PHASE33_PUBLIC_INPUT_FIELD_COUNT],
-    ) -> bool {
-        expected == observed
-    }
-
-    fn phase36_phase37_parse_load_surface_accepts(
-        file_is_regular: bool,
-        bytes_within_limit: bool,
-        json_well_formed: bool,
-        verifier_accepts: bool,
-    ) -> bool {
-        file_is_regular && bytes_within_limit && json_well_formed && verifier_accepts
-    }
 
     #[kani::proof]
     fn kani_phase37_hash32_accepts_lowercase_hex_boundary() {
-        let byte = kani::any::<u8>();
-        kani::assume(phase37_is_lower_hex_byte(byte));
+        const LOWER_ZERO: &str = concat!(
+            "00000000", "00000000", "00000000", "00000000", "00000000", "00000000", "00000000",
+            "00000000"
+        );
+        const LOWER_F: &str = concat!(
+            "ffffffff", "ffffffff", "ffffffff", "ffffffff", "ffffffff", "ffffffff", "ffffffff",
+            "ffffffff"
+        );
 
-        assert!(phase37_hash32_bytes_are_lower_hex(&[byte; 64]));
-        assert!(phase37_hash32_bytes_are_lower_hex(&[b'0'; 64]));
-        assert!(phase37_hash32_bytes_are_lower_hex(&[b'f'; 64]));
+        assert!(phase37_is_hash32_lower_hex(LOWER_ZERO));
+        assert!(phase37_is_hash32_lower_hex(LOWER_F));
+        assert!(phase37_is_hash32_lower_hex(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        ));
     }
 
     #[kani::proof]
-    fn kani_phase37_hash32_rejects_any_non_lowercase_hex_byte() {
-        let bad_index = kani::any::<usize>();
-        kani::assume(bad_index < 64);
-        let bad_byte = kani::any::<u8>();
-        kani::assume(!phase37_is_lower_hex_byte(bad_byte));
+    fn kani_phase37_hash32_rejects_non_lowercase_hex_examples() {
+        const UPPERCASE: &str = concat!(
+            "G", "aaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa",
+            "aaaaaaaa"
+        );
+        const PUNCTUATION: &str = concat!(
+            "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa",
+            "aaaaaaa", ":"
+        );
 
-        let mut candidate = [b'a'; 64];
-        candidate[bad_index] = bad_byte;
-
-        assert!(!phase37_hash32_bytes_are_lower_hex(&candidate));
+        assert!(UPPERCASE.len() == 64);
+        assert!(PUNCTUATION.len() == 64);
+        assert!(!phase37_is_lower_hex_byte(b'G'));
+        assert!(!phase37_is_lower_hex_byte(b':'));
+        assert!(!phase37_is_hash32_lower_hex(UPPERCASE));
+        assert!(!phase37_is_hash32_lower_hex(PUNCTUATION));
     }
 
     #[kani::proof]
@@ -1686,58 +1700,24 @@ mod kani_phase36_phase37_proofs {
 
     #[kani::proof]
     fn kani_phase33_public_input_ordering_accepts_canonical_order() {
-        let expected = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let observed = phase33_ordered_public_input_tags(1, 2, 3, 4, 5, 6, 7, 8, 9);
-
-        assert!(phase33_public_input_ordering_is_preserved(
-            &expected, &observed
+        assert!(phase33_public_input_lanes_are_canonical(
+            &PHASE33_PUBLIC_INPUT_LANES
         ));
     }
 
     #[kani::proof]
     fn kani_phase33_public_input_ordering_rejects_any_lane_drift() {
-        let expected = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let mut observed = phase33_ordered_public_input_tags(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        let mut observed = PHASE33_PUBLIC_INPUT_LANES;
         let bad_lane = kani::any::<usize>();
-        kani::assume(bad_lane < PHASE33_PUBLIC_INPUT_FIELD_COUNT);
-        observed[bad_lane] = observed[bad_lane].wrapping_add(9);
-        kani::assume(observed[bad_lane] != expected[bad_lane]);
+        kani::assume(bad_lane < PHASE33_PUBLIC_INPUT_LANES.len());
+        observed[bad_lane] =
+            if observed[bad_lane] == Phase33PublicInputLane::Phase32RecursiveStatementContract {
+                Phase33PublicInputLane::TotalSteps
+            } else {
+                Phase33PublicInputLane::Phase32RecursiveStatementContract
+            };
 
-        assert!(!phase33_public_input_ordering_is_preserved(
-            &expected, &observed
-        ));
-    }
-
-    #[kani::proof]
-    fn kani_phase36_phase37_parser_wrapper_accepts_only_explicit_ok() {
-        let file_is_regular = kani::any::<bool>();
-        let bytes_within_limit = kani::any::<bool>();
-        let json_well_formed = kani::any::<bool>();
-        let verifier_accepts = kani::any::<bool>();
-
-        if phase36_phase37_parse_load_surface_accepts(
-            file_is_regular,
-            bytes_within_limit,
-            json_well_formed,
-            verifier_accepts,
-        ) {
-            assert!(file_is_regular);
-            assert!(bytes_within_limit);
-            assert!(json_well_formed);
-            assert!(verifier_accepts);
-        }
-    }
-
-    #[kani::proof]
-    fn kani_phase36_phase37_parser_wrapper_rejects_any_error_class() {
-        let mut classes = [true; 4];
-        let bad_class = kani::any::<usize>();
-        kani::assume(bad_class < 4);
-        classes[bad_class] = false;
-
-        assert!(!phase36_phase37_parse_load_surface_accepts(
-            classes[0], classes[1], classes[2], classes[3],
-        ));
+        assert!(!phase33_public_input_lanes_are_canonical(&observed));
     }
 }
 
@@ -3259,6 +3239,17 @@ pub fn verify_phase36_recursive_verifier_harness_receipt(
                 .to_string(),
         ));
     }
+    if !phase36_receipt_flag_surface_is_valid(
+        receipt.recursive_verification_claimed,
+        receipt.cryptographic_compression_claimed,
+        receipt.target_manifest_verified,
+        receipt.source_binding_verified,
+        receipt.total_steps,
+    ) {
+        return Err(VmError::InvalidConfig(
+            "Phase 36 recursive verifier harness receipt flag surface is invalid".to_string(),
+        ));
+    }
     for (label, value) in [
         (
             "phase35_recursive_target_manifest_commitment",
@@ -3502,6 +3493,26 @@ pub fn verify_phase37_recursive_artifact_chain_harness_receipt(
         return Err(VmError::InvalidConfig(
             "Phase 37 recursive artifact-chain harness receipt requires at least one decode step"
                 .to_string(),
+        ));
+    }
+    if !phase37_receipt_flag_surface_is_valid(
+        receipt.recursive_verification_claimed,
+        receipt.cryptographic_compression_claimed,
+        &[
+            receipt.phase29_input_contract_verified,
+            receipt.phase30_step_envelope_manifest_verified,
+            receipt.phase31_decode_boundary_bridge_verified,
+            receipt.phase32_statement_contract_verified,
+            receipt.phase33_public_inputs_verified,
+            receipt.phase34_shared_lookup_verified,
+            receipt.phase35_target_manifest_verified,
+            receipt.phase36_verifier_harness_receipt_verified,
+            receipt.source_binding_verified,
+        ],
+        receipt.total_steps,
+    ) {
+        return Err(VmError::InvalidConfig(
+            "Phase 37 recursive artifact-chain harness receipt flag surface is invalid".to_string(),
         ));
     }
     for (label, value) in [
@@ -3988,6 +3999,65 @@ pub fn commit_phase32_recursive_compression_statement_contract(
 }
 
 #[cfg(feature = "stwo-backend")]
+fn phase33_update_public_input_lane(
+    hasher: &mut Blake2bVar,
+    manifest: &Phase33RecursiveCompressionPublicInputManifest,
+    lane: Phase33PublicInputLane,
+) {
+    match lane {
+        Phase33PublicInputLane::Phase32RecursiveStatementContract => {
+            phase29_update_len_prefixed(
+                hasher,
+                manifest
+                    .phase32_recursive_statement_contract_commitment
+                    .as_bytes(),
+            );
+        }
+        Phase33PublicInputLane::TotalSteps => {
+            phase29_update_usize(hasher, manifest.total_steps);
+        }
+        Phase33PublicInputLane::Phase30SourceChain => {
+            phase29_update_len_prefixed(
+                hasher,
+                manifest.phase30_source_chain_commitment.as_bytes(),
+            );
+        }
+        Phase33PublicInputLane::Phase30StepEnvelopes => {
+            phase29_update_len_prefixed(
+                hasher,
+                manifest.phase30_step_envelopes_commitment.as_bytes(),
+            );
+        }
+        Phase33PublicInputLane::Phase31DecodeBoundaryBridge => {
+            phase29_update_len_prefixed(
+                hasher,
+                manifest
+                    .phase31_decode_boundary_bridge_commitment
+                    .as_bytes(),
+            );
+        }
+        Phase33PublicInputLane::ChainStartBoundary => {
+            phase29_update_len_prefixed(
+                hasher,
+                manifest.chain_start_boundary_commitment.as_bytes(),
+            );
+        }
+        Phase33PublicInputLane::ChainEndBoundary => {
+            phase29_update_len_prefixed(hasher, manifest.chain_end_boundary_commitment.as_bytes());
+        }
+        Phase33PublicInputLane::SourceTemplate => {
+            phase29_update_len_prefixed(hasher, manifest.source_template_commitment.as_bytes());
+        }
+        Phase33PublicInputLane::AggregationTemplate => {
+            phase29_update_len_prefixed(
+                hasher,
+                manifest.aggregation_template_commitment.as_bytes(),
+            );
+        }
+    }
+}
+
+#[cfg(feature = "stwo-backend")]
 pub fn commit_phase33_recursive_compression_public_input_manifest(
     manifest: &Phase33RecursiveCompressionPublicInputManifest,
 ) -> Result<String> {
@@ -4008,40 +4078,9 @@ pub fn commit_phase33_recursive_compression_public_input_manifest(
     phase29_update_bool(&mut hasher, manifest.cryptographic_compression_claimed);
     phase29_update_len_prefixed(&mut hasher, manifest.phase32_contract_version.as_bytes());
     phase29_update_len_prefixed(&mut hasher, manifest.phase32_semantic_scope.as_bytes());
-    phase29_update_len_prefixed(
-        &mut hasher,
-        manifest
-            .phase32_recursive_statement_contract_commitment
-            .as_bytes(),
-    );
-    phase29_update_usize(&mut hasher, manifest.total_steps);
-    phase29_update_len_prefixed(
-        &mut hasher,
-        manifest.phase30_source_chain_commitment.as_bytes(),
-    );
-    phase29_update_len_prefixed(
-        &mut hasher,
-        manifest.phase30_step_envelopes_commitment.as_bytes(),
-    );
-    phase29_update_len_prefixed(
-        &mut hasher,
-        manifest
-            .phase31_decode_boundary_bridge_commitment
-            .as_bytes(),
-    );
-    phase29_update_len_prefixed(
-        &mut hasher,
-        manifest.chain_start_boundary_commitment.as_bytes(),
-    );
-    phase29_update_len_prefixed(
-        &mut hasher,
-        manifest.chain_end_boundary_commitment.as_bytes(),
-    );
-    phase29_update_len_prefixed(&mut hasher, manifest.source_template_commitment.as_bytes());
-    phase29_update_len_prefixed(
-        &mut hasher,
-        manifest.aggregation_template_commitment.as_bytes(),
-    );
+    for lane in PHASE33_PUBLIC_INPUT_LANES {
+        phase33_update_public_input_lane(&mut hasher, manifest, lane);
+    }
     let mut out = [0u8; 32];
     hasher.finalize_variable(&mut out).map_err(|err| {
         VmError::InvalidConfig(format!(


### PR DESCRIPTION
## Summary
- add bounded Kani harnesses for Phase 33 public-input ordering and lane-to-field wiring, Phase 36/37 receipt flags, and Phase 37 lowercase 32-byte hex syntax
- route Phase 33 public-input serialization through a shared production lane order and lane-payload helper checked by Kani
- route Phase 36/37 receipt flag surfaces through production helpers checked by Kani
- document the formal pilot scope and paper evidence without claiming parser/load proof coverage

## Local validation
- scripts/run_formal_contract_suite.sh
- cargo +nightly-2025-07-14 check --quiet --features stwo-backend
- cargo +nightly-2025-07-14 test -q --features stwo-backend phase33
- cargo +nightly-2025-07-14 test -q --features stwo-backend phase36_recursive_verifier_harness_receipt
- cargo +nightly-2025-07-14 test -q --features stwo-backend phase37_recursive_artifact_chain_harness_receipt
- scripts/run_shellcheck_suite.sh
- python3 scripts/paper/paper_preflight.py
- cargo fmt --check
- git diff --check

## Non-claims
- no recursive proof closure claim
- no full verifier/backend/parser proof claim
- no formal parser/load proof coverage; malformed, oversized, non-regular, and load-wrapper cases remain runtime-negative-test covered

[skip ci]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the formal-contract pilot to cover additional protocol phases (Phases 24–37), added bounded commitment syntax (64‑char lowercase hex), tightened receipt-posture requirements, clarified mechanization/model wording, switched evidence expectation to dedicated local-runner output, and narrowed non-goals around parser memory-safety and formal load coverage.

* **Tests**
  * Added formal verification harnesses for hash-format boundaries, receipt-flag/posture validation, and public-input ordering; the test runner is updated to include these new harnesses and stricter receipt checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->