### PR TITLE
[codex] Broaden experimental proof tamper coverage

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -28,8 +28,9 @@ The active split is now:
   `wrap_delta_abs_bits`, `wrap_delta_sign`, and `wrap_delta_square` witness
   drift.
 - Gate 2d: the follow-up serialized-proof review adds disk-backed round-trip and
-  tamper tests for experimental proof JSON payload bytes and outer claim
-  commitments.
+  tamper tests for experimental proof JSON payload bytes, outer claim
+  commitments, backend-version drift, steps/equivalence drift, and final-state
+  drift.
 - Gate 2e: the honest `8`-step family now has explicit coverage for signed and
   non-unit `MulMemory` wrap deltas, the sticky-carry `Store` rows that follow
   them, and a full positive trace-constraint sweep across all eight seeds.
@@ -77,8 +78,8 @@ Use these in order of authority for current state:
 ## Next sensible moves
 
 1. Broaden review of the experimental backend beyond the current decoding-step
-   family, now that proof-file tamper coverage and the honest `8`-step
-   multiply/store carry patterns are both checked.
+   family, now that the disk-backed proof-file tamper matrix and the honest
+   `8`-step multiply/store carry patterns are both checked.
 2. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -42,7 +42,9 @@ The experimental carry-aware lane now has one real higher-layer scaling result:
 ## Next likely technical steps
 
 1. Broaden experimental carry-aware review beyond the current decoding-step
-   family, now that the honest `8`-step multiply/store carry patterns and proof-file tamper checks are covered.
+   family, now that the honest `8`-step multiply/store carry patterns and the
+   proof-file tamper matrix (payload bytes, commitments, backend metadata,
+   steps/equivalence drift, final-state drift) are covered.
 2. Re-run the Phase44D experimental frontier only after any material AIR or
    verifier change.
 3. Raise the Phase43/Phase44D experimental ceiling beyond `1024` only after

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -35,7 +35,8 @@ This repository now has two live lanes.
   `wrap_delta_abs_bits`, `wrap_delta_sign`, and `wrap_delta_square` witness
   drift.
 - The follow-up serialized-proof review adds disk-backed round-trip and tamper
-  tests for experimental proof JSON payload bytes and outer claim commitments.
+  tests for experimental proof JSON payload bytes, outer claim commitments,
+  backend-version drift, steps/equivalence drift, and final-state drift.
 - A second April 25 follow-up covers signed/non-unit `MulMemory` wrap patterns,
   sticky-carry `Store` preservation, and a full positive trace sweep on the
   honest `8`-step family.
@@ -66,8 +67,8 @@ verified. Do not describe it as a faster FRI or cryptographic verifier.
 ## Next sensible moves
 
 1. Broaden review of the experimental backend beyond the current decoding-step
-   family, now that proof-file tamper coverage and the honest `8`-step
-   multiply/store carry patterns are both checked.
+   family, now that the disk-backed proof-file tamper matrix and the honest
+   `8`-step multiply/store carry patterns are both checked.
 2. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -106,17 +106,17 @@ Added focused tamper tests:
    - loads the tampered file through the public proof loader
    - expects commitment validation to reject before proof acceptance
 
-1. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_backend_version_file`
+8. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_backend_version_file`
    - mutates the serialized outer `proof_backend_version`
    - loads the tampered file through the public proof loader
    - expects the experimental-only backend-version gate to reject
 
-1. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_steps_file`
+9. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_steps_file`
    - mutates the serialized outer `claim.steps`
    - loads the tampered file through the public proof loader
    - expects the equivalence metadata guard to reject the claim drift before proof acceptance
 
-1. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_final_state_file`
+10. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_final_state_file`
    - mutates the serialized outer `claim.final_state.acc`
    - loads the tampered file through the public proof loader
    - expects the equivalence fingerprint guard to reject the claim drift before proof acceptance

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -106,6 +106,21 @@ Added focused tamper tests:
    - loads the tampered file through the public proof loader
    - expects commitment validation to reject before proof acceptance
 
+1. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_backend_version_file`
+   - mutates the serialized outer `proof_backend_version`
+   - loads the tampered file through the public proof loader
+   - expects the experimental-only backend-version gate to reject
+
+1. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_steps_file`
+   - mutates the serialized outer `claim.steps`
+   - loads the tampered file through the public proof loader
+   - expects the equivalence metadata guard to reject the claim drift before proof acceptance
+
+1. `experimental_phase12_carry_aware_loaded_proof_rejects_tampered_final_state_file`
+   - mutates the serialized outer `claim.final_state.acc`
+   - loads the tampered file through the public proof loader
+   - expects the equivalence fingerprint guard to reject the claim drift before proof acceptance
+
 1. `carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family`
    - scans the honest `8`-step family and confirms the current carry-bearing
      surface consists of `MulMemory` rows plus the sticky-carry `Store` rows
@@ -157,6 +172,9 @@ cargo +nightly-2025-07-14 test phase44d_source_emission_experimental_carry_aware
 cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_proof_serialization_round_trip --features stwo-backend --lib
 cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_payload_file --features stwo-backend --lib
 cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_commitment_file --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_backend_version_file --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_steps_file --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_final_state_file --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_trace_builder_rejects_store_row_that_drops_live_carry --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_air_rejects_negative_wrap_delta_sign_drift --features stwo-backend --lib

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1599,10 +1599,13 @@ HALT
         let loaded = load_tampered_phase12_four_step_overflow_carry_aware_proof(
             "phase12-carry-aware-proof-final-state",
             |proof_json| {
-                let acc = proof_json["claim"]["final_state"]["acc"]
-                    .as_i64()
-                    .expect("final-state acc as i64");
-                proof_json["claim"]["final_state"]["acc"] = serde_json::json!(acc + 1);
+                let acc = i16::try_from(
+                    proof_json["claim"]["final_state"]["acc"]
+                        .as_i64()
+                        .expect("final-state acc as i64"),
+                )
+                .expect("final-state acc should fit in i16");
+                proof_json["claim"]["final_state"]["acc"] = serde_json::json!(acc.wrapping_add(1));
             },
         );
         let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1249,6 +1249,30 @@ mod tests {
         .expect("experimental carry-aware proof")
     }
 
+    #[cfg(feature = "stwo-backend")]
+    fn load_tampered_phase12_four_step_overflow_carry_aware_proof(
+        stem: &str,
+        mutate: impl FnOnce(&mut serde_json::Value),
+    ) -> VanillaStarkExecutionProof {
+        let proof = prove_phase12_four_step_overflow_carry_aware_proof();
+        let tempdir = temp_proof_dir(stem);
+        let proof_path = tempdir.path().join("valid.json");
+        let tampered_path = tempdir.path().join("tampered.json");
+
+        save_execution_stark_proof(&proof, &proof_path).expect("save");
+        let mut proof_json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&proof_path).expect("read proof"))
+                .expect("proof json");
+        mutate(&mut proof_json);
+        std::fs::write(
+            &tampered_path,
+            serde_json::to_vec(&proof_json).expect("encode tampered proof"),
+        )
+        .expect("write tampered proof");
+
+        load_execution_stark_proof(&tampered_path).expect("load tampered proof")
+    }
+
     fn temp_proof_dir(stem: &str) -> tempfile::TempDir {
         tempfile::Builder::new()
             .prefix(&format!("llm-provable-computer-{stem}-"))
@@ -1509,23 +1533,12 @@ HALT
     #[cfg(feature = "stwo-backend")]
     #[test]
     fn experimental_phase12_carry_aware_loaded_proof_rejects_tampered_payload_file() {
-        let proof = prove_phase12_four_step_overflow_carry_aware_proof();
-        let tempdir = temp_proof_dir("phase12-carry-aware-proof-bad-payload");
-        let proof_path = tempdir.path().join("valid.json");
-        let tampered_path = tempdir.path().join("tampered.json");
-
-        save_execution_stark_proof(&proof, &proof_path).expect("save");
-        let mut proof_json: serde_json::Value =
-            serde_json::from_slice(&std::fs::read(&proof_path).expect("read proof"))
-                .expect("proof json");
-        proof_json["proof"] = serde_json::json!([0]);
-        std::fs::write(
-            &tampered_path,
-            serde_json::to_vec(&proof_json).expect("encode bad proof"),
-        )
-        .expect("write bad proof");
-
-        let loaded = load_execution_stark_proof(&tampered_path).expect("load tampered proof");
+        let loaded = load_tampered_phase12_four_step_overflow_carry_aware_proof(
+            "phase12-carry-aware-proof-bad-payload",
+            |proof_json| {
+                proof_json["proof"] = serde_json::json!([0]);
+            },
+        );
         let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
             .expect_err("tampered payload file should fail");
         assert!(matches!(err, VmError::Serialization(_)), "{err}");
@@ -1534,27 +1547,71 @@ HALT
     #[cfg(feature = "stwo-backend")]
     #[test]
     fn experimental_phase12_carry_aware_loaded_proof_rejects_tampered_commitment_file() {
-        let proof = prove_phase12_four_step_overflow_carry_aware_proof();
-        let tempdir = temp_proof_dir("phase12-carry-aware-proof-commitments");
-        let proof_path = tempdir.path().join("valid.json");
-        let tampered_path = tempdir.path().join("tampered.json");
-
-        save_execution_stark_proof(&proof, &proof_path).expect("save");
-        let mut proof_json: serde_json::Value =
-            serde_json::from_slice(&std::fs::read(&proof_path).expect("read proof"))
-                .expect("proof json");
-        proof_json["claim"]["commitments"]["program_hash"] =
-            serde_json::Value::String("00".repeat(32));
-        std::fs::write(
-            &tampered_path,
-            serde_json::to_vec(&proof_json).expect("encode bad proof"),
-        )
-        .expect("write bad proof");
-
-        let loaded = load_execution_stark_proof(&tampered_path).expect("load tampered proof");
+        let loaded = load_tampered_phase12_four_step_overflow_carry_aware_proof(
+            "phase12-carry-aware-proof-commitments",
+            |proof_json| {
+                proof_json["claim"]["commitments"]["program_hash"] =
+                    serde_json::Value::String("00".repeat(32));
+            },
+        );
         let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
             .expect_err("tampered commitment file should fail");
         assert!(err.to_string().contains("invalid program_hash commitment"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_loaded_proof_rejects_tampered_backend_version_file() {
+        let loaded = load_tampered_phase12_four_step_overflow_carry_aware_proof(
+            "phase12-carry-aware-proof-backend-version",
+            |proof_json| {
+                proof_json["proof_backend_version"] =
+                    serde_json::Value::String(stwo_backend::STWO_BACKEND_VERSION_PHASE12.into());
+            },
+        );
+        let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
+            .expect_err("tampered backend version file should fail");
+        assert!(err
+            .to_string()
+            .contains("experimental Phase12 carry-aware proof backend version"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_loaded_proof_rejects_tampered_steps_file() {
+        let loaded = load_tampered_phase12_four_step_overflow_carry_aware_proof(
+            "phase12-carry-aware-proof-steps",
+            |proof_json| {
+                let steps = proof_json["claim"]["steps"]
+                    .as_u64()
+                    .expect("claim steps as u64");
+                proof_json["claim"]["steps"] = serde_json::json!(steps + 1);
+            },
+        );
+        let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
+            .expect_err("tampered steps file should fail");
+        assert!(err.to_string().contains("equivalence checked_steps"));
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_loaded_proof_rejects_tampered_final_state_file() {
+        let loaded = load_tampered_phase12_four_step_overflow_carry_aware_proof(
+            "phase12-carry-aware-proof-final-state",
+            |proof_json| {
+                let acc = proof_json["claim"]["final_state"]["acc"]
+                    .as_i64()
+                    .expect("final-state acc as i64");
+                proof_json["claim"]["final_state"]["acc"] = serde_json::json!(acc + 1);
+            },
+        );
+        let err = verify_execution_stark_phase12_carry_aware_experimental_with_reexecution(&loaded)
+            .expect_err("tampered final-state file should fail");
+        assert!(
+            err.to_string()
+                .contains("invalid transformer equivalence fingerprint"),
+            "{err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a reusable disk-backed helper for mutating serialized experimental carry-aware execution proofs
- extend the public proof-loader tamper matrix to cover backend-version drift, steps/equivalence drift, and final-state drift
- update the carry-aware soundness review and handoff notes so the checked-in repo state matches the new proof-surface coverage

## Validation
- `cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_ --features stwo-backend --lib`
- `cargo +nightly-2025-07-14 test carry_aware --features stwo-backend`
- `cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm`
- `cargo +nightly-2025-07-14 fmt --check`
- `git diff --check`

## Notes
- I had to clear shared debug build cache under `/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target/debug` because the machine was down to ~116 MiB free and cargo could not create temp artifacts. No tracked files outside this branch were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests to ensure proof loading rejects tampered backend version, altered claim steps, and modified final-state commitments across the experimental verification path.

* **Documentation**
  * Expanded engineering docs to describe the broader validation coverage and updated next steps, including a disk-backed proof-file tamper matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->