### PR TITLE
[codex] Broaden carry-aware opcode coverage

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -31,8 +31,8 @@ The active split is now:
   tamper tests for experimental proof JSON payload bytes and outer claim
   commitments.
 - Gate 2e: the honest `8`-step family now has explicit coverage for signed and
-  non-unit `MulMemory` wrap deltas plus the sticky-carry `Store` rows that
-  follow them.
+  non-unit `MulMemory` wrap deltas, the sticky-carry `Store` rows that follow
+  them, and a full positive trace-constraint sweep across all eight seeds.
 - Gate 3: the experimental Phase44D typed-boundary reuse sweep clears `2,4,8,16,32,64,128,256,512,1024`.
 
 At `1024` steps, the experimental shared path records:

--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -30,6 +30,9 @@ The active split is now:
 - Gate 2d: the follow-up serialized-proof review adds disk-backed round-trip and
   tamper tests for experimental proof JSON payload bytes and outer claim
   commitments.
+- Gate 2e: the honest `8`-step family now has explicit coverage for signed and
+  non-unit `MulMemory` wrap deltas plus the sticky-carry `Store` rows that
+  follow them.
 - Gate 3: the experimental Phase44D typed-boundary reuse sweep clears `2,4,8,16,32,64,128,256,512,1024`.
 
 At `1024` steps, the experimental shared path records:
@@ -74,7 +77,8 @@ Use these in order of authority for current state:
 ## Next sensible moves
 
 1. Broaden review of the experimental backend beyond the current decoding-step
-   family and proof-file tamper coverage.
+   family, now that proof-file tamper coverage and the honest `8`-step
+   multiply/store carry patterns are both checked.
 2. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -26,6 +26,7 @@ This repository currently has two live lanes.
 2. Experimental core-proving lane
    - The carry-aware backend `stwo-phase12-decoding-family-v10-carry-aware-experimental` is the active upside research lane.
    - It clears the honest `8`-step Phase12 family, has AIR-level `wrap_delta` range constraints, and the experimental Phase44D scaling sweep currently clears through `2,4,8,16,32,64,128,256,512,1024`.
+   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns plus sticky-carry `Store` preservation on the honest `8`-step family.
 
 Do not collapse these two lanes into one claim.
 
@@ -41,7 +42,7 @@ The experimental carry-aware lane now has one real higher-layer scaling result:
 ## Next likely technical steps
 
 1. Broaden experimental carry-aware review beyond the current decoding-step
-   family and proof-file tamper checks.
+   family, now that the honest `8`-step multiply/store carry patterns and proof-file tamper checks are covered.
 2. Re-run the Phase44D experimental frontier only after any material AIR or
    verifier change.
 3. Raise the Phase43/Phase44D experimental ceiling beyond `1024` only after

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -26,7 +26,7 @@ This repository currently has two live lanes.
 2. Experimental core-proving lane
    - The carry-aware backend `stwo-phase12-decoding-family-v10-carry-aware-experimental` is the active upside research lane.
    - It clears the honest `8`-step Phase12 family, has AIR-level `wrap_delta` range constraints, and the experimental Phase44D scaling sweep currently clears through `2,4,8,16,32,64,128,256,512,1024`.
-   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns plus sticky-carry `Store` preservation on the honest `8`-step family.
+   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, and a full honest `8`-step trace sweep.
 
 Do not collapse these two lanes into one claim.
 

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -36,6 +36,8 @@ This repository now has two live lanes.
   drift.
 - The follow-up serialized-proof review adds disk-backed round-trip and tamper
   tests for experimental proof JSON payload bytes and outer claim commitments.
+- A second April 25 follow-up covers signed/non-unit `MulMemory` wrap patterns
+  plus sticky-carry `Store` preservation on the honest `8`-step family.
 - The experimental Phase44D typed-boundary sweep clears `2,4,8,16,32,64,128,256,512,1024`.
 - At `1024` steps, the experimental shared path records `427.209 ms` verification versus
   `133430.237 ms` for the Phase30 replay baseline, with `156,614` bytes versus `1,464,721` bytes.
@@ -63,7 +65,8 @@ verified. Do not describe it as a faster FRI or cryptographic verifier.
 ## Next sensible moves
 
 1. Broaden review of the experimental backend beyond the current decoding-step
-   family and proof-file tamper coverage.
+   family, now that proof-file tamper coverage and the honest `8`-step
+   multiply/store carry patterns are both checked.
 2. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -36,8 +36,9 @@ This repository now has two live lanes.
   drift.
 - The follow-up serialized-proof review adds disk-backed round-trip and tamper
   tests for experimental proof JSON payload bytes and outer claim commitments.
-- A second April 25 follow-up covers signed/non-unit `MulMemory` wrap patterns
-  plus sticky-carry `Store` preservation on the honest `8`-step family.
+- A second April 25 follow-up covers signed/non-unit `MulMemory` wrap patterns,
+  sticky-carry `Store` preservation, and a full positive trace sweep on the
+  honest `8`-step family.
 - The experimental Phase44D typed-boundary sweep clears `2,4,8,16,32,64,128,256,512,1024`.
 - At `1024` steps, the experimental shared path records `427.209 ms` verification versus
   `133430.237 ms` for the Phase30 replay baseline, with `156,614` bytes versus `1,464,721` bytes.

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -106,6 +106,23 @@ Added focused tamper tests:
    - loads the tampered file through the public proof loader
    - expects commitment validation to reject before proof acceptance
 
+8. `carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family`
+   - scans the honest `8`-step family and confirms the current carry-bearing
+     surface consists of `MulMemory` rows plus the sticky-carry `Store` rows
+     that follow them
+   - pins the observed wrap-delta coverage to `{-41, -20, 0, 1, 3}` so future
+     claim-widening happens deliberately
+
+9. `carry_aware_trace_builder_rejects_store_row_that_drops_live_carry`
+   - mutates the post-multiply `Store` row in the honest `8`-step family to
+     clear a live carry flag
+   - expects the trace builder to reject before proving
+
+10. `carry_aware_air_rejects_negative_wrap_delta_sign_drift`
+   - mutates the sign witness on a negative-wrap `MulMemory` row from the
+     honest `8`-step family
+   - expects the AIR signed-reconstruction constraint to reject
+
 These complement the existing tests for out-of-range `wrap_delta`, ADD/SUB
 unit range, proof-payload tampering, backend-version isolation, and reexecution.
 
@@ -114,7 +131,8 @@ unit range, proof-payload tampering, backend-version isolation, and reexecution.
 This increment does not make the experimental backend publication-ready.
 Remaining review items before any promotion decision:
 
-1. Broaden op-pattern coverage beyond the current decoding-step family.
+1. Broaden coverage beyond the current multiply/store carry patterns and beyond
+   the current decoding-step family.
 2. Re-run the Phase44D scaling frontier after any material AIR or verifier
    change.
 3. Keep describing the 1024-step Phase44D result as manifest replay avoidance,
@@ -133,6 +151,9 @@ cargo +nightly-2025-07-14 test phase44d_source_emission_experimental_carry_aware
 cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_proof_serialization_round_trip --features stwo-backend --lib
 cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_payload_file --features stwo-backend --lib
 cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_commitment_file --features stwo-backend --lib
+cargo +nightly-2025-07-14 test carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family --features stwo-backend --lib
+cargo +nightly-2025-07-14 test carry_aware_trace_builder_rejects_store_row_that_drops_live_carry --features stwo-backend --lib
+cargo +nightly-2025-07-14 test carry_aware_air_rejects_negative_wrap_delta_sign_drift --features stwo-backend --lib
 ```
 
 Recommended merge gate for this increment:

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -123,6 +123,12 @@ Added focused tamper tests:
      honest `8`-step family
    - expects the AIR signed-reconstruction constraint to reject
 
+11. `carry_aware_phase12_eight_step_family_trace_satisfies_constraints`
+   - runs the carry-aware trace-constraint path across every honest seed in the
+     `8`-step family
+   - ensures the widened family-level coverage claim is backed by the real
+     positive trace path, not just prototype-row inspection
+
 These complement the existing tests for out-of-range `wrap_delta`, ADD/SUB
 unit range, proof-payload tampering, backend-version isolation, and reexecution.
 
@@ -154,6 +160,7 @@ cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rej
 cargo +nightly-2025-07-14 test carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_trace_builder_rejects_store_row_that_drops_live_carry --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_air_rejects_negative_wrap_delta_sign_drift --features stwo-backend --lib
+cargo +nightly-2025-07-14 test carry_aware_phase12_eight_step_family_trace_satisfies_constraints --features stwo-backend --lib
 ```
 
 Recommended merge gate for this increment:

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -106,27 +106,27 @@ Added focused tamper tests:
    - loads the tampered file through the public proof loader
    - expects commitment validation to reject before proof acceptance
 
-8. `carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family`
+1. `carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family`
    - scans the honest `8`-step family and confirms the current carry-bearing
      surface consists of `MulMemory` rows plus the sticky-carry `Store` rows
      that follow them
    - pins the observed wrap-delta coverage to `{-41, -20, 0, 1, 3}` so future
      claim-widening happens deliberately
 
-9. `carry_aware_trace_builder_rejects_store_row_that_drops_live_carry`
+1. `carry_aware_trace_builder_rejects_store_row_that_drops_live_carry`
    - mutates the post-multiply `Store` row in the honest `8`-step family to
      clear a live carry flag
    - expects the trace builder to reject before proving
 
-10. `carry_aware_air_rejects_negative_wrap_delta_sign_drift`
+1. `carry_aware_air_rejects_negative_wrap_delta_sign_drift`
    - mutates the sign witness on a negative-wrap `MulMemory` row from the
      honest `8`-step family
    - expects the AIR signed-reconstruction constraint to reject
 
-11. `carry_aware_phase12_eight_step_family_trace_satisfies_constraints`
+1. `carry_aware_phase12_eight_step_family_trace_satisfies_constraints`
    - runs the carry-aware trace-constraint path across every honest seed in the
      `8`-step family
-   - ensures the widened family-level coverage claim is backed by the real
+   - ensures the widened family-level coverage claim is backed by the
      positive trace path, not just prototype-row inspection
 
 These complement the existing tests for out-of-range `wrap_delta`, ADD/SUB

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -4039,34 +4039,23 @@ mod tests {
         assert_trace_polys_satisfy_constraints_for_program(compile_program(path));
     }
 
-    fn assert_phase12_carry_aware_trace_satisfies_constraints_for_four_step_overflow_seed() {
-        let layout = phase12_default_decoding_layout();
-        let initial_memory = phase12_demo_initial_memories_for_steps(&layout, 4)
-            .expect("memories")
-            .into_iter()
-            .nth(3)
-            .expect("fourth memory");
-        let program =
-            decoding_step_v2_program_with_initial_memory(&layout, initial_memory).expect("program");
-        let mut runtime = NativeInterpreter::new(
-            program.clone(),
-            Attention2DMode::AverageHard,
-            program.instructions().len() + 1,
-        );
-        let result = runtime.run().expect("run");
-        assert!(result.halted);
-
+    fn assert_phase12_carry_aware_trace_satisfies_constraints_for_seed(
+        total_steps: usize,
+        seed_step_index: usize,
+    ) {
+        let (program, states, _) = phase12_carry_aware_family_fixture(total_steps, seed_step_index);
         let trace = build_trace_bundle_with_mode(
             &program,
-            runtime.trace(),
+            &states,
             ArithmeticSubsetProofMode::Phase12CarryAwareExperimental,
         )
         .expect("trace bundle");
+        let final_state = states.last().cloned().expect("final state");
         let eval_state = Phase12CarryAwareArithmeticSubsetEval {
             log_size: trace.log_size,
             memory_size: program.memory_size(),
             initial_state: PublicState::from_initial_memory(program.initial_memory()),
-            final_state: PublicState::from_machine_state(result.final_state.clone()),
+            final_state: PublicState::from_machine_state(final_state),
         };
         let preprocessed = trace
             .preprocessed_trace
@@ -4091,6 +4080,10 @@ mod tests {
             },
             SecureField::zero(),
         );
+    }
+
+    fn assert_phase12_carry_aware_trace_satisfies_constraints_for_four_step_overflow_seed() {
+        assert_phase12_carry_aware_trace_satisfies_constraints_for_seed(4, 3);
     }
 
     fn bit_reversed_row_index(index: usize, log_size: u32) -> usize {
@@ -4126,6 +4119,29 @@ mod tests {
         let rows = collect_carry_aware_arithmetic_subset_prototype_rows(&program, &states)
             .expect("prototype rows");
         (program, states, rows)
+    }
+
+    fn phase12_carry_aware_family_fixture_matching<F>(
+        total_steps: usize,
+        row_selector: &F,
+        pattern_label: &str,
+    ) -> (
+        usize,
+        Program,
+        Vec<MachineState>,
+        Vec<CarryAwareArithmeticSubsetPrototypeRow>,
+    )
+    where
+        F: Fn(&CarryAwareArithmeticSubsetPrototypeRow) -> bool,
+    {
+        for seed_step_index in 0..total_steps {
+            let (program, states, rows) =
+                phase12_carry_aware_family_fixture(total_steps, seed_step_index);
+            if rows.iter().any(row_selector) {
+                return (seed_step_index, program, states, rows);
+            }
+        }
+        panic!("honest {total_steps}-step family should contain {pattern_label}");
     }
 
     fn assert_carry_aware_four_step_overflow_trace_mutation_rejected(
@@ -4212,15 +4228,17 @@ mod tests {
         assert!(result.is_err(), "{rejection_message}");
     }
 
-    fn assert_carry_aware_phase12_family_trace_mutation_rejected(
+    fn assert_carry_aware_phase12_family_trace_mutation_rejected<F>(
         total_steps: usize,
-        seed_step_index: usize,
-        row_selector: impl Fn(&CarryAwareArithmeticSubsetPrototypeRow) -> bool,
+        row_selector: F,
+        pattern_label: &str,
         mutate: impl FnOnce(&CarryAwareTraceLayout, usize, &mut [Vec<BaseField>]),
         rejection_message: &str,
-    ) {
-        let (program, states, rows) =
-            phase12_carry_aware_family_fixture(total_steps, seed_step_index);
+    ) where
+        F: Fn(&CarryAwareArithmeticSubsetPrototypeRow) -> bool,
+    {
+        let (seed_step_index, program, states, rows) =
+            phase12_carry_aware_family_fixture_matching(total_steps, &row_selector, pattern_label);
         let selected_row = rows
             .iter()
             .find(|row| row_selector(row))
@@ -4876,6 +4894,13 @@ mod tests {
     }
 
     #[test]
+    fn carry_aware_phase12_eight_step_family_trace_satisfies_constraints() {
+        for seed_step_index in 0..8 {
+            assert_phase12_carry_aware_trace_satisfies_constraints_for_seed(8, seed_step_index);
+        }
+    }
+
+    #[test]
     fn carry_aware_phase12_four_step_trace_satisfies_constraints() {
         assert_phase12_carry_aware_trace_satisfies_constraints_for_four_step_overflow_seed();
     }
@@ -4968,11 +4993,15 @@ mod tests {
 
     #[test]
     fn carry_aware_trace_builder_rejects_store_row_that_drops_live_carry() {
-        let (program, mut states, rows) = phase12_carry_aware_family_fixture(8, 4);
+        let (_, program, mut states, rows) = phase12_carry_aware_family_fixture_matching(
+            8,
+            &|row| row.instruction.starts_with("Store(") && row.carry_after,
+            "a store row with live carry",
+        );
         let store_row = rows
             .iter()
             .find(|row| row.instruction.starts_with("Store(") && row.carry_after)
-            .expect("seed 4 should contain a store row with live carry");
+            .expect("selected seed should contain a store row with live carry");
         states[store_row.step_index + 1].carry_flag = false;
 
         let err = match build_trace_bundle_with_mode(
@@ -4993,8 +5022,8 @@ mod tests {
     fn carry_aware_air_rejects_negative_wrap_delta_sign_drift() {
         assert_carry_aware_phase12_family_trace_mutation_rejected(
             8,
-            4,
             |row| row.instruction.starts_with("MulMemory(") && row.wrap_delta < 0,
+            "a negative-wrap multiply row",
             |carry_layout, row, base| {
                 let current_sign = base[carry_layout.wrap_delta_sign()][row];
                 base[carry_layout.wrap_delta_sign()][row] = if current_sign == bool_base(true) {

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -4090,6 +4090,64 @@ mod tests {
         index.reverse_bits() >> (usize::BITS - log_size)
     }
 
+    type CarryAwareFamilyFixture = (
+        usize,
+        Program,
+        Vec<MachineState>,
+        Vec<CarryAwareArithmeticSubsetPrototypeRow>,
+    );
+
+    fn build_phase12_carry_aware_family_fixtures(
+        total_steps: usize,
+    ) -> Vec<CarryAwareFamilyFixture> {
+        let layout = phase12_default_decoding_layout();
+        let initial_memories =
+            phase12_demo_initial_memories_for_steps(&layout, total_steps).expect("memories");
+        assert_eq!(
+            initial_memories.len(),
+            total_steps,
+            "requested {total_steps}-step family should yield {total_steps} demo seeds"
+        );
+        // `total_steps` is the number of demo seeds in the family, not the VM
+        // runtime length of each generated decoding-step program.
+        initial_memories
+            .into_iter()
+            .enumerate()
+            .map(|(seed_step_index, initial_memory)| {
+                let program = decoding_step_v2_program_with_initial_memory(&layout, initial_memory)
+                    .expect("program");
+                let mut runtime = NativeInterpreter::new(
+                    program.clone(),
+                    Attention2DMode::AverageHard,
+                    program.instructions().len() + 1,
+                );
+                let result = runtime.run().expect("run");
+                assert!(result.halted, "seed {seed_step_index} should halt");
+                let states = runtime.trace().to_vec();
+                let rows = collect_carry_aware_arithmetic_subset_prototype_rows(&program, &states)
+                    .expect("prototype rows");
+                (seed_step_index, program, states, rows)
+            })
+            .collect()
+    }
+
+    fn cached_phase12_carry_aware_family_fixtures(
+        total_steps: usize,
+    ) -> Vec<CarryAwareFamilyFixture> {
+        static FOUR_STEP_FIXTURES: OnceLock<Vec<CarryAwareFamilyFixture>> = OnceLock::new();
+        static EIGHT_STEP_FIXTURES: OnceLock<Vec<CarryAwareFamilyFixture>> = OnceLock::new();
+
+        match total_steps {
+            4 => FOUR_STEP_FIXTURES
+                .get_or_init(|| build_phase12_carry_aware_family_fixtures(4))
+                .clone(),
+            8 => EIGHT_STEP_FIXTURES
+                .get_or_init(|| build_phase12_carry_aware_family_fixtures(8))
+                .clone(),
+            _ => build_phase12_carry_aware_family_fixtures(total_steps),
+        }
+    }
+
     fn phase12_carry_aware_family_fixture(
         total_steps: usize,
         seed_step_index: usize,
@@ -4098,26 +4156,14 @@ mod tests {
         Vec<MachineState>,
         Vec<CarryAwareArithmeticSubsetPrototypeRow>,
     ) {
-        let layout = phase12_default_decoding_layout();
-        let initial_memory = phase12_demo_initial_memories_for_steps(&layout, total_steps)
-            .expect("memories")
+        let (_, program, states, rows) = cached_phase12_carry_aware_family_fixtures(total_steps)
             .into_iter()
-            .nth(seed_step_index)
+            .find(|(candidate_seed_step_index, _, _, _)| {
+                *candidate_seed_step_index == seed_step_index
+            })
             .unwrap_or_else(|| {
                 panic!("seed {seed_step_index} missing from {total_steps}-step family")
             });
-        let program =
-            decoding_step_v2_program_with_initial_memory(&layout, initial_memory).expect("program");
-        let mut runtime = NativeInterpreter::new(
-            program.clone(),
-            Attention2DMode::AverageHard,
-            program.instructions().len() + 1,
-        );
-        let result = runtime.run().expect("run");
-        assert!(result.halted, "seed {seed_step_index} should halt");
-        let states = runtime.trace().to_vec();
-        let rows = collect_carry_aware_arithmetic_subset_prototype_rows(&program, &states)
-            .expect("prototype rows");
         (program, states, rows)
     }
 
@@ -4134,14 +4180,12 @@ mod tests {
     where
         F: Fn(&CarryAwareArithmeticSubsetPrototypeRow) -> bool,
     {
-        for seed_step_index in 0..total_steps {
-            let (program, states, rows) =
-                phase12_carry_aware_family_fixture(total_steps, seed_step_index);
-            if rows.iter().any(row_selector) {
-                return (seed_step_index, program, states, rows);
-            }
-        }
-        panic!("honest {total_steps}-step family should contain {pattern_label}");
+        cached_phase12_carry_aware_family_fixtures(total_steps)
+            .into_iter()
+            .find(|(_, _, _, rows)| rows.iter().any(row_selector))
+            .unwrap_or_else(|| {
+                panic!("honest {total_steps}-step family should contain {pattern_label}")
+            })
     }
 
     fn assert_carry_aware_four_step_overflow_trace_mutation_rejected(

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -3731,6 +3731,7 @@ mod tests {
     };
     use crate::{production_v1_stark_options, prove_execution_stark_with_backend_and_options};
     use crate::{ProgramCompiler, TransformerVm, TransformerVmConfig};
+    use std::collections::BTreeSet;
     use std::panic::{catch_unwind, AssertUnwindSafe};
     use std::sync::OnceLock;
     use stwo::core::pcs::utils::TreeVec;
@@ -4096,6 +4097,37 @@ mod tests {
         index.reverse_bits() >> (usize::BITS - log_size)
     }
 
+    fn phase12_carry_aware_family_fixture(
+        total_steps: usize,
+        seed_step_index: usize,
+    ) -> (
+        Program,
+        Vec<MachineState>,
+        Vec<CarryAwareArithmeticSubsetPrototypeRow>,
+    ) {
+        let layout = phase12_default_decoding_layout();
+        let initial_memory = phase12_demo_initial_memories_for_steps(&layout, total_steps)
+            .expect("memories")
+            .into_iter()
+            .nth(seed_step_index)
+            .unwrap_or_else(|| {
+                panic!("seed {seed_step_index} missing from {total_steps}-step family")
+            });
+        let program =
+            decoding_step_v2_program_with_initial_memory(&layout, initial_memory).expect("program");
+        let mut runtime = NativeInterpreter::new(
+            program.clone(),
+            Attention2DMode::AverageHard,
+            program.instructions().len() + 1,
+        );
+        let result = runtime.run().expect("run");
+        assert!(result.halted, "seed {seed_step_index} should halt");
+        let states = runtime.trace().to_vec();
+        let rows = collect_carry_aware_arithmetic_subset_prototype_rows(&program, &states)
+            .expect("prototype rows");
+        (program, states, rows)
+    }
+
     fn assert_carry_aware_four_step_overflow_trace_mutation_rejected(
         mutate: impl FnOnce(&CarryAwareTraceLayout, usize, &mut [Vec<BaseField>]),
         rejection_message: &str,
@@ -4161,6 +4193,67 @@ mod tests {
             base_u32(0),
             "fixture should contain a non-zero wrap_delta row"
         );
+        mutate(&carry_layout, row, &mut base);
+
+        let tree = TreeVec(vec![
+            preprocessed.iter().collect::<Vec<_>>(),
+            base.iter().collect::<Vec<_>>(),
+        ]);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            assert_constraints_on_trace(
+                &tree,
+                trace.log_size,
+                |eval| {
+                    let _ = eval_state.evaluate(eval);
+                },
+                SecureField::zero(),
+            );
+        }));
+        assert!(result.is_err(), "{rejection_message}");
+    }
+
+    fn assert_carry_aware_phase12_family_trace_mutation_rejected(
+        total_steps: usize,
+        seed_step_index: usize,
+        row_selector: impl Fn(&CarryAwareArithmeticSubsetPrototypeRow) -> bool,
+        mutate: impl FnOnce(&CarryAwareTraceLayout, usize, &mut [Vec<BaseField>]),
+        rejection_message: &str,
+    ) {
+        let (program, states, rows) =
+            phase12_carry_aware_family_fixture(total_steps, seed_step_index);
+        let selected_row = rows
+            .iter()
+            .find(|row| row_selector(row))
+            .unwrap_or_else(|| {
+                panic!(
+                    "seed {seed_step_index} should contain the requested carry-aware prototype row"
+                )
+            });
+        let trace = build_trace_bundle_with_mode(
+            &program,
+            &states,
+            ArithmeticSubsetProofMode::Phase12CarryAwareExperimental,
+        )
+        .expect("trace bundle");
+        let final_state = states.last().cloned().expect("final state");
+        let eval_state = Phase12CarryAwareArithmeticSubsetEval {
+            log_size: trace.log_size,
+            memory_size: program.memory_size(),
+            initial_state: PublicState::from_initial_memory(program.initial_memory()),
+            final_state: PublicState::from_machine_state(final_state),
+        };
+        let preprocessed = trace
+            .preprocessed_trace
+            .iter()
+            .map(|column| column.values.to_cpu())
+            .collect::<Vec<_>>();
+        let mut base = trace
+            .base_trace
+            .iter()
+            .map(|column| column.values.to_cpu())
+            .collect::<Vec<_>>();
+        let row = bit_reversed_row_index(selected_row.step_index, trace.log_size);
+        let carry_layout = CarryAwareTraceLayout::new(program.memory_size());
         mutate(&carry_layout, row, &mut base);
 
         let tree = TreeVec(vec![
@@ -4728,6 +4821,61 @@ mod tests {
     }
 
     #[test]
+    fn carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family(
+    ) {
+        let mut carry_instruction_families = BTreeSet::new();
+        let mut wrap_deltas = BTreeSet::new();
+        let mut saw_positive_wrap = false;
+        let mut saw_negative_wrap = false;
+        let mut saw_non_unit_wrap = false;
+        let mut saw_store_with_live_carry = false;
+
+        for seed_step_index in 0..8 {
+            let (_, _, rows) = phase12_carry_aware_family_fixture(8, seed_step_index);
+            for row in rows.iter().filter(|row| row.carry_after) {
+                let family = row
+                    .instruction
+                    .split('(')
+                    .next()
+                    .expect("instruction family");
+                carry_instruction_families.insert(family.to_string());
+                wrap_deltas.insert(row.wrap_delta);
+                saw_positive_wrap |= row.wrap_delta > 0;
+                saw_negative_wrap |= row.wrap_delta < 0;
+                saw_non_unit_wrap |= row.wrap_delta.abs() > 1;
+                saw_store_with_live_carry |= family == "Store";
+            }
+        }
+
+        assert_eq!(
+            carry_instruction_families,
+            BTreeSet::from(["MulMemory".to_string(), "Store".to_string(),]),
+            "honest 8-step family should only surface multiply rows plus sticky-carry stores today"
+        );
+        assert!(
+            saw_positive_wrap,
+            "honest 8-step family should expose at least one positive wrap_delta row"
+        );
+        assert!(
+            saw_negative_wrap,
+            "honest 8-step family should expose at least one negative wrap_delta row"
+        );
+        assert!(
+            saw_non_unit_wrap,
+            "honest 8-step family should expose a non-unit wrap_delta magnitude"
+        );
+        assert!(
+            saw_store_with_live_carry,
+            "honest 8-step family should include store rows that preserve a live carry flag"
+        );
+        assert_eq!(
+            wrap_deltas,
+            BTreeSet::from([-41, -20, 0, 1, 3]),
+            "carry-aware 8-step family coverage drifted; update the review note before widening claims"
+        );
+    }
+
+    #[test]
     fn carry_aware_phase12_four_step_trace_satisfies_constraints() {
         assert_phase12_carry_aware_trace_satisfies_constraints_for_four_step_overflow_seed();
     }
@@ -4816,5 +4964,46 @@ mod tests {
             Err(err) => err,
         };
         assert!(err.to_string().contains("expected next carry true"));
+    }
+
+    #[test]
+    fn carry_aware_trace_builder_rejects_store_row_that_drops_live_carry() {
+        let (program, mut states, rows) = phase12_carry_aware_family_fixture(8, 4);
+        let store_row = rows
+            .iter()
+            .find(|row| row.instruction.starts_with("Store(") && row.carry_after)
+            .expect("seed 4 should contain a store row with live carry");
+        states[store_row.step_index + 1].carry_flag = false;
+
+        let err = match build_trace_bundle_with_mode(
+            &program,
+            &states,
+            ArithmeticSubsetProofMode::Phase12CarryAwareExperimental,
+        ) {
+            Ok(_) => panic!("store row dropping a live carry must fail"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("expected next carry true"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn carry_aware_air_rejects_negative_wrap_delta_sign_drift() {
+        assert_carry_aware_phase12_family_trace_mutation_rejected(
+            8,
+            4,
+            |row| row.instruction.starts_with("MulMemory(") && row.wrap_delta < 0,
+            |carry_layout, row, base| {
+                let current_sign = base[carry_layout.wrap_delta_sign()][row];
+                base[carry_layout.wrap_delta_sign()][row] = if current_sign == bool_base(true) {
+                    bool_base(false)
+                } else {
+                    bool_base(true)
+                };
+            },
+            "negative wrap_delta sign drift must violate carry-aware AIR constraints",
+        );
     }
 }

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -3731,6 +3731,7 @@ mod tests {
     };
     use crate::{production_v1_stark_options, prove_execution_stark_with_backend_and_options};
     use crate::{ProgramCompiler, TransformerVm, TransformerVmConfig};
+    use std::borrow::Cow;
     use std::collections::BTreeSet;
     use std::panic::{catch_unwind, AssertUnwindSafe};
     use std::sync::OnceLock;
@@ -4040,10 +4041,11 @@ mod tests {
     }
 
     fn assert_phase12_carry_aware_trace_satisfies_constraints_for_seed(
-        total_steps: usize,
+        family_seed_count: usize,
         seed_step_index: usize,
     ) {
-        let (program, states, _) = phase12_carry_aware_family_fixture(total_steps, seed_step_index);
+        let (program, states, _) =
+            phase12_carry_aware_family_fixture(family_seed_count, seed_step_index);
         let trace = build_trace_bundle_with_mode(
             &program,
             &states,
@@ -4098,18 +4100,18 @@ mod tests {
     );
 
     fn build_phase12_carry_aware_family_fixtures(
-        total_steps: usize,
+        family_seed_count: usize,
     ) -> Vec<CarryAwareFamilyFixture> {
         let layout = phase12_default_decoding_layout();
         let initial_memories =
-            phase12_demo_initial_memories_for_steps(&layout, total_steps).expect("memories");
+            phase12_demo_initial_memories_for_steps(&layout, family_seed_count).expect("memories");
         assert_eq!(
             initial_memories.len(),
-            total_steps,
-            "requested {total_steps}-step family should yield {total_steps} demo seeds"
+            family_seed_count,
+            "requested {family_seed_count}-step family should yield {family_seed_count} demo seeds"
         );
-        // `total_steps` is the number of demo seeds in the family, not the VM
-        // runtime length of each generated decoding-step program.
+        // `family_seed_count` is the number of demo seeds in the family, not
+        // the VM runtime length of each generated decoding-step program.
         initial_memories
             .into_iter()
             .enumerate()
@@ -4132,43 +4134,49 @@ mod tests {
     }
 
     fn cached_phase12_carry_aware_family_fixtures(
-        total_steps: usize,
-    ) -> Vec<CarryAwareFamilyFixture> {
+        family_seed_count: usize,
+    ) -> Cow<'static, [CarryAwareFamilyFixture]> {
         static FOUR_STEP_FIXTURES: OnceLock<Vec<CarryAwareFamilyFixture>> = OnceLock::new();
         static EIGHT_STEP_FIXTURES: OnceLock<Vec<CarryAwareFamilyFixture>> = OnceLock::new();
 
-        match total_steps {
-            4 => FOUR_STEP_FIXTURES
-                .get_or_init(|| build_phase12_carry_aware_family_fixtures(4))
-                .clone(),
-            8 => EIGHT_STEP_FIXTURES
-                .get_or_init(|| build_phase12_carry_aware_family_fixtures(8))
-                .clone(),
-            _ => build_phase12_carry_aware_family_fixtures(total_steps),
+        match family_seed_count {
+            4 => Cow::Borrowed(
+                FOUR_STEP_FIXTURES
+                    .get_or_init(|| build_phase12_carry_aware_family_fixtures(4))
+                    .as_slice(),
+            ),
+            8 => Cow::Borrowed(
+                EIGHT_STEP_FIXTURES
+                    .get_or_init(|| build_phase12_carry_aware_family_fixtures(8))
+                    .as_slice(),
+            ),
+            _ => Cow::Owned(build_phase12_carry_aware_family_fixtures(family_seed_count)),
         }
     }
 
     fn phase12_carry_aware_family_fixture(
-        total_steps: usize,
+        family_seed_count: usize,
         seed_step_index: usize,
     ) -> (
         Program,
         Vec<MachineState>,
         Vec<CarryAwareArithmeticSubsetPrototypeRow>,
     ) {
-        let (_, program, states, rows) = cached_phase12_carry_aware_family_fixtures(total_steps)
-            .into_iter()
-            .find(|(candidate_seed_step_index, _, _, _)| {
-                *candidate_seed_step_index == seed_step_index
-            })
-            .unwrap_or_else(|| {
-                panic!("seed {seed_step_index} missing from {total_steps}-step family")
-            });
+        let (_, program, states, rows) =
+            cached_phase12_carry_aware_family_fixtures(family_seed_count)
+                .iter()
+                .find(|(candidate_seed_step_index, _, _, _)| {
+                    *candidate_seed_step_index == seed_step_index
+                })
+                .cloned()
+                .unwrap_or_else(|| {
+                    panic!("seed {seed_step_index} missing from {family_seed_count}-step family")
+                });
         (program, states, rows)
     }
 
     fn phase12_carry_aware_family_fixture_matching<F>(
-        total_steps: usize,
+        family_seed_count: usize,
         row_selector: &F,
         pattern_label: &str,
     ) -> (
@@ -4180,11 +4188,12 @@ mod tests {
     where
         F: Fn(&CarryAwareArithmeticSubsetPrototypeRow) -> bool,
     {
-        cached_phase12_carry_aware_family_fixtures(total_steps)
-            .into_iter()
+        cached_phase12_carry_aware_family_fixtures(family_seed_count)
+            .iter()
             .find(|(_, _, _, rows)| rows.iter().any(row_selector))
+            .cloned()
             .unwrap_or_else(|| {
-                panic!("honest {total_steps}-step family should contain {pattern_label}")
+                panic!("honest {family_seed_count}-step family should contain {pattern_label}")
             })
     }
 
@@ -4273,7 +4282,7 @@ mod tests {
     }
 
     fn assert_carry_aware_phase12_family_trace_mutation_rejected<F>(
-        total_steps: usize,
+        family_seed_count: usize,
         row_selector: F,
         pattern_label: &str,
         mutate: impl FnOnce(&CarryAwareTraceLayout, usize, &mut [Vec<BaseField>]),
@@ -4281,8 +4290,11 @@ mod tests {
     ) where
         F: Fn(&CarryAwareArithmeticSubsetPrototypeRow) -> bool,
     {
-        let (seed_step_index, program, states, rows) =
-            phase12_carry_aware_family_fixture_matching(total_steps, &row_selector, pattern_label);
+        let (seed_step_index, program, states, rows) = phase12_carry_aware_family_fixture_matching(
+            family_seed_count,
+            &row_selector,
+            pattern_label,
+        );
         let selected_row = rows
             .iter()
             .find(|row| row_selector(row))


### PR DESCRIPTION
## Summary
- broaden carry-aware hardening from the single four-step overflow seed to the honest eight-step Phase12 family
- add signed and non-unit `MulMemory` coverage plus sticky-carry `Store` preservation checks in `src/stwo_backend/arithmetic_subset_prover.rs`
- update the local and tracked handoff notes plus the April 25 soundness review to reflect the new coverage boundary

## Why
The remaining review gap after the serialized-proof pass was not proof-file tampering anymore. It was that the carry-aware negative tests still mostly hung off one positive-wrap four-step seed. The honest eight-step family exposes a richer but still narrow real carry surface today: signed and non-unit multiply wraps, plus the following store rows that must preserve a live carry flag.

## What changed
- added a fixture helper for the honest Phase12 carry-aware family in the arithmetic subset tests
- pinned the observed eight-step carry-pattern coverage to the current real surface: `MulMemory` plus sticky-carry `Store`, with wrap deltas `{-41, -20, 0, 1, 3}`
- added a trace-builder negative test that rejects clearing carry on the post-multiply store row
- added an AIR negative test that flips the sign witness on a negative-wrap `MulMemory` row
- updated `.codex/START_HERE.md`, `.codex/HANDOFF.md`, `docs/engineering/codex-repo-handoff-2026-04-24.md`, and `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`

## Validation
- `CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target cargo +nightly-2025-07-14 test carry_aware --features stwo-backend`
- `CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm`
- `cargo +nightly-2025-07-14 fmt --check`
- `git diff --check`

## Hardening
- keeps the experimental/publication lane split unchanged
- narrows a real soundness-review gap without widening any public claim surface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded engineering docs with added experimental validation and broadened review guidance to include honest 8-step multiply/store carry patterns and follow-up evidence.

* **Tests**
  * Added carry-aware regression tests covering the honest 8-step family, full-seed constraint verification, and targeted mutation-rejection cases for carry/sign drift and store mutations; updated test commands.

* **Chores**
  * Improved test harness to support parameterized family runs, cached fixtures, and reusable mutation assertion helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->