### PR TITLE
[codex] Broaden experimental chain and boundary tamper coverage

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -31,6 +31,11 @@ The active split is now:
   tamper tests for experimental proof JSON payload bytes, outer claim
   commitments, backend-version drift, steps/equivalence drift, and final-state
   drift.
+- Gate 2f: the next serialized-artifact increment extends that coverage one
+  layer up to proof-checked experimental Phase12 chain JSON and Phase44D typed
+  boundary JSON, including nested proof payload drift, nested backend metadata
+  drift, nested steps/final-state drift, and replay-flag drift on the typed
+  boundary surface.
 - Gate 2e: the honest `8`-step family now has explicit coverage for signed and
   non-unit `MulMemory` wrap deltas, the sticky-carry `Store` rows that follow
   them, and a full positive trace-constraint sweep across all eight seeds.
@@ -78,8 +83,9 @@ Use these in order of authority for current state:
 ## Next sensible moves
 
 1. Broaden review of the experimental backend beyond the current decoding-step
-   family, now that the disk-backed proof-file tamper matrix and the honest
-   `8`-step multiply/store carry patterns are both checked.
+   family, now that the disk-backed proof-file tamper matrix, serialized
+   Phase12-chain and Phase44D-boundary tamper coverage, and the honest `8`-step
+   multiply/store carry patterns are all checked.
 2. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -26,7 +26,7 @@ This repository currently has two live lanes.
 2. Experimental core-proving lane
    - The carry-aware backend `stwo-phase12-decoding-family-v10-carry-aware-experimental` is the active upside research lane.
    - It clears the honest `8`-step Phase12 family, has AIR-level `wrap_delta` range constraints, and the experimental Phase44D scaling sweep currently clears through `2,4,8,16,32,64,128,256,512,1024`.
-   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, and a full honest `8`-step trace sweep.
+   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, and serialized Phase44D typed-boundary tamper coverage.
 
 Do not collapse these two lanes into one claim.
 
@@ -42,9 +42,10 @@ The experimental carry-aware lane now has one real higher-layer scaling result:
 ## Next likely technical steps
 
 1. Broaden experimental carry-aware review beyond the current decoding-step
-   family, now that the honest `8`-step multiply/store carry patterns and the
-   proof-file tamper matrix (payload bytes, commitments, backend metadata,
-   steps/equivalence drift, final-state drift) are covered.
+   family, now that the honest `8`-step multiply/store carry patterns, the
+   proof-file tamper matrix, the serialized proof-checked Phase12-chain tamper
+   matrix, and the serialized Phase44D typed-boundary tamper checks are
+   covered.
 2. Re-run the Phase44D experimental frontier only after any material AIR or
    verifier change.
 3. Raise the Phase43/Phase44D experimental ceiling beyond `1024` only after

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -37,6 +37,10 @@ This repository now has two live lanes.
 - The follow-up serialized-proof review adds disk-backed round-trip and tamper
   tests for experimental proof JSON payload bytes, outer claim commitments,
   backend-version drift, steps/equivalence drift, and final-state drift.
+- The next serialized-artifact increment extends that coverage to proof-checked
+  experimental Phase12 chain JSON and Phase44D typed-boundary JSON, including
+  nested proof payload drift, nested backend metadata drift, nested
+  steps/final-state drift, and replay-flag drift on the typed boundary surface.
 - A second April 25 follow-up covers signed/non-unit `MulMemory` wrap patterns,
   sticky-carry `Store` preservation, and a full positive trace sweep on the
   honest `8`-step family.
@@ -67,8 +71,9 @@ verified. Do not describe it as a faster FRI or cryptographic verifier.
 ## Next sensible moves
 
 1. Broaden review of the experimental backend beyond the current decoding-step
-   family, now that the disk-backed proof-file tamper matrix and the honest
-   `8`-step multiply/store carry patterns are both checked.
+   family, now that the disk-backed proof-file tamper matrix, serialized
+   Phase12-chain and Phase44D-boundary tamper coverage, and the honest `8`-step
+   multiply/store carry patterns are both checked.
 2. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -121,6 +121,39 @@ Added focused tamper tests:
    - loads the tampered file through the public proof loader
    - expects the equivalence fingerprint guard to reject the claim drift before proof acceptance
 
+11. `experimental_phase12_carry_aware_chain_serialization_round_trip`
+   - saves a proof-checked experimental Phase12 decoding chain to JSON and loads it back
+   - confirms the loaded chain still verifies through the full chain verifier path
+
+12. `experimental_phase12_carry_aware_loaded_chain_rejects_tampered_payload_file`
+   - mutates serialized inner execution-proof bytes inside a saved experimental Phase12 chain
+   - loads the tampered chain through the public chain loader
+   - expects the proof-checked chain verifier to reject the malformed inner payload
+
+13. `experimental_phase12_carry_aware_loaded_chain_rejects_tampered_step_backend_version_file`
+   - mutates a serialized nested step `proof_backend_version` inside the saved chain
+   - loads the tampered chain through the public chain loader
+   - expects manifest-vs-step backend metadata binding to reject
+
+14. `experimental_phase12_carry_aware_loaded_chain_rejects_tampered_steps_file`
+   - mutates a serialized nested step `claim.steps` inside the saved chain
+   - loads the tampered chain through the public chain loader
+   - expects the nested proof equivalence metadata guard to reject before chain acceptance
+
+15. `experimental_phase12_carry_aware_loaded_chain_rejects_tampered_final_state_file`
+   - mutates a serialized nested step `claim.final_state.acc` inside the saved chain
+   - loads the tampered chain through the public chain loader
+   - expects the nested proof equivalence fingerprint guard to reject before chain acceptance
+
+16. `phase44d_source_emission_public_output_boundary_json_round_trip_preserves_acceptance`
+   - saves a Phase44D typed source-chain public-output boundary to JSON and loads it back
+   - confirms the loaded boundary still passes both acceptance and binding verification
+
+17. `phase44d_source_emission_public_output_boundary_loaded_json_rejects_replay_flags`
+   - mutates the serialized replay flags on a saved Phase44D boundary artifact
+   - loads the tampered boundary through the JSON surface
+   - expects the typed boundary validator to reject the replay drift
+
 1. `carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family`
    - scans the honest `8`-step family and confirms the current carry-bearing
      surface consists of `MulMemory` rows plus the sticky-carry `Store` rows
@@ -175,10 +208,17 @@ cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rej
 cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_backend_version_file --features stwo-backend --lib
 cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_steps_file --features stwo-backend --lib
 cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_proof_rejects_tampered_final_state_file --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_chain_serialization_round_trip --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_chain_rejects_tampered_payload_file --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_chain_rejects_tampered_step_backend_version_file --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_chain_rejects_tampered_steps_file --features stwo-backend --lib
+cargo +nightly-2025-07-14 test experimental_phase12_carry_aware_loaded_chain_rejects_tampered_final_state_file --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_trace_builder_rejects_store_row_that_drops_live_carry --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_air_rejects_negative_wrap_delta_sign_drift --features stwo-backend --lib
 cargo +nightly-2025-07-14 test carry_aware_phase12_eight_step_family_trace_satisfies_constraints --features stwo-backend --lib
+cargo +nightly-2025-07-14 test phase44d_source_emission_public_output_boundary_json_round_trip_preserves_acceptance --features stwo-backend --lib
+cargo +nightly-2025-07-14 test phase44d_source_emission_public_output_boundary_loaded_json_rejects_replay_flags --features stwo-backend --lib
 ```
 
 Recommended merge gate for this increment:

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -18082,6 +18082,159 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "stwo-backend")]
+    fn sample_phase12_carry_aware_chain_fixture() -> &'static Phase12DecodingChainManifest {
+        static FIXTURE: OnceLock<Phase12DecodingChainManifest> = OnceLock::new();
+        FIXTURE.get_or_init(|| {
+            let layout = phase12_default_decoding_layout();
+            prove_phase12_decoding_demo_for_layout_steps_publication_phase12_carry_aware_experimental(
+                &layout, 4,
+            )
+            .expect("experimental Phase12 carry-aware chain fixture")
+        })
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    fn sample_phase12_carry_aware_chain() -> Phase12DecodingChainManifest {
+        sample_phase12_carry_aware_chain_fixture().clone()
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    fn load_tampered_phase12_carry_aware_chain(
+        stem: &str,
+        mutate: impl FnOnce(&mut serde_json::Value),
+    ) -> Phase12DecodingChainManifest {
+        let manifest = sample_phase12_carry_aware_chain();
+        let tempdir = tempfile::Builder::new()
+            .prefix(&format!("llm-provable-computer-{stem}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let manifest_path = tempdir.path().join("valid.json");
+        let tampered_path = tempdir.path().join("tampered.json");
+
+        save_phase12_decoding_chain(&manifest, &manifest_path).expect("save");
+        let mut manifest_json: serde_json::Value =
+            serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
+                .expect("manifest json");
+        mutate(&mut manifest_json);
+        fs::write(
+            &tampered_path,
+            serde_json::to_vec(&manifest_json).expect("encode tampered manifest"),
+        )
+        .expect("write tampered manifest");
+
+        load_phase12_decoding_chain(&tampered_path).expect("load tampered manifest")
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_chain_serialization_round_trip() {
+        let manifest = sample_phase12_carry_aware_chain();
+        let tempdir = tempfile::Builder::new()
+            .prefix("llm-provable-computer-phase12-carry-aware-chain-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = tempdir.path().join("chain.json");
+
+        save_phase12_decoding_chain(&manifest, &path).expect("save");
+        let loaded = load_phase12_decoding_chain(&path).expect("load");
+
+        assert_eq!(loaded, manifest);
+        verify_phase12_decoding_chain_with_proof_checks(&loaded)
+            .expect("verify loaded experimental chain");
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_loaded_chain_rejects_tampered_payload_file() {
+        let loaded = load_tampered_phase12_carry_aware_chain(
+            "phase12-carry-aware-chain-bad-payload",
+            |manifest_json| {
+                manifest_json["steps"][0]["proof"]["proof"] = serde_json::json!([0]);
+            },
+        );
+
+        let err = verify_phase12_decoding_chain_with_proof_checks(&loaded)
+            .expect_err("tampered proof payload in serialized chain should fail");
+        let message = err.to_string();
+        assert!(
+            message.contains("failed to deserialize")
+                || message.contains("serialization")
+                || message.contains("deserial"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_loaded_chain_rejects_tampered_step_backend_version_file() {
+        let loaded = load_tampered_phase12_carry_aware_chain(
+            "phase12-carry-aware-chain-backend-version",
+            |manifest_json| {
+                manifest_json["steps"][0]["proof"]["proof_backend_version"] =
+                    serde_json::Value::String(
+                        crate::stwo_backend::STWO_BACKEND_VERSION_PHASE12.to_string(),
+                    );
+            },
+        );
+
+        let err = verify_phase12_decoding_chain_with_proof_checks(&loaded)
+            .expect_err("tampered step backend version in serialized chain should fail");
+        assert!(
+            err.to_string().contains("does not match manifest"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_loaded_chain_rejects_tampered_steps_file() {
+        let loaded = load_tampered_phase12_carry_aware_chain(
+            "phase12-carry-aware-chain-steps",
+            |manifest_json| {
+                let steps = manifest_json["steps"][0]["proof"]["claim"]["steps"]
+                    .as_u64()
+                    .expect("claim steps as u64");
+                manifest_json["steps"][0]["proof"]["claim"]["steps"] = serde_json::json!(steps + 1);
+            },
+        );
+
+        let err = verify_phase12_decoding_chain_with_proof_checks(&loaded)
+            .expect_err("tampered step count in serialized chain should fail");
+        let message = err.to_string();
+        assert!(
+            message.contains("checked_steps") || message.contains("claim steps"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn experimental_phase12_carry_aware_loaded_chain_rejects_tampered_final_state_file() {
+        let loaded = load_tampered_phase12_carry_aware_chain(
+            "phase12-carry-aware-chain-final-state",
+            |manifest_json| {
+                let acc = i16::try_from(
+                    manifest_json["steps"][0]["proof"]["claim"]["final_state"]["acc"]
+                        .as_i64()
+                        .expect("final-state acc as i64"),
+                )
+                .expect("final-state acc should fit in i16");
+                manifest_json["steps"][0]["proof"]["claim"]["final_state"]["acc"] =
+                    serde_json::json!(acc.wrapping_add(1));
+            },
+        );
+
+        let err = verify_phase12_decoding_chain_with_proof_checks(&loaded)
+            .expect_err("tampered final state in serialized chain should fail");
+        let message = err.to_string();
+        assert!(
+            message.contains("invalid transformer equivalence fingerprint")
+                || message.contains("final_state"),
+            "unexpected error: {message}"
+        );
+    }
+
     #[test]
     fn save_phase14_decoding_chain_rejects_manifest_exceeding_json_budget() {
         let layout = phase12_default_decoding_layout();

--- a/src/stwo_backend/decoding.rs
+++ b/src/stwo_backend/decoding.rs
@@ -18095,16 +18095,11 @@ mod tests {
     }
 
     #[cfg(feature = "stwo-backend")]
-    fn sample_phase12_carry_aware_chain() -> Phase12DecodingChainManifest {
-        sample_phase12_carry_aware_chain_fixture().clone()
-    }
-
-    #[cfg(feature = "stwo-backend")]
     fn load_tampered_phase12_carry_aware_chain(
         stem: &str,
         mutate: impl FnOnce(&mut serde_json::Value),
     ) -> Phase12DecodingChainManifest {
-        let manifest = sample_phase12_carry_aware_chain();
+        let manifest = sample_phase12_carry_aware_chain_fixture();
         let tempdir = tempfile::Builder::new()
             .prefix(&format!("llm-provable-computer-{stem}-"))
             .tempdir()
@@ -18129,7 +18124,7 @@ mod tests {
     #[cfg(feature = "stwo-backend")]
     #[test]
     fn experimental_phase12_carry_aware_chain_serialization_round_trip() {
-        let manifest = sample_phase12_carry_aware_chain();
+        let manifest = sample_phase12_carry_aware_chain_fixture();
         let tempdir = tempfile::Builder::new()
             .prefix("llm-provable-computer-phase12-carry-aware-chain-")
             .tempdir()
@@ -18139,7 +18134,7 @@ mod tests {
         save_phase12_decoding_chain(&manifest, &path).expect("save");
         let loaded = load_phase12_decoding_chain(&path).expect("load");
 
-        assert_eq!(loaded, manifest);
+        assert_eq!(&loaded, manifest);
         verify_phase12_decoding_chain_with_proof_checks(&loaded)
             .expect("verify loaded experimental chain");
     }

--- a/src/stwo_backend/history_replay_projection_prover.rs
+++ b/src/stwo_backend/history_replay_projection_prover.rs
@@ -5096,13 +5096,9 @@ mod tests {
 
     fn load_tampered_phase44d_source_chain_public_output_boundary(
         stem: &str,
+        boundary: &Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary,
         mutate: impl FnOnce(&mut serde_json::Value),
     ) -> Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
         let tempdir = tempfile::Builder::new()
             .prefix(&format!("llm-provable-computer-{stem}-"))
             .tempdir()
@@ -6101,12 +6097,18 @@ mod tests {
 
     #[test]
     fn phase44d_source_emission_public_output_boundary_loaded_json_rejects_replay_flags() {
-        let (trace, _) = sample_trace_and_phase30();
+        let (trace, phase30) = sample_trace_and_phase30();
         let compact_envelope =
             prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
                 .expect("prove Phase44 compact projection");
+        let original_boundary =
+            emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+                &trace, &phase30,
+            )
+            .expect("emit Phase44D source-chain public output boundary");
         let mut boundary = load_tampered_phase44d_source_chain_public_output_boundary(
             "phase44d-boundary-replay-flags",
+            &original_boundary,
             |boundary_json| {
                 boundary_json["verifier_requires_phase43_trace"] = serde_json::json!(true);
                 boundary_json["verifier_embeds_expected_rows"] = serde_json::json!(true);

--- a/src/stwo_backend/history_replay_projection_prover.rs
+++ b/src/stwo_backend/history_replay_projection_prover.rs
@@ -5094,6 +5094,41 @@ mod tests {
         (trace, phase30)
     }
 
+    fn load_tampered_phase44d_source_chain_public_output_boundary(
+        stem: &str,
+        mutate: impl FnOnce(&mut serde_json::Value),
+    ) -> Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary {
+        let (trace, phase30) = sample_trace_and_phase30();
+        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+            &trace, &phase30,
+        )
+        .expect("emit Phase44D source-chain public output boundary");
+        let tempdir = tempfile::Builder::new()
+            .prefix(&format!("llm-provable-computer-{stem}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let boundary_path = tempdir.path().join("valid.json");
+        let tampered_path = tempdir.path().join("tampered.json");
+
+        std::fs::write(
+            &boundary_path,
+            serde_json::to_vec(&boundary).expect("encode boundary"),
+        )
+        .expect("write boundary");
+        let mut boundary_json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&boundary_path).expect("read boundary"))
+                .expect("boundary json");
+        mutate(&mut boundary_json);
+        std::fs::write(
+            &tampered_path,
+            serde_json::to_vec(&boundary_json).expect("encode tampered boundary"),
+        )
+        .expect("write tampered boundary");
+
+        serde_json::from_slice(&std::fs::read(&tampered_path).expect("read tampered boundary"))
+            .expect("load tampered boundary")
+    }
+
     fn recommit_trace(trace: &mut Phase43HistoryReplayTrace) {
         trace.appended_pairs_commitment = test_commit_appended_pairs(trace);
         trace.lookup_rows_commitments_commitment = test_commit_lookup_rows(trace);
@@ -5946,6 +5981,44 @@ mod tests {
     }
 
     #[test]
+    fn phase44d_source_emission_public_output_boundary_json_round_trip_preserves_acceptance() {
+        let (trace, phase30) = sample_trace_and_phase30();
+        let compact_envelope =
+            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+                .expect("prove Phase44 compact projection");
+        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+            &trace, &phase30,
+        )
+        .expect("emit Phase44D source-chain public output boundary");
+        let tempdir = tempfile::Builder::new()
+            .prefix("llm-provable-computer-phase44d-boundary-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = tempdir.path().join("boundary.json");
+
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&boundary).expect("encode boundary"),
+        )
+        .expect("write boundary");
+        let loaded: Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary =
+            serde_json::from_slice(&std::fs::read(&path).expect("read boundary"))
+                .expect("load boundary");
+
+        assert_eq!(loaded, boundary);
+        verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance(
+            &loaded,
+            &compact_envelope,
+        )
+        .expect("loaded boundary acceptance should verify");
+        verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding(
+            &loaded,
+            &compact_envelope.claim,
+        )
+        .expect("loaded boundary binding should verify");
+    }
+
+    #[test]
     fn phase44d_source_emission_public_output_boundary_binding_matches_full_acceptance() {
         let (trace, phase30) = sample_trace_and_phase30();
         let compact_envelope =
@@ -6022,6 +6095,35 @@ mod tests {
                 &compact_envelope,
             )
             .expect_err("replay flags must reject source-chain public output boundary");
+
+        assert!(error.to_string().contains("without verifier trace replay"));
+    }
+
+    #[test]
+    fn phase44d_source_emission_public_output_boundary_loaded_json_rejects_replay_flags() {
+        let (trace, _) = sample_trace_and_phase30();
+        let compact_envelope =
+            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+                .expect("prove Phase44 compact projection");
+        let mut boundary = load_tampered_phase44d_source_chain_public_output_boundary(
+            "phase44d-boundary-replay-flags",
+            |boundary_json| {
+                boundary_json["verifier_requires_phase43_trace"] = serde_json::json!(true);
+                boundary_json["verifier_embeds_expected_rows"] = serde_json::json!(true);
+            },
+        );
+        boundary.source_chain_public_output_boundary_commitment =
+            commit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+                &boundary,
+            )
+            .expect("recommit replay flag drift");
+
+        let error =
+            verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance(
+                &boundary,
+                &compact_envelope,
+            )
+            .expect_err("serialized replay flag drift must reject source-chain boundary");
 
         assert!(error.to_string().contains("without verifier trace replay"));
     }


### PR DESCRIPTION
## Summary
- add disk-backed tamper coverage for proof-checked experimental Phase12 chain JSON
- add serialized JSON round-trip and replay-flag tamper coverage for the Phase44D typed source boundary
- refresh local and tracked handoff/soundness review notes so the checked-in state matches the new artifact-level coverage

## Validation
- `export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target && cargo +nightly-2025-07-14 test --features stwo-backend --lib experimental_phase12_carry_aware_`
- `export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target && cargo +nightly-2025-07-14 test --features stwo-backend --lib phase44d_source_emission_public_output_boundary_`
- `export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target && cargo +nightly-2025-07-14 test carry_aware --features stwo-backend`
- `export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target && cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm`
- `cargo +nightly-2025-07-14 fmt --check`
- `git diff --check`
