### PR TITLE
Wire evidence checks into local merge gate [skip ci]

### DIFF
--- a/docs/engineering/hardening-policy.md
+++ b/docs/engineering/hardening-policy.md
@@ -59,6 +59,8 @@ scripts/run_dependency_audit_suite.sh
 python3 scripts/fuzz/generate_decoding_fuzz_corpus.py
 FUZZ_TIME_PER_TARGET=20 scripts/run_fuzz_smoke_suite.sh
 scripts/run_known_bad_phase_artifact_corpus.sh
+scripts/run_paper_preflight_suite.sh
+scripts/run_approximation_budget_suite.sh
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_miri_suite.sh
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_ub_checks_suite.sh
 HARDENING_TOOLCHAIN=nightly-2025-07-14 scripts/run_asan_suite.sh
@@ -74,6 +76,12 @@ rewrite tracked fuzz seeds as a side effect.
 29-37 known-bad artifact corpus. It derives valid artifacts in memory, mutates
 them, and checks that public parsers and source-bound verifiers reject both
 stale-root and self-consistent bad artifacts.
+
+`scripts/run_paper_preflight_suite.sh` runs the publication preflight unit tests
+and the full paper preflight, including the Paper 2 and Paper 3 claim-evidence
+matrices. `scripts/run_approximation_budget_suite.sh` runs approximation-budget
+unit tests, accepts the positive fixture, and checks that the negative fixture
+fails closed.
 
 The sanitizer and UB hardening scripts use the curated exact test lists in
 `scripts/hardening_test_names.sh`; update that file when adding new trusted-core
@@ -145,8 +153,11 @@ Available local command tiers:
 - `--mode full`: runs the same PR-range whitespace and formatting hygiene, full
   library tests, integration tests, doctests, the same conditional workflow
   auditing, dependency auditing, and shellcheck, and the exact pinned-nightly
-  `stwo-backend` smokes, plus the Phase 29-37 known-bad artifact corpus when
-  relevant files change.
+  `stwo-backend` smokes, plus the Phase 29-37 known-bad artifact corpus, paper
+  preflight, approximation-budget suite, independent reference verifier, Phase
+  37 mutation generator, fuzz smoke, benchmark reproducibility suite, release
+  evidence suite, and mutation-survivor tracking suite when their relevant files
+  change.
 - `--mode hardening`: runs the `full` tier, including the same conditional
   workflow auditing for `.github/workflows/**` and `zizmor.yml`, the same
   conditional dependency auditing for `Cargo.toml`, `Cargo.lock`,
@@ -158,9 +169,11 @@ Available local command tiers:
   records mutation survivors through `scripts/collect_mutation_survivors.py`
   when mutation output exists, and validates the mutation-survivor ledger when
   that evidence surface changes. It also runs the Phase 29-37 known-bad
-  artifact corpus when relevant files change. The inherited whitespace gate is
-  still scoped to the committed PR delta, not the whole worktree. Prefer running
-  this tier inside Lima for Linux parity.
+  artifact corpus, paper preflight, approximation-budget suite, independent
+  reference verifier, Phase 37 mutation generator, benchmark reproducibility
+  suite, and release evidence suite when relevant files change. The inherited
+  whitespace gate is still scoped to the committed PR delta, not the whole
+  worktree. Prefer running this tier inside Lima for Linux parity.
 - `--mode none`: only checks GitHub status, review-thread state, and the
   seven-minute AI-review quiet window. Use this only after a prior evidence run
   for the same PR head SHA.

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -501,7 +501,11 @@ changed_path_is_fuzz_surface() {
 
 changed_path_is_paper_preflight_surface() {
   changed_path_has_prefix "docs/paper/" ||
-    changed_path_has_prefix "docs/engineering/" ||
+    changed_path_has_prefix "docs/engineering/paper2-claim-evidence.yml" ||
+    changed_path_has_prefix "docs/engineering/paper3-claim-evidence.yml" ||
+    changed_path_has_prefix "docs/engineering/design/phase29-recursive-compression-input-contract-spec.md" ||
+    changed_path_has_prefix "docs/engineering/paper3-composition-prototype.md" ||
+    changed_path_has_prefix "docs/engineering/reproducibility.md" ||
     changed_path_has_prefix "src/" ||
     changed_path_has_prefix "spec/" ||
     changed_path_has_prefix "tools/reference_verifier/" ||

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -501,6 +501,17 @@ changed_path_is_fuzz_surface() {
 
 changed_path_is_paper_preflight_surface() {
   changed_path_has_prefix "docs/paper/" ||
+    changed_path_has_prefix "docs/engineering/" ||
+    changed_path_has_prefix "src/" ||
+    changed_path_has_prefix "spec/" ||
+    changed_path_has_prefix "tools/reference_verifier/" ||
+    changed_path_has_prefix "fuzz/fuzz_targets/" ||
+    changed_path_has_prefix "scripts/generate_bad_phase37_artifacts.py" ||
+    changed_path_has_prefix "scripts/run_formal_contract_suite.sh" ||
+    changed_path_has_prefix "scripts/run_fuzz_smoke_suite.sh" ||
+    changed_path_has_prefix "scripts/run_mutation_survivor_tracking_suite.sh" ||
+    changed_path_has_prefix "scripts/run_phase37_mutation_generator_suite.sh" ||
+    changed_path_has_prefix "scripts/run_reference_verifier_suite.sh" ||
     changed_path_has_prefix "docs/engineering/paper2-claim-evidence.yml" ||
     changed_path_has_prefix "docs/engineering/paper3-claim-evidence.yml" ||
     changed_path_has_prefix "scripts/paper/" ||

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -512,8 +512,6 @@ changed_path_is_paper_preflight_surface() {
     changed_path_has_prefix "scripts/run_mutation_survivor_tracking_suite.sh" ||
     changed_path_has_prefix "scripts/run_phase37_mutation_generator_suite.sh" ||
     changed_path_has_prefix "scripts/run_reference_verifier_suite.sh" ||
-    changed_path_has_prefix "docs/engineering/paper2-claim-evidence.yml" ||
-    changed_path_has_prefix "docs/engineering/paper3-claim-evidence.yml" ||
     changed_path_has_prefix "scripts/paper/" ||
     changed_path_has_prefix "scripts/run_paper_preflight_suite.sh" ||
     changed_path_has_prefix "scripts/local_merge_gate.sh"

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -499,6 +499,25 @@ changed_path_is_fuzz_surface() {
     changed_path_has_prefix "scripts/local_merge_gate.sh"
 }
 
+changed_path_is_paper_preflight_surface() {
+  changed_path_has_prefix "docs/paper/" ||
+    changed_path_has_prefix "docs/engineering/paper2-claim-evidence.yml" ||
+    changed_path_has_prefix "docs/engineering/paper3-claim-evidence.yml" ||
+    changed_path_has_prefix "scripts/paper/" ||
+    changed_path_has_prefix "scripts/run_paper_preflight_suite.sh" ||
+    changed_path_has_prefix "scripts/local_merge_gate.sh"
+}
+
+changed_path_is_approximation_budget_surface() {
+  changed_path_has_prefix "docs/engineering/approximation-budget.md" ||
+    changed_path_has_prefix "scripts/check_approximation_budget.py" ||
+    changed_path_has_prefix "scripts/tests/test_check_approximation_budget.py" ||
+    changed_path_has_prefix "scripts/run_approximation_budget_suite.sh" ||
+    changed_path_has_prefix "tests/fixtures/reference_cases/toy_approximation_budget_bundle.json" ||
+    changed_path_has_prefix "tests/fixtures/reference_cases/toy_approximation_budget_negative_bundle.json" ||
+    changed_path_has_prefix "scripts/local_merge_gate.sh"
+}
+
 changed_path_is_benchmark_reproducibility_surface() {
   changed_path_has_prefix "benchmarks/" ||
     changed_path_has_prefix "docs/engineering/benchmark-methodology.md" ||
@@ -640,6 +659,18 @@ run_fuzz_smoke_if_needed() {
   fi
 }
 
+run_paper_preflight_if_needed() {
+  if changed_path_is_paper_preflight_surface; then
+    run_logged paper-preflight bash scripts/run_paper_preflight_suite.sh
+  fi
+}
+
+run_approximation_budget_if_needed() {
+  if changed_path_is_approximation_budget_surface; then
+    run_logged approximation-budget bash scripts/run_approximation_budget_suite.sh
+  fi
+}
+
 run_benchmark_reproducibility_if_needed() {
   if changed_path_is_benchmark_reproducibility_surface; then
     run_logged benchmark-reproducibility bash scripts/run_benchmark_reproducibility_suite.sh
@@ -748,6 +779,8 @@ if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then
   run_reference_verifier_if_needed
   run_phase37_mutation_generator_if_needed
   run_fuzz_smoke_if_needed
+  run_paper_preflight_if_needed
+  run_approximation_budget_if_needed
   run_benchmark_reproducibility_if_needed
   run_release_evidence_if_needed
   run_mutation_survivor_tracking_if_needed
@@ -777,6 +810,8 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then
   run_reference_verifier_if_needed
   run_phase37_mutation_generator_if_needed
   run_fuzz_smoke_if_needed
+  run_paper_preflight_if_needed
+  run_approximation_budget_if_needed
   run_benchmark_reproducibility_if_needed
   run_release_evidence_if_needed
   run_mutation_survivor_tracking_if_needed
@@ -805,6 +840,8 @@ elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then
   fi
   run_reference_verifier_if_needed
   run_phase37_mutation_generator_if_needed
+  run_paper_preflight_if_needed
+  run_approximation_budget_if_needed
   run_benchmark_reproducibility_if_needed
   run_release_evidence_if_needed
   run_mutation_survivor_tracking_if_needed

--- a/scripts/run_approximation_budget_suite.sh
+++ b/scripts/run_approximation_budget_suite.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONDONTWRITEBYTECODE=1
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+out_dir="${APPROXIMATION_BUDGET_OUT_DIR:-target/local-validation/approximation-budget}"
+mkdir -p "$out_dir"
+
+python3 -B -m unittest scripts/tests/test_check_approximation_budget.py -q
+python3 scripts/check_approximation_budget.py \
+  tests/fixtures/reference_cases/toy_approximation_budget_bundle.json
+
+negative_log="$out_dir/negative-budget.log"
+if python3 scripts/check_approximation_budget.py \
+  tests/fixtures/reference_cases/toy_approximation_budget_negative_bundle.json \
+  >"$negative_log" 2>&1; then
+  echo "negative approximation-budget fixture unexpectedly passed" >&2
+  exit 1
+fi
+
+grep -q "exceeds budget\\|below budget\\|required\\|must be" "$negative_log"
+echo "approximation budget suite passed: $out_dir"

--- a/scripts/run_paper_preflight_suite.sh
+++ b/scripts/run_paper_preflight_suite.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONDONTWRITEBYTECODE=1
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 -B -m unittest scripts/paper/tests/test_paper_preflight.py -q
+python3 scripts/paper/paper_preflight.py --repo-root .

--- a/scripts/tests/test_local_merge_gate_wiring.py
+++ b/scripts/tests/test_local_merge_gate_wiring.py
@@ -29,8 +29,6 @@ class LocalMergeGateWiringTests(unittest.TestCase):
             "scripts/run_mutation_survivor_tracking_suite.sh",
             "scripts/run_phase37_mutation_generator_suite.sh",
             "scripts/run_reference_verifier_suite.sh",
-            "docs/engineering/paper2-claim-evidence.yml",
-            "docs/engineering/paper3-claim-evidence.yml",
             "scripts/paper/",
             "scripts/run_paper_preflight_suite.sh",
             "scripts/local_merge_gate.sh",

--- a/scripts/tests/test_local_merge_gate_wiring.py
+++ b/scripts/tests/test_local_merge_gate_wiring.py
@@ -23,6 +23,10 @@ class LocalMergeGateWiringTests(unittest.TestCase):
         self.assertIsNotNone(match, f"missing function: {fn_name}")
         return match.group("body")
 
+    def _shell_call_site_count(self, fn_name: str) -> int:
+        # Count invocation lines only; this intentionally excludes definitions.
+        return len(re.findall(rf"(?m)^\s*{re.escape(fn_name)}\s*$", self.script))
+
     def test_paper_preflight_surface_is_conditionally_wired(self) -> None:
         self.assertIn("changed_path_is_paper_preflight_surface()", self.script)
         body = self._shell_function_body("changed_path_is_paper_preflight_surface")
@@ -51,9 +55,16 @@ class LocalMergeGateWiringTests(unittest.TestCase):
             with self.subTest(trigger=trigger):
                 self.assertIn(f'changed_path_has_prefix "{trigger}"', body)
         self.assertNotIn('changed_path_has_prefix "docs/engineering/"', body)
-        self.assertIn("run_paper_preflight_if_needed()", self.script)
-        self.assertIn("run_logged paper-preflight bash scripts/run_paper_preflight_suite.sh", self.script)
-        self.assertGreaterEqual(len(re.findall(r"run_paper_preflight_if_needed", self.script)), 4)
+        runner_body = self._shell_function_body("run_paper_preflight_if_needed")
+        self.assertIn("if changed_path_is_paper_preflight_surface; then", runner_body)
+        self.assertIn(
+            "run_logged paper-preflight bash scripts/run_paper_preflight_suite.sh",
+            runner_body,
+        )
+        self.assertGreaterEqual(
+            self._shell_call_site_count("run_paper_preflight_if_needed"),
+            3,
+        )
 
     def test_approximation_budget_surface_is_conditionally_wired(self) -> None:
         self.assertIn("changed_path_is_approximation_budget_surface()", self.script)
@@ -70,14 +81,18 @@ class LocalMergeGateWiringTests(unittest.TestCase):
         for trigger in expected_triggers:
             with self.subTest(trigger=trigger):
                 self.assertIn(f'changed_path_has_prefix "{trigger}"', body)
-        self.assertIn("run_approximation_budget_if_needed()", self.script)
+        runner_body = self._shell_function_body("run_approximation_budget_if_needed")
+        self.assertIn(
+            "if changed_path_is_approximation_budget_surface; then",
+            runner_body,
+        )
         self.assertIn(
             "run_logged approximation-budget bash scripts/run_approximation_budget_suite.sh",
-            self.script,
+            runner_body,
         )
         self.assertGreaterEqual(
-            len(re.findall(r"run_approximation_budget_if_needed", self.script)),
-            4,
+            self._shell_call_site_count("run_approximation_budget_if_needed"),
+            3,
         )
 
 

--- a/scripts/tests/test_local_merge_gate_wiring.py
+++ b/scripts/tests/test_local_merge_gate_wiring.py
@@ -14,8 +14,18 @@ class LocalMergeGateWiringTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.script = MERGE_GATE.read_text(encoding="utf-8")
 
+    def _shell_function_body(self, fn_name: str) -> str:
+        match = re.search(
+            rf"^{re.escape(fn_name)}\(\) \{{(?P<body>.*?)^\}}",
+            self.script,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, f"missing function: {fn_name}")
+        return match.group("body")
+
     def test_paper_preflight_surface_is_conditionally_wired(self) -> None:
         self.assertIn("changed_path_is_paper_preflight_surface()", self.script)
+        body = self._shell_function_body("changed_path_is_paper_preflight_surface")
         expected_triggers = [
             "docs/paper/",
             "docs/engineering/",
@@ -35,13 +45,14 @@ class LocalMergeGateWiringTests(unittest.TestCase):
         ]
         for trigger in expected_triggers:
             with self.subTest(trigger=trigger):
-                self.assertIn(f'changed_path_has_prefix "{trigger}"', self.script)
+                self.assertIn(f'changed_path_has_prefix "{trigger}"', body)
         self.assertIn("run_paper_preflight_if_needed()", self.script)
         self.assertIn("run_logged paper-preflight bash scripts/run_paper_preflight_suite.sh", self.script)
         self.assertGreaterEqual(len(re.findall(r"run_paper_preflight_if_needed", self.script)), 4)
 
     def test_approximation_budget_surface_is_conditionally_wired(self) -> None:
         self.assertIn("changed_path_is_approximation_budget_surface()", self.script)
+        body = self._shell_function_body("changed_path_is_approximation_budget_surface")
         expected_triggers = [
             "docs/engineering/approximation-budget.md",
             "scripts/check_approximation_budget.py",
@@ -53,7 +64,7 @@ class LocalMergeGateWiringTests(unittest.TestCase):
         ]
         for trigger in expected_triggers:
             with self.subTest(trigger=trigger):
-                self.assertIn(f'changed_path_has_prefix "{trigger}"', self.script)
+                self.assertIn(f'changed_path_has_prefix "{trigger}"', body)
         self.assertIn("run_approximation_budget_if_needed()", self.script)
         self.assertIn(
             "run_logged approximation-budget bash scripts/run_approximation_budget_suite.sh",

--- a/scripts/tests/test_local_merge_gate_wiring.py
+++ b/scripts/tests/test_local_merge_gate_wiring.py
@@ -23,9 +23,32 @@ class LocalMergeGateWiringTests(unittest.TestCase):
         self.assertIsNotNone(match, f"missing function: {fn_name}")
         return match.group("body")
 
-    def _shell_call_site_count(self, fn_name: str) -> int:
-        # Count invocation lines only; this intentionally excludes definitions.
-        return len(re.findall(rf"(?m)^\s*{re.escape(fn_name)}\s*$", self.script))
+    def _run_mode_body(self, mode: str) -> str:
+        markers = [
+            ("smoke", 'if (( RUN_LOCAL )) && [[ "$RUN_MODE" == "smoke" ]]; then'),
+            ("full", 'elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "full" ]]; then'),
+            ("hardening", 'elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "hardening" ]]; then'),
+            ("none", 'elif (( RUN_LOCAL )) && [[ "$RUN_MODE" == "none" ]]; then'),
+        ]
+        marker_by_mode = dict(markers)
+        marker = marker_by_mode[mode]
+        start = self.script.find(marker)
+        self.assertNotEqual(start, -1, f"missing RUN_MODE block: {mode}")
+        body_start = start + len(marker)
+        next_starts = [
+            self.script.find(next_marker, body_start)
+            for next_mode, next_marker in markers
+            if next_mode != mode
+        ]
+        next_starts = [index for index in next_starts if index != -1 and index > start]
+        self.assertTrue(next_starts, f"missing end marker for RUN_MODE block: {mode}")
+        return self.script[body_start : min(next_starts)]
+
+    def _assert_runner_in_local_modes(self, fn_name: str) -> None:
+        pattern = rf"(?m)^\s*{re.escape(fn_name)}(?!\(\))\b"
+        for mode in ("smoke", "full", "hardening"):
+            with self.subTest(mode=mode, runner=fn_name):
+                self.assertRegex(self._run_mode_body(mode), pattern)
 
     def test_paper_preflight_surface_is_conditionally_wired(self) -> None:
         self.assertIn("changed_path_is_paper_preflight_surface()", self.script)
@@ -61,10 +84,7 @@ class LocalMergeGateWiringTests(unittest.TestCase):
             "run_logged paper-preflight bash scripts/run_paper_preflight_suite.sh",
             runner_body,
         )
-        self.assertGreaterEqual(
-            self._shell_call_site_count("run_paper_preflight_if_needed"),
-            3,
-        )
+        self._assert_runner_in_local_modes("run_paper_preflight_if_needed")
 
     def test_approximation_budget_surface_is_conditionally_wired(self) -> None:
         self.assertIn("changed_path_is_approximation_budget_surface()", self.script)
@@ -90,10 +110,7 @@ class LocalMergeGateWiringTests(unittest.TestCase):
             "run_logged approximation-budget bash scripts/run_approximation_budget_suite.sh",
             runner_body,
         )
-        self.assertGreaterEqual(
-            self._shell_call_site_count("run_approximation_budget_if_needed"),
-            3,
-        )
+        self._assert_runner_in_local_modes("run_approximation_budget_if_needed")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_local_merge_gate_wiring.py
+++ b/scripts/tests/test_local_merge_gate_wiring.py
@@ -28,7 +28,11 @@ class LocalMergeGateWiringTests(unittest.TestCase):
         body = self._shell_function_body("changed_path_is_paper_preflight_surface")
         expected_triggers = [
             "docs/paper/",
-            "docs/engineering/",
+            "docs/engineering/paper2-claim-evidence.yml",
+            "docs/engineering/paper3-claim-evidence.yml",
+            "docs/engineering/design/phase29-recursive-compression-input-contract-spec.md",
+            "docs/engineering/paper3-composition-prototype.md",
+            "docs/engineering/reproducibility.md",
             "src/",
             "spec/",
             "tools/reference_verifier/",
@@ -46,6 +50,7 @@ class LocalMergeGateWiringTests(unittest.TestCase):
         for trigger in expected_triggers:
             with self.subTest(trigger=trigger):
                 self.assertIn(f'changed_path_has_prefix "{trigger}"', body)
+        self.assertNotIn('changed_path_has_prefix "docs/engineering/"', body)
         self.assertIn("run_paper_preflight_if_needed()", self.script)
         self.assertIn("run_logged paper-preflight bash scripts/run_paper_preflight_suite.sh", self.script)
         self.assertGreaterEqual(len(re.findall(r"run_paper_preflight_if_needed", self.script)), 4)

--- a/scripts/tests/test_local_merge_gate_wiring.py
+++ b/scripts/tests/test_local_merge_gate_wiring.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MERGE_GATE = REPO / "scripts" / "local_merge_gate.sh"
+
+
+class LocalMergeGateWiringTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.script = MERGE_GATE.read_text(encoding="utf-8")
+
+    def test_paper_preflight_surface_is_conditionally_wired(self) -> None:
+        self.assertIn("changed_path_is_paper_preflight_surface()", self.script)
+        self.assertIn('changed_path_has_prefix "docs/paper/"', self.script)
+        self.assertIn('changed_path_has_prefix "docs/engineering/paper2-claim-evidence.yml"', self.script)
+        self.assertIn('changed_path_has_prefix "docs/engineering/paper3-claim-evidence.yml"', self.script)
+        self.assertIn("run_paper_preflight_if_needed()", self.script)
+        self.assertIn("run_logged paper-preflight bash scripts/run_paper_preflight_suite.sh", self.script)
+        self.assertGreaterEqual(len(re.findall(r"run_paper_preflight_if_needed", self.script)), 4)
+
+    def test_approximation_budget_surface_is_conditionally_wired(self) -> None:
+        self.assertIn("changed_path_is_approximation_budget_surface()", self.script)
+        self.assertIn('changed_path_has_prefix "docs/engineering/approximation-budget.md"', self.script)
+        self.assertIn('changed_path_has_prefix "scripts/check_approximation_budget.py"', self.script)
+        self.assertIn("run_approximation_budget_if_needed()", self.script)
+        self.assertIn(
+            "run_logged approximation-budget bash scripts/run_approximation_budget_suite.sh",
+            self.script,
+        )
+        self.assertGreaterEqual(
+            len(re.findall(r"run_approximation_budget_if_needed", self.script)),
+            4,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_local_merge_gate_wiring.py
+++ b/scripts/tests/test_local_merge_gate_wiring.py
@@ -16,17 +16,46 @@ class LocalMergeGateWiringTests(unittest.TestCase):
 
     def test_paper_preflight_surface_is_conditionally_wired(self) -> None:
         self.assertIn("changed_path_is_paper_preflight_surface()", self.script)
-        self.assertIn('changed_path_has_prefix "docs/paper/"', self.script)
-        self.assertIn('changed_path_has_prefix "docs/engineering/paper2-claim-evidence.yml"', self.script)
-        self.assertIn('changed_path_has_prefix "docs/engineering/paper3-claim-evidence.yml"', self.script)
+        expected_triggers = [
+            "docs/paper/",
+            "docs/engineering/",
+            "src/",
+            "spec/",
+            "tools/reference_verifier/",
+            "fuzz/fuzz_targets/",
+            "scripts/generate_bad_phase37_artifacts.py",
+            "scripts/run_formal_contract_suite.sh",
+            "scripts/run_fuzz_smoke_suite.sh",
+            "scripts/run_mutation_survivor_tracking_suite.sh",
+            "scripts/run_phase37_mutation_generator_suite.sh",
+            "scripts/run_reference_verifier_suite.sh",
+            "docs/engineering/paper2-claim-evidence.yml",
+            "docs/engineering/paper3-claim-evidence.yml",
+            "scripts/paper/",
+            "scripts/run_paper_preflight_suite.sh",
+            "scripts/local_merge_gate.sh",
+        ]
+        for trigger in expected_triggers:
+            with self.subTest(trigger=trigger):
+                self.assertIn(f'changed_path_has_prefix "{trigger}"', self.script)
         self.assertIn("run_paper_preflight_if_needed()", self.script)
         self.assertIn("run_logged paper-preflight bash scripts/run_paper_preflight_suite.sh", self.script)
         self.assertGreaterEqual(len(re.findall(r"run_paper_preflight_if_needed", self.script)), 4)
 
     def test_approximation_budget_surface_is_conditionally_wired(self) -> None:
         self.assertIn("changed_path_is_approximation_budget_surface()", self.script)
-        self.assertIn('changed_path_has_prefix "docs/engineering/approximation-budget.md"', self.script)
-        self.assertIn('changed_path_has_prefix "scripts/check_approximation_budget.py"', self.script)
+        expected_triggers = [
+            "docs/engineering/approximation-budget.md",
+            "scripts/check_approximation_budget.py",
+            "scripts/tests/test_check_approximation_budget.py",
+            "scripts/run_approximation_budget_suite.sh",
+            "tests/fixtures/reference_cases/toy_approximation_budget_bundle.json",
+            "tests/fixtures/reference_cases/toy_approximation_budget_negative_bundle.json",
+            "scripts/local_merge_gate.sh",
+        ]
+        for trigger in expected_triggers:
+            with self.subTest(trigger=trigger):
+                self.assertIn(f'changed_path_has_prefix "{trigger}"', self.script)
         self.assertIn("run_approximation_budget_if_needed()", self.script)
         self.assertIn(
             "run_logged approximation-budget bash scripts/run_approximation_budget_suite.sh",


### PR DESCRIPTION
## Summary

Part of #161. This fills the local-gate wiring gap in the breakthrough evidence plan.

- add paper preflight suite wrapper for paper claim/evidence matrices
- add approximation-budget suite wrapper with positive and negative controls
- wire both suites into smoke/full/hardening local merge-gate modes when their evidence surfaces change
- document the new local evidence gates

## Local evidence

- scripts/run_approximation_budget_suite.sh
- scripts/run_paper_preflight_suite.sh
- python3 -B -m unittest scripts/tests/test_local_merge_gate_wiring.py -q
- python3 -B -m unittest discover -s scripts/tests -q
- scripts/run_shellcheck_suite.sh
- cargo fmt --check
- git diff --check
- cargo test -q --lib statement_spec_contract_is_synced_with_constants

GitHub Actions are intentionally skipped; local merge gate evidence is required before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paper preflight and approximation‑budget validation suites to local validation; they run conditionally when related files change and are included in smoke, full, and hardening local modes.

* **Documentation**
  * Updated hardening policy to enumerate these suites and their conditional inclusion in "full" and "hardening" tiers.

* **Tests**
  * Added wiring tests to verify the local gate conditionally triggers the new suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->