### PR TITLE
[codex] Trace Phase12 overflow provenance

### DIFF
--- a/docs/engineering/phase44d-overflow-provenance-2026-04-24.md
+++ b/docs/engineering/phase44d-overflow-provenance-2026-04-24.md
@@ -1,0 +1,133 @@
+# Phase44D Overflow Provenance
+
+Date: 2026-04-24
+
+## Scope
+
+This note records the bounded overflow-provenance spike that followed the
+Phase44D source-emission scaling attempt.
+
+Goal:
+
+1. Identify the first concrete carry-producing operation in the `4`-step
+   Phase12 source chain used by the Phase44D benchmark.
+2. Prove whether the failure is a compiled-model artifact or part of the
+   native VM semantics.
+3. Decide whether the next move is a local patch or a new core-proving lane.
+
+## Result
+
+The `4`-step failure is a real arithmetic overflow in the active Phase12
+program, not a Phase44D boundary bug and not a compare/branch carry artifact.
+
+The first carry-bearing transition is:
+
+| Field | Value |
+|---|---|
+| Seed step index | `3` (the fourth seed in `phase12_demo_initial_memories_for_steps`) |
+| Runtime step | `45` |
+| Instruction | `MulMemory(28)` |
+| State before `acc` | `1373` |
+| Memory cell `28` | `64` |
+| Raw accumulator | `87872` |
+| Wrapped `i16` accumulator | `22336` |
+| Carry after step | `true` |
+
+This was captured by the new checked tests in
+`/Users/espejelomar/StarkNet/zk-ai/_pr_work/overflow-provenance-v1/src/stwo_backend/decoding.rs`.
+
+## Why this happens
+
+For the default Phase12 layout:
+
+- `output_range = 24..27`
+- `lookup_range = 27..35`
+- `lookup[1] = 64`
+
+The first failing instruction is the lookup-scaling multiply in the Phase12
+template:
+
+- `LOAD output[0]`
+- `MUL lookup[1]`
+
+So the first carry does **not** come from the initial dot-product build-up.
+It comes from the later lookup-backed scaling tail of the program, after
+`output[0]` has already reached `1373`.
+
+The next multiply in the same tail is even larger:
+
+- `output[1] = 1413`
+- `lookup[5] = 128`
+- inferred raw product: `180864`
+
+This second number is an inference from the checked runtime snapshot plus the
+template program order; it is not needed to explain the first failure, but it
+does show that the first overflow is not an isolated one-off.
+
+## Why this is not a one-line proof patch
+
+The active proof surface rejects carry-bearing traces in two places:
+
+1. `src/proof.rs` rejects any execution whose runtime trace contains
+   `carry_flag = true`.
+2. `src/stwo_backend/arithmetic_subset_prover.rs` also rejects any row whose
+   public state carries `carry_flag = true`.
+
+So removing the precheck in `src/proof.rs` would not unblock the `4`-step
+Phase44D path. The current arithmetic-subset proving surface itself still
+assumes carry-free traces.
+
+## Native vs compiled model
+
+The new regression tests show that:
+
+- the native interpreter and
+- the compiled execution runtime
+
+agree on the first overflowing step and on the raw arithmetic that produces it.
+
+That means the failure is part of the current VM semantics on this workload,
+not just a compiled-model mismatch.
+
+## Decision
+
+For the current paper:
+
+- keep the existing honest statement:
+  - Phase44D is verified at `2` steps
+  - `4+` is blocked by the current execution-proof surface
+- do **not** hold publication for this
+
+For future research:
+
+- a cheap local workaround would be to rescale or refactor the Phase12
+  lookup-scaling tail so it stays inside the `i16` accumulator budget
+  for the benchmarked seeds
+- the stronger research lane is different:
+  - widen the execution arithmetic surface or
+  - introduce a carry-aware / limb-aware proving surface
+
+That stronger lane is a real proving project, not a benchmark tweak.
+
+## Practical next step
+
+If this lane is opened, keep it bounded:
+
+1. Prototype one local arithmetic-widening or carry-aware design.
+2. Require it to prove the `4`-step default Phase12 seed honestly.
+3. Stop if it cannot do that without destabilizing the active proof surface.
+
+## Reproduction
+
+Targeted checks:
+
+```bash
+CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/llm-provable-computer-codex/target \
+cargo +nightly-2025-07-14 test --features stwo-backend --lib phase12_four_step_ -- --nocapture
+```
+
+These tests now cover:
+
+- exact first-overflow provenance
+- native-vs-compiled agreement on the first carry-bearing step
+- direct proof-surface rejection of the first overflowing seed

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -14074,11 +14074,13 @@ mod kani_phase30_proofs {
 mod tests {
     use super::*;
     use crate::config::Attention2DMode;
+    use crate::engine::ExecutionTraceEntry;
     use crate::interpreter::NativeInterpreter;
     use crate::proof::{
         production_v1_stark_options, prove_execution_stark_with_backend_and_options,
         ExecutionClaimCommitments, VanillaStarkExecutionClaim,
     };
+    use crate::runtime::ExecutionRuntime;
     use crate::state::MachineState;
     use crate::stwo_backend::lookup_component::Phase3LookupTableRow;
     use crate::stwo_backend::shared_lookup_artifact::{
@@ -14094,6 +14096,13 @@ mod tests {
     use proptest::prelude::*;
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use std::sync::OnceLock;
+
+    #[derive(Debug, Clone)]
+    struct Phase12ExecutionCarryProvenance {
+        seed_step_index: usize,
+        event: ExecutionTraceEntry,
+        raw_acc: i64,
+    }
 
     fn sample_commitments() -> ExecutionClaimCommitments {
         ExecutionClaimCommitments {
@@ -14175,6 +14184,98 @@ mod tests {
                 commitments: Some(sample_commitments()),
             },
             proof: sample_phase12_proof_payload(layout, &final_memory),
+        }
+    }
+
+    fn phase12_first_execution_carry_for_steps(
+        layout: &Phase12DecodingLayout,
+        total_steps: usize,
+    ) -> Phase12ExecutionCarryProvenance {
+        let config = TransformerVmConfig {
+            num_layers: 1,
+            attention_mode: Attention2DMode::AverageHard,
+            ..TransformerVmConfig::default()
+        };
+
+        for (seed_step_index, initial_memory) in
+            phase12_demo_initial_memories_for_steps(layout, total_steps)
+                .expect("demo memories")
+                .into_iter()
+                .enumerate()
+        {
+            let program = decoding_step_v2_program_with_initial_memory(layout, initial_memory)
+                .expect("program");
+            let step_limit = decoding_program_step_limit(&program).expect("step limit");
+            let model = ProgramCompiler
+                .compile_program(program, config.clone())
+                .expect("compile");
+            let mut runtime = ExecutionRuntime::new(model, step_limit);
+            let result = runtime.run().expect("runtime run");
+            assert!(result.halted, "compiled Phase12 demo runtime should halt");
+
+            if let Some(event) = runtime
+                .events()
+                .iter()
+                .find(|event| event.state_after.carry_flag)
+                .cloned()
+            {
+                return Phase12ExecutionCarryProvenance {
+                    seed_step_index,
+                    raw_acc: phase12_execution_event_raw_acc(&event),
+                    event,
+                };
+            }
+        }
+
+        panic!("expected a carry-bearing execution event");
+    }
+
+    fn phase12_execution_event_raw_acc(event: &ExecutionTraceEntry) -> i64 {
+        match event.instruction {
+            Instruction::LoadImmediate(value) => i64::from(value),
+            Instruction::Load(address) => i64::from(event.state_before.memory[usize::from(address)]),
+            Instruction::Pop => i64::from(event.state_before.memory[usize::from(event.state_before.sp)]),
+            Instruction::AddImmediate(value) => {
+                i64::from(event.state_before.acc) + i64::from(value)
+            }
+            Instruction::AddMemory(address) => {
+                i64::from(event.state_before.acc)
+                    + i64::from(event.state_before.memory[usize::from(address)])
+            }
+            Instruction::SubImmediate(value) => {
+                i64::from(event.state_before.acc) - i64::from(value)
+            }
+            Instruction::SubMemory(address) => {
+                i64::from(event.state_before.acc)
+                    - i64::from(event.state_before.memory[usize::from(address)])
+            }
+            Instruction::MulImmediate(value) => {
+                i64::from(event.state_before.acc) * i64::from(value)
+            }
+            Instruction::MulMemory(address) => {
+                i64::from(event.state_before.acc)
+                    * i64::from(event.state_before.memory[usize::from(address)])
+            }
+            Instruction::AndImmediate(value) => i64::from(event.state_before.acc & value),
+            Instruction::AndMemory(address) => {
+                i64::from(event.state_before.acc & event.state_before.memory[usize::from(address)])
+            }
+            Instruction::OrImmediate(value) => i64::from(event.state_before.acc | value),
+            Instruction::OrMemory(address) => {
+                i64::from(event.state_before.acc | event.state_before.memory[usize::from(address)])
+            }
+            Instruction::XorImmediate(value) => i64::from(event.state_before.acc ^ value),
+            Instruction::XorMemory(address) => {
+                i64::from(event.state_before.acc ^ event.state_before.memory[usize::from(address)])
+            }
+            Instruction::CmpImmediate(value) => {
+                i64::from(event.state_before.acc) - i64::from(value)
+            }
+            Instruction::CmpMemory(address) => {
+                i64::from(event.state_before.acc)
+                    - i64::from(event.state_before.memory[usize::from(address)])
+            }
+            _ => i64::from(event.state_after.acc),
         }
     }
 
@@ -19090,6 +19191,116 @@ mod tests {
                 )
             });
         }
+    }
+
+    #[test]
+    fn phase12_four_step_execution_carry_provenance_is_lookup_scaling_overflow() {
+        let layout = phase12_default_decoding_layout();
+        let provenance = phase12_first_execution_carry_for_steps(&layout, 4);
+
+        assert_eq!(provenance.seed_step_index, 3);
+        assert_eq!(provenance.event.step, 45);
+        assert_eq!(provenance.event.layer_idx, Some(0));
+        assert_eq!(provenance.event.instruction, Instruction::MulMemory(28));
+        assert_eq!(provenance.event.state_before.pc, 44);
+        assert_eq!(provenance.event.state_before.acc, 1373);
+        assert_eq!(provenance.event.state_before.memory[28], 64);
+        assert!(!provenance.event.state_before.carry_flag);
+        assert_eq!(provenance.raw_acc, 87_872);
+        assert_eq!(provenance.event.state_after.acc, 22_336);
+        assert!(provenance.event.state_after.carry_flag);
+    }
+
+    #[test]
+    fn phase12_four_step_native_and_compiled_runtimes_agree_on_first_overflowing_step() {
+        let layout = phase12_default_decoding_layout();
+        let initial_memory = phase12_demo_initial_memories_for_steps(&layout, 4)
+            .expect("memories")
+            .into_iter()
+            .nth(3)
+            .expect("fourth memory");
+        let program = decoding_step_v2_program_with_initial_memory(&layout, initial_memory)
+            .expect("program");
+        let step_limit = decoding_program_step_limit(&program).expect("step limit");
+        let mut native = NativeInterpreter::new(
+            program.clone(),
+            Attention2DMode::AverageHard,
+            step_limit,
+        );
+        let native_result = native.run().expect("native run");
+        assert!(native_result.halted);
+        let native_event = native
+            .events()
+            .iter()
+            .find(|event| event.state_after.carry_flag)
+            .expect("native carry event");
+
+        let config = TransformerVmConfig {
+            num_layers: 1,
+            attention_mode: Attention2DMode::AverageHard,
+            ..TransformerVmConfig::default()
+        };
+        let model = ProgramCompiler
+            .compile_program(program, config)
+            .expect("compile");
+        let mut runtime = ExecutionRuntime::new(model, step_limit);
+        let runtime_result = runtime.run().expect("compiled run");
+        assert!(runtime_result.halted);
+        let runtime_event = runtime
+            .events()
+            .iter()
+            .find(|event| event.state_after.carry_flag)
+            .expect("compiled carry event");
+
+        assert_eq!(native_event.step, 45);
+        assert_eq!(native_event.instruction, Instruction::MulMemory(28));
+        assert_eq!(native_event.state_before.acc, 1373);
+        assert_eq!(native_event.state_before.memory[28], 64);
+        assert_eq!(native_event.state_after.acc, 22_336);
+        assert!(native_event.state_after.carry_flag);
+
+        assert_eq!(runtime_event.step, native_event.step);
+        assert_eq!(runtime_event.instruction, native_event.instruction);
+        assert_eq!(runtime_event.state_before.acc, native_event.state_before.acc);
+        assert_eq!(runtime_event.state_before.memory[28], native_event.state_before.memory[28]);
+        assert_eq!(runtime_event.state_after.acc, native_event.state_after.acc);
+        assert_eq!(
+            phase12_execution_event_raw_acc(runtime_event),
+            phase12_execution_event_raw_acc(native_event)
+        );
+    }
+
+    #[test]
+    fn phase12_four_step_first_overflowing_seed_is_rejected_by_execution_proof_surface() {
+        let layout = phase12_default_decoding_layout();
+        let initial_memory = phase12_demo_initial_memories_for_steps(&layout, 4)
+            .expect("memories")
+            .into_iter()
+            .nth(3)
+            .expect("fourth memory");
+        let program = decoding_step_v2_program_with_initial_memory(&layout, initial_memory)
+            .expect("program");
+        let model = ProgramCompiler
+            .compile_program(
+                program,
+                TransformerVmConfig {
+                    num_layers: 1,
+                    attention_mode: Attention2DMode::AverageHard,
+                    ..TransformerVmConfig::default()
+                },
+            )
+            .expect("compile");
+
+        let error = prove_execution_stark_with_backend_and_options(
+            &model,
+            128,
+            StarkProofBackend::Stwo,
+            production_v1_stark_options(),
+        )
+        .expect_err("4-step seed should hit the carry/overflow guard before proving");
+        assert!(error
+            .to_string()
+            .contains("overflowing arithmetic is not supported by the current execution-proof surface"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add checked Phase12 overflow-provenance regressions for the 4-step Phase44D source-chain barrier
- prove the first carry-bearing transition is a real arithmetic overflow in the Phase12 lookup-scaling tail
- record the bounded spike result and the local-vs-core-fix decision in an engineering note

## What changed
- add a provenance helper in `src/stwo_backend/decoding.rs` tests to locate the first compiled-runtime carry-bearing event
- assert the exact first overflowing transition: fourth seed, runtime step 45, `MulMemory(28)`, raw accumulator `87872`
- assert native and compiled runtimes agree on the first overflowing step
- assert the first overflowing seed is rejected directly by the current execution-proof surface
- add `docs/engineering/phase44d-overflow-provenance-2026-04-24.md`

## Why this matters
The previous Phase44D scaling attempt showed that `2` steps works and `4+` fails, but it did not identify the concrete failing operation. This PR closes that gap. It also shows the issue is deeper than the top-level guard in `src/proof.rs`: the active arithmetic-subset surface still assumes carry-free traces.

## Validation
- `CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/llm-provable-computer-codex/target cargo +nightly-2025-07-14 test --features stwo-backend --lib phase12_four_step_ -- --nocapture`
- `CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/llm-provable-computer-codex/target cargo +nightly-2025-07-14 test --features stwo-backend --lib phase44d_source_emission_benchmark_surfaces_execution_proof_overflow_at_four_steps -- --nocapture`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added engineering documentation detailing findings on arithmetic overflow behavior in Phase12 programs, including investigation outcomes and next steps.

* **Tests**
  * Enhanced test coverage for overflow scenarios, including validation that runtime systems correctly identify and reject arithmetic overflow conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->