### PR TITLE
[codex] Extend wrapper artifact tamper coverage

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -41,6 +41,11 @@ The active split is now:
   Phase45 public-input bridge, and the Phase46 Stwo proof-adapter receipt,
   including replay-flag drift, reordered public-input lanes, and terminal
   interaction-claim drift after recommit.
+- Gate 2h: the next wrapper-surface increment extends serialized JSON coverage
+  one layer higher again to the Phase47 recursive-verifier wrapper candidate
+  and the Phase48 recursive proof-wrapper attempt, including replay-flag drift
+  on the wrapper candidate and blocking-reason drift on the Phase48 no-go
+  artifact after recommit.
 - Gate 2e: the honest `8`-step family now has explicit coverage for signed and
   non-unit `MulMemory` wrap deltas, the sticky-carry `Store` rows that follow
   them, and a full positive trace-constraint sweep across all eight seeds.
@@ -90,8 +95,8 @@ Use these in order of authority for current state:
 1. Broaden review of the experimental backend beyond the current decoding-step
    family, now that the disk-backed proof-file tamper matrix, serialized
    Phase12-chain tamper coverage, serialized Phase44D boundary/handoff/bridge/receipt
-   coverage, and the honest `8`-step multiply/store carry patterns are all
-   checked.
+   coverage, serialized Phase47/48 wrapper coverage, and the honest `8`-step
+   multiply/store carry patterns are all checked.
 2. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after

--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -44,8 +44,8 @@ The active split is now:
 - Gate 2h: the next wrapper-surface increment extends serialized JSON coverage
   one layer higher again to the Phase47 recursive-verifier wrapper candidate
   and the Phase48 recursive proof-wrapper attempt, including replay-flag drift
-  on the wrapper candidate and blocking-reason drift on the Phase48 no-go
-  artifact after recommit.
+  and stale-commitment rejection on the wrapper candidate plus blocking-reason
+  drift and stale-commitment rejection on the Phase48 no-go artifact.
 - Gate 2e: the honest `8`-step family now has explicit coverage for signed and
   non-unit `MulMemory` wrap deltas, the sticky-carry `Store` rows that follow
   them, and a full positive trace-constraint sweep across all eight seeds.

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -26,7 +26,7 @@ This repository currently has two live lanes.
 2. Experimental core-proving lane
    - The carry-aware backend `stwo-phase12-decoding-family-v10-carry-aware-experimental` is the active upside research lane.
    - It clears the honest `8`-step Phase12 family, has AIR-level `wrap_delta` range constraints, and the experimental Phase44D scaling sweep currently clears through `2,4,8,16,32,64,128,256,512,1024`.
-   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, serialized Phase44D typed-boundary tamper coverage, and serialized Phase44D handoff / Phase45 bridge / Phase46 receipt tamper coverage.
+   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, serialized Phase44D typed-boundary tamper coverage, serialized Phase44D handoff / Phase45 bridge / Phase46 receipt tamper coverage, and serialized Phase47 wrapper-candidate / Phase48 wrapper-attempt tamper coverage.
 
 Do not collapse these two lanes into one claim.
 
@@ -44,8 +44,9 @@ The experimental carry-aware lane now has one real higher-layer scaling result:
 1. Broaden experimental carry-aware review beyond the current decoding-step
    family, now that the honest `8`-step multiply/store carry patterns, the
    proof-file tamper matrix, the serialized proof-checked Phase12-chain tamper
-   matrix, and the serialized Phase44D boundary / handoff / bridge / receipt
-   tamper checks are covered.
+   matrix, the serialized Phase44D boundary / handoff / bridge / receipt
+   tamper checks, and the serialized Phase47 / Phase48 wrapper checks are
+   covered.
 2. Re-run the Phase44D experimental frontier only after any material AIR or
    verifier change.
 3. Raise the Phase43/Phase44D experimental ceiling beyond `1024` only after

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -26,7 +26,7 @@ This repository currently has two live lanes.
 2. Experimental core-proving lane
    - The carry-aware backend `stwo-phase12-decoding-family-v10-carry-aware-experimental` is the active upside research lane.
    - It clears the honest `8`-step Phase12 family, has AIR-level `wrap_delta` range constraints, and the experimental Phase44D scaling sweep currently clears through `2,4,8,16,32,64,128,256,512,1024`.
-   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, serialized Phase44D typed-boundary tamper coverage, serialized Phase44D handoff / Phase45 bridge / Phase46 receipt tamper coverage, and serialized Phase47 wrapper-candidate / Phase48 wrapper-attempt tamper coverage.
+   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, serialized Phase44D typed-boundary tamper coverage, serialized Phase44D handoff / Phase45 bridge / Phase46 receipt tamper coverage, and serialized Phase47 wrapper-candidate / Phase48 wrapper-attempt tamper coverage including stale-commitment rejection.
 
 Do not collapse these two lanes into one claim.
 

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -45,6 +45,11 @@ This repository now has two live lanes.
   the Phase44D recursive handoff, the Phase45 public-input bridge, and the
   Phase46 Stwo proof-adapter receipt, including replay-flag drift, reordered
   public-input lanes, and terminal interaction-claim drift after recommit.
+- The next wrapper-surface increment extends serialized JSON coverage one layer
+  higher to the Phase47 recursive-verifier wrapper candidate and the Phase48
+  recursive proof-wrapper attempt, including replay-flag drift on the wrapper
+  candidate and blocking-reason drift on the Phase48 no-go artifact after
+  recommit.
 - A second April 25 follow-up covers signed/non-unit `MulMemory` wrap patterns,
   sticky-carry `Store` preservation, and a full positive trace sweep on the
   honest `8`-step family.
@@ -77,8 +82,8 @@ verified. Do not describe it as a faster FRI or cryptographic verifier.
 1. Broaden review of the experimental backend beyond the current decoding-step
    family, now that the disk-backed proof-file tamper matrix, serialized
    Phase12-chain tamper coverage, serialized Phase44D boundary/handoff/bridge/receipt
-   coverage, and the honest `8`-step multiply/store carry patterns are both
-   checked.
+   coverage, serialized Phase47/48 wrapper coverage, and the honest `8`-step
+   multiply/store carry patterns are both checked.
 2. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -47,9 +47,9 @@ This repository now has two live lanes.
   public-input lanes, and terminal interaction-claim drift after recommit.
 - The next wrapper-surface increment extends serialized JSON coverage one layer
   higher to the Phase47 recursive-verifier wrapper candidate and the Phase48
-  recursive proof-wrapper attempt, including replay-flag drift on the wrapper
-  candidate and blocking-reason drift on the Phase48 no-go artifact after
-  recommit.
+  recursive proof-wrapper attempt, including replay-flag drift and
+  stale-commitment rejection on the wrapper candidate plus blocking-reason
+  drift and stale-commitment rejection on the Phase48 no-go artifact.
 - A second April 25 follow-up covers signed/non-unit `MulMemory` wrap patterns,
   sticky-carry `Store` preservation, and a full positive trace sweep on the
   honest `8`-step family.

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -181,56 +181,58 @@ Added focused tamper tests:
    - loads the tampered receipt through the JSON surface
    - recommits the receipt and expects terminal LogUp cancellation verification to reject
 
-1. `phase47_recursive_verifier_wrapper_candidate_json_round_trip_preserves_acceptance`
+<!-- markdownlint-disable MD029 -->
+24. `phase47_recursive_verifier_wrapper_candidate_json_round_trip_preserves_acceptance`
    - saves a Phase47 recursive-verifier wrapper candidate to JSON and loads it back
    - confirms the loaded candidate still passes both standalone and Phase46-bound verification
 
-1. `phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_replay_flags`
+25. `phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_replay_flags`
    - mutates the serialized replay flags on a saved Phase47 wrapper candidate
    - loads the tampered candidate through the JSON surface
    - recommits the candidate and expects the wrapper replay-input guard to reject
 
-1. `phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_stale_commitment`
+26. `phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_stale_commitment`
    - mutates the serialized `compact_envelope_commitment` on a saved Phase47 wrapper candidate
    - loads the tampered candidate through the JSON surface without recommitting it
-   - expects the stale top-level commitment to reject before any wrapper-surface drift could pass
+   - expects the stale top-level commitment to reject the serialized tampering
 
-1. `phase48_recursive_proof_wrapper_attempt_json_round_trip_preserves_acceptance`
+27. `phase48_recursive_proof_wrapper_attempt_json_round_trip_preserves_acceptance`
    - saves a Phase48 recursive proof-wrapper attempt to JSON and loads it back
    - confirms the loaded attempt still passes both standalone and Phase47-bound verification
 
-1. `phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_blocking_reason_drift`
+28. `phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_blocking_reason_drift`
    - mutates the serialized blocking-reason list on a saved Phase48 wrapper attempt
    - loads the tampered attempt through the JSON surface
    - recommits the attempt and expects the missing Phase43 Cairo AIR blocker guard to reject
 
-1. `phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_stale_commitment`
+29. `phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_stale_commitment`
    - mutates the serialized `compact_envelope_commitment` on a saved Phase48 wrapper attempt
    - loads the tampered attempt through the JSON surface without recommitting it
-   - expects the stale top-level commitment to reject before the blocker drift could be masked
+   - expects the stale top-level commitment to reject the serialized tampering
 
-1. `carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family`
+30. `carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family`
    - scans the honest `8`-step family and confirms the current carry-bearing
      surface consists of `MulMemory` rows plus the sticky-carry `Store` rows
      that follow them
    - pins the observed wrap-delta coverage to `{-41, -20, 0, 1, 3}` so future
      claim-widening happens deliberately
 
-1. `carry_aware_trace_builder_rejects_store_row_that_drops_live_carry`
+31. `carry_aware_trace_builder_rejects_store_row_that_drops_live_carry`
    - mutates the post-multiply `Store` row in the honest `8`-step family to
      clear a live carry flag
    - expects the trace builder to reject before proving
 
-1. `carry_aware_air_rejects_negative_wrap_delta_sign_drift`
+32. `carry_aware_air_rejects_negative_wrap_delta_sign_drift`
    - mutates the sign witness on a negative-wrap `MulMemory` row from the
      honest `8`-step family
    - expects the AIR signed-reconstruction constraint to reject
 
-1. `carry_aware_phase12_eight_step_family_trace_satisfies_constraints`
+33. `carry_aware_phase12_eight_step_family_trace_satisfies_constraints`
    - runs the carry-aware trace-constraint path across every honest seed in the
      `8`-step family
    - ensures the widened family-level coverage claim is backed by the
      positive trace path, not just prototype-row inspection
+<!-- markdownlint-enable MD029 -->
 
 These complement the existing tests for out-of-range `wrap_delta`, ADD/SUB
 unit range, proof-payload tampering, backend-version isolation, and reexecution.

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -181,23 +181,33 @@ Added focused tamper tests:
    - loads the tampered receipt through the JSON surface
    - recommits the receipt and expects terminal LogUp cancellation verification to reject
 
-24. `phase47_recursive_verifier_wrapper_candidate_json_round_trip_preserves_acceptance`
+1. `phase47_recursive_verifier_wrapper_candidate_json_round_trip_preserves_acceptance`
    - saves a Phase47 recursive-verifier wrapper candidate to JSON and loads it back
    - confirms the loaded candidate still passes both standalone and Phase46-bound verification
 
-25. `phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_replay_flags`
+1. `phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_replay_flags`
    - mutates the serialized replay flags on a saved Phase47 wrapper candidate
    - loads the tampered candidate through the JSON surface
    - recommits the candidate and expects the wrapper replay-input guard to reject
 
-26. `phase48_recursive_proof_wrapper_attempt_json_round_trip_preserves_acceptance`
+1. `phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_stale_commitment`
+   - mutates the serialized replay flags on a saved Phase47 wrapper candidate
+   - loads the tampered candidate through the JSON surface without recommitting it
+   - expects the stale top-level commitment to reject before any wrapper-surface drift could pass
+
+1. `phase48_recursive_proof_wrapper_attempt_json_round_trip_preserves_acceptance`
    - saves a Phase48 recursive proof-wrapper attempt to JSON and loads it back
    - confirms the loaded attempt still passes both standalone and Phase47-bound verification
 
-27. `phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_blocking_reason_drift`
+1. `phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_blocking_reason_drift`
    - mutates the serialized blocking-reason list on a saved Phase48 wrapper attempt
    - loads the tampered attempt through the JSON surface
    - recommits the attempt and expects the missing Phase43 Cairo AIR blocker guard to reject
+
+1. `phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_stale_commitment`
+   - mutates the serialized blocking-reason list on a saved Phase48 wrapper attempt
+   - loads the tampered attempt through the JSON surface without recommitting it
+   - expects the stale top-level commitment to reject before the blocker drift could be masked
 
 1. `carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family`
    - scans the honest `8`-step family and confirms the current carry-bearing

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -181,6 +181,24 @@ Added focused tamper tests:
    - loads the tampered receipt through the JSON surface
    - recommits the receipt and expects terminal LogUp cancellation verification to reject
 
+24. `phase47_recursive_verifier_wrapper_candidate_json_round_trip_preserves_acceptance`
+   - saves a Phase47 recursive-verifier wrapper candidate to JSON and loads it back
+   - confirms the loaded candidate still passes both standalone and Phase46-bound verification
+
+25. `phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_replay_flags`
+   - mutates the serialized replay flags on a saved Phase47 wrapper candidate
+   - loads the tampered candidate through the JSON surface
+   - recommits the candidate and expects the wrapper replay-input guard to reject
+
+26. `phase48_recursive_proof_wrapper_attempt_json_round_trip_preserves_acceptance`
+   - saves a Phase48 recursive proof-wrapper attempt to JSON and loads it back
+   - confirms the loaded attempt still passes both standalone and Phase47-bound verification
+
+27. `phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_blocking_reason_drift`
+   - mutates the serialized blocking-reason list on a saved Phase48 wrapper attempt
+   - loads the tampered attempt through the JSON surface
+   - recommits the attempt and expects the missing Phase43 Cairo AIR blocker guard to reject
+
 1. `carry_aware_subset_prototype_maps_signed_multi_wrap_and_store_patterns_on_honest_eight_step_family`
    - scans the honest `8`-step family and confirms the current carry-bearing
      surface consists of `MulMemory` rows plus the sticky-carry `Store` rows
@@ -249,6 +267,8 @@ cargo +nightly-2025-07-14 test phase44d_source_emission_public_output_boundary_l
 cargo +nightly-2025-07-14 test phase44d_source_emission_recursive_handoff_ --features stwo-backend --lib
 cargo +nightly-2025-07-14 test phase45_public_input_bridge_ --features stwo-backend --lib
 cargo +nightly-2025-07-14 test phase46_stwo_proof_adapter_receipt_ --features stwo-backend --lib
+cargo +nightly-2025-07-14 test phase47_recursive_verifier_wrapper_candidate_ --features stwo-backend --lib
+cargo +nightly-2025-07-14 test phase48_recursive_proof_wrapper_attempt_ --features stwo-backend --lib
 ```
 
 Recommended merge gate for this increment:

--- a/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
+++ b/docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md
@@ -191,7 +191,7 @@ Added focused tamper tests:
    - recommits the candidate and expects the wrapper replay-input guard to reject
 
 1. `phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_stale_commitment`
-   - mutates the serialized replay flags on a saved Phase47 wrapper candidate
+   - mutates the serialized `compact_envelope_commitment` on a saved Phase47 wrapper candidate
    - loads the tampered candidate through the JSON surface without recommitting it
    - expects the stale top-level commitment to reject before any wrapper-surface drift could pass
 
@@ -205,7 +205,7 @@ Added focused tamper tests:
    - recommits the attempt and expects the missing Phase43 Cairo AIR blocker guard to reject
 
 1. `phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_stale_commitment`
-   - mutates the serialized blocking-reason list on a saved Phase48 wrapper attempt
+   - mutates the serialized `compact_envelope_commitment` on a saved Phase48 wrapper attempt
    - loads the tampered attempt through the JSON surface without recommitting it
    - expects the stale top-level commitment to reject before the blocker drift could be masked
 

--- a/src/stwo_backend/history_replay_projection_prover.rs
+++ b/src/stwo_backend/history_replay_projection_prover.rs
@@ -5109,6 +5109,10 @@ mod tests {
         handoff: super::super::recursion::Phase44DRecursiveVerifierPublicOutputHandoff,
         bridge: super::super::recursion::Phase45RecursiveVerifierPublicInputBridge,
         receipt: super::super::recursion::Phase46StwoProofAdapterReceipt,
+    }
+
+    #[derive(Debug, Clone)]
+    struct Phase47Phase48WrapperFixture {
         candidate: Phase47RecursiveVerifierWrapperCandidate,
         attempt: Phase48RecursiveProofWrapperAttempt,
     }
@@ -5138,10 +5142,6 @@ mod tests {
             .expect("prepare cached Phase45 public-input bridge");
             let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
                 .expect("prepare cached Phase46 Stwo proof-adapter receipt");
-            let candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
-                .expect("prepare cached Phase47 recursive-verifier wrapper candidate");
-            let attempt = phase48_prepare_recursive_proof_wrapper_attempt(&candidate)
-                .expect("prepare cached Phase48 recursive proof-wrapper attempt");
 
             Phase44DComposedArtifactFixture {
                 compact_envelope,
@@ -5149,9 +5149,19 @@ mod tests {
                 handoff,
                 bridge,
                 receipt,
-                candidate,
-                attempt,
             }
+        })
+    }
+
+    fn sample_phase47_phase48_wrapper_fixture() -> &'static Phase47Phase48WrapperFixture {
+        static FIXTURE: OnceLock<Phase47Phase48WrapperFixture> = OnceLock::new();
+        FIXTURE.get_or_init(|| {
+            let fixture = sample_phase44d_composed_artifact_fixture();
+            let candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&fixture.receipt)
+                .expect("prepare cached Phase47 recursive-verifier wrapper candidate");
+            let attempt = phase48_prepare_recursive_proof_wrapper_attempt(&candidate)
+                .expect("prepare cached Phase48 recursive proof-wrapper attempt");
+            Phase47Phase48WrapperFixture { candidate, attempt }
         })
     }
 
@@ -6735,39 +6745,41 @@ mod tests {
 
     #[test]
     fn phase47_recursive_verifier_wrapper_candidate_accepts_phase46_receipt() {
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
         let fixture = sample_phase44d_composed_artifact_fixture();
 
-        verify_phase47_recursive_verifier_wrapper_candidate(&fixture.candidate)
+        verify_phase47_recursive_verifier_wrapper_candidate(&wrapper_fixture.candidate)
             .expect("verify standalone Phase47 wrapper candidate");
         verify_phase47_recursive_verifier_wrapper_candidate_against_phase46(
-            &fixture.candidate,
+            &wrapper_fixture.candidate,
             &fixture.receipt,
         )
         .expect("verify Phase47 wrapper candidate against Phase46 receipt");
 
         assert_eq!(
-            fixture.candidate.adapter_receipt_commitment,
+            wrapper_fixture.candidate.adapter_receipt_commitment,
             fixture.receipt.adapter_receipt_commitment
         );
         assert_eq!(
-            fixture.candidate.proof_commitment_roots.len(),
+            wrapper_fixture.candidate.proof_commitment_roots.len(),
             fixture.receipt.proof_commitment_roots.len()
         );
-        assert!(fixture.candidate.consumes_phase46_receipt_only);
-        assert!(!fixture.candidate.recursive_proof_available);
-        assert!(!fixture.candidate.recursive_verification_claimed);
-        assert!(!fixture.candidate.cryptographic_compression_claimed);
+        assert!(wrapper_fixture.candidate.consumes_phase46_receipt_only);
+        assert!(!wrapper_fixture.candidate.recursive_proof_available);
+        assert!(!wrapper_fixture.candidate.recursive_verification_claimed);
+        assert!(!wrapper_fixture.candidate.cryptographic_compression_claimed);
     }
 
     #[test]
     fn phase47_recursive_verifier_wrapper_candidate_json_round_trip_preserves_acceptance() {
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
         let fixture = sample_phase44d_composed_artifact_fixture();
         let loaded = round_trip_serialized_artifact(
             "phase47-recursive-wrapper-candidate-roundtrip",
-            &fixture.candidate,
+            &wrapper_fixture.candidate,
         );
 
-        assert_eq!(&loaded, &fixture.candidate);
+        assert_eq!(&loaded, &wrapper_fixture.candidate);
         verify_phase47_recursive_verifier_wrapper_candidate(&loaded)
             .expect("verify standalone loaded Phase47 wrapper candidate");
         verify_phase47_recursive_verifier_wrapper_candidate_against_phase46(
@@ -6779,8 +6791,8 @@ mod tests {
 
     #[test]
     fn phase47_recursive_verifier_wrapper_candidate_rejects_replay_flags_even_when_recommitted() {
-        let fixture = sample_phase44d_composed_artifact_fixture();
-        let mut candidate = fixture.candidate.clone();
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
+        let mut candidate = wrapper_fixture.candidate.clone();
 
         candidate.wrapper_requires_phase43_trace = true;
         candidate.wrapper_requires_phase30_manifest = true;
@@ -6795,10 +6807,10 @@ mod tests {
 
     #[test]
     fn phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_replay_flags() {
-        let fixture = sample_phase44d_composed_artifact_fixture();
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
         let mut loaded = load_tampered_serialized_artifact(
             "phase47-recursive-wrapper-candidate-replay-flags",
-            &fixture.candidate,
+            &wrapper_fixture.candidate,
             |candidate_json| {
                 candidate_json["wrapper_requires_phase43_trace"] = serde_json::json!(true);
                 candidate_json["wrapper_requires_phase30_manifest"] = serde_json::json!(true);
@@ -6813,9 +6825,25 @@ mod tests {
     }
 
     #[test]
+    fn phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_stale_commitment() {
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
+        let loaded = load_tampered_serialized_artifact(
+            "phase47-recursive-wrapper-candidate-stale-commitment",
+            &wrapper_fixture.candidate,
+            |candidate_json| {
+                candidate_json["compact_envelope_commitment"] = serde_json::json!(hash32('c'));
+            },
+        );
+
+        let error = verify_phase47_recursive_verifier_wrapper_candidate(&loaded)
+            .expect_err("serialized Phase47 wrapper candidate with stale commitment must reject");
+        assert!(error.to_string().contains("commitment"));
+    }
+
+    #[test]
     fn phase47_recursive_verifier_wrapper_candidate_rejects_false_compression_claim() {
-        let fixture = sample_phase44d_composed_artifact_fixture();
-        let mut candidate = fixture.candidate.clone();
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
+        let mut candidate = wrapper_fixture.candidate.clone();
 
         candidate.recursive_proof_available = true;
         candidate.recursive_verification_claimed = true;
@@ -6831,8 +6859,8 @@ mod tests {
 
     #[test]
     fn phase47_recursive_verifier_wrapper_candidate_rejects_proof_root_drift() {
-        let fixture = sample_phase44d_composed_artifact_fixture();
-        let mut candidate = fixture.candidate.clone();
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
+        let mut candidate = wrapper_fixture.candidate.clone();
 
         candidate
             .proof_commitment_roots
@@ -6853,26 +6881,34 @@ mod tests {
 
     #[test]
     fn phase48_recursive_proof_wrapper_attempt_records_no_go_after_phase47() {
-        let fixture = sample_phase44d_composed_artifact_fixture();
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
 
-        verify_phase48_recursive_proof_wrapper_attempt(&fixture.attempt)
+        verify_phase48_recursive_proof_wrapper_attempt(&wrapper_fixture.attempt)
             .expect("verify standalone Phase48 recursive proof-wrapper attempt");
         verify_phase48_recursive_proof_wrapper_attempt_against_phase47(
-            &fixture.attempt,
-            &fixture.candidate,
+            &wrapper_fixture.attempt,
+            &wrapper_fixture.candidate,
         )
         .expect("verify Phase48 recursive proof-wrapper attempt against Phase47");
 
         assert_eq!(
-            fixture.attempt.phase47_candidate_commitment,
-            fixture.candidate.candidate_commitment
+            wrapper_fixture.attempt.phase47_candidate_commitment,
+            wrapper_fixture.candidate.candidate_commitment
         );
-        assert!(fixture.attempt.local_stwo_core_verifier_detected);
-        assert!(fixture.attempt.local_stwo_cairo_verifier_core_detected);
-        assert!(!fixture.attempt.local_phase43_projection_cairo_air_detected);
-        assert!(!fixture.attempt.actual_recursive_wrapper_available);
-        assert!(!fixture.attempt.recursive_proof_constructed);
-        assert!(fixture
+        assert!(wrapper_fixture.attempt.local_stwo_core_verifier_detected);
+        assert!(
+            wrapper_fixture
+                .attempt
+                .local_stwo_cairo_verifier_core_detected
+        );
+        assert!(
+            !wrapper_fixture
+                .attempt
+                .local_phase43_projection_cairo_air_detected
+        );
+        assert!(!wrapper_fixture.attempt.actual_recursive_wrapper_available);
+        assert!(!wrapper_fixture.attempt.recursive_proof_constructed);
+        assert!(wrapper_fixture
             .attempt
             .decision
             .contains("missing_phase43_projection_cairo_air"));
@@ -6880,23 +6916,26 @@ mod tests {
 
     #[test]
     fn phase48_recursive_proof_wrapper_attempt_json_round_trip_preserves_acceptance() {
-        let fixture = sample_phase44d_composed_artifact_fixture();
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
         let loaded = round_trip_serialized_artifact(
             "phase48-recursive-proof-wrapper-attempt-roundtrip",
-            &fixture.attempt,
+            &wrapper_fixture.attempt,
         );
 
-        assert_eq!(&loaded, &fixture.attempt);
+        assert_eq!(&loaded, &wrapper_fixture.attempt);
         verify_phase48_recursive_proof_wrapper_attempt(&loaded)
             .expect("verify standalone loaded Phase48 proof-wrapper attempt");
-        verify_phase48_recursive_proof_wrapper_attempt_against_phase47(&loaded, &fixture.candidate)
-            .expect("verify loaded Phase48 proof-wrapper attempt against Phase47");
+        verify_phase48_recursive_proof_wrapper_attempt_against_phase47(
+            &loaded,
+            &wrapper_fixture.candidate,
+        )
+        .expect("verify loaded Phase48 proof-wrapper attempt against Phase47");
     }
 
     #[test]
     fn phase48_recursive_proof_wrapper_attempt_rejects_false_recursive_claim() {
-        let fixture = sample_phase44d_composed_artifact_fixture();
-        let mut attempt = fixture.attempt.clone();
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
+        let mut attempt = wrapper_fixture.attempt.clone();
 
         attempt.actual_recursive_wrapper_available = true;
         attempt.recursive_proof_constructed = true;
@@ -6912,8 +6951,8 @@ mod tests {
 
     #[test]
     fn phase48_recursive_proof_wrapper_attempt_requires_phase43_cairo_air_blocker() {
-        let fixture = sample_phase44d_composed_artifact_fixture();
-        let mut attempt = fixture.attempt.clone();
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
+        let mut attempt = wrapper_fixture.attempt.clone();
 
         attempt.blocking_reasons = vec!["generic wrapper blocker".to_string()];
         attempt.attempt_commitment = commit_phase48_recursive_proof_wrapper_attempt(&attempt)
@@ -6926,10 +6965,10 @@ mod tests {
 
     #[test]
     fn phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_blocking_reason_drift() {
-        let fixture = sample_phase44d_composed_artifact_fixture();
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
         let mut loaded = load_tampered_serialized_artifact(
             "phase48-recursive-proof-wrapper-attempt-blocking-drift",
-            &fixture.attempt,
+            &wrapper_fixture.attempt,
             |attempt_json| {
                 attempt_json["blocking_reasons"] = serde_json::json!(["generic wrapper blocker"]);
             },
@@ -6943,8 +6982,25 @@ mod tests {
         assert!(error.to_string().contains("missing Phase43 Cairo AIR"));
     }
 
+    #[test]
+    fn phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_stale_commitment() {
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
+        let loaded = load_tampered_serialized_artifact(
+            "phase48-recursive-proof-wrapper-attempt-stale-commitment",
+            &wrapper_fixture.attempt,
+            |attempt_json| {
+                attempt_json["compact_envelope_commitment"] = serde_json::json!(hash32('d'));
+            },
+        );
+
+        let error = verify_phase48_recursive_proof_wrapper_attempt(&loaded).expect_err(
+            "serialized Phase48 proof-wrapper attempt with stale commitment must reject",
+        );
+        assert!(error.to_string().contains("commitment"));
+    }
+
     fn sample_phase48_attempt_for_phase49() -> Phase48RecursiveProofWrapperAttempt {
-        sample_phase44d_composed_artifact_fixture().attempt.clone()
+        sample_phase47_phase48_wrapper_fixture().attempt.clone()
     }
 
     #[test]

--- a/src/stwo_backend/history_replay_projection_prover.rs
+++ b/src/stwo_backend/history_replay_projection_prover.rs
@@ -4706,9 +4706,9 @@ mod tests {
         verify_phase68_independent_replay_audit_claim_against_sources,
         verify_phase69_symbolic_artifact_mapping_claim,
         verify_phase69_symbolic_artifact_mapping_claim_against_sources,
-        verify_phase69_symbolic_artifact_mapping_row, Phase48RecursiveProofWrapperAttempt,
-        Phase49LayerwiseTensorClaimPropagationContract, Phase50LayerIoClaim,
-        Phase51FirstLayerRelationClaim, Phase52LayerEndpointAnchoringClaim,
+        verify_phase69_symbolic_artifact_mapping_row, Phase47RecursiveVerifierWrapperCandidate,
+        Phase48RecursiveProofWrapperAttempt, Phase49LayerwiseTensorClaimPropagationContract,
+        Phase50LayerIoClaim, Phase51FirstLayerRelationClaim, Phase52LayerEndpointAnchoringClaim,
         Phase53FirstLayerRelationBenchmarkClaim, Phase54FirstLayerSumcheckSkeletonClaim,
         Phase55FirstLayerCompressionEffectivenessClaim, Phase56FirstLayerExecutableSumcheckClaim,
         Phase57FirstLayerMleOpeningVerifierClaim, Phase58FirstLayerWitnessPcsOpeningClaim,
@@ -5109,6 +5109,8 @@ mod tests {
         handoff: super::super::recursion::Phase44DRecursiveVerifierPublicOutputHandoff,
         bridge: super::super::recursion::Phase45RecursiveVerifierPublicInputBridge,
         receipt: super::super::recursion::Phase46StwoProofAdapterReceipt,
+        candidate: Phase47RecursiveVerifierWrapperCandidate,
+        attempt: Phase48RecursiveProofWrapperAttempt,
     }
 
     fn sample_phase44d_composed_artifact_fixture() -> &'static Phase44DComposedArtifactFixture {
@@ -5136,6 +5138,10 @@ mod tests {
             .expect("prepare cached Phase45 public-input bridge");
             let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
                 .expect("prepare cached Phase46 Stwo proof-adapter receipt");
+            let candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
+                .expect("prepare cached Phase47 recursive-verifier wrapper candidate");
+            let attempt = phase48_prepare_recursive_proof_wrapper_attempt(&candidate)
+                .expect("prepare cached Phase48 recursive proof-wrapper attempt");
 
             Phase44DComposedArtifactFixture {
                 compact_envelope,
@@ -5143,6 +5149,8 @@ mod tests {
                 handoff,
                 bridge,
                 receipt,
+                candidate,
+                attempt,
             }
         })
     }
@@ -6727,70 +6735,52 @@ mod tests {
 
     #[test]
     fn phase47_recursive_verifier_wrapper_candidate_accepts_phase46_receipt() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-            .expect("prepare Phase46 Stwo proof-adapter receipt");
+        let fixture = sample_phase44d_composed_artifact_fixture();
 
-        let candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
-            .expect("prepare Phase47 recursive-verifier wrapper candidate");
-        verify_phase47_recursive_verifier_wrapper_candidate(&candidate)
+        verify_phase47_recursive_verifier_wrapper_candidate(&fixture.candidate)
             .expect("verify standalone Phase47 wrapper candidate");
-        verify_phase47_recursive_verifier_wrapper_candidate_against_phase46(&candidate, &receipt)
-            .expect("verify Phase47 wrapper candidate against Phase46 receipt");
+        verify_phase47_recursive_verifier_wrapper_candidate_against_phase46(
+            &fixture.candidate,
+            &fixture.receipt,
+        )
+        .expect("verify Phase47 wrapper candidate against Phase46 receipt");
 
         assert_eq!(
-            candidate.adapter_receipt_commitment,
-            receipt.adapter_receipt_commitment
+            fixture.candidate.adapter_receipt_commitment,
+            fixture.receipt.adapter_receipt_commitment
         );
         assert_eq!(
-            candidate.proof_commitment_roots.len(),
-            receipt.proof_commitment_roots.len()
+            fixture.candidate.proof_commitment_roots.len(),
+            fixture.receipt.proof_commitment_roots.len()
         );
-        assert!(candidate.consumes_phase46_receipt_only);
-        assert!(!candidate.recursive_proof_available);
-        assert!(!candidate.recursive_verification_claimed);
-        assert!(!candidate.cryptographic_compression_claimed);
+        assert!(fixture.candidate.consumes_phase46_receipt_only);
+        assert!(!fixture.candidate.recursive_proof_available);
+        assert!(!fixture.candidate.recursive_verification_claimed);
+        assert!(!fixture.candidate.cryptographic_compression_claimed);
+    }
+
+    #[test]
+    fn phase47_recursive_verifier_wrapper_candidate_json_round_trip_preserves_acceptance() {
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let loaded = round_trip_serialized_artifact(
+            "phase47-recursive-wrapper-candidate-roundtrip",
+            &fixture.candidate,
+        );
+
+        assert_eq!(&loaded, &fixture.candidate);
+        verify_phase47_recursive_verifier_wrapper_candidate(&loaded)
+            .expect("verify standalone loaded Phase47 wrapper candidate");
+        verify_phase47_recursive_verifier_wrapper_candidate_against_phase46(
+            &loaded,
+            &fixture.receipt,
+        )
+        .expect("verify loaded Phase47 wrapper candidate against Phase46 receipt");
     }
 
     #[test]
     fn phase47_recursive_verifier_wrapper_candidate_rejects_replay_flags_even_when_recommitted() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-            .expect("prepare Phase46 Stwo proof-adapter receipt");
-        let mut candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
-            .expect("prepare Phase47 recursive-verifier wrapper candidate");
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let mut candidate = fixture.candidate.clone();
 
         candidate.wrapper_requires_phase43_trace = true;
         candidate.wrapper_requires_phase30_manifest = true;
@@ -6804,28 +6794,28 @@ mod tests {
     }
 
     #[test]
+    fn phase47_recursive_verifier_wrapper_candidate_loaded_json_rejects_replay_flags() {
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let mut loaded = load_tampered_serialized_artifact(
+            "phase47-recursive-wrapper-candidate-replay-flags",
+            &fixture.candidate,
+            |candidate_json| {
+                candidate_json["wrapper_requires_phase43_trace"] = serde_json::json!(true);
+                candidate_json["wrapper_requires_phase30_manifest"] = serde_json::json!(true);
+            },
+        );
+        loaded.candidate_commitment = commit_phase47_recursive_verifier_wrapper_candidate(&loaded)
+            .expect("recommit forged Phase47 wrapper candidate");
+
+        let error = verify_phase47_recursive_verifier_wrapper_candidate(&loaded)
+            .expect_err("serialized Phase47 wrapper candidate must reject replay flags");
+        assert!(error.to_string().contains("must not reintroduce"));
+    }
+
+    #[test]
     fn phase47_recursive_verifier_wrapper_candidate_rejects_false_compression_claim() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-            .expect("prepare Phase46 Stwo proof-adapter receipt");
-        let mut candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
-            .expect("prepare Phase47 recursive-verifier wrapper candidate");
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let mut candidate = fixture.candidate.clone();
 
         candidate.recursive_proof_available = true;
         candidate.recursive_verification_claimed = true;
@@ -6841,27 +6831,8 @@ mod tests {
 
     #[test]
     fn phase47_recursive_verifier_wrapper_candidate_rejects_proof_root_drift() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-            .expect("prepare Phase46 Stwo proof-adapter receipt");
-        let mut candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
-            .expect("prepare Phase47 recursive-verifier wrapper candidate");
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let mut candidate = fixture.candidate.clone();
 
         candidate
             .proof_commitment_roots
@@ -6882,74 +6853,50 @@ mod tests {
 
     #[test]
     fn phase48_recursive_proof_wrapper_attempt_records_no_go_after_phase47() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-            .expect("prepare Phase46 Stwo proof-adapter receipt");
-        let candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
-            .expect("prepare Phase47 recursive-verifier wrapper candidate");
+        let fixture = sample_phase44d_composed_artifact_fixture();
 
-        let attempt = phase48_prepare_recursive_proof_wrapper_attempt(&candidate)
-            .expect("prepare Phase48 recursive proof-wrapper attempt");
-        verify_phase48_recursive_proof_wrapper_attempt(&attempt)
+        verify_phase48_recursive_proof_wrapper_attempt(&fixture.attempt)
             .expect("verify standalone Phase48 recursive proof-wrapper attempt");
-        verify_phase48_recursive_proof_wrapper_attempt_against_phase47(&attempt, &candidate)
-            .expect("verify Phase48 recursive proof-wrapper attempt against Phase47");
+        verify_phase48_recursive_proof_wrapper_attempt_against_phase47(
+            &fixture.attempt,
+            &fixture.candidate,
+        )
+        .expect("verify Phase48 recursive proof-wrapper attempt against Phase47");
 
         assert_eq!(
-            attempt.phase47_candidate_commitment,
-            candidate.candidate_commitment
+            fixture.attempt.phase47_candidate_commitment,
+            fixture.candidate.candidate_commitment
         );
-        assert!(attempt.local_stwo_core_verifier_detected);
-        assert!(attempt.local_stwo_cairo_verifier_core_detected);
-        assert!(!attempt.local_phase43_projection_cairo_air_detected);
-        assert!(!attempt.actual_recursive_wrapper_available);
-        assert!(!attempt.recursive_proof_constructed);
-        assert!(attempt
+        assert!(fixture.attempt.local_stwo_core_verifier_detected);
+        assert!(fixture.attempt.local_stwo_cairo_verifier_core_detected);
+        assert!(!fixture.attempt.local_phase43_projection_cairo_air_detected);
+        assert!(!fixture.attempt.actual_recursive_wrapper_available);
+        assert!(!fixture.attempt.recursive_proof_constructed);
+        assert!(fixture
+            .attempt
             .decision
             .contains("missing_phase43_projection_cairo_air"));
     }
 
     #[test]
+    fn phase48_recursive_proof_wrapper_attempt_json_round_trip_preserves_acceptance() {
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let loaded = round_trip_serialized_artifact(
+            "phase48-recursive-proof-wrapper-attempt-roundtrip",
+            &fixture.attempt,
+        );
+
+        assert_eq!(&loaded, &fixture.attempt);
+        verify_phase48_recursive_proof_wrapper_attempt(&loaded)
+            .expect("verify standalone loaded Phase48 proof-wrapper attempt");
+        verify_phase48_recursive_proof_wrapper_attempt_against_phase47(&loaded, &fixture.candidate)
+            .expect("verify loaded Phase48 proof-wrapper attempt against Phase47");
+    }
+
+    #[test]
     fn phase48_recursive_proof_wrapper_attempt_rejects_false_recursive_claim() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-            .expect("prepare Phase46 Stwo proof-adapter receipt");
-        let candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
-            .expect("prepare Phase47 recursive-verifier wrapper candidate");
-        let mut attempt = phase48_prepare_recursive_proof_wrapper_attempt(&candidate)
-            .expect("prepare Phase48 recursive proof-wrapper attempt");
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let mut attempt = fixture.attempt.clone();
 
         attempt.actual_recursive_wrapper_available = true;
         attempt.recursive_proof_constructed = true;
@@ -6965,29 +6912,8 @@ mod tests {
 
     #[test]
     fn phase48_recursive_proof_wrapper_attempt_requires_phase43_cairo_air_blocker() {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-            .expect("prepare Phase46 Stwo proof-adapter receipt");
-        let candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
-            .expect("prepare Phase47 recursive-verifier wrapper candidate");
-        let mut attempt = phase48_prepare_recursive_proof_wrapper_attempt(&candidate)
-            .expect("prepare Phase48 recursive proof-wrapper attempt");
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let mut attempt = fixture.attempt.clone();
 
         attempt.blocking_reasons = vec!["generic wrapper blocker".to_string()];
         attempt.attempt_commitment = commit_phase48_recursive_proof_wrapper_attempt(&attempt)
@@ -6998,30 +6924,27 @@ mod tests {
         assert!(error.to_string().contains("missing Phase43 Cairo AIR"));
     }
 
+    #[test]
+    fn phase48_recursive_proof_wrapper_attempt_loaded_json_rejects_blocking_reason_drift() {
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let mut loaded = load_tampered_serialized_artifact(
+            "phase48-recursive-proof-wrapper-attempt-blocking-drift",
+            &fixture.attempt,
+            |attempt_json| {
+                attempt_json["blocking_reasons"] = serde_json::json!(["generic wrapper blocker"]);
+            },
+        );
+        loaded.attempt_commitment = commit_phase48_recursive_proof_wrapper_attempt(&loaded)
+            .expect("recommit forged Phase48 attempt");
+
+        let error = verify_phase48_recursive_proof_wrapper_attempt(&loaded).expect_err(
+            "serialized Phase48 proof-wrapper attempt must retain the Cairo AIR blocker",
+        );
+        assert!(error.to_string().contains("missing Phase43 Cairo AIR"));
+    }
+
     fn sample_phase48_attempt_for_phase49() -> Phase48RecursiveProofWrapperAttempt {
-        let (trace, phase30) = sample_trace_and_phase30();
-        let compact_envelope =
-            prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
-                .expect("prove Phase44 compact projection");
-        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
-            &trace, &phase30,
-        )
-        .expect("emit Phase44D source-chain public output boundary");
-        let handoff =
-            phase44d_prepare_recursive_verifier_public_output_handoff(&boundary, &compact_envelope)
-                .expect("prepare Phase44D recursive-verifier handoff");
-        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
-            &boundary,
-            &compact_envelope,
-            &handoff,
-        )
-        .expect("prepare Phase45 public-input bridge");
-        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
-            .expect("prepare Phase46 Stwo proof-adapter receipt");
-        let candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
-            .expect("prepare Phase47 recursive-verifier wrapper candidate");
-        phase48_prepare_recursive_proof_wrapper_attempt(&candidate)
-            .expect("prepare Phase48 recursive proof-wrapper attempt")
+        sample_phase44d_composed_artifact_fixture().attempt.clone()
     }
 
     #[test]


### PR DESCRIPTION
# Summary

- extend serialized JSON round-trip and tamper coverage one layer above Phase46 to the Phase47 recursive-verifier wrapper candidate and the Phase48 recursive proof-wrapper attempt
- decouple the Phase47/48 cached wrapper fixture from the Phase44D/45/46 composed-artifact fixture so lower-layer tests do not pay unnecessary wrapper setup cost
- add stale-commitment rejection coverage for both wrapper surfaces and update the experimental-lane handoff and soundness-review notes to record the broader serialized-artifact matrix

## Validation

- [x] `cargo +nightly-2025-07-14 check --quiet --features stwo-backend`
- [x] targeted tests listed below
- [x] `just gate-fast`
- [x] `just gate-no-nightly`

Commands run:

```text
export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target
cargo +nightly-2025-07-14 fmt --check
cargo +nightly-2025-07-14 test --features stwo-backend --lib phase44d_source_emission_public_output_boundary_
cargo +nightly-2025-07-14 test --features stwo-backend --lib phase44d_source_emission_recursive_handoff_
cargo +nightly-2025-07-14 test --features stwo-backend --lib phase45_public_input_bridge_
cargo +nightly-2025-07-14 test --features stwo-backend --lib phase46_stwo_proof_adapter_receipt_
cargo +nightly-2025-07-14 test --features stwo-backend --lib phase47_recursive_verifier_wrapper_candidate_
cargo +nightly-2025-07-14 test --features stwo-backend --lib phase48_recursive_proof_wrapper_attempt_
cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm
just gate-fast
just gate-no-nightly
git diff --check
```

## Hardening

- [x] targeted regression and tamper-path coverage added or updated
- [ ] oracle or differential checks added/updated, or marked not applicable below
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below
- [ ] Kani / formal-kernel impact reviewed, or marked not applicable below

Not applicable notes:

```text
No oracle/differential layer applies here because these Phase47/48 artifacts are repository-local structural wrapper/no-go receipts, not alternate proving backends or math kernels.

No Kani/formal-kernel harness changed here. The trusted-core change is new serialized round-trip/tamper coverage plus cached fixture reuse inside the existing Rust test layer.

Resource-bound impact reviewed: the lower Phase44D/45/46 composed-artifact fixture no longer builds Phase47/48 wrappers eagerly, and the new Phase47/48 wrapper fixture is OnceLock-backed and borrowed across tests to avoid reproving or deep-cloning wrapper artifacts per test process.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test suite with cached fixture reuse, JSON round-trip acceptance checks, and targeted tampering/negative tests covering Phase47 and Phase48 wrapper verification paths (replay-flag and blocking-reason drift, plus stale-commitment rejection).

* **Documentation**
  * Updated engineering docs to describe the new Phase47/48 wrapper coverage, added the negative-test scenarios to test lists, and adjusted the backend review checklist and test command references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->