### PR TITLE
Harden serialized carry-aware proof review

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -27,6 +27,9 @@ The active split is now:
 - Gate 2c: the focused April 25 review adds negative AIR tests for
   `wrap_delta_abs_bits`, `wrap_delta_sign`, and `wrap_delta_square` witness
   drift.
+- Gate 2d: the follow-up serialized-proof review adds disk-backed round-trip and
+  tamper tests for experimental proof JSON payload bytes and outer claim
+  commitments.
 - Gate 3: the experimental Phase44D typed-boundary reuse sweep clears `2,4,8,16,32,64,128,256,512,1024`.
 
 At `1024` steps, the experimental shared path records:
@@ -70,11 +73,13 @@ Use these in order of authority for current state:
 
 ## Next sensible moves
 
-1. Continue broadening review of the experimental backend beyond the focused
-   `wrap_delta` witness-binding increment.
-2. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after
+1. Broaden review of the experimental backend beyond the current decoding-step
+   family and proof-file tamper coverage.
+2. Re-run the experimental Phase44D frontier only after any material AIR or
+   verifier change.
+3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after
    review changes stay clean.
-3. Only after those steps decide whether any part of the experimental lane
+4. Only after those steps decide whether any part of the experimental lane
    should be promoted toward the paper/publication surface.
 
 ## Resume protocol

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -40,11 +40,13 @@ The experimental carry-aware lane now has one real higher-layer scaling result:
 
 ## Next likely technical steps
 
-1. Continue broadening the experimental backend review beyond the focused
-   `wrap_delta` witness-binding checks.
-2. Raise the Phase43/Phase44D experimental ceiling beyond `1024` only after
+1. Broaden experimental carry-aware review beyond the current decoding-step
+   family and proof-file tamper checks.
+2. Re-run the Phase44D experimental frontier only after any material AIR or
+   verifier change.
+3. Raise the Phase43/Phase44D experimental ceiling beyond `1024` only after
    review changes stay clean.
-3. Keep the experimental backend isolated from the default/publication lane
+4. Keep the experimental backend isolated from the default/publication lane
    until a deliberate promotion pass.
 
 ## What not to do

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -34,6 +34,8 @@ This repository now has two live lanes.
 - The focused April 25 soundness-review increment adds negative AIR tests for
   `wrap_delta_abs_bits`, `wrap_delta_sign`, and `wrap_delta_square` witness
   drift.
+- The follow-up serialized-proof review adds disk-backed round-trip and tamper
+  tests for experimental proof JSON payload bytes and outer claim commitments.
 - The experimental Phase44D typed-boundary sweep clears `2,4,8,16,32,64,128,256,512,1024`.
 - At `1024` steps, the experimental shared path records `427.209 ms` verification versus
   `133430.237 ms` for the Phase30 replay baseline, with `156,614` bytes versus `1,464,721` bytes.
@@ -60,8 +62,10 @@ verified. Do not describe it as a faster FRI or cryptographic verifier.
 
 ## Next sensible moves
 
-1. Continue broadening review of the experimental backend beyond the focused
-   `wrap_delta` witness-binding increment.
-2. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after
+1. Broaden review of the experimental backend beyond the current decoding-step
+   family and proof-file tamper coverage.
+2. Re-run the experimental Phase44D frontier only after any material AIR or
+   verifier change.
+3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after
    review changes stay clean.
-3. Only after those steps decide whether any part of the experimental lane should be promoted toward the paper/publication surface.
+4. Only after those steps decide whether any part of the experimental lane should be promoted toward the paper/publication surface.

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -125,6 +125,7 @@ Remaining review items before any promotion decision:
 Targeted tests:
 
 ```bash
+just proof-tests
 cargo +nightly-2025-07-14 test carry_aware_air_rejects_wrap_delta_abs_bit_reconstruction_drift --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_air_rejects_wrap_delta_sign_drift --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_air_rejects_wrap_delta_square_drift --features stwo-backend --lib
@@ -141,4 +142,6 @@ cargo +nightly-2025-07-14 test carry_aware --features stwo-backend
 cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm
 cargo +nightly-2025-07-14 fmt --check
 git diff --check
+just gate
+# or: just gate-no-nightly
 ```

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -91,6 +91,21 @@ Added focused tamper tests:
    - expects the typed Phase44D boundary-plus-compact verification path to
      reject
 
+5. `experimental_phase12_carry_aware_proof_serialization_round_trip`
+   - saves an experimental carry-aware execution proof to JSON and loads it back
+   - confirms the loaded proof still verifies on the experimental route and is
+     still rejected by the legacy verifier route
+
+6. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_payload_file`
+   - mutates the serialized `proof` bytes in the outer JSON artifact
+   - loads the tampered file through the public proof loader
+   - expects the experimental verifier to reject the malformed inner payload
+
+7. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_commitment_file`
+   - mutates the serialized outer `claim.commitments.program_hash`
+   - loads the tampered file through the public proof loader
+   - expects commitment validation to reject before proof acceptance
+
 These complement the existing tests for out-of-range `wrap_delta`, ADD/SUB
 unit range, proof-payload tampering, backend-version isolation, and reexecution.
 
@@ -100,11 +115,9 @@ This increment does not make the experimental backend publication-ready.
 Remaining review items before any promotion decision:
 
 1. Broaden op-pattern coverage beyond the current decoding-step family.
-2. Add more end-to-end tamper tests around serialized experimental execution
-   proofs, not only row-local AIR witness mutations.
-3. Re-run the Phase44D scaling frontier after any material AIR or verifier
+2. Re-run the Phase44D scaling frontier after any material AIR or verifier
    change.
-4. Keep describing the 1024-step Phase44D result as manifest replay avoidance,
+3. Keep describing the 1024-step Phase44D result as manifest replay avoidance,
    not as faster FRI or faster cryptographic verification.
 
 ## Validation
@@ -116,6 +129,9 @@ cargo +nightly-2025-07-14 test carry_aware_air_rejects_wrap_delta_abs_bit_recons
 cargo +nightly-2025-07-14 test carry_aware_air_rejects_wrap_delta_sign_drift --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_air_rejects_wrap_delta_square_drift --features stwo-backend --lib
 cargo +nightly-2025-07-14 test phase44d_source_emission_experimental_carry_aware_benchmark_rejects_tampered_compact_proof --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_proof_serialization_round_trip --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_payload_file --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_commitment_file --features stwo-backend --lib
 ```
 
 Recommended merge gate for this increment:

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -263,7 +263,6 @@ pub(crate) fn prove_execution_stark_phase12_carry_aware_experimental_with_option
     stwo_backend::prove_phase12_carry_aware_arithmetic_subset_experimental(witness)
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 #[allow(dead_code)]
 #[cfg(not(feature = "stwo-backend"))]
 pub(crate) fn prove_execution_stark_phase12_carry_aware_experimental_with_options(
@@ -305,7 +304,6 @@ pub(crate) fn verify_execution_stark_phase12_carry_aware_experimental_with_reexe
     Ok(true)
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 #[allow(dead_code)]
 #[cfg(not(feature = "stwo-backend"))]
 pub(crate) fn verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(
@@ -1252,14 +1250,7 @@ mod tests {
     }
 
     fn unique_temp_proof_path(stem: &str) -> std::path::PathBuf {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time before unix epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!(
-            "llm-provable-computer-{stem}-{}-{now}.json",
-            std::process::id()
-        ))
+        std::env::temp_dir().join(format!("llm-provable-computer-{stem}.json"))
     }
 
     #[test]
@@ -1499,6 +1490,7 @@ HALT
     fn experimental_phase12_carry_aware_proof_serialization_round_trip() {
         let proof = prove_phase12_four_step_overflow_carry_aware_proof();
         let path = unique_temp_proof_path("phase12-carry-aware-proof");
+        let _ = std::fs::remove_file(&path);
 
         save_execution_stark_proof(&proof, &path).expect("save");
         let loaded = load_execution_stark_proof(&path).expect("load");
@@ -1521,6 +1513,8 @@ HALT
         let proof = prove_phase12_four_step_overflow_carry_aware_proof();
         let proof_path = unique_temp_proof_path("phase12-carry-aware-proof-valid");
         let tampered_path = unique_temp_proof_path("phase12-carry-aware-proof-bad-payload");
+        let _ = std::fs::remove_file(&proof_path);
+        let _ = std::fs::remove_file(&tampered_path);
 
         save_execution_stark_proof(&proof, &proof_path).expect("save");
         let mut proof_json: serde_json::Value =
@@ -1536,14 +1530,7 @@ HALT
         let loaded = load_execution_stark_proof(&tampered_path).expect("load tampered proof");
         let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
             .expect_err("tampered payload file should fail");
-        let message = err.to_string();
-        assert!(
-            message.contains("expected value")
-                || message.contains("expected ident")
-                || message.contains("Serialization")
-                || message.contains("EOF while parsing"),
-            "{message}"
-        );
+        assert!(matches!(err, VmError::Serialization(_)), "{err}");
 
         let _ = std::fs::remove_file(&proof_path);
         let _ = std::fs::remove_file(&tampered_path);
@@ -1556,6 +1543,8 @@ HALT
         let proof_path = unique_temp_proof_path("phase12-carry-aware-proof-commitments");
         let tampered_path =
             unique_temp_proof_path("phase12-carry-aware-proof-commitments-tampered");
+        let _ = std::fs::remove_file(&proof_path);
+        let _ = std::fs::remove_file(&tampered_path);
 
         save_execution_stark_proof(&proof, &proof_path).expect("save");
         let mut proof_json: serde_json::Value =

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1249,8 +1249,11 @@ mod tests {
         .expect("experimental carry-aware proof")
     }
 
-    fn unique_temp_proof_path(stem: &str) -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("llm-provable-computer-{stem}.json"))
+    fn temp_proof_dir(stem: &str) -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix(&format!("llm-provable-computer-{stem}-"))
+            .tempdir()
+            .expect("create temp dir")
     }
 
     #[test]
@@ -1472,14 +1475,11 @@ HALT
     #[test]
     fn proof_serialization_round_trip() {
         let proof = prove_program("programs/addition.tvm", 32);
-        let path = std::env::temp_dir().join(format!(
-            "llm-provable-computer-proof-{}.json",
-            std::process::id()
-        ));
+        let tempdir = temp_proof_dir("proof");
+        let path = tempdir.path().join("proof.json");
 
         save_execution_stark_proof(&proof, &path).expect("save");
         let loaded = load_execution_stark_proof(&path).expect("load");
-        let _ = std::fs::remove_file(&path);
 
         assert_eq!(loaded, proof);
         assert!(verify_execution_stark(&loaded).expect("verify"));
@@ -1489,12 +1489,11 @@ HALT
     #[test]
     fn experimental_phase12_carry_aware_proof_serialization_round_trip() {
         let proof = prove_phase12_four_step_overflow_carry_aware_proof();
-        let path = unique_temp_proof_path("phase12-carry-aware-proof");
-        let _ = std::fs::remove_file(&path);
+        let tempdir = temp_proof_dir("phase12-carry-aware-proof");
+        let path = tempdir.path().join("proof.json");
 
         save_execution_stark_proof(&proof, &path).expect("save");
         let loaded = load_execution_stark_proof(&path).expect("load");
-        let _ = std::fs::remove_file(&path);
 
         assert_eq!(loaded, proof);
         assert!(
@@ -1511,10 +1510,9 @@ HALT
     #[test]
     fn experimental_phase12_carry_aware_loaded_proof_rejects_tampered_payload_file() {
         let proof = prove_phase12_four_step_overflow_carry_aware_proof();
-        let proof_path = unique_temp_proof_path("phase12-carry-aware-proof-valid");
-        let tampered_path = unique_temp_proof_path("phase12-carry-aware-proof-bad-payload");
-        let _ = std::fs::remove_file(&proof_path);
-        let _ = std::fs::remove_file(&tampered_path);
+        let tempdir = temp_proof_dir("phase12-carry-aware-proof-bad-payload");
+        let proof_path = tempdir.path().join("valid.json");
+        let tampered_path = tempdir.path().join("tampered.json");
 
         save_execution_stark_proof(&proof, &proof_path).expect("save");
         let mut proof_json: serde_json::Value =
@@ -1531,20 +1529,15 @@ HALT
         let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
             .expect_err("tampered payload file should fail");
         assert!(matches!(err, VmError::Serialization(_)), "{err}");
-
-        let _ = std::fs::remove_file(&proof_path);
-        let _ = std::fs::remove_file(&tampered_path);
     }
 
     #[cfg(feature = "stwo-backend")]
     #[test]
     fn experimental_phase12_carry_aware_loaded_proof_rejects_tampered_commitment_file() {
         let proof = prove_phase12_four_step_overflow_carry_aware_proof();
-        let proof_path = unique_temp_proof_path("phase12-carry-aware-proof-commitments");
-        let tampered_path =
-            unique_temp_proof_path("phase12-carry-aware-proof-commitments-tampered");
-        let _ = std::fs::remove_file(&proof_path);
-        let _ = std::fs::remove_file(&tampered_path);
+        let tempdir = temp_proof_dir("phase12-carry-aware-proof-commitments");
+        let proof_path = tempdir.path().join("valid.json");
+        let tampered_path = tempdir.path().join("tampered.json");
 
         save_execution_stark_proof(&proof, &proof_path).expect("save");
         let mut proof_json: serde_json::Value =
@@ -1562,9 +1555,6 @@ HALT
         let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
             .expect_err("tampered commitment file should fail");
         assert!(err.to_string().contains("invalid program_hash commitment"));
-
-        let _ = std::fs::remove_file(&proof_path);
-        let _ = std::fs::remove_file(&tampered_path);
     }
 
     #[test]

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1240,6 +1240,28 @@ mod tests {
             .1
     }
 
+    #[cfg(feature = "stwo-backend")]
+    fn prove_phase12_four_step_overflow_carry_aware_proof() -> VanillaStarkExecutionProof {
+        let model = phase12_four_step_overflow_model();
+        prove_execution_stark_phase12_carry_aware_experimental_with_options(
+            &model,
+            256,
+            production_v1_stark_options(),
+        )
+        .expect("experimental carry-aware proof")
+    }
+
+    fn unique_temp_proof_path(stem: &str) -> std::path::PathBuf {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "llm-provable-computer-{stem}-{}-{now}.json",
+            std::process::id()
+        ))
+    }
+
     #[test]
     fn addition_round_trips_through_stark_proof() {
         let proof = prove_program("programs/addition.tvm", 32);
@@ -1470,6 +1492,90 @@ HALT
 
         assert_eq!(loaded, proof);
         assert!(verify_execution_stark(&loaded).expect("verify"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_proof_serialization_round_trip() {
+        let proof = prove_phase12_four_step_overflow_carry_aware_proof();
+        let path = unique_temp_proof_path("phase12-carry-aware-proof");
+
+        save_execution_stark_proof(&proof, &path).expect("save");
+        let loaded = load_execution_stark_proof(&path).expect("load");
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(loaded, proof);
+        assert!(
+            verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
+                .expect("experimental verification")
+        );
+        let err = verify_execution_stark(&loaded).expect_err("legacy verifier should reject");
+        assert!(err
+            .to_string()
+            .contains("does not match expected `stwo-phase12-decoding-family-v9`"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_loaded_proof_rejects_tampered_payload_file() {
+        let proof = prove_phase12_four_step_overflow_carry_aware_proof();
+        let proof_path = unique_temp_proof_path("phase12-carry-aware-proof-valid");
+        let tampered_path = unique_temp_proof_path("phase12-carry-aware-proof-bad-payload");
+
+        save_execution_stark_proof(&proof, &proof_path).expect("save");
+        let mut proof_json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&proof_path).expect("read proof"))
+                .expect("proof json");
+        proof_json["proof"] = serde_json::json!([0]);
+        std::fs::write(
+            &tampered_path,
+            serde_json::to_vec(&proof_json).expect("encode bad proof"),
+        )
+        .expect("write bad proof");
+
+        let loaded = load_execution_stark_proof(&tampered_path).expect("load tampered proof");
+        let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
+            .expect_err("tampered payload file should fail");
+        let message = err.to_string();
+        assert!(
+            message.contains("expected value")
+                || message.contains("expected ident")
+                || message.contains("Serialization")
+                || message.contains("EOF while parsing"),
+            "{message}"
+        );
+
+        let _ = std::fs::remove_file(&proof_path);
+        let _ = std::fs::remove_file(&tampered_path);
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_loaded_proof_rejects_tampered_commitment_file() {
+        let proof = prove_phase12_four_step_overflow_carry_aware_proof();
+        let proof_path = unique_temp_proof_path("phase12-carry-aware-proof-commitments");
+        let tampered_path =
+            unique_temp_proof_path("phase12-carry-aware-proof-commitments-tampered");
+
+        save_execution_stark_proof(&proof, &proof_path).expect("save");
+        let mut proof_json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&proof_path).expect("read proof"))
+                .expect("proof json");
+        proof_json["claim"]["commitments"]["program_hash"] =
+            serde_json::Value::String("00".repeat(32));
+        std::fs::write(
+            &tampered_path,
+            serde_json::to_vec(&proof_json).expect("encode bad proof"),
+        )
+        .expect("write bad proof");
+
+        let loaded = load_execution_stark_proof(&tampered_path).expect("load tampered proof");
+        let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
+            .expect_err("tampered commitment file should fail");
+        assert!(err.to_string().contains("invalid program_hash commitment"));
+
+        let _ = std::fs::remove_file(&proof_path);
+        let _ = std::fs::remove_file(&tampered_path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add disk-backed save/load coverage for experimental carry-aware execution proofs
- add serialized proof-file tamper tests for inner proof bytes and outer claim commitments
- update the carry-aware review note and handoff text so the next gap is broader op-pattern coverage, not proof-file tampering

## Claim Boundary

This stays on the experimental carry-aware lane. It does not promote `stwo-phase12-decoding-family-v10-carry-aware-experimental` into the default/publication path and does not move any experimental measurements into `docs/paper/`.

## Validation

- `cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_proof_serialization_round_trip --features stwo-backend --lib`
- `cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_payload_file --features stwo-backend --lib`
- `cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_commitment_file --features stwo-backend --lib`
- `cargo +nightly-2025-07-14 test carry_aware --features stwo-backend`
- `cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm`
- `cargo +nightly-2025-07-14 fmt --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded engineering docs with additional evidence requirements, reordered review steps, and a new prerequisite to re-run Phase44D after verifier changes.
  * Added guidance for experimental proof tamper checks and new validation/merge-gate helper commands.

* **Tests**
  * Added experimental tests covering proof JSON save/load round-trips, tampering of serialized proof bytes, and tampering of commitment fields to validate verifier acceptance/rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->