### PR TITLE
Harden carry-aware soundness review checks

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -24,6 +24,9 @@ The active split is now:
 - Gate 1: the honest default `4`-step Phase12 seed now proves and verifies on the experimental backend.
 - Gate 2: the honest default `8`-step Phase12 family clears on the same backend.
 - Gate 2b: the concrete `wrap_delta` range gap is closed at the AIR layer with bit-decomposed magnitude, sign, square, and ADD/SUB unit-range constraints.
+- Gate 2c: the focused April 25 review adds negative AIR tests for
+  `wrap_delta_abs_bits`, `wrap_delta_sign`, and `wrap_delta_square` witness
+  drift.
 - Gate 3: the experimental Phase44D typed-boundary reuse sweep clears `2,4,8,16,32,64,128,256,512,1024`.
 
 At `1024` steps, the experimental shared path records:
@@ -46,8 +49,9 @@ Use these in order of authority for current state:
 4. `docs/engineering/codex-repo-handoff-2026-04-24.md`
 5. `docs/engineering/phase12-carry-aware-arithmetic-subset-gate-2026-04-24.md`
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
-7. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-8. `docs/engineering/reproducibility.md`
+7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
+8. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+9. `docs/engineering/reproducibility.md`
 
 ## Merge culture
 
@@ -66,9 +70,12 @@ Use these in order of authority for current state:
 
 ## Next sensible moves
 
-1. Raise the experimental Phase43/Phase44D ceiling beyond `1024`.
-2. Broaden review of the experimental backend before making any promotion decisions.
-3. Only after those steps decide whether any part of the experimental lane should be promoted toward the paper/publication surface.
+1. Continue broadening review of the experimental backend beyond the focused
+   `wrap_delta` witness-binding increment.
+2. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after
+   review changes stay clean.
+3. Only after those steps decide whether any part of the experimental lane
+   should be promoted toward the paper/publication surface.
 
 ## Resume protocol
 

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -10,9 +10,10 @@ This is the fast local entrypoint for a fresh agent working in this repository.
 4. `docs/engineering/codex-repo-handoff-2026-04-24.md`
 5. `docs/engineering/phase12-carry-aware-arithmetic-subset-gate-2026-04-24.md`
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
-7. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-8. `docs/engineering/reproducibility.md`
-8. `git status --short --branch`
+7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
+8. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+9. `docs/engineering/reproducibility.md`
+10. `git status --short --branch`
 
 ## What this repository is now
 
@@ -39,9 +40,12 @@ The experimental carry-aware lane now has one real higher-layer scaling result:
 
 ## Next likely technical steps
 
-1. Raise the Phase43/Phase44D experimental ceiling beyond `1024`.
-2. Keep the experimental backend isolated from the default/publication lane until it survives broader review.
-3. Only then decide whether any piece of the experimental lane is mature enough for explicit promotion work.
+1. Continue broadening the experimental backend review beyond the focused
+   `wrap_delta` witness-binding checks.
+2. Raise the Phase43/Phase44D experimental ceiling beyond `1024` only after
+   review changes stay clean.
+3. Keep the experimental backend isolated from the default/publication lane
+   until a deliberate promotion pass.
 
 ## What not to do
 
@@ -57,5 +61,6 @@ git status --short --branch
 git rev-parse HEAD
 git rev-parse origin/main
 sed -n '1,220p' docs/engineering/phase12-carry-aware-arithmetic-subset-gate-2026-04-24.md
+sed -n '1,220p' docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
 sed -n '1,260p' docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md
 ```

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -12,9 +12,10 @@ If you are in a local checkout, prefer `AGENTS.md`, `.codex/START_HERE.md`, and
 4. `docs/engineering/codex-repo-handoff-2026-04-24.md`
 5. `docs/engineering/phase12-carry-aware-arithmetic-subset-gate-2026-04-24.md`
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
-7. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-8. `docs/engineering/reproducibility.md`
-8. `git status --short --branch`
+7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
+8. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+9. `docs/engineering/reproducibility.md`
+10. `git status --short --branch`
 
 ## Current lane split
 
@@ -30,6 +31,9 @@ This repository now has two live lanes.
 
 - Backend version: `stwo-phase12-decoding-family-v10-carry-aware-experimental`
 - The honest default `4`-step seed and honest `8`-step family clear on this backend.
+- The focused April 25 soundness-review increment adds negative AIR tests for
+  `wrap_delta_abs_bits`, `wrap_delta_sign`, and `wrap_delta_square` witness
+  drift.
 - The experimental Phase44D typed-boundary sweep clears `2,4,8,16,32,64,128,256,512,1024`.
 - At `1024` steps, the experimental shared path records `427.209 ms` verification versus
   `133430.237 ms` for the Phase30 replay baseline, with `156,614` bytes versus `1,464,721` bytes.
@@ -56,6 +60,8 @@ verified. Do not describe it as a faster FRI or cryptographic verifier.
 
 ## Next sensible moves
 
-1. Raise the experimental Phase43/Phase44D ceiling beyond `1024`.
-2. Broaden review of the experimental backend before making any promotion decision.
+1. Continue broadening review of the experimental backend beyond the focused
+   `wrap_delta` witness-binding increment.
+2. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after
+   review changes stay clean.
 3. Only after those steps decide whether any part of the experimental lane should be promoted toward the paper/publication surface.

--- a/docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md
+++ b/docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md
@@ -62,6 +62,23 @@ The hardening adds tests for the two concrete misuse classes:
 Existing tamper tests also cover proof payload bytes, canonical preprocessing,
 shared lookup scope, and false host-side carry construction.
 
+The follow-up review increment on April 25 adds three narrower AIR witness
+binding tests:
+
+1. `carry_aware_air_rejects_wrap_delta_abs_bit_reconstruction_drift`
+   - mutates the absolute-value bit decomposition while leaving the rest of the
+     row committed
+
+2. `carry_aware_air_rejects_wrap_delta_sign_drift`
+   - mutates the sign witness on a non-zero carry row
+
+3. `carry_aware_air_rejects_wrap_delta_square_drift`
+   - mutates the square witness on a non-zero carry row
+
+4. `phase44d_source_emission_experimental_carry_aware_benchmark_rejects_tampered_compact_proof`
+   - mutates the compact Phase43 proof bytes after building a Phase44D input
+     from the experimental carry-aware Phase12 chain
+
 ## Important Caveat
 
 This closes the known `wrap_delta` range gap. It does not promote the

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -1,0 +1,128 @@
+# Phase12 Carry-Aware Soundness Review Increment (April 25, 2026)
+
+## Decision
+
+**GREEN for the focused witness-binding increment.**
+
+This review did not promote the experimental carry-aware backend into the
+publication/default lane. It narrowed the remaining review surface after the
+April 24 `wrap_delta` hardening and added regression tests for the witness
+bindings that would be easy to weaken accidentally.
+
+## Scope
+
+- Backend:
+  `stwo-phase12-decoding-family-v10-carry-aware-experimental`
+- Main files reviewed:
+  - `src/stwo_backend/arithmetic_subset_prover.rs`
+  - `src/stwo_backend/decoding.rs`
+  - `src/proof.rs`
+- Claim boundary:
+  experimental engineering lane only
+
+## What Was Rechecked
+
+### 1. `wrap_delta` range binding
+
+The AIR now constrains the carry witness through:
+
+- boolean decomposition of `wrap_delta_abs_bits`
+- reconstruction of `wrap_delta_abs`
+- signed reconstruction of `wrap_delta`
+- `wrap_delta_square = wrap_delta^2`
+- `abs(wrap_delta) <= 2^14`
+- ADD/SUB unit-range enforcement through
+  `wrap_delta_square == next_carry_active`
+
+The earlier field-only relation:
+
+```text
+raw_acc - next_acc = wrap_delta * 2^16
+```
+
+is no longer the only carry constraint. The witness is range-bound inside the
+AIR, not just in host-side trace construction.
+
+### 2. Higher-layer Phase12 chain routing
+
+`verify_supported_phase12_decoding_step_proof` routes experimental Phase12
+decoding proofs through
+`verify_execution_stark_phase12_carry_aware_experimental_with_reexecution`.
+
+That means a Phase12 decoding chain containing the experimental backend still
+performs:
+
+- backend-version checks
+- statement metadata checks
+- claim/input checks
+- native reexecution against the claimed final state
+- the carry-aware Stwo verifier path
+- equivalence-scope checks
+
+The unsuffixed `verify_phase12_decoding_chain` remains safe-by-default because
+it delegates to `verify_phase12_decoding_chain_with_proof_checks`.
+
+### 3. Default-lane isolation
+
+The default verifier still rejects proofs carrying the experimental backend
+version. This keeps the publication/default lane on the shipped carry-free
+surface until a deliberate promotion pass happens.
+
+## Tests Added
+
+Added focused tamper tests:
+
+1. `carry_aware_air_rejects_wrap_delta_abs_bit_reconstruction_drift`
+   - flips a committed absolute-value bit on an overflow row
+   - expects the AIR reconstruction constraint to reject
+
+2. `carry_aware_air_rejects_wrap_delta_sign_drift`
+   - flips the sign witness on an overflow row
+   - expects the AIR signed-reconstruction constraint to reject
+
+3. `carry_aware_air_rejects_wrap_delta_square_drift`
+   - changes the square witness on an overflow row
+   - expects the AIR square constraint to reject
+
+4. `phase44d_source_emission_experimental_carry_aware_benchmark_rejects_tampered_compact_proof`
+   - builds a Phase44D source-emission benchmark input from the experimental
+     carry-aware Phase12 chain
+   - mutates the compact Phase43 proof bytes
+   - expects the typed Phase44D boundary-plus-compact verification path to
+     reject
+
+These complement the existing tests for out-of-range `wrap_delta`, ADD/SUB
+unit range, proof-payload tampering, backend-version isolation, and reexecution.
+
+## Residual Risks
+
+This increment does not make the experimental backend publication-ready.
+Remaining review items before any promotion decision:
+
+1. Broaden op-pattern coverage beyond the current decoding-step family.
+2. Add more end-to-end tamper tests around serialized experimental execution
+   proofs, not only row-local AIR witness mutations.
+3. Re-run the Phase44D scaling frontier after any material AIR or verifier
+   change.
+4. Keep describing the 1024-step Phase44D result as manifest replay avoidance,
+   not as faster FRI or faster cryptographic verification.
+
+## Validation
+
+Targeted tests:
+
+```bash
+cargo +nightly-2025-07-14 test carry_aware_air_rejects_wrap_delta_abs_bit_reconstruction_drift --features stwo-backend --lib
+cargo +nightly-2025-07-14 test carry_aware_air_rejects_wrap_delta_sign_drift --features stwo-backend --lib
+cargo +nightly-2025-07-14 test carry_aware_air_rejects_wrap_delta_square_drift --features stwo-backend --lib
+cargo +nightly-2025-07-14 test phase44d_source_emission_experimental_carry_aware_benchmark_rejects_tampered_compact_proof --features stwo-backend --lib
+```
+
+Recommended merge gate for this increment:
+
+```bash
+cargo +nightly-2025-07-14 test carry_aware --features stwo-backend
+cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm
+cargo +nightly-2025-07-14 fmt --check
+git diff --check
+```

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -4096,6 +4096,90 @@ mod tests {
         index.reverse_bits() >> (usize::BITS - log_size)
     }
 
+    fn assert_carry_aware_four_step_overflow_trace_mutation_rejected(
+        mutate: impl FnOnce(&CarryAwareTraceLayout, usize, &mut [Vec<BaseField>]),
+        rejection_message: &str,
+    ) {
+        let layout = phase12_default_decoding_layout();
+        let initial_memory = phase12_demo_initial_memories_for_steps(&layout, 4)
+            .expect("memories")
+            .into_iter()
+            .nth(3)
+            .expect("fourth memory");
+        let program =
+            decoding_step_v2_program_with_initial_memory(&layout, initial_memory).expect("program");
+        let mut runtime = NativeInterpreter::new(
+            program.clone(),
+            Attention2DMode::AverageHard,
+            program.instructions().len() + 1,
+        );
+        let result = runtime.run().expect("run");
+        assert!(result.halted);
+        let overflow_index = runtime
+            .trace()
+            .windows(2)
+            .position(|window| {
+                let current = &window[0];
+                let next = &window[1];
+                matches!(
+                    program.instruction_at(current.pc).expect("instruction"),
+                    Instruction::AddImmediate(_)
+                        | Instruction::AddMemory(_)
+                        | Instruction::SubMemory(_)
+                        | Instruction::MulMemory(_)
+                ) && next.carry_flag
+            })
+            .expect("overflow transition");
+
+        let trace = build_trace_bundle_with_mode(
+            &program,
+            runtime.trace(),
+            ArithmeticSubsetProofMode::Phase12CarryAwareExperimental,
+        )
+        .expect("trace bundle");
+        let eval_state = Phase12CarryAwareArithmeticSubsetEval {
+            log_size: trace.log_size,
+            memory_size: program.memory_size(),
+            initial_state: PublicState::from_initial_memory(program.initial_memory()),
+            final_state: PublicState::from_machine_state(result.final_state.clone()),
+        };
+        let preprocessed = trace
+            .preprocessed_trace
+            .iter()
+            .map(|column| column.values.to_cpu())
+            .collect::<Vec<_>>();
+        let mut base = trace
+            .base_trace
+            .iter()
+            .map(|column| column.values.to_cpu())
+            .collect::<Vec<_>>();
+
+        let row = bit_reversed_row_index(overflow_index, trace.log_size);
+        let carry_layout = CarryAwareTraceLayout::new(program.memory_size());
+        assert_ne!(
+            base[carry_layout.wrap_delta_abs()][row],
+            base_u32(0),
+            "fixture should contain a non-zero wrap_delta row"
+        );
+        mutate(&carry_layout, row, &mut base);
+
+        let tree = TreeVec(vec![
+            preprocessed.iter().collect::<Vec<_>>(),
+            base.iter().collect::<Vec<_>>(),
+        ]);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            assert_constraints_on_trace(
+                &tree,
+                trace.log_size,
+                |eval| {
+                    let _ = eval_state.evaluate(eval);
+                },
+                SecureField::zero(),
+            );
+        }));
+        assert!(result.is_err(), "{rejection_message}");
+    }
+
     #[test]
     fn carry_aware_air_rejects_out_of_range_wrap_delta_witness() {
         let layout = phase12_default_decoding_layout();
@@ -4285,6 +4369,47 @@ mod tests {
         assert!(
             result.is_err(),
             "ADD/SUB wrap_delta outside {{-1, 0, 1}} must violate carry-aware AIR constraints"
+        );
+    }
+
+    #[test]
+    fn carry_aware_air_rejects_wrap_delta_abs_bit_reconstruction_drift() {
+        assert_carry_aware_four_step_overflow_trace_mutation_rejected(
+            |carry_layout, row, base| {
+                let bit_index = (0..CARRY_AWARE_WRAP_DELTA_ABS_BITS)
+                    .find(|index| {
+                        base[carry_layout.wrap_delta_abs_bit(*index)][row] == bool_base(true)
+                    })
+                    .expect("overflow row should set at least one abs bit");
+                base[carry_layout.wrap_delta_abs_bit(bit_index)][row] = bool_base(false);
+            },
+            "wrap_delta abs-bit drift must violate carry-aware AIR constraints",
+        );
+    }
+
+    #[test]
+    fn carry_aware_air_rejects_wrap_delta_sign_drift() {
+        assert_carry_aware_four_step_overflow_trace_mutation_rejected(
+            |carry_layout, row, base| {
+                let current_sign = base[carry_layout.wrap_delta_sign()][row];
+                base[carry_layout.wrap_delta_sign()][row] = if current_sign == bool_base(true) {
+                    bool_base(false)
+                } else {
+                    bool_base(true)
+                };
+            },
+            "wrap_delta sign drift must violate carry-aware AIR constraints",
+        );
+    }
+
+    #[test]
+    fn carry_aware_air_rejects_wrap_delta_square_drift() {
+        assert_carry_aware_four_step_overflow_trace_mutation_rejected(
+            |carry_layout, row, base| {
+                base[carry_layout.wrap_delta_square()][row] =
+                    base[carry_layout.wrap_delta_square()][row] + base_u32(1);
+            },
+            "wrap_delta square drift must violate carry-aware AIR constraints",
         );
     }
 

--- a/src/stwo_backend/primitive_benchmark.rs
+++ b/src/stwo_backend/primitive_benchmark.rs
@@ -5633,6 +5633,24 @@ mod tests {
     }
 
     #[test]
+    fn phase44d_source_emission_experimental_carry_aware_benchmark_rejects_tampered_compact_proof()
+    {
+        let layout = phase12_default_decoding_layout();
+        let chain =
+            prove_phase12_decoding_demo_for_layout_steps_publication_phase12_carry_aware_experimental(
+                &layout, 4,
+            )
+            .expect("experimental carry-aware phase12 decoding family demo");
+        let mut input =
+            phase44d_source_emission_benchmark_input(&chain, false).expect("benchmark input");
+        input.compact_envelope.proof[0] ^= 0x01;
+
+        let error = measure_phase44d_source_emission_shared(&input, false)
+            .expect_err("tampered experimental compact proof must fail");
+        assert!(!error.to_string().is_empty());
+    }
+
+    #[test]
     fn phase44d_source_emission_experimental_benchmark_clears_honest_eight_steps() {
         let report =
             run_stwo_phase44d_source_emission_experimental_benchmark_for_steps(&[8], false)


### PR DESCRIPTION
## Summary

- add focused AIR negative tests for carry-aware `wrap_delta_abs_bits`, `wrap_delta_sign`, and `wrap_delta_square` witness drift
- add an experimental Phase44D carry-aware tamper test that rejects mutated compact Phase43 proof bytes
- record the April 25 focused soundness-review increment and update repo handoff/read-order notes

## Claim Boundary

This stays in the experimental carry-aware lane. It does not promote `stwo-phase12-decoding-family-v10-carry-aware-experimental` into the default/publication path and does not move Phase44D experimental numbers into `docs/paper/`.

## Validation

- `cargo +nightly-2025-07-14 test carry_aware --features stwo-backend`
- `cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm`
- `cargo +nightly-2025-07-14 fmt --check`
- `git diff --check`
