### PR TITLE
Evidence-map Paper 2 claim surface [skip ci]

### DIFF
--- a/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
+++ b/docs/paper/paper2/proof-carrying-decode-surfaces-2026.md
@@ -325,6 +325,32 @@ still does not verify the statement's signature or trust chain. It keeps the
 provenance surface aligned with existing release workflows without turning the
 manifest into a supply-chain theorem.
 
+### 5.4 Evidence ledger
+
+Every strong claim in this draft is tied to the machine-readable evidence ledger
+in `docs/engineering/paper2-claim-evidence.yml`. The ledger records
+implementation anchors, schema/spec anchors, positive controls, negative
+controls, evidence commands, and explicit non-claim boundaries. The table below
+is the paper-facing index into that ledger.
+
+| Evidence anchor | What the paper is allowed to claim | Boundary that must travel with the claim |
+| --- | --- | --- |
+| `evidence:phase29_recursive_input_contract` | Phase 29 defines a recursive-adjacent input contract derived from a verified pre-recursive aggregate. | No recursive proof verification and no cryptographic compression. |
+| `evidence:phase30_step_envelope_manifest` | Phase 30 binds ordered decode-step envelopes, source-chain commitment, and chain boundary commitments. | No recursive proof closure and no full model-inference proving. |
+| `evidence:phase31_decode_boundary_bridge` | Phase 31 bridges the Phase 29 input contract and Phase 30 envelope manifest without changing the public decode statement. | No recursive proof closure and no new recursive statement surface. |
+| `evidence:phase32_recursive_statement_contract` | Phase 32 restates the bridged decode boundary as a future recursive target statement contract. | No recursive proof closure and no semantic-equivalence theorem across runtimes. |
+| `evidence:phase33_public_input_manifest` | Phase 33 freezes the ordered public-input surface that future recursion must preserve. | No complete recursive verifier and only bounded formal coverage of ordering and lane-to-field wiring. |
+| `evidence:phase34_shared_lookup_manifest` | Phase 34 freezes the ordered lookup-facing public inputs derived from Phase 33 and Phase 30. | No recursive shared-table accumulation as a compressed proof object. |
+| `evidence:phase35_recursive_target_manifest` | Phase 35 binds the Phase 32 statement, Phase 33 public inputs, and Phase 34 lookup inputs into one canonical recursive target manifest. | No recursive proof closure and no cryptographic compression. |
+| `evidence:phase36_verifier_harness_receipt` | Phase 36 records source-bound verifier-harness checking of the Phase 35 target and source artifacts. | No recursive proof verification, no cryptographic compression, and only bounded formal flag-surface checks. |
+| `evidence:phase37_artifact_chain_harness_receipt` | Phase 37 recomputes the Phase 29 plus Phase 30 through Phase 36 source-bound artifact chain as heavier operational evidence. | No recursively verifiable compressed proof object and only bounded formal syntax, flag-surface, and ordering checks. |
+| `evidence:bounded_runtime_semantic_agreement` | The research-v3 artifacts provide bounded semantic-agreement evidence. | No general compiler, frontend, graph-rewrite, or runtime-equivalence theorem. |
+| `evidence:release_provenance_boundary` | HF provenance manifests bind release and artifact identity as reproducibility guardrails. | No complete supply-chain attestation theorem and no verified external builder trust unless attestations are actually verified. |
+
+This table is intentionally conservative. If a sentence in the paper cannot be
+connected to one of these anchors or to an explicit non-claim, it should be
+weakened before publication.
+
 ______________________________________________________________________
 
 ## 6. Negative Results and Non-Claims

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -478,24 +478,27 @@ def split_evidence_path_anchor(entry: str) -> tuple[str, str | None]:
 
 def resolve_repo_relative_path(
     repo_root: pathlib.Path, rel_path: str
-) -> pathlib.Path | None:
+) -> tuple[pathlib.Path | None, str | None]:
     relative_path = pathlib.Path(rel_path)
     windows_path = pathlib.PureWindowsPath(rel_path)
+    if relative_path.is_absolute() or windows_path.is_absolute():
+        return None, "path must be repo-relative"
     if (
-        relative_path.is_absolute()
-        or windows_path.is_absolute()
-        or ".." in relative_path.parts
+        ".." in relative_path.parts
         or ".." in windows_path.parts
     ):
-        return None
+        return None, "path must not contain `..`"
 
     try:
         root = repo_root.resolve()
         target = (root / relative_path).resolve()
+    except (OSError, RuntimeError) as exc:
+        return None, f"failed to resolve path: {exc}"
+    try:
         target.relative_to(root)
-    except (OSError, RuntimeError, ValueError):
-        return None
-    return target
+    except ValueError:
+        return None, "path escapes repo root"
+    return target, None
 
 
 def check_claim_evidence_path_anchor(
@@ -507,11 +510,10 @@ def check_claim_evidence_path_anchor(
     findings: Findings,
 ) -> None:
     rel_path, anchor = split_evidence_path_anchor(entry)
-    target = resolve_repo_relative_path(repo_root, rel_path)
+    target, path_error = resolve_repo_relative_path(repo_root, rel_path)
     if target is None:
         findings.error(
-            f"{evidence_path}: claim `{claim_id}` `{key}` path must be repo-relative "
-            f"and must not contain `..`: {entry}"
+            f"{evidence_path}: claim `{claim_id}` `{key}` invalid path `{entry}`: {path_error}"
         )
         return
 
@@ -566,16 +568,22 @@ def check_paper2_evidence_anchors(
             continue
 
         searched: list[str] = []
+        skipped: list[str] = []
+        unreadable: list[str] = []
         found = False
         for entry in locations:
             rel_path, location_anchor = split_evidence_path_anchor(entry)
             searched.append(rel_path)
-            path = resolve_repo_relative_path(repo_root, rel_path)
-            if path is None or not path.exists() or not path.is_file():
+            path, path_error = resolve_repo_relative_path(repo_root, rel_path)
+            if path is None:
+                skipped.append(f"{rel_path} ({path_error})")
+                continue
+            if not path.exists() or not path.is_file():
                 continue
             try:
                 text = path.read_text(encoding="utf-8", errors="ignore")
-            except (OSError, UnicodeError):
+            except (OSError, UnicodeError) as exc:
+                unreadable.append(f"{rel_path} ({exc})")
                 continue
             search_text = text
             if location_anchor is not None:
@@ -583,14 +591,19 @@ def check_paper2_evidence_anchors(
                 if anchor_offset < 0:
                     continue
                 search_text = text[anchor_offset:]
-            if anchor in search_text:
+            if re.search(rf"{re.escape(anchor)}(?![A-Za-z0-9_])", search_text):
                 found = True
                 break
 
         if not found:
+            details = f"searched locations: {searched}"
+            if skipped:
+                details += f"; skipped invalid paths: {skipped}"
+            if unreadable:
+                details += f"; unreadable locations: {unreadable}"
             findings.error(
                 f"{evidence_path}: claim `{claim_id}` is not explicitly cited by "
-                f"`{anchor}` in any declared paper location: {searched}"
+                f"`{anchor}` in any declared paper location; {details}"
             )
 
 

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -546,12 +546,12 @@ def list_field(record: dict[str, object], key: str) -> list[str]:
     return []
 
 
-def fragment_scoped_search_text(text: str, anchor_offset: int) -> str:
+def fragment_scoped_search_text(text: str, anchor_offset: int) -> str | None:
     """Return the text region governed by a declared paper fragment.
 
     For Markdown headings, the fragment owns that heading's section up to the
-    next heading at the same or a higher level. For non-heading anchors, retain
-    the historical behavior and search from the anchor to EOF.
+    next heading at the same or a higher level. Non-heading matches are invalid
+    fragment references; returning None prevents broadening the search to EOF.
     """
 
     line_start = text.rfind("\n", 0, anchor_offset) + 1
@@ -559,14 +559,14 @@ def fragment_scoped_search_text(text: str, anchor_offset: int) -> str:
     if line_end < 0:
         line_end = len(text)
     heading_line = text[line_start:line_end]
-    heading_match = re.match(r"^(#{1,6})\s+", heading_line)
+    heading_match = re.match(r"^\s{0,3}(#{1,6})\s+", heading_line)
     if heading_match is None:
-        return text[anchor_offset:]
+        return None
 
     heading_level = len(heading_match.group(1))
     remainder_start = min(line_end + 1, len(text))
     remainder = text[remainder_start:]
-    next_heading = re.search(rf"(?m)^#{{1,{heading_level}}}\s+", remainder)
+    next_heading = re.search(rf"(?m)^\s{{0,3}}#{{1,{heading_level}}}\s+", remainder)
     section_end = (
         len(text) if next_heading is None else remainder_start + next_heading.start()
     )
@@ -599,6 +599,7 @@ def check_paper2_evidence_anchors(
         searched: list[str] = []
         invalid_paths: list[str] = []
         missing_fragments: list[str] = []
+        invalid_fragments: list[str] = []
         unreadable: list[str] = []
         found = False
         for entry in locations:
@@ -623,7 +624,13 @@ def check_paper2_evidence_anchors(
                         f"{entry} (fragment `{location_anchor}` not found)"
                     )
                     continue
-                search_text = fragment_scoped_search_text(text, anchor_offset)
+                scoped_text = fragment_scoped_search_text(text, anchor_offset)
+                if scoped_text is None:
+                    invalid_fragments.append(
+                        f"{entry} (fragment `{location_anchor}` does not identify a Markdown heading)"
+                    )
+                    continue
+                search_text = scoped_text
             if re.search(rf"{re.escape(anchor)}(?![A-Za-z0-9_])", search_text):
                 found = True
                 break
@@ -634,6 +641,8 @@ def check_paper2_evidence_anchors(
                 details += f"; skipped invalid paths: {invalid_paths}"
             if missing_fragments:
                 details += f"; missing fragments: {missing_fragments}"
+            if invalid_fragments:
+                details += f"; invalid fragments: {invalid_fragments}"
             if unreadable:
                 details += f"; unreadable locations: {unreadable}"
             findings.error(

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -559,18 +559,40 @@ def fragment_scoped_search_text(text: str, anchor_offset: int) -> str | None:
     if line_end < 0:
         line_end = len(text)
     heading_line = text[line_start:line_end]
-    heading_match = re.match(r"^\s{0,3}(#{1,6})\s+", heading_line)
+    heading_match = re.match(r"^[ \t]{0,3}(#{1,6})[ \t]+", heading_line)
     if heading_match is None:
         return None
 
     heading_level = len(heading_match.group(1))
     remainder_start = min(line_end + 1, len(text))
     remainder = text[remainder_start:]
-    next_heading = re.search(rf"(?m)^\s{{0,3}}#{{1,{heading_level}}}\s+", remainder)
+    next_heading = re.search(rf"(?m)^[ \t]{{0,3}}#{{1,{heading_level}}}[ \t]+", remainder)
     section_end = (
         len(text) if next_heading is None else remainder_start + next_heading.start()
     )
     return text[line_start:section_end]
+
+
+def markdown_heading_title(heading_line: str) -> str | None:
+    heading_match = re.match(r"^[ \t]{0,3}#{1,6}[ \t]+(.*?)[ \t]*$", heading_line)
+    if heading_match is None:
+        return None
+    # CommonMark permits optional closing hashes, e.g. "## Title ##".
+    return re.sub(r"\s+#+\s*$", "", heading_match.group(1)).strip()
+
+
+def fragment_scoped_search_texts(text: str, location_anchor: str) -> list[str]:
+    """Return Markdown sections whose heading title exactly matches a fragment."""
+
+    scoped_sections: list[str] = []
+    for heading_match in re.finditer(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+.*$", text):
+        heading_line = heading_match.group(0)
+        if markdown_heading_title(heading_line) != location_anchor:
+            continue
+        scoped_text = fragment_scoped_search_text(text, heading_match.start())
+        if scoped_text is not None:
+            scoped_sections.append(scoped_text)
+    return scoped_sections
 
 
 def check_paper2_evidence_anchors(
@@ -616,22 +638,18 @@ def check_paper2_evidence_anchors(
             except (OSError, UnicodeError) as exc:
                 unreadable.append(f"{rel_path} ({exc})")
                 continue
-            search_text = text
+            search_texts = [text]
             if location_anchor is not None:
-                anchor_offset = text.find(location_anchor)
-                if anchor_offset < 0:
+                search_texts = fragment_scoped_search_texts(text, location_anchor)
+                if not search_texts:
                     missing_fragments.append(
-                        f"{entry} (fragment `{location_anchor}` not found)"
+                        f"{entry} (heading fragment `{location_anchor}` not found)"
                     )
                     continue
-                scoped_text = fragment_scoped_search_text(text, anchor_offset)
-                if scoped_text is None:
-                    invalid_fragments.append(
-                        f"{entry} (fragment `{location_anchor}` does not identify a Markdown heading)"
-                    )
-                    continue
-                search_text = scoped_text
-            if re.search(rf"{re.escape(anchor)}(?![A-Za-z0-9_])", search_text):
+            if any(
+                re.search(rf"{re.escape(anchor)}(?![A-Za-z0-9_])", search_text)
+                for search_text in search_texts
+            ):
                 found = True
                 break
 

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -467,13 +467,15 @@ def find_repo_tokens(repo_root: pathlib.Path, tokens: set[str]) -> set[str]:
 
 
 def split_evidence_path_anchor(entry: str) -> tuple[str, str | None]:
-    path_part = entry.split("#", 1)[0]
+    path_part, fragment = (
+        entry.split("#", 1) if "#" in entry else (entry, None)
+    )
     if ":" not in path_part:
-        return path_part, None
+        return path_part, fragment or None
     rel_path, anchor = path_part.rsplit(":", 1)
     if "/" not in rel_path and not rel_path.endswith((".rs", ".py", ".md", ".json", ".yml")):
-        return path_part, None
-    return rel_path, anchor or None
+        return path_part, fragment or None
+    return rel_path, anchor or fragment or None
 
 
 def resolve_repo_relative_path(
@@ -487,7 +489,7 @@ def resolve_repo_relative_path(
         ".." in relative_path.parts
         or ".." in windows_path.parts
     ):
-        return None, "path must not contain `..`"
+        return None, "path must be repo-relative (must not contain `..`)"
 
     try:
         root = repo_root.resolve()
@@ -573,7 +575,7 @@ def check_paper2_evidence_anchors(
         found = False
         for entry in locations:
             rel_path, location_anchor = split_evidence_path_anchor(entry)
-            searched.append(rel_path)
+            searched.append(entry)
             path, path_error = resolve_repo_relative_path(repo_root, rel_path)
             if path is None:
                 skipped.append(f"{rel_path} ({path_error})")

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -542,6 +542,52 @@ def list_field(record: dict[str, object], key: str) -> list[str]:
     return []
 
 
+def check_paper2_evidence_anchors(
+    repo_root: pathlib.Path,
+    evidence_path: pathlib.Path,
+    records: list[dict[str, object]],
+    findings: Findings,
+) -> None:
+    """Require each evidence-ledger claim to be cited by Paper 2 prose.
+
+    The evidence matrix says where a claim appears. The paper text must contain
+    an explicit `evidence:<claim_id>` anchor in at least one declared location,
+    otherwise a strong paper claim can drift away from its implementation,
+    negative controls, evidence commands, and non-claim boundary.
+    """
+
+    for record in records:
+        claim_id = str(record.get("id", "")).strip()
+        if not claim_id:
+            continue
+        anchor = f"evidence:{claim_id}"
+        locations = list_field(record, "paper_locations")
+        if not locations:
+            continue
+
+        searched: list[str] = []
+        found = False
+        for entry in locations:
+            rel_path, _anchor = split_evidence_path_anchor(entry)
+            path = repo_root / rel_path
+            searched.append(rel_path)
+            if not path.exists():
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                continue
+            if anchor in text:
+                found = True
+                break
+
+        if not found:
+            findings.error(
+                f"{evidence_path}: claim `{claim_id}` is not explicitly cited by "
+                f"`{anchor}` in any declared paper location: {searched}"
+            )
+
+
 def check_claim_evidence_matrix(repo_root: pathlib.Path, findings: Findings) -> None:
     evidence_path = repo_root / CLAIM_EVIDENCE_FILE
     if not evidence_path.exists():
@@ -622,6 +668,7 @@ def check_claim_evidence_matrix(repo_root: pathlib.Path, findings: Findings) -> 
         findings.warn(
             f"{evidence_path}: extra paper-2 claim evidence ids not in required set: {extra_ids}"
         )
+    check_paper2_evidence_anchors(repo_root, evidence_path, records, findings)
 
 
 def paragraph_start_line(text: str, offset: int) -> int:

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -546,6 +546,33 @@ def list_field(record: dict[str, object], key: str) -> list[str]:
     return []
 
 
+def fragment_scoped_search_text(text: str, anchor_offset: int) -> str:
+    """Return the text region governed by a declared paper fragment.
+
+    For Markdown headings, the fragment owns that heading's section up to the
+    next heading at the same or a higher level. For non-heading anchors, retain
+    the historical behavior and search from the anchor to EOF.
+    """
+
+    line_start = text.rfind("\n", 0, anchor_offset) + 1
+    line_end = text.find("\n", anchor_offset)
+    if line_end < 0:
+        line_end = len(text)
+    heading_line = text[line_start:line_end]
+    heading_match = re.match(r"^(#{1,6})\s+", heading_line)
+    if heading_match is None:
+        return text[anchor_offset:]
+
+    heading_level = len(heading_match.group(1))
+    remainder_start = min(line_end + 1, len(text))
+    remainder = text[remainder_start:]
+    next_heading = re.search(rf"(?m)^#{{1,{heading_level}}}\s+", remainder)
+    section_end = (
+        len(text) if next_heading is None else remainder_start + next_heading.start()
+    )
+    return text[line_start:section_end]
+
+
 def check_paper2_evidence_anchors(
     repo_root: pathlib.Path,
     evidence_path: pathlib.Path,
@@ -570,7 +597,8 @@ def check_paper2_evidence_anchors(
             continue
 
         searched: list[str] = []
-        skipped: list[str] = []
+        invalid_paths: list[str] = []
+        missing_fragments: list[str] = []
         unreadable: list[str] = []
         found = False
         for entry in locations:
@@ -578,7 +606,7 @@ def check_paper2_evidence_anchors(
             searched.append(entry)
             path, path_error = resolve_repo_relative_path(repo_root, rel_path)
             if path is None:
-                skipped.append(f"{rel_path} ({path_error})")
+                invalid_paths.append(f"{rel_path} ({path_error})")
                 continue
             if not path.exists() or not path.is_file():
                 continue
@@ -591,19 +619,21 @@ def check_paper2_evidence_anchors(
             if location_anchor is not None:
                 anchor_offset = text.find(location_anchor)
                 if anchor_offset < 0:
-                    skipped.append(
+                    missing_fragments.append(
                         f"{entry} (fragment `{location_anchor}` not found)"
                     )
                     continue
-                search_text = text[anchor_offset:]
+                search_text = fragment_scoped_search_text(text, anchor_offset)
             if re.search(rf"{re.escape(anchor)}(?![A-Za-z0-9_])", search_text):
                 found = True
                 break
 
         if not found:
             details = f"searched locations: {searched}"
-            if skipped:
-                details += f"; skipped invalid paths: {skipped}"
+            if invalid_paths:
+                details += f"; skipped invalid paths: {invalid_paths}"
+            if missing_fragments:
+                details += f"; missing fragments: {missing_fragments}"
             if unreadable:
                 details += f"; unreadable locations: {unreadable}"
             findings.error(

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -476,6 +476,28 @@ def split_evidence_path_anchor(entry: str) -> tuple[str, str | None]:
     return rel_path, anchor or None
 
 
+def resolve_repo_relative_path(
+    repo_root: pathlib.Path, rel_path: str
+) -> pathlib.Path | None:
+    relative_path = pathlib.Path(rel_path)
+    windows_path = pathlib.PureWindowsPath(rel_path)
+    if (
+        relative_path.is_absolute()
+        or windows_path.is_absolute()
+        or ".." in relative_path.parts
+        or ".." in windows_path.parts
+    ):
+        return None
+
+    try:
+        root = repo_root.resolve()
+        target = (root / relative_path).resolve()
+        target.relative_to(root)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return target
+
+
 def check_claim_evidence_path_anchor(
     repo_root: pathlib.Path,
     evidence_path: pathlib.Path,
@@ -485,33 +507,11 @@ def check_claim_evidence_path_anchor(
     findings: Findings,
 ) -> None:
     rel_path, anchor = split_evidence_path_anchor(entry)
-    relative_path = pathlib.Path(rel_path)
-    windows_path = pathlib.PureWindowsPath(rel_path)
-    if (
-        relative_path.is_absolute()
-        or windows_path.is_absolute()
-        or ".." in relative_path.parts
-        or ".." in windows_path.parts
-    ):
+    target = resolve_repo_relative_path(repo_root, rel_path)
+    if target is None:
         findings.error(
             f"{evidence_path}: claim `{claim_id}` `{key}` path must be repo-relative "
             f"and must not contain `..`: {entry}"
-        )
-        return
-
-    try:
-        root = repo_root.resolve()
-        target = (root / relative_path).resolve()
-    except (OSError, RuntimeError) as exc:
-        findings.error(
-            f"{evidence_path}: claim `{claim_id}` `{key}` failed to resolve path {entry}: {exc}"
-        )
-        return
-    try:
-        target.relative_to(root)
-    except ValueError:
-        findings.error(
-            f"{evidence_path}: claim `{claim_id}` `{key}` path escapes repo root: {entry}"
         )
         return
 
@@ -568,16 +568,22 @@ def check_paper2_evidence_anchors(
         searched: list[str] = []
         found = False
         for entry in locations:
-            rel_path, _anchor = split_evidence_path_anchor(entry)
-            path = repo_root / rel_path
+            rel_path, location_anchor = split_evidence_path_anchor(entry)
             searched.append(rel_path)
-            if not path.exists():
+            path = resolve_repo_relative_path(repo_root, rel_path)
+            if path is None or not path.exists() or not path.is_file():
                 continue
             try:
-                text = path.read_text(encoding="utf-8")
+                text = path.read_text(encoding="utf-8", errors="ignore")
             except (OSError, UnicodeError):
                 continue
-            if anchor in text:
+            search_text = text
+            if location_anchor is not None:
+                anchor_offset = text.find(location_anchor)
+                if anchor_offset < 0:
+                    continue
+                search_text = text[anchor_offset:]
+            if anchor in search_text:
                 found = True
                 break
 

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -591,6 +591,9 @@ def check_paper2_evidence_anchors(
             if location_anchor is not None:
                 anchor_offset = text.find(location_anchor)
                 if anchor_offset < 0:
+                    skipped.append(
+                        f"{entry} (fragment `{location_anchor}` not found)"
+                    )
                     continue
                 search_text = text[anchor_offset:]
             if re.search(rf"{re.escape(anchor)}(?![A-Za-z0-9_])", search_text):

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -461,7 +461,7 @@ class PaperPreflightTests(unittest.TestCase):
             write_text(
                 path,
                 (
-                    "## Target Section\n"
+                    "  ## Target Section\n"
                     "Scoped evidence can live in this section.\n\n"
                     "### Evidence paragraph\n"
                     "`evidence:phase29_recursive_input_contract`\n\n"
@@ -493,6 +493,34 @@ class PaperPreflightTests(unittest.TestCase):
             self.assertTrue(findings.errors)
             self.assertIn("missing fragments:", findings.errors[0])
             self.assertNotIn("skipped invalid paths:", findings.errors[0])
+
+    def test_paper2_evidence_anchor_rejects_non_heading_fragment_match(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(
+                repo / "docs/paper/paper2/paper.md",
+                (
+                    "# Paper\n"
+                    "The phrase Target Section appears in body text.\n\n"
+                    "## Later Section\n"
+                    "`evidence:phase29_recursive_input_contract`\n"
+                ),
+            )
+            records = [
+                {
+                    "id": "phase29_recursive_input_contract",
+                    "paper_locations": ["docs/paper/paper2/paper.md#Target Section"],
+                }
+            ]
+
+            findings = MOD.Findings()
+            MOD.check_paper2_evidence_anchors(
+                repo, repo / MOD.CLAIM_EVIDENCE_FILE, records, findings
+            )
+
+            self.assertTrue(findings.errors)
+            self.assertIn("invalid fragments:", findings.errors[0])
+            self.assertIn("does not identify a Markdown heading", findings.errors[0])
 
     def test_claim_evidence_matrix_rejects_missing_required_claim_id(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -434,7 +434,13 @@ class PaperPreflightTests(unittest.TestCase):
             path = repo / "docs/paper/paper2/paper.md"
             write_text(
                 path,
-                "`evidence:phase29_recursive_input_contract`\n\n## Target Section\n",
+                (
+                    "`evidence:phase29_recursive_input_contract`\n\n"
+                    "## Target Section\n"
+                    "No scoped evidence here.\n\n"
+                    "## Later Section\n"
+                    "`evidence:phase29_recursive_input_contract`\n"
+                ),
             )
             records = [
                 {
@@ -454,13 +460,39 @@ class PaperPreflightTests(unittest.TestCase):
 
             write_text(
                 path,
-                "## Target Section\n`evidence:phase29_recursive_input_contract`\n",
+                (
+                    "## Target Section\n"
+                    "Scoped evidence can live in this section.\n\n"
+                    "### Evidence paragraph\n"
+                    "`evidence:phase29_recursive_input_contract`\n\n"
+                    "## Later Section\n"
+                ),
             )
             findings = MOD.Findings()
             MOD.check_paper2_evidence_anchors(
                 repo, repo / MOD.CLAIM_EVIDENCE_FILE, records, findings
             )
             self.assertEqual(findings.errors, [])
+
+    def test_paper2_evidence_anchor_reports_missing_fragments_separately(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(repo / "docs/paper/paper2/paper.md", "## Other Section\n")
+            records = [
+                {
+                    "id": "phase29_recursive_input_contract",
+                    "paper_locations": ["docs/paper/paper2/paper.md#Target Section"],
+                }
+            ]
+
+            findings = MOD.Findings()
+            MOD.check_paper2_evidence_anchors(
+                repo, repo / MOD.CLAIM_EVIDENCE_FILE, records, findings
+            )
+
+            self.assertTrue(findings.errors)
+            self.assertIn("missing fragments:", findings.errors[0])
+            self.assertNotIn("skipped invalid paths:", findings.errors[0])
 
     def test_claim_evidence_matrix_rejects_missing_required_claim_id(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -413,12 +413,53 @@ class PaperPreflightTests(unittest.TestCase):
 """
                 )
             write_text(
+                repo / "docs/paper/paper2/appendix-artifact-map.md",
+                "\n".join(
+                    f"`evidence:{claim_id}`"
+                    for claim_id in sorted(MOD.REQUIRED_CLAIM_IDS)
+                ),
+            )
+            write_text(
                 repo / MOD.CLAIM_EVIDENCE_FILE,
                 "\n".join(records),
             )
 
             findings = MOD.Findings()
             MOD.check_claim_evidence_matrix(repo, findings)
+            self.assertEqual(findings.errors, [])
+
+    def test_paper2_evidence_anchor_honors_fragment_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            path = repo / "docs/paper/paper2/paper.md"
+            write_text(
+                path,
+                "`evidence:phase29_recursive_input_contract`\n\n## Target Section\n",
+            )
+            records = [
+                {
+                    "id": "phase29_recursive_input_contract",
+                    "paper_locations": ["docs/paper/paper2/paper.md#Target Section"],
+                }
+            ]
+
+            findings = MOD.Findings()
+            MOD.check_paper2_evidence_anchors(
+                repo, repo / MOD.CLAIM_EVIDENCE_FILE, records, findings
+            )
+            self.assertTrue(
+                any("not explicitly cited" in msg for msg in findings.errors),
+                findings.errors,
+            )
+
+            write_text(
+                path,
+                "## Target Section\n`evidence:phase29_recursive_input_contract`\n",
+            )
+            findings = MOD.Findings()
+            MOD.check_paper2_evidence_anchors(
+                repo, repo / MOD.CLAIM_EVIDENCE_FILE, records, findings
+            )
             self.assertEqual(findings.errors, [])
 
     def test_claim_evidence_matrix_rejects_missing_required_claim_id(self):

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -494,7 +494,33 @@ class PaperPreflightTests(unittest.TestCase):
             self.assertIn("missing fragments:", findings.errors[0])
             self.assertNotIn("skipped invalid paths:", findings.errors[0])
 
-    def test_paper2_evidence_anchor_rejects_non_heading_fragment_match(self):
+    def test_paper2_evidence_anchor_ignores_body_text_fragment_match(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            write_text(
+                repo / "docs/paper/paper2/paper.md",
+                (
+                    "# Paper\n"
+                    "The phrase Target Section appears in body text.\n\n"
+                    "## Target Section\n"
+                    "`evidence:phase29_recursive_input_contract`\n"
+                ),
+            )
+            records = [
+                {
+                    "id": "phase29_recursive_input_contract",
+                    "paper_locations": ["docs/paper/paper2/paper.md#Target Section"],
+                }
+            ]
+
+            findings = MOD.Findings()
+            MOD.check_paper2_evidence_anchors(
+                repo, repo / MOD.CLAIM_EVIDENCE_FILE, records, findings
+            )
+
+            self.assertEqual(findings.errors, [])
+
+    def test_paper2_evidence_anchor_requires_fragment_to_be_heading(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo = pathlib.Path(tmp)
             write_text(
@@ -519,8 +545,8 @@ class PaperPreflightTests(unittest.TestCase):
             )
 
             self.assertTrue(findings.errors)
-            self.assertIn("invalid fragments:", findings.errors[0])
-            self.assertIn("does not identify a Markdown heading", findings.errors[0])
+            self.assertIn("missing fragments:", findings.errors[0])
+            self.assertNotIn("invalid fragments:", findings.errors[0])
 
     def test_claim_evidence_matrix_rejects_missing_required_claim_id(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add a Paper 2 evidence-ledger section that maps every strong draft claim to an explicit evidence anchor
- record the non-claim boundary beside each evidence-mapped claim in the paper text
- extend paper preflight so every claim in docs/engineering/paper2-claim-evidence.yml must be explicitly cited in at least one declared Paper 2 location
- harden evidence-location path handling, fragment scoping, exact anchor matching, and diagnostics

## Local validation
- python3 scripts/paper/paper_preflight.py
- python3 -m py_compile scripts/paper/paper_preflight.py
- python3 -m unittest scripts/paper/tests/test_paper_preflight.py -q
- scripts/run_shellcheck_suite.sh
- cargo fmt --check
- git diff --check

## Non-claims
- this is an evidence-mapping/editorial hardening pass, not a new proof implementation
- it does not enlarge the Paper 2 proof surface beyond the existing evidence ledger

[skip ci]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an "Evidence ledger" section mapping evidence anchors to allowed claim statements and explicit non-claim boundaries, clarifying permitted and disallowed claim scopes.

* **Chores**
  * Enhanced preflight validation to more robustly resolve and validate referenced evidence locations, consolidate invalid-path reporting, and skip/unreadable targets with actionable details.

* **Tests**
  * Added tests ensuring evidence anchors are found within declared files and respect fragment/section scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->