### PR TITLE
[codex] Broaden composed artifact tamper coverage

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -36,6 +36,11 @@ The active split is now:
   boundary JSON, including nested proof payload drift, nested backend metadata
   drift, nested steps/final-state drift, and replay-flag drift on the typed
   boundary surface.
+- Gate 2g: the follow-up composed-artifact increment extends serialized JSON
+  coverage further up the same stack to the Phase44D recursive handoff, the
+  Phase45 public-input bridge, and the Phase46 Stwo proof-adapter receipt,
+  including replay-flag drift, reordered public-input lanes, and terminal
+  interaction-claim drift after recommit.
 - Gate 2e: the honest `8`-step family now has explicit coverage for signed and
   non-unit `MulMemory` wrap deltas, the sticky-carry `Store` rows that follow
   them, and a full positive trace-constraint sweep across all eight seeds.
@@ -84,8 +89,9 @@ Use these in order of authority for current state:
 
 1. Broaden review of the experimental backend beyond the current decoding-step
    family, now that the disk-backed proof-file tamper matrix, serialized
-   Phase12-chain and Phase44D-boundary tamper coverage, and the honest `8`-step
-   multiply/store carry patterns are all checked.
+   Phase12-chain tamper coverage, serialized Phase44D boundary/handoff/bridge/receipt
+   coverage, and the honest `8`-step multiply/store carry patterns are all
+   checked.
 2. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -26,7 +26,7 @@ This repository currently has two live lanes.
 2. Experimental core-proving lane
    - The carry-aware backend `stwo-phase12-decoding-family-v10-carry-aware-experimental` is the active upside research lane.
    - It clears the honest `8`-step Phase12 family, has AIR-level `wrap_delta` range constraints, and the experimental Phase44D scaling sweep currently clears through `2,4,8,16,32,64,128,256,512,1024`.
-   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, and serialized Phase44D typed-boundary tamper coverage.
+   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, serialized Phase44D typed-boundary tamper coverage, and serialized Phase44D handoff / Phase45 bridge / Phase46 receipt tamper coverage.
 
 Do not collapse these two lanes into one claim.
 
@@ -44,8 +44,8 @@ The experimental carry-aware lane now has one real higher-layer scaling result:
 1. Broaden experimental carry-aware review beyond the current decoding-step
    family, now that the honest `8`-step multiply/store carry patterns, the
    proof-file tamper matrix, the serialized proof-checked Phase12-chain tamper
-   matrix, and the serialized Phase44D typed-boundary tamper checks are
-   covered.
+   matrix, and the serialized Phase44D boundary / handoff / bridge / receipt
+   tamper checks are covered.
 2. Re-run the Phase44D experimental frontier only after any material AIR or
    verifier change.
 3. Raise the Phase43/Phase44D experimental ceiling beyond `1024` only after

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -41,6 +41,10 @@ This repository now has two live lanes.
   experimental Phase12 chain JSON and Phase44D typed-boundary JSON, including
   nested proof payload drift, nested backend metadata drift, nested
   steps/final-state drift, and replay-flag drift on the typed boundary surface.
+- The follow-up composed-artifact increment extends serialized JSON coverage to
+  the Phase44D recursive handoff, the Phase45 public-input bridge, and the
+  Phase46 Stwo proof-adapter receipt, including replay-flag drift, reordered
+  public-input lanes, and terminal interaction-claim drift after recommit.
 - A second April 25 follow-up covers signed/non-unit `MulMemory` wrap patterns,
   sticky-carry `Store` preservation, and a full positive trace sweep on the
   honest `8`-step family.
@@ -72,8 +76,9 @@ verified. Do not describe it as a faster FRI or cryptographic verifier.
 
 1. Broaden review of the experimental backend beyond the current decoding-step
    family, now that the disk-backed proof-file tamper matrix, serialized
-   Phase12-chain and Phase44D-boundary tamper coverage, and the honest `8`-step
-   multiply/store carry patterns are both checked.
+   Phase12-chain tamper coverage, serialized Phase44D boundary/handoff/bridge/receipt
+   coverage, and the honest `8`-step multiply/store carry patterns are both
+   checked.
 2. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -154,6 +154,33 @@ Added focused tamper tests:
    - loads the tampered boundary through the JSON surface
    - expects the typed boundary validator to reject the replay drift
 
+18. `phase44d_source_emission_recursive_handoff_json_round_trip_preserves_acceptance`
+   - saves a Phase44D recursive-verifier public-output handoff to JSON and loads it back
+   - confirms the loaded handoff still passes both standalone and source-bound verification
+
+19. `phase44d_source_emission_recursive_handoff_loaded_json_rejects_replay_flags`
+   - mutates the serialized replay flags on a saved Phase44D recursive handoff
+   - loads the tampered handoff through the JSON surface
+   - recommits the handoff and expects the boundary-width verifier contract to reject
+
+20. `phase45_public_input_bridge_json_round_trip_preserves_acceptance`
+   - saves a Phase45 recursive-verifier public-input bridge to JSON and loads it back
+   - confirms the loaded bridge still passes both standalone and source-bound verification
+
+21. `phase45_public_input_bridge_loaded_json_rejects_reordered_lanes`
+   - mutates the serialized ordered public-input lane list on a saved Phase45 bridge
+   - loads the tampered bridge through the JSON surface
+   - recommits the bridge and expects lane-order verification to reject
+
+22. `phase46_stwo_proof_adapter_receipt_json_round_trip_preserves_acceptance`
+   - saves a Phase46 Stwo proof-adapter receipt to JSON and loads it back
+   - confirms the loaded receipt still passes both standalone and source-bound verification
+
+23. `phase46_stwo_proof_adapter_receipt_loaded_json_rejects_interaction_claim_drift`
+   - mutates the serialized terminal interaction-claim limb on a saved Phase46 receipt
+   - loads the tampered receipt through the JSON surface
+   - recommits the receipt and expects terminal LogUp cancellation verification to reject
+
 1. `carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family`
    - scans the honest `8`-step family and confirms the current carry-bearing
      surface consists of `MulMemory` rows plus the sticky-carry `Store` rows
@@ -219,6 +246,9 @@ cargo +nightly-2025-07-14 test carry_aware_air_rejects_negative_wrap_delta_sign_
 cargo +nightly-2025-07-14 test carry_aware_phase12_eight_step_family_trace_satisfies_constraints --features stwo-backend --lib
 cargo +nightly-2025-07-14 test phase44d_source_emission_public_output_boundary_json_round_trip_preserves_acceptance --features stwo-backend --lib
 cargo +nightly-2025-07-14 test phase44d_source_emission_public_output_boundary_loaded_json_rejects_replay_flags --features stwo-backend --lib
+cargo +nightly-2025-07-14 test phase44d_source_emission_recursive_handoff_ --features stwo-backend --lib
+cargo +nightly-2025-07-14 test phase45_public_input_bridge_ --features stwo-backend --lib
+cargo +nightly-2025-07-14 test phase46_stwo_proof_adapter_receipt_ --features stwo-backend --lib
 ```
 
 Recommended merge gate for this increment:

--- a/src/stwo_backend/history_replay_projection_prover.rs
+++ b/src/stwo_backend/history_replay_projection_prover.rs
@@ -5111,43 +5111,40 @@ mod tests {
         receipt: super::super::recursion::Phase46StwoProofAdapterReceipt,
     }
 
-    fn sample_phase44d_composed_artifact_fixture() -> Phase44DComposedArtifactFixture {
+    fn sample_phase44d_composed_artifact_fixture() -> &'static Phase44DComposedArtifactFixture {
         static FIXTURE: OnceLock<Phase44DComposedArtifactFixture> = OnceLock::new();
-        FIXTURE
-            .get_or_init(|| {
-                let (trace, phase30) = sample_trace_and_phase30();
-                let compact_envelope =
-                    prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                        .expect("prove cached Phase44 compact projection");
-                let boundary =
-                    emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-                        &trace, &phase30,
-                    )
-                    .expect("emit cached Phase44D source-chain public output boundary");
-                let handoff = phase44d_prepare_recursive_verifier_public_output_handoff(
-                    &boundary,
-                    &compact_envelope,
+        FIXTURE.get_or_init(|| {
+            let (trace, phase30) = sample_trace_and_phase30();
+            let compact_envelope =
+                prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+                    .expect("prove cached Phase44 compact projection");
+            let boundary =
+                emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+                    &trace, &phase30,
                 )
-                .expect("prepare cached Phase44D recursive-verifier handoff");
-                let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-                    &boundary,
-                    &compact_envelope,
-                    &handoff,
-                )
-                .expect("prepare cached Phase45 public-input bridge");
-                let receipt =
-                    phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-                        .expect("prepare cached Phase46 Stwo proof-adapter receipt");
+                .expect("emit cached Phase44D source-chain public output boundary");
+            let handoff = phase44d_prepare_recursive_verifier_public_output_handoff(
+                &boundary,
+                &compact_envelope,
+            )
+            .expect("prepare cached Phase44D recursive-verifier handoff");
+            let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
+                &boundary,
+                &compact_envelope,
+                &handoff,
+            )
+            .expect("prepare cached Phase45 public-input bridge");
+            let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
+                .expect("prepare cached Phase46 Stwo proof-adapter receipt");
 
-                Phase44DComposedArtifactFixture {
-                    compact_envelope,
-                    boundary,
-                    handoff,
-                    bridge,
-                    receipt,
-                }
-            })
-            .clone()
+            Phase44DComposedArtifactFixture {
+                compact_envelope,
+                boundary,
+                handoff,
+                bridge,
+                receipt,
+            }
+        })
     }
 
     fn load_tampered_phase44d_source_chain_public_output_boundary(

--- a/src/stwo_backend/history_replay_projection_prover.rs
+++ b/src/stwo_backend/history_replay_projection_prover.rs
@@ -4725,6 +4725,7 @@ mod tests {
     use super::super::STWO_BACKEND_VERSION_PHASE12;
     use super::*;
     use crate::proof::CLAIM_STATEMENT_VERSION_V1;
+    use serde::de::DeserializeOwned;
     use stwo::core::pcs::TreeVec;
     use stwo_constraint_framework::assert_constraints_on_trace;
 
@@ -5099,30 +5100,48 @@ mod tests {
         boundary: &Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary,
         mutate: impl FnOnce(&mut serde_json::Value),
     ) -> Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary {
+        load_tampered_serialized_artifact(stem, boundary, mutate)
+    }
+
+    fn load_tampered_serialized_artifact<T>(
+        stem: &str,
+        artifact: &T,
+        mutate: impl FnOnce(&mut serde_json::Value),
+    ) -> T
+    where
+        T: serde::Serialize + DeserializeOwned,
+    {
         let tempdir = tempfile::Builder::new()
             .prefix(&format!("llm-provable-computer-{stem}-"))
             .tempdir()
             .expect("create temp dir");
-        let boundary_path = tempdir.path().join("valid.json");
+        let artifact_path = tempdir.path().join("valid.json");
         let tampered_path = tempdir.path().join("tampered.json");
 
         std::fs::write(
-            &boundary_path,
-            serde_json::to_vec(&boundary).expect("encode boundary"),
+            &artifact_path,
+            serde_json::to_vec(artifact).expect("encode artifact"),
         )
-        .expect("write boundary");
-        let mut boundary_json: serde_json::Value =
-            serde_json::from_slice(&std::fs::read(&boundary_path).expect("read boundary"))
-                .expect("boundary json");
-        mutate(&mut boundary_json);
+        .expect("write artifact");
+        let mut artifact_json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&artifact_path).expect("read artifact"))
+                .expect("artifact json");
+        mutate(&mut artifact_json);
         std::fs::write(
             &tampered_path,
-            serde_json::to_vec(&boundary_json).expect("encode tampered boundary"),
+            serde_json::to_vec(&artifact_json).expect("encode tampered artifact"),
         )
-        .expect("write tampered boundary");
+        .expect("write tampered artifact");
 
-        serde_json::from_slice(&std::fs::read(&tampered_path).expect("read tampered boundary"))
-            .expect("load tampered boundary")
+        serde_json::from_slice(&std::fs::read(&tampered_path).expect("read tampered artifact"))
+            .expect("load tampered artifact")
+    }
+
+    fn round_trip_serialized_artifact<T>(stem: &str, artifact: &T) -> T
+    where
+        T: serde::Serialize + DeserializeOwned,
+    {
+        load_tampered_serialized_artifact(stem, artifact, |_| {})
     }
 
     fn recommit_trace(trace: &mut Phase43HistoryReplayTrace) {
@@ -6229,6 +6248,33 @@ mod tests {
     }
 
     #[test]
+    fn phase44d_source_emission_recursive_handoff_json_round_trip_preserves_acceptance() {
+        let (trace, phase30) = sample_trace_and_phase30();
+        let compact_envelope =
+            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+                .expect("prove Phase44 compact projection");
+        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+            &trace, &phase30,
+        )
+        .expect("emit Phase44D source-chain public output boundary");
+        let handoff =
+            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
+                .expect("prepare Phase44D recursive-verifier handoff");
+        let loaded =
+            round_trip_serialized_artifact("phase44d-recursive-handoff-roundtrip", &handoff);
+
+        assert_eq!(loaded, handoff);
+        verify_phase44d_recursive_verifier_public_output_handoff(&loaded)
+            .expect("verify standalone loaded Phase44D recursive-verifier handoff");
+        verify_phase44d_recursive_verifier_public_output_handoff_against_boundary(
+            &loaded,
+            &boundary,
+            &compact_envelope,
+        )
+        .expect("verify loaded Phase44D recursive-verifier handoff against boundary");
+    }
+
+    #[test]
     fn phase44d_terminal_logup_closure_accepts_stwo_cancellation_shape() {
         let (trace, phase30) = sample_trace_and_phase30();
         let source_claim =
@@ -6389,6 +6435,40 @@ mod tests {
     }
 
     #[test]
+    fn phase45_public_input_bridge_json_round_trip_preserves_acceptance() {
+        let (trace, phase30) = sample_trace_and_phase30();
+        let compact_envelope =
+            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+                .expect("prove Phase44 compact projection");
+        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+            &trace, &phase30,
+        )
+        .expect("emit Phase44D source-chain public output boundary");
+        let handoff =
+            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
+                .expect("prepare Phase44D recursive-verifier handoff");
+        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
+            &boundary,
+            &compact_envelope,
+            &handoff,
+        )
+        .expect("prepare Phase45 public-input bridge");
+        let loaded =
+            round_trip_serialized_artifact("phase45-public-input-bridge-roundtrip", &bridge);
+
+        assert_eq!(loaded, bridge);
+        verify_phase45_recursive_verifier_public_input_bridge(&loaded)
+            .expect("verify standalone loaded Phase45 public-input bridge");
+        verify_phase45_recursive_verifier_public_input_bridge_against_sources(
+            &loaded,
+            &boundary,
+            &compact_envelope,
+            &handoff,
+        )
+        .expect("verify loaded Phase45 public-input bridge against sources");
+    }
+
+    #[test]
     fn phase45_public_input_bridge_rejects_reordered_lanes_even_when_recommitted() {
         let (trace, phase30) = sample_trace_and_phase30();
         let compact_envelope =
@@ -6417,6 +6497,46 @@ mod tests {
 
         let error = verify_phase45_recursive_verifier_public_input_bridge(&bridge)
             .expect_err("reordered public-input lanes must reject");
+        assert!(error.to_string().contains("lane order"));
+    }
+
+    #[test]
+    fn phase45_public_input_bridge_loaded_json_rejects_reordered_lanes() {
+        let (trace, phase30) = sample_trace_and_phase30();
+        let compact_envelope =
+            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+                .expect("prove Phase44 compact projection");
+        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+            &trace, &phase30,
+        )
+        .expect("emit Phase44D source-chain public output boundary");
+        let handoff =
+            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
+                .expect("prepare Phase44D recursive-verifier handoff");
+        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
+            &boundary,
+            &compact_envelope,
+            &handoff,
+        )
+        .expect("prepare Phase45 public-input bridge");
+        let mut loaded = load_tampered_serialized_artifact(
+            "phase45-public-input-bridge-reordered-lanes",
+            &bridge,
+            |bridge_json| {
+                let lanes = bridge_json["ordered_public_input_lanes"]
+                    .as_array_mut()
+                    .expect("ordered public input lanes array");
+                lanes.swap(0, 1);
+            },
+        );
+        loaded.ordered_public_inputs_commitment =
+            commit_phase45_recursive_verifier_public_inputs(&loaded.ordered_public_input_lanes)
+                .expect("recommit reordered public inputs");
+        loaded.bridge_commitment = commit_phase45_recursive_verifier_public_input_bridge(&loaded)
+            .expect("recommit reordered bridge");
+
+        let error = verify_phase45_recursive_verifier_public_input_bridge(&loaded)
+            .expect_err("serialized reordered public-input lanes must reject");
         assert!(error.to_string().contains("lane order"));
     }
 
@@ -6495,6 +6615,45 @@ mod tests {
     }
 
     #[test]
+    fn phase46_stwo_proof_adapter_receipt_json_round_trip_preserves_acceptance() {
+        let (trace, phase30) = sample_trace_and_phase30();
+        let compact_envelope =
+            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+                .expect("prove Phase44 compact projection");
+        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+            &trace, &phase30,
+        )
+        .expect("emit Phase44D source-chain public output boundary");
+        let handoff =
+            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
+                .expect("prepare Phase44D recursive-verifier handoff");
+        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
+            &boundary,
+            &compact_envelope,
+            &handoff,
+        )
+        .expect("prepare Phase45 public-input bridge");
+        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
+            .expect("prepare Phase46 Stwo proof-adapter receipt");
+        let loaded = round_trip_serialized_artifact(
+            "phase46-stwo-proof-adapter-receipt-roundtrip",
+            &receipt,
+        );
+
+        assert_eq!(loaded, receipt);
+        verify_phase46_stwo_proof_adapter_receipt(&loaded)
+            .expect("verify standalone loaded Phase46 Stwo proof-adapter receipt");
+        verify_phase46_stwo_proof_adapter_receipt_against_sources(
+            &loaded,
+            &bridge,
+            &boundary,
+            &compact_envelope,
+            &handoff,
+        )
+        .expect("verify loaded Phase46 Stwo proof-adapter receipt against sources");
+    }
+
+    #[test]
     fn phase46_stwo_proof_adapter_receipt_rejects_interaction_claim_drift_even_when_recommitted() {
         let (trace, phase30) = sample_trace_and_phase30();
         let compact_envelope =
@@ -6523,6 +6682,46 @@ mod tests {
 
         let error = verify_phase46_stwo_proof_adapter_receipt(&receipt)
             .expect_err("Phase46 receipt must reject terminal interaction-claim drift");
+        assert!(error.to_string().contains("does not cancel"));
+    }
+
+    #[test]
+    fn phase46_stwo_proof_adapter_receipt_loaded_json_rejects_interaction_claim_drift() {
+        let (trace, phase30) = sample_trace_and_phase30();
+        let compact_envelope =
+            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+                .expect("prove Phase44 compact projection");
+        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+            &trace, &phase30,
+        )
+        .expect("emit Phase44D source-chain public output boundary");
+        let handoff =
+            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
+                .expect("prepare Phase44D recursive-verifier handoff");
+        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
+            &boundary,
+            &compact_envelope,
+            &handoff,
+        )
+        .expect("prepare Phase45 public-input bridge");
+        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
+            .expect("prepare Phase46 Stwo proof-adapter receipt");
+        let mut loaded = load_tampered_serialized_artifact(
+            "phase46-stwo-proof-adapter-receipt-interaction-claim-drift",
+            &receipt,
+            |receipt_json| {
+                let claimed_sum = receipt_json["terminal_boundary_component_claimed_sum_limbs"][0]
+                    .as_u64()
+                    .expect("claimed sum limb as u64");
+                receipt_json["terminal_boundary_component_claimed_sum_limbs"][0] =
+                    serde_json::json!((claimed_sum + 1) % u64::from(M31_MODULUS));
+            },
+        );
+        loaded.adapter_receipt_commitment = commit_phase46_stwo_proof_adapter_receipt(&loaded)
+            .expect("recommit forged Phase46 receipt");
+
+        let error = verify_phase46_stwo_proof_adapter_receipt(&loaded)
+            .expect_err("serialized Phase46 receipt must reject terminal interaction-claim drift");
         assert!(error.to_string().contains("does not cancel"));
     }
 
@@ -10634,6 +10833,36 @@ mod tests {
 
         let error = verify_phase44d_recursive_verifier_public_output_handoff(&handoff)
             .expect_err("replay handoff must reject even when recommitted");
+        assert!(error.to_string().contains("must remain boundary-width"));
+    }
+
+    #[test]
+    fn phase44d_source_emission_recursive_handoff_loaded_json_rejects_replay_flags() {
+        let (trace, phase30) = sample_trace_and_phase30();
+        let compact_envelope =
+            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+                .expect("prove Phase44 compact projection");
+        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+            &trace, &phase30,
+        )
+        .expect("emit Phase44D source-chain public output boundary");
+        let handoff =
+            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
+                .expect("prepare Phase44D recursive-verifier handoff");
+        let mut loaded = load_tampered_serialized_artifact(
+            "phase44d-recursive-handoff-replay-flags",
+            &handoff,
+            |handoff_json| {
+                handoff_json["verifier_requires_phase43_trace"] = serde_json::json!(true);
+                handoff_json["verifier_embeds_expected_rows"] = serde_json::json!(true);
+            },
+        );
+        loaded.handoff_commitment =
+            commit_phase44d_recursive_verifier_public_output_handoff(&loaded)
+                .expect("recommit forged replay handoff");
+
+        let error = verify_phase44d_recursive_verifier_public_output_handoff(&loaded)
+            .expect_err("serialized replay handoff must reject even when recommitted");
         assert!(error.to_string().contains("must remain boundary-width"));
     }
 

--- a/src/stwo_backend/history_replay_projection_prover.rs
+++ b/src/stwo_backend/history_replay_projection_prover.rs
@@ -4726,6 +4726,7 @@ mod tests {
     use super::*;
     use crate::proof::CLAIM_STATEMENT_VERSION_V1;
     use serde::de::DeserializeOwned;
+    use std::sync::OnceLock;
     use stwo::core::pcs::TreeVec;
     use stwo_constraint_framework::assert_constraints_on_trace;
 
@@ -4984,7 +4985,13 @@ mod tests {
         Phase43HistoryReplayTrace,
         Phase30DecodingStepProofEnvelopeManifest,
     ) {
-        sample_trace_and_phase30_for_layout_steps(2, 2, 2)
+        static FIXTURE: OnceLock<(
+            Phase43HistoryReplayTrace,
+            Phase30DecodingStepProofEnvelopeManifest,
+        )> = OnceLock::new();
+        FIXTURE
+            .get_or_init(|| sample_trace_and_phase30_for_layout_steps(2, 2, 2))
+            .clone()
     }
 
     fn sample_trace_and_phase30_for_layout_steps(
@@ -5093,6 +5100,54 @@ mod tests {
         trace.trace_commitment = commit_phase43_history_replay_trace(&trace).expect("commit trace");
         verify_phase43_history_replay_trace(&trace).expect("sample trace verifies");
         (trace, phase30)
+    }
+
+    #[derive(Debug, Clone)]
+    struct Phase44DComposedArtifactFixture {
+        compact_envelope: Phase43HistoryReplayProjectionCompactProofEnvelope,
+        boundary: Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary,
+        handoff: super::super::recursion::Phase44DRecursiveVerifierPublicOutputHandoff,
+        bridge: super::super::recursion::Phase45RecursiveVerifierPublicInputBridge,
+        receipt: super::super::recursion::Phase46StwoProofAdapterReceipt,
+    }
+
+    fn sample_phase44d_composed_artifact_fixture() -> Phase44DComposedArtifactFixture {
+        static FIXTURE: OnceLock<Phase44DComposedArtifactFixture> = OnceLock::new();
+        FIXTURE
+            .get_or_init(|| {
+                let (trace, phase30) = sample_trace_and_phase30();
+                let compact_envelope =
+                    prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+                        .expect("prove cached Phase44 compact projection");
+                let boundary =
+                    emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+                        &trace, &phase30,
+                    )
+                    .expect("emit cached Phase44D source-chain public output boundary");
+                let handoff = phase44d_prepare_recursive_verifier_public_output_handoff(
+                    &boundary,
+                    &compact_envelope,
+                )
+                .expect("prepare cached Phase44D recursive-verifier handoff");
+                let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
+                    &boundary,
+                    &compact_envelope,
+                    &handoff,
+                )
+                .expect("prepare cached Phase45 public-input bridge");
+                let receipt =
+                    phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
+                        .expect("prepare cached Phase46 Stwo proof-adapter receipt");
+
+                Phase44DComposedArtifactFixture {
+                    compact_envelope,
+                    boundary,
+                    handoff,
+                    bridge,
+                    receipt,
+                }
+            })
+            .clone()
     }
 
     fn load_tampered_phase44d_source_chain_public_output_boundary(
@@ -5997,14 +6052,7 @@ mod tests {
 
     #[test]
     fn phase44d_source_emission_public_output_boundary_json_round_trip_preserves_acceptance() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
+        let fixture = sample_phase44d_composed_artifact_fixture();
         let tempdir = tempfile::Builder::new()
             .prefix("llm-provable-computer-phase44d-boundary-")
             .tempdir()
@@ -6013,22 +6061,22 @@ mod tests {
 
         std::fs::write(
             &path,
-            serde_json::to_vec(&boundary).expect("encode boundary"),
+            serde_json::to_vec(&fixture.boundary).expect("encode boundary"),
         )
         .expect("write boundary");
         let loaded: Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary =
             serde_json::from_slice(&std::fs::read(&path).expect("read boundary"))
                 .expect("load boundary");
 
-        assert_eq!(loaded, boundary);
+        assert_eq!(&loaded, &fixture.boundary);
         verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance(
             &loaded,
-            &compact_envelope,
+            &fixture.compact_envelope,
         )
         .expect("loaded boundary acceptance should verify");
         verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding(
             &loaded,
-            &compact_envelope.claim,
+            &fixture.compact_envelope.claim,
         )
         .expect("loaded boundary binding should verify");
     }
@@ -6116,18 +6164,10 @@ mod tests {
 
     #[test]
     fn phase44d_source_emission_public_output_boundary_loaded_json_rejects_replay_flags() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let original_boundary =
-            emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-                &trace, &phase30,
-            )
-            .expect("emit Phase44D source-chain public output boundary");
+        let fixture = sample_phase44d_composed_artifact_fixture();
         let mut boundary = load_tampered_phase44d_source_chain_public_output_boundary(
             "phase44d-boundary-replay-flags",
-            &original_boundary,
+            &fixture.boundary,
             |boundary_json| {
                 boundary_json["verifier_requires_phase43_trace"] = serde_json::json!(true);
                 boundary_json["verifier_embeds_expected_rows"] = serde_json::json!(true);
@@ -6142,7 +6182,7 @@ mod tests {
         let error =
             verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance(
                 &boundary,
-                &compact_envelope,
+                &fixture.compact_envelope,
             )
             .expect_err("serialized replay flag drift must reject source-chain boundary");
 
@@ -6249,27 +6289,19 @@ mod tests {
 
     #[test]
     fn phase44d_source_emission_recursive_handoff_json_round_trip_preserves_acceptance() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let loaded =
-            round_trip_serialized_artifact("phase44d-recursive-handoff-roundtrip", &handoff);
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let loaded = round_trip_serialized_artifact(
+            "phase44d-recursive-handoff-roundtrip",
+            &fixture.handoff,
+        );
 
-        assert_eq!(loaded, handoff);
+        assert_eq!(&loaded, &fixture.handoff);
         verify_phase44d_recursive_verifier_public_output_handoff(&loaded)
             .expect("verify standalone loaded Phase44D recursive-verifier handoff");
         verify_phase44d_recursive_verifier_public_output_handoff_against_boundary(
             &loaded,
-            &boundary,
-            &compact_envelope,
+            &fixture.boundary,
+            &fixture.compact_envelope,
         )
         .expect("verify loaded Phase44D recursive-verifier handoff against boundary");
     }
@@ -6436,34 +6468,20 @@ mod tests {
 
     #[test]
     fn phase45_public_input_bridge_json_round_trip_preserves_acceptance() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let loaded =
-            round_trip_serialized_artifact("phase45-public-input-bridge-roundtrip", &bridge);
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let loaded = round_trip_serialized_artifact(
+            "phase45-public-input-bridge-roundtrip",
+            &fixture.bridge,
+        );
 
-        assert_eq!(loaded, bridge);
+        assert_eq!(&loaded, &fixture.bridge);
         verify_phase45_recursive_verifier_public_input_bridge(&loaded)
             .expect("verify standalone loaded Phase45 public-input bridge");
         verify_phase45_recursive_verifier_public_input_bridge_against_sources(
             &loaded,
-            &boundary,
-            &compact_envelope,
-            &handoff,
+            &fixture.boundary,
+            &fixture.compact_envelope,
+            &fixture.handoff,
         )
         .expect("verify loaded Phase45 public-input bridge against sources");
     }
@@ -6502,26 +6520,10 @@ mod tests {
 
     #[test]
     fn phase45_public_input_bridge_loaded_json_rejects_reordered_lanes() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
+        let fixture = sample_phase44d_composed_artifact_fixture();
         let mut loaded = load_tampered_serialized_artifact(
             "phase45-public-input-bridge-reordered-lanes",
-            &bridge,
+            &fixture.bridge,
             |bridge_json| {
                 let lanes = bridge_json["ordered_public_input_lanes"]
                     .as_array_mut()
@@ -6616,39 +6618,21 @@ mod tests {
 
     #[test]
     fn phase46_stwo_proof_adapter_receipt_json_round_trip_preserves_acceptance() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-            .expect("prepare Phase46 Stwo proof-adapter receipt");
+        let fixture = sample_phase44d_composed_artifact_fixture();
         let loaded = round_trip_serialized_artifact(
             "phase46-stwo-proof-adapter-receipt-roundtrip",
-            &receipt,
+            &fixture.receipt,
         );
 
-        assert_eq!(loaded, receipt);
+        assert_eq!(&loaded, &fixture.receipt);
         verify_phase46_stwo_proof_adapter_receipt(&loaded)
             .expect("verify standalone loaded Phase46 Stwo proof-adapter receipt");
         verify_phase46_stwo_proof_adapter_receipt_against_sources(
             &loaded,
-            &bridge,
-            &boundary,
-            &compact_envelope,
-            &handoff,
+            &fixture.bridge,
+            &fixture.boundary,
+            &fixture.compact_envelope,
+            &fixture.handoff,
         )
         .expect("verify loaded Phase46 Stwo proof-adapter receipt against sources");
     }
@@ -6687,28 +6671,10 @@ mod tests {
 
     #[test]
     fn phase46_stwo_proof_adapter_receipt_loaded_json_rejects_interaction_claim_drift() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-            .expect("prepare Phase46 Stwo proof-adapter receipt");
+        let fixture = sample_phase44d_composed_artifact_fixture();
         let mut loaded = load_tampered_serialized_artifact(
             "phase46-stwo-proof-adapter-receipt-interaction-claim-drift",
-            &receipt,
+            &fixture.receipt,
             |receipt_json| {
                 let claimed_sum = receipt_json["terminal_boundary_component_claimed_sum_limbs"][0]
                     .as_u64()
@@ -10838,20 +10804,10 @@ mod tests {
 
     #[test]
     fn phase44d_source_emission_recursive_handoff_loaded_json_rejects_replay_flags() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
+        let fixture = sample_phase44d_composed_artifact_fixture();
         let mut loaded = load_tampered_serialized_artifact(
             "phase44d-recursive-handoff-replay-flags",
-            &handoff,
+            &fixture.handoff,
             |handoff_json| {
                 handoff_json["verifier_requires_phase43_trace"] = serde_json::json!(true);
                 handoff_json["verifier_embeds_expected_rows"] = serde_json::json!(true);


### PR DESCRIPTION
## Summary
- add serialized JSON round-trip and tamper coverage for the Phase44D recursive handoff
- add serialized JSON round-trip and tamper coverage for the Phase45 public-input bridge
- add serialized JSON round-trip and tamper coverage for the Phase46 Stwo proof-adapter receipt
- refresh handoff and soundness review notes so the checked-in lane state matches the composed artifact coverage

## Validation
- `export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target && cargo +nightly-2025-07-14 test --features stwo-backend --lib phase44d_source_emission_recursive_handoff_`
- `export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target && cargo +nightly-2025-07-14 test --features stwo-backend --lib phase45_public_input_bridge_`
- `export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target && cargo +nightly-2025-07-14 test --features stwo-backend --lib phase46_stwo_proof_adapter_receipt_`
- `export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target && cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm`
- `cargo +nightly-2025-07-14 fmt --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended specification coverage for serialization and verification across multiple system phases.
  * Added detailed regression test documentation for JSON round-trip validation.

* **Tests**
  * Implemented new test coverage for JSON serialization integrity and verification rejection scenarios.
  * Improved test infrastructure with fixture caching and generic serialization utilities.
  * Added validation tests for component interactions across multiple verification stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->