### PR TITLE
[codex] Refresh publication freeze package

### DIFF
--- a/docs/paper/PUBLICATION_RELEASE.md
+++ b/docs/paper/PUBLICATION_RELEASE.md
@@ -1,11 +1,11 @@
 # Publication Release Package
 
-Snapshot date: **April 20, 2026**
+Snapshot date: **April 24, 2026**
 
-Planned publication tag after repository transfer: `paper-publication-v5-2026-04-20`
+Planned publication tag after repository transfer: `paper-publication-v6-2026-04-24`
 
-Canonical publication snapshot after transfer: The canonical v5 publication snapshot is
-the release tag `paper-publication-v5-2026-04-20` once cut in the final publication
+Canonical publication snapshot after transfer: The canonical v6 publication snapshot is
+the release tag `paper-publication-v6-2026-04-24` once cut in the final publication
 repository. Until that transfer and tag cut happen, the paper keeps Reference `[30]`
 pointed at the staging commit-pinned snapshot below. The final publication tag
 intentionally need not match the pinned carried-state evidence commit used by the
@@ -52,11 +52,19 @@ one monolithic benchmark claim.
   - `docs/paper/figures/section4-ratio-vs-context.tsv`
   - `docs/paper/figures/section4-decomposition-vs-context.tsv`
   - `docs/paper/figures/section5-carried-state-ladder.svg`
+  - `docs/paper/figures/stwo-phase44d-source-emission-2026-04.svg`
+  - `docs/paper/figures/stwo-phase71-handoff-receipt-2026-04.svg`
   - `scripts/paper/generate_section4_ratio_figure.py`
   - `scripts/paper/generate_section4_decomposition_figure.py`
+  - `scripts/paper/generate_stwo_phase44d_source_emission_benchmark.sh`
+  - `scripts/paper/generate_stwo_phase44d_source_emission_figure.py`
+  - `scripts/paper/generate_stwo_phase71_handoff_receipt_benchmark.sh`
+  - `scripts/paper/generate_stwo_phase71_handoff_receipt_figure.py`
 - External evidence snapshots:
   - `docs/paper/evidence/web-2026-04-06/`
   - `docs/paper/evidence/gemma-config-snapshots/`
+  - `docs/paper/evidence/published-zkml-numbers-2026-04.tsv`
+  - `docs/paper/evidence/published-zkml-calibration-note-2026-04-24.md`
 
 ## Claim posture
 
@@ -70,6 +78,13 @@ one monolithic benchmark claim.
 - The April 21 `stwo-transformer-shaped-v1` bundle freezes one reproducible
   transformer-shaped `stwo` artifact with `28s` prepare, `9s` verify, `9,348,044`
   artifact bytes, a five-step source chain, and two translated segment manifests.
+- The April 24 evidence set adds two higher-layer verifier-bound calibration rows:
+  a Phase44D typed source-emission boundary that wins on local verification latency
+  but not serialized bytes, and a Phase71 handoff receipt that wins on serialized
+  surface but not on verification time.
+- The April 24 literature-facing calibration snapshot now records three distinct
+  local regimes rather than one catch-all internal row: the Phase12 proving bundle,
+  the Phase44D typed-boundary latency row, and the Phase71 handoff-receipt size row.
 - Older carried-state artifact bundles are retained as archival provenance; see
   `docs/paper/artifacts/README.md`. The proof-carrying aggregation bundle is the
   publication-facing artifact bundle for the carried-state aggregation line.
@@ -99,6 +114,9 @@ one monolithic benchmark claim.
   - `python3 scripts/paper/extract_gemma_config_snapshots.py`
 - Paper preflight checks:
   - `python3 scripts/paper/paper_preflight.py --repo-root .`
+- Higher-layer benchmark evidence:
+  - `BENCH_RUNS=5 CAPTURE_TIMINGS=1 ALLOW_HOST_DEPENDENT_OUTPUTS=1 PNG_OUT= PDF_OUT= ./scripts/paper/generate_stwo_phase44d_source_emission_benchmark.sh`
+  - `BENCH_RUNS=5 CAPTURE_TIMINGS=1 ALLOW_HOST_DEPENDENT_OUTPUTS=1 PNG_OUT= PDF_OUT= ./scripts/paper/generate_stwo_phase71_handoff_receipt_benchmark.sh`
 
 ## Publication check
 
@@ -109,9 +127,9 @@ Before cutting a release tag, verify:
 2. the main paper and appendices refer to the same repo state and evidence tiers,
 3. the design note matches the current experimental `stwo` status,
 4. no stale top-level README language still describes S-two as merely prospective,
-5. Reference `[30]` remains commit-pinned until the repository transfer and v5
+5. Reference `[30]` remains commit-pinned until the repository transfer and v6
    publication tag exist; after that tag is cut in the final publication repository,
-   update `[30]` to the v5 publication tag while keeping the aggregation bundle directly
+   update `[30]` to the v6 publication tag while keeping the aggregation bundle directly
    pinned by Reference `[46]`,
 6. the formal author line and affiliation text are confirmed before public release,
 7. `paper preflight` passes (citation integrity, immutable local repo links, figure/link

--- a/docs/paper/PUBLICATION_RELEASE.md
+++ b/docs/paper/PUBLICATION_RELEASE.md
@@ -115,8 +115,10 @@ one monolithic benchmark claim.
 - Paper preflight checks:
   - `python3 scripts/paper/paper_preflight.py --repo-root .`
 - Higher-layer benchmark evidence:
-  - `BENCH_RUNS=5 CAPTURE_TIMINGS=1 ALLOW_HOST_DEPENDENT_OUTPUTS=1 PNG_OUT= PDF_OUT= ./scripts/paper/generate_stwo_phase44d_source_emission_benchmark.sh`
-  - `BENCH_RUNS=5 CAPTURE_TIMINGS=1 ALLOW_HOST_DEPENDENT_OUTPUTS=1 PNG_OUT= PDF_OUT= ./scripts/paper/generate_stwo_phase71_handoff_receipt_benchmark.sh`
+  - `mkdir -p ./out/paper-bench`
+  - `BENCH_RUNS=5 CAPTURE_TIMINGS=1 TSV_OUT=./out/paper-bench/stwo-phase44d-source-emission-2026-04.tsv JSON_OUT=./out/paper-bench/stwo-phase44d-source-emission-2026-04.json SVG_OUT=./out/paper-bench/stwo-phase44d-source-emission-2026-04.svg PNG_OUT= PDF_OUT= ./scripts/paper/generate_stwo_phase44d_source_emission_benchmark.sh`
+  - `BENCH_RUNS=5 CAPTURE_TIMINGS=1 TSV_OUT=./out/paper-bench/stwo-phase71-handoff-receipt-2026-04.tsv JSON_OUT=./out/paper-bench/stwo-phase71-handoff-receipt-2026-04.json SVG_OUT=./out/paper-bench/stwo-phase71-handoff-receipt-2026-04.svg PNG_OUT= PDF_OUT= ./scripts/paper/generate_stwo_phase71_handoff_receipt_benchmark.sh`
+  - `ALLOW_HOST_DEPENDENT_OUTPUTS` stays unset here on purpose so scratch captures cannot overwrite the frozen tracked evidence under `docs/paper/`.
 
 ## Publication check
 

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -25,6 +25,16 @@ Current paper-freeze addendum:
 - `artifacts/phase66-69-proof-carrying-hardening-v1-2026-04-21/`
 - `artifacts/phase70-80-proof-checked-decode-bridge-v1-2026-04-21/`
 - `artifacts/stwo-transformer-shaped-v1-2026-04-21/`
+- `figures/stwo-phase44d-source-emission-2026-04.svg`
+- `figures/stwo-phase71-handoff-receipt-2026-04.svg`
+- `evidence/stwo-phase44d-source-emission-2026-04.tsv`
+- `evidence/stwo-phase71-handoff-receipt-2026-04.tsv`
+- `evidence/published-zkml-numbers-2026-04.tsv`
+- `evidence/published-zkml-calibration-note-2026-04-24.md`
+
+This April 24 freeze extends the earlier carried-state publication package with the
+two higher-layer verifier-bound reuse calibrations and the refreshed workload-scope
+external calibration snapshot.
 
 Later bridge work remains implemented in-repo but is not yet part of the frozen
 publication-facing artifact bundle:

--- a/docs/paper/stark-transformer-alignment-2026.md
+++ b/docs/paper/stark-transformer-alignment-2026.md
@@ -339,17 +339,19 @@ symbolic model was trying to isolate: once one canonical table identity is made
 verifier-visible across repeated steps, proof growth can flatten sharply instead of
 scaling with the number of independent envelopes.
 
-Read together, Figures 3, 4, and 4B give the external-calibration boundary the paper
-should actually claim. Figure 3 is the honest one-shot anchor: on tiny isolated
+Read together, Figures 3, 4, 4B, 4E, and 4F give the external-calibration boundary the
+paper should actually claim. Figure 3 is the honest one-shot anchor: on tiny isolated
 primitive proofs, the current lookup-backed paths are still somewhat larger and slower
 than the arithmetic baselines. Figure 4 is the reuse-sensitive single-table anchor:
 once the verifier-visible statement carries one canonical table identity across repeated
 rows, the shared-table path can flatten sharply while the independent baselines
 continue to scale with `N`. Figure 4B shows that the same reuse-sensitive behavior
-survives in a verifier-bound two-table bundle. External comparisons should therefore
-track regime, not backend branding. The one-shot rows calibrate current implementation
-constants; the repeated-step rows calibrate the architectural claim about carried
-lookup identity.
+survives in a verifier-bound two-table bundle. Figures 4E and 4F then sharpen the
+higher-layer story: the typed Phase44D boundary helps local verification latency, while
+the Phase71 handoff receipt helps serialized handoff size. External comparisons should
+therefore track regime, not backend branding. The one-shot rows calibrate current
+implementation constants; the repeated-step rows calibrate the architectural claim about
+carried lookup identity and higher-layer packaging tradeoffs.
 
 ### 4.5 Inference layer versus settlement layer
 


### PR DESCRIPTION
## What changed
- updated `docs/paper/PUBLICATION_RELEASE.md` to the April 24 package snapshot
- updated `docs/paper/README.md` to list the new higher-layer figures/evidence and external calibration snapshot
- tightened one paper summary paragraph so the publication package narrative matches the new higher-layer split

## Why it changed
The repo had already accumulated the higher-layer benchmark and calibration work, but the formal publication package still described the older April 20 surface. This PR refreshes the release-facing documentation so the frozen package and tag language match the actual paper evidence set now on the stack.

## Publication impact
- snapshot date advanced to April 24, 2026
- planned publication tag advanced to `paper-publication-v6-2026-04-24`
- release package now explicitly includes the Phase44D / Phase71 figures and the refreshed calibration note

## Validation
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `/Users/espejelomar/.local/bin/python3.10 -m unittest scripts.paper.tests.test_paper_preflight`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Publication package updated to version 6 (April 24, 2026 snapshot)
  * Added new figure assets and benchmark evidence files, including published zkML numbers and a calibration note
  * Expanded calibration narrative to include additional figures and higher-layer verifier-bound calibrations linking latency and serialized-size observations
  * Added a higher-layer benchmark evidence workflow and updated the publication check to retarget Reference [30] to v6
<!-- end of auto-generated comment: release notes by coderabbit.ai -->