### PR TITLE
Assess Phase71 second-boundary viability

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -19,8 +19,8 @@ The active split is now:
 - Do not widen publication claims using experimental engineering evidence without a deliberate promotion pass.
 - The bounded April 25 Phase71 follow-up shows the existing handoff receipt is
   a compactness surface, not a second Tablero-style replay-elimination
-  boundary, and the publication-lane execution-proof surface still fails closed
-  at `4+` steps.
+  boundary, and the first blocked point on the publication-lane
+  execution-proof surface is `4` steps.
 
 ### Experimental carry-aware lane
 

--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -1,8 +1,8 @@
 # HANDOFF
 
-Last refreshed: 2026-04-24
-Repository: `/Users/espejelomar/StarkNet/zk-ai/llm-provable-computer-codex`
-Mainline reference at refresh: `6b4b435cfef6764faa991a0e9228012094f4f6c0`
+Last refreshed: 2026-04-25
+Repository: `/Users/espejelomar/StarkNet/zk-ai`
+Mainline reference at refresh: `203b3bc763e9f7683fa1505e7b9cc0a6d1ca3395`
 
 ## Immediate orientation
 
@@ -17,6 +17,10 @@ The active split is now:
 - Keep the current paper package and shipped default backend on the conservative carry-free route.
 - Use `docs/paper/` plus `docs/paper/PUBLICATION_RELEASE.md` as the source of truth for paper-facing claims.
 - Do not widen publication claims using experimental engineering evidence without a deliberate promotion pass.
+- The bounded April 25 Phase71 follow-up shows the existing handoff receipt is
+  a compactness surface, not a second Tablero-style replay-elimination
+  boundary, and the publication-lane execution-proof surface still fails closed
+  at `4+` steps.
 
 ### Experimental carry-aware lane
 
@@ -73,7 +77,9 @@ Use these in order of authority for current state:
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
 7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
 8. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-9. `docs/engineering/reproducibility.md`
+9. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
+10. `docs/engineering/reproducibility.md`
+10. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
 
 ## Merge culture
 
@@ -103,6 +109,10 @@ Use these in order of authority for current state:
    review changes stay clean.
 4. Only after those steps decide whether any part of the experimental lane
    should be promoted toward the paper/publication surface.
+5. Do not spend more time pushing the current publication/default Phase71
+   surface as a second-boundary reproduction; if that question matters, move it
+   to the experimental lane or a boundary that actually removes replay
+   dependencies.
 
 ## Resume protocol
 

--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -79,6 +79,7 @@ Use these in order of authority for current state:
 8. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
 9. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
 10. `docs/engineering/reproducibility.md`
+11. `git status --short --branch`
 10. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
 
 ## Merge culture

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -12,8 +12,9 @@ This is the fast local entrypoint for a fresh agent working in this repository.
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
 7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
 8. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-9. `docs/engineering/reproducibility.md`
-10. `git status --short --branch`
+9. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
+10. `docs/engineering/reproducibility.md`
+11. `git status --short --branch`
 
 ## What this repository is now
 
@@ -59,6 +60,10 @@ The experimental carry-aware lane now has one real higher-layer scaling result:
 - Do not revive the deleted tensor-native or Gemma-window line as the current main route.
 - Do not move experimental carry-aware numbers into `docs/paper/` just because they are large.
 - Do not switch the default backend away from the shipped carry-free path without an explicit promotion task.
+- Do not keep trying to turn the current publication/default Phase71 handoff
+  receipt into a second Tablero-style boundary result; it still depends on the
+  ordered Phase30 manifest and the publication-lane surface fails closed at
+  `4+` steps.
 - Do not merge PRs with live review threads or by merge commit.
 
 ## First commands after a resume

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -62,8 +62,8 @@ The experimental carry-aware lane now has one real higher-layer scaling result:
 - Do not switch the default backend away from the shipped carry-free path without an explicit promotion task.
 - Do not keep trying to turn the current publication/default Phase71 handoff
   receipt into a second Tablero-style boundary result; it still depends on the
-  ordered Phase30 manifest and the publication-lane surface fails closed at
-  `4+` steps.
+  ordered Phase30 manifest and the first blocked point on the
+  publication-lane surface is `4` steps.
 - Do not merge PRs with live review threads or by merge commit.
 
 ## First commands after a resume

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -14,8 +14,9 @@ If you are in a local checkout, prefer `AGENTS.md`, `.codex/START_HERE.md`, and
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
 7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
 8. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-9. `docs/engineering/reproducibility.md`
-10. `git status --short --branch`
+9. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
+10. `docs/engineering/reproducibility.md`
+11. `git status --short --branch`
 
 ## Current lane split
 
@@ -26,6 +27,10 @@ This repository now has two live lanes.
 - Source of truth: `docs/paper/` and the shipped carry-free backend path.
 - Keep paper-facing claims conservative and tied to the frozen bundle and evidence set.
 - Do not silently import experimental engineering results into publication docs.
+- The bounded April 25 Phase71 follow-up shows the existing handoff receipt is
+  a compactness surface, not a second Tablero-style replay-elimination
+  boundary, and the publication-lane execution-proof surface still fails closed
+  at `4+` steps.
 
 ### 2. Experimental carry-aware lane
 
@@ -89,3 +94,7 @@ verified. Do not describe it as a faster FRI or cryptographic verifier.
 3. Raise the experimental Phase43/Phase44D ceiling beyond `1024` only after
    review changes stay clean.
 4. Only after those steps decide whether any part of the experimental lane should be promoted toward the paper/publication surface.
+5. Do not spend more time pushing the current publication/default Phase71
+   surface as a second-boundary reproduction; if that question matters, move it
+   to the experimental lane or a boundary that actually removes replay
+   dependencies.

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -29,8 +29,8 @@ This repository now has two live lanes.
 - Do not silently import experimental engineering results into publication docs.
 - The bounded April 25 Phase71 follow-up shows the existing handoff receipt is
   a compactness surface, not a second Tablero-style replay-elimination
-  boundary, and the publication-lane execution-proof surface still fails closed
-  at `4+` steps.
+  boundary, and the first blocked point on the publication-lane
+  execution-proof surface is `4` steps.
 
 ### 2. Experimental carry-aware lane
 

--- a/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
+++ b/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
@@ -32,8 +32,10 @@ publication lane:
 - Evidence files:
   - `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.tsv`
   - `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.json`
-- Paper evidence regeneration:
+- Paper evidence scripts:
   - `scripts/paper/generate_stwo_phase71_handoff_receipt_benchmark.sh`
+    (defaults to `CAPTURE_TIMINGS=0` and canonical tracked outputs; use the
+    reproduction block below for the measured-median env overrides)
   - `scripts/paper/aggregate_stwo_phase71_handoff_receipt_benchmark.py`
 
 | Steps | Shared Phase71 receipt | Phase30 manifest baseline |

--- a/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
+++ b/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
@@ -149,13 +149,19 @@ Validation:
 ```bash
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 
+just gate-fast
+
 cargo +nightly-2025-07-14 test --features stwo-backend --lib \
   phase71_handoff_receipt_benchmark_
 
 cargo +nightly-2025-07-14 test --features stwo-backend --bin tvm \
   phase71_handoff_receipt_benchmark_command_
 
+just integration
+
 cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm
+
+just gate
 ```
 
 Checked-in median-of-5 paper evidence (`1,2,3` default step counts):

--- a/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
+++ b/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
@@ -22,6 +22,15 @@ the publication/default lane.
 The checked-in median-of-5 evidence already shows the relevant shape on the
 publication lane:
 
+- Backend version: `stwo-phase12-decoding-family-v9`
+- STARK profile: `publication-v1`
+- Timing mode: `measured_median`
+- Timing policy: `median_of_5_runs_from_microsecond_capture`
+- Step counts: `1, 2, 3`
+- Evidence files:
+  - `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.tsv`
+  - `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.json`
+
 | Steps | Shared Phase71 receipt | Phase30 manifest baseline |
 |---|---:|---:|
 | 1 | `1533` bytes, `12.324 ms` | `2188` bytes, `8.598 ms` |
@@ -113,10 +122,18 @@ If a second Tablero-style reproduction is still the goal, pursue it either:
 
 ## Reproduction
 
+Backend configuration:
+
+- Backend version: `stwo-phase12-decoding-family-v9`
+- Lane: publication/default carry-free backend
+- Cargo feature: `--features stwo-backend`
+- Optional target-dir override:
+  `export CARGO_TARGET_DIR=\"${CARGO_TARGET_DIR:-target}\"`
+
 Validation:
 
 ```bash
-export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 
 cargo +nightly-2025-07-14 test --features stwo-backend --lib \
   phase71_handoff_receipt_benchmark_
@@ -130,7 +147,7 @@ cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm
 Bounded CLI sweep on supported publication-lane counts:
 
 ```bash
-export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 
 cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
   bench-stwo-phase71-handoff-receipt-reuse \
@@ -143,7 +160,7 @@ cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
 Fail-closed overflow barrier:
 
 ```bash
-export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 
 cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
   bench-stwo-phase71-handoff-receipt-reuse \

--- a/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
+++ b/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
@@ -32,6 +32,9 @@ publication lane:
 - Evidence files:
   - `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.tsv`
   - `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.json`
+- Paper evidence regeneration:
+  - `scripts/paper/generate_stwo_phase71_handoff_receipt_benchmark.sh`
+  - `scripts/paper/aggregate_stwo_phase71_handoff_receipt_benchmark.py`
 
 | Steps | Shared Phase71 receipt | Phase30 manifest baseline |
 |---|---:|---:|
@@ -153,7 +156,29 @@ cargo +nightly-2025-07-14 test --features stwo-backend --bin tvm \
 cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm
 ```
 
-Bounded CLI sweep on supported publication-lane counts:
+Checked-in median-of-5 paper evidence (`1,2,3` default step counts):
+
+```bash
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+
+CAPTURE_TIMINGS=1 \
+BENCH_RUNS=5 \
+TSV_OUT=target/phase71-second-boundary/paper-phase71-median.tsv \
+JSON_OUT=target/phase71-second-boundary/paper-phase71-median.json \
+SVG_OUT=target/phase71-second-boundary/paper-phase71-median.svg \
+PNG_OUT= \
+PDF_OUT= \
+bash scripts/paper/generate_stwo_phase71_handoff_receipt_benchmark.sh
+```
+
+The generator above is the exact median pipeline for the checked-in paper
+evidence: it runs the default `bench-stwo-phase71-handoff-receipt-reuse`
+surface five times with `--capture-timings`, keeps the paper step counts
+`1,2,3`, and then aggregates the five single-run JSON payloads through
+`scripts/paper/aggregate_stwo_phase71_handoff_receipt_benchmark.py` into
+`measured_median` TSV/JSON outputs.
+
+Bounded single-run CLI probe on supported publication-lane counts:
 
 ```bash
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
@@ -166,7 +191,12 @@ cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
   --output-json target/phase71-second-boundary/phase71-1-3.json
 ```
 
-Fail-closed overflow barrier:
+That bounded `--step-counts 1,3` command is only an engineering probe for the
+new custom-step path added in this branch. Because it is a single
+`--capture-timings` run, it produces `measured_single_run`, not the checked-in
+paper median outputs above.
+
+Fail-closed overflow barrier at the first blocked publication-lane point:
 
 ```bash
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}"

--- a/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
+++ b/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
@@ -1,0 +1,152 @@
+# Phase71 Second-Boundary Assessment (April 25, 2026)
+
+This note records the bounded follow-up on whether the existing Phase71
+handoff-receipt surface is a credible second Tablero-style boundary result on
+the publication/default lane.
+
+## Scope
+
+- Lane: publication/default carry-free backend
+- Surface: `phase71_actual_stwo_step_envelope_handoff_receipt`
+- New harness support: bounded custom step counts through
+  `bench-stwo-phase71-handoff-receipt-reuse --step-counts ...`
+- Question: does Phase71 behave like Phase44D by removing verifier-side replay
+  work, or is it only a smaller receipt surface over the same replay-dependent
+  source path?
+
+## Checked-in evidence
+
+- `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.tsv`
+- `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.json`
+
+The checked-in median-of-5 evidence already shows the relevant shape on the
+publication lane:
+
+| Steps | Shared Phase71 receipt | Phase30 manifest baseline |
+|---|---:|---:|
+| 1 | `1533` bytes, `12.324 ms` | `2188` bytes, `8.598 ms` |
+| 2 | `1533` bytes, `23.223 ms` | `3443` bytes, `16.134 ms` |
+| 3 | `1533` bytes, `34.613 ms` | `4698` bytes, `23.795 ms` |
+
+So the Phase71 receipt is smaller on bytes, but slower on verifier time across
+the current checked-in sweep.
+
+## Structural cause
+
+Phase71 does not remove the ordered Phase30 manifest dependency the way Phase44D
+does.
+
+The source verifier for the receipt still rebuilds the expected receipt from the
+full proof-checked Phase12 chain and the full ordered Phase30 manifest:
+
+- `src/stwo_backend/recursion.rs`
+  - `verify_phase71_actual_stwo_step_envelope_handoff_receipt_against_sources`
+  - `phase71_prepare_actual_stwo_step_envelope_handoff_receipt`
+
+That means the receipt is a compact source-bound handoff summary, but not a
+typed boundary that eliminates Phase30 replay work from the verifier path.
+
+The benchmark path confirms the same dependency shape:
+
+- `src/stwo_backend/primitive_benchmark.rs`
+  - shared path: verifies the Phase71 receipt against the same chain plus the
+    shared Phase30 manifest
+  - baseline path: verifies the ordered Phase30 manifest directly against the
+    same chain
+
+This is why Phase71 behaves as a compactness result, not a replay-avoidance
+result.
+
+## Bounded follow-up
+
+This branch adds a narrow experimental hook so the benchmark can be exercised on
+selected step counts without widening the default paper-facing sweep:
+
+- library helper:
+  `run_stwo_phase71_handoff_receipt_benchmark_for_steps`
+- CLI option:
+  `bench-stwo-phase71-handoff-receipt-reuse --step-counts ...`
+
+The bounded follow-up encodes two important facts:
+
+1. The custom sweep path itself works for supported publication-lane counts.
+2. The current publication/default execution-proof surface still fails closed at
+   `4` steps and above.
+
+The fail-closed regression is now explicit in:
+
+- `src/stwo_backend/primitive_benchmark.rs`
+  - `phase71_handoff_receipt_benchmark_reports_publication_surface_overflow_barrier`
+
+The expected error remains:
+
+```text
+overflowing arithmetic is not supported by the current execution-proof surface
+```
+
+## Decision
+
+Phase71 on the publication/default lane is not currently a strong second
+Tablero-style reproduction.
+
+What it is:
+
+- a compact handoff receipt that reduces serialized bytes
+- a source-bound summary that still depends on the ordered Phase30 manifest
+
+What it is not:
+
+- a Phase44D-style replay-elimination boundary on the current publication lane
+- a clean `4+` scaling path on the current carry-free execution-proof surface
+
+## Next step
+
+Do not spend more time trying to force the current publication/default Phase71
+surface into the “second boundary” role.
+
+If a second Tablero-style reproduction is still the goal, pursue it either:
+
+1. on the experimental carry-aware lane, where higher step counts already clear,
+   or
+2. on a different boundary surface that actually removes verifier-side replay
+   dependencies instead of compacting them.
+
+## Reproduction
+
+Validation:
+
+```bash
+export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target
+
+cargo +nightly-2025-07-14 test --features stwo-backend --lib \
+  phase71_handoff_receipt_benchmark_
+
+cargo +nightly-2025-07-14 test --features stwo-backend --bin tvm \
+  phase71_handoff_receipt_benchmark_command_
+
+cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm
+```
+
+Bounded CLI sweep on supported publication-lane counts:
+
+```bash
+export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target
+
+cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
+  bench-stwo-phase71-handoff-receipt-reuse \
+  --step-counts 1,3 \
+  --capture-timings \
+  --output-tsv target/phase71-second-boundary/phase71-1-3.tsv \
+  --output-json target/phase71-second-boundary/phase71-1-3.json
+```
+
+Fail-closed overflow barrier:
+
+```bash
+export CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_pr_work/phase44d-1024-v1/target
+
+cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
+  bench-stwo-phase71-handoff-receipt-reuse \
+  --step-counts 4 \
+  --output-tsv target/phase71-second-boundary/phase71-4.tsv
+```

--- a/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
+++ b/docs/engineering/phase71-second-boundary-assessment-2026-04-25.md
@@ -16,6 +16,8 @@ the publication/default lane.
 
 ## Checked-in evidence
 
+- Gate note: this file,
+  `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
 - `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.tsv`
 - `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.json`
 
@@ -79,8 +81,10 @@ selected step counts without widening the default paper-facing sweep:
 The bounded follow-up encodes two important facts:
 
 1. The custom sweep path itself works for supported publication-lane counts.
-2. The current publication/default execution-proof surface still fails closed at
-   `4` steps and above.
+2. The first blocked point on the current publication/default execution-proof
+   surface is `4` steps.
+3. The custom step-count surface stays resource-bounded: at most `6` steps per
+   point and at most `6` total requested steps per run.
 
 The fail-closed regression is now explicit in:
 
@@ -106,7 +110,8 @@ What it is:
 What it is not:
 
 - a Phase44D-style replay-elimination boundary on the current publication lane
-- a clean `4+` scaling path on the current carry-free execution-proof surface
+- a clean scaling path beyond the first blocked point on the current carry-free
+  execution-proof surface
 
 ## Next step
 
@@ -115,7 +120,11 @@ surface into the “second boundary” role.
 
 If a second Tablero-style reproduction is still the goal, pursue it either:
 
-1. on the experimental carry-aware lane, where higher step counts already clear,
+1. on the experimental carry-aware lane, where the checked-in Phase44D scaling
+   gate already clears `2,4,8,16,32,64,128,256,512,1024`:
+   `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+   and
+   `docs/engineering/evidence/phase44d-carry-aware-experimental-scaling-2026-04.tsv`,
    or
 2. on a different boundary surface that actually removes verifier-side replay
    dependencies instead of compacting them.
@@ -128,7 +137,7 @@ Backend configuration:
 - Lane: publication/default carry-free backend
 - Cargo feature: `--features stwo-backend`
 - Optional target-dir override:
-  `export CARGO_TARGET_DIR=\"${CARGO_TARGET_DIR:-target}\"`
+  `export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}"`
 
 Validation:
 

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -13954,8 +13954,8 @@ mod cli_dispatch_tests {
 
     #[cfg(feature = "stwo-backend")]
     #[test]
-    fn phase71_handoff_receipt_benchmark_command_preserves_step_counts() {
-        let normalized = normalize_args(
+    fn phase71_handoff_receipt_benchmark_command_parses_step_counts_values() {
+        let cli = Cli::try_parse_from(normalize_args(
             [
                 "tvm",
                 "bench-stwo-phase71-handoff-receipt-reuse",
@@ -13966,18 +13966,12 @@ mod cli_dispatch_tests {
             ]
             .into_iter()
             .map(OsString::from),
-        );
-        assert_eq!(
-            normalized,
-            vec![
-                OsString::from("tvm"),
-                OsString::from("bench-stwo-phase71-handoff-receipt-reuse"),
-                OsString::from("--step-counts"),
-                OsString::from("1,4,8"),
-                OsString::from("--output-tsv"),
-                OsString::from("phase71.tsv"),
-            ]
-        );
+        ))
+        .expect("phase71 handoff receipt benchmark command should parse");
+        let Command::BenchStwoPhase71HandoffReceiptReuse { step_counts, .. } = cli.command else {
+            panic!("expected phase71 handoff receipt benchmark command");
+        };
+        assert_eq!(step_counts, vec![1, 4, 8]);
     }
 
     #[cfg(not(feature = "stwo-backend"))]

--- a/src/bin/tvm.rs
+++ b/src/bin/tvm.rs
@@ -100,6 +100,7 @@ use llm_provable_computer::{
     run_stwo_phase44d_source_emission_experimental_benchmark_for_steps,
     run_stwo_phase44d_source_emission_experimental_benchmark_with_options,
     run_stwo_phase71_handoff_receipt_benchmark,
+    run_stwo_phase71_handoff_receipt_benchmark_for_steps,
     run_stwo_phase71_handoff_receipt_benchmark_with_options,
     run_stwo_primitive_lookup_vs_naive_benchmark, run_stwo_shared_table_reuse_benchmark,
     run_stwo_shared_table_reuse_benchmark_with_options,
@@ -562,6 +563,9 @@ enum Command {
         /// Optional file where the benchmark JSON will be written.
         #[arg(long = "output-json")]
         output_json: Option<PathBuf>,
+        /// Optional comma-delimited step counts. Defaults to the Phase71 calibration sweep.
+        #[arg(long = "step-counts", value_delimiter = ',', num_args = 1..)]
+        step_counts: Vec<usize>,
         /// Capture host-dependent wall-clock timings in the report output.
         #[arg(long = "capture-timings", default_value_t = false)]
         capture_timings: bool,
@@ -2060,10 +2064,12 @@ fn run() -> llm_provable_computer::Result<()> {
         Command::BenchStwoPhase71HandoffReceiptReuse {
             output_tsv,
             output_json,
+            step_counts,
             capture_timings,
         } => bench_stwo_phase71_handoff_receipt_reuse_command(
             &output_tsv,
             output_json.as_deref(),
+            &step_counts,
             capture_timings,
         )?,
         Command::ProveStwoDecodingDemo { output } => prove_stwo_decoding_demo_command(&output)?,
@@ -3730,12 +3736,14 @@ fn bench_stwo_phase44d_rescaled_exploratory_command(
 fn bench_stwo_phase71_handoff_receipt_reuse_command(
     output_tsv: &Path,
     output_json: Option<&Path>,
+    step_counts: &[usize],
     capture_timings: bool,
 ) -> llm_provable_computer::Result<()> {
     #[cfg(not(feature = "stwo-backend"))]
     {
         let _ = output_tsv;
         let _ = output_json;
+        let _ = step_counts;
         let _ = capture_timings;
         return Err(VmError::UnsupportedProof(
             "S-two Phase71 handoff receipt benchmark requires building with `--features stwo-backend`"
@@ -3759,10 +3767,14 @@ fn bench_stwo_phase71_handoff_receipt_reuse_command(
                 }
             }
         }
-        let report = if capture_timings {
-            run_stwo_phase71_handoff_receipt_benchmark_with_options(true)?
+        let report = if step_counts.is_empty() {
+            if capture_timings {
+                run_stwo_phase71_handoff_receipt_benchmark_with_options(true)?
+            } else {
+                run_stwo_phase71_handoff_receipt_benchmark()?
+            }
         } else {
-            run_stwo_phase71_handoff_receipt_benchmark()?
+            run_stwo_phase71_handoff_receipt_benchmark_for_steps(step_counts, capture_timings)?
         };
         save_stwo_phase71_handoff_receipt_benchmark_report_tsv(&report, output_tsv)?;
         if let Some(path) = output_json {
@@ -13940,6 +13952,34 @@ mod cli_dispatch_tests {
         );
     }
 
+    #[cfg(feature = "stwo-backend")]
+    #[test]
+    fn phase71_handoff_receipt_benchmark_command_preserves_step_counts() {
+        let normalized = normalize_args(
+            [
+                "tvm",
+                "bench-stwo-phase71-handoff-receipt-reuse",
+                "--step-counts",
+                "1,4,8",
+                "--output-tsv",
+                "phase71.tsv",
+            ]
+            .into_iter()
+            .map(OsString::from),
+        );
+        assert_eq!(
+            normalized,
+            vec![
+                OsString::from("tvm"),
+                OsString::from("bench-stwo-phase71-handoff-receipt-reuse"),
+                OsString::from("--step-counts"),
+                OsString::from("1,4,8"),
+                OsString::from("--output-tsv"),
+                OsString::from("phase71.tsv"),
+            ]
+        );
+    }
+
     #[cfg(not(feature = "stwo-backend"))]
     #[test]
     fn phase12_shared_lookup_artifact_reuse_benchmark_command_is_hidden_without_stwo_backend() {
@@ -14202,6 +14242,7 @@ mod cli_dispatch_tests {
                 let Command::BenchStwoPhase71HandoffReceiptReuse {
                     output_tsv,
                     output_json,
+                    step_counts,
                     capture_timings,
                 } = cli.command
                 else {
@@ -14211,6 +14252,7 @@ mod cli_dispatch_tests {
                 let err = super::bench_stwo_phase71_handoff_receipt_reuse_command(
                     &output_tsv,
                     output_json.as_deref(),
+                    &step_counts,
                     capture_timings,
                 )
                 .expect_err("identical output paths must fail before benchmark execution");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,6 +599,7 @@ pub use stwo_backend::{
     run_stwo_phase44d_source_emission_experimental_benchmark_for_steps,
     run_stwo_phase44d_source_emission_experimental_benchmark_with_options,
     run_stwo_phase71_handoff_receipt_benchmark,
+    run_stwo_phase71_handoff_receipt_benchmark_for_steps,
     run_stwo_phase71_handoff_receipt_benchmark_with_options,
     run_stwo_primitive_lookup_vs_naive_benchmark, run_stwo_shared_table_reuse_benchmark,
     run_stwo_shared_table_reuse_benchmark_with_options,

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -317,6 +317,7 @@ pub use primitive_benchmark::{
     run_stwo_phase44d_source_emission_experimental_benchmark_for_steps,
     run_stwo_phase44d_source_emission_experimental_benchmark_with_options,
     run_stwo_phase71_handoff_receipt_benchmark,
+    run_stwo_phase71_handoff_receipt_benchmark_for_steps,
     run_stwo_phase71_handoff_receipt_benchmark_with_options,
     run_stwo_primitive_lookup_vs_naive_benchmark, run_stwo_shared_table_reuse_benchmark,
     run_stwo_shared_table_reuse_benchmark_with_options,

--- a/src/stwo_backend/primitive_benchmark.rs
+++ b/src/stwo_backend/primitive_benchmark.rs
@@ -145,6 +145,8 @@ const PHASE44D_SOURCE_EMISSION_EXPERIMENTAL_STEP_COUNTS: [usize; 10] =
 const PHASE44D_SOURCE_EMISSION_MAX_STEPS: usize = 512;
 const PHASE44D_SOURCE_EMISSION_EXPERIMENTAL_MAX_STEPS: usize = 1024;
 const PHASE71_HANDOFF_RECEIPT_STEP_COUNTS: [usize; 3] = [1, 2, 3];
+const PHASE71_HANDOFF_RECEIPT_MAX_STEP_COUNT: usize = 4;
+const PHASE71_HANDOFF_RECEIPT_MAX_TOTAL_STEPS: usize = 6;
 const PHASE12_ARITHMETIC_BUDGET_MAP_MAX_STEPS: usize = 64;
 const PHASE44D_RESCALED_EXPLORATORY_STEP_COUNTS: [usize; 6] = [2, 4, 8, 16, 32, 64];
 const PHASE44D_RESEARCH_INCOMING_DIVISOR_CANDIDATES: [i16; 10] =
@@ -1541,6 +1543,29 @@ fn run_stwo_phase71_handoff_receipt_benchmark_for_step_counts_internal(
         return Err(VmError::InvalidConfig(
             "phase71 handoff receipt benchmark step counts must be strictly increasing".to_string(),
         ));
+    }
+    if step_counts
+        .iter()
+        .any(|&steps| steps > PHASE71_HANDOFF_RECEIPT_MAX_STEP_COUNT)
+    {
+        return Err(VmError::InvalidConfig(format!(
+            "phase71 handoff receipt benchmark supports at most {} steps per point",
+            PHASE71_HANDOFF_RECEIPT_MAX_STEP_COUNT
+        )));
+    }
+    let total_steps = step_counts
+        .iter()
+        .try_fold(0usize, |acc, &steps| acc.checked_add(steps))
+        .ok_or_else(|| {
+            VmError::InvalidConfig(
+                "phase71 handoff receipt benchmark total requested steps overflowed".to_string(),
+            )
+        })?;
+    if total_steps > PHASE71_HANDOFF_RECEIPT_MAX_TOTAL_STEPS {
+        return Err(VmError::InvalidConfig(format!(
+            "phase71 handoff receipt benchmark supports at most {} total requested steps",
+            PHASE71_HANDOFF_RECEIPT_MAX_TOTAL_STEPS
+        )));
     }
 
     let layout = phase12_default_decoding_layout();
@@ -5858,6 +5883,24 @@ mod tests {
         let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[0], false)
             .expect_err("zero step count must fail");
         assert!(error.to_string().contains("must be positive"));
+    }
+
+    #[test]
+    fn phase71_handoff_receipt_benchmark_rejects_step_count_above_supported_cap() {
+        let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[5], false)
+            .expect_err("step counts above the supported cap must fail");
+        assert!(error
+            .to_string()
+            .contains("supports at most 4 steps per point"));
+    }
+
+    #[test]
+    fn phase71_handoff_receipt_benchmark_rejects_total_requested_steps_above_cap() {
+        let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[1, 2, 4], false)
+            .expect_err("total requested steps above the bounded surface must fail");
+        assert!(error
+            .to_string()
+            .contains("supports at most 6 total requested steps"));
     }
 
     #[test]

--- a/src/stwo_backend/primitive_benchmark.rs
+++ b/src/stwo_backend/primitive_benchmark.rs
@@ -1498,22 +1498,32 @@ pub fn run_stwo_phase44d_rescaled_exploratory_benchmark_for_steps(
 
 pub fn run_stwo_phase71_handoff_receipt_benchmark(
 ) -> Result<StwoPhase71HandoffReceiptBenchmarkReport> {
-    run_stwo_phase71_handoff_receipt_benchmark_for_step_counts(
+    run_stwo_phase71_handoff_receipt_benchmark_for_step_counts_internal(
         &PHASE71_HANDOFF_RECEIPT_STEP_COUNTS,
         false,
+    )
+}
+
+pub fn run_stwo_phase71_handoff_receipt_benchmark_for_steps(
+    step_counts: &[usize],
+    capture_timings: bool,
+) -> Result<StwoPhase71HandoffReceiptBenchmarkReport> {
+    run_stwo_phase71_handoff_receipt_benchmark_for_step_counts_internal(
+        step_counts,
+        capture_timings,
     )
 }
 
 pub fn run_stwo_phase71_handoff_receipt_benchmark_with_options(
     capture_timings: bool,
 ) -> Result<StwoPhase71HandoffReceiptBenchmarkReport> {
-    run_stwo_phase71_handoff_receipt_benchmark_for_step_counts(
+    run_stwo_phase71_handoff_receipt_benchmark_for_step_counts_internal(
         &PHASE71_HANDOFF_RECEIPT_STEP_COUNTS,
         capture_timings,
     )
 }
 
-fn run_stwo_phase71_handoff_receipt_benchmark_for_step_counts(
+fn run_stwo_phase71_handoff_receipt_benchmark_for_step_counts_internal(
     step_counts: &[usize],
     capture_timings: bool,
 ) -> Result<StwoPhase71HandoffReceiptBenchmarkReport> {
@@ -5816,7 +5826,7 @@ mod tests {
 
     #[test]
     fn phase71_handoff_receipt_benchmark_defaults_to_zero_timings_without_capture() {
-        let report = run_stwo_phase71_handoff_receipt_benchmark_for_step_counts(&[1], false)
+        let report = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[1], false)
             .expect("phase71 handoff receipt benchmark should run");
         assert_eq!(report.rows.len(), 2);
         assert_eq!(report.timing_mode, BENCHMARK_TIMING_MODE_DETERMINISTIC);
@@ -5829,7 +5839,7 @@ mod tests {
 
     #[test]
     fn phase71_handoff_receipt_benchmark_rejects_empty_step_counts() {
-        let error = run_stwo_phase71_handoff_receipt_benchmark_for_step_counts(&[], false)
+        let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[], false)
             .expect_err("empty step counts must fail");
         assert!(error
             .to_string()
@@ -5838,16 +5848,37 @@ mod tests {
 
     #[test]
     fn phase71_handoff_receipt_benchmark_rejects_non_monotonic_step_counts() {
-        let error = run_stwo_phase71_handoff_receipt_benchmark_for_step_counts(&[1, 4, 2], false)
+        let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[1, 4, 2], false)
             .expect_err("unsorted step counts must fail");
         assert!(error.to_string().contains("must be strictly increasing"));
     }
 
     #[test]
     fn phase71_handoff_receipt_benchmark_rejects_zero_step_count() {
-        let error = run_stwo_phase71_handoff_receipt_benchmark_for_step_counts(&[0], false)
+        let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[0], false)
             .expect_err("zero step count must fail");
         assert!(error.to_string().contains("must be positive"));
+    }
+
+    #[test]
+    fn phase71_handoff_receipt_benchmark_accepts_custom_step_counts() {
+        let report = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[1, 3], false)
+            .expect("custom step counts should run");
+        assert_eq!(report.rows.len(), 4);
+        assert_eq!(report.rows[0].steps, 1);
+        assert_eq!(report.rows[1].steps, 1);
+        assert_eq!(report.rows[2].steps, 3);
+        assert_eq!(report.rows[3].steps, 3);
+    }
+
+    #[test]
+    fn phase71_handoff_receipt_benchmark_reports_publication_surface_overflow_barrier() {
+        let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[4], false).expect_err(
+            "4-step Phase71 publication sweep should hit the current execution barrier",
+        );
+        assert!(error.to_string().contains(
+            "overflowing arithmetic is not supported by the current execution-proof surface"
+        ));
     }
 
     #[test]

--- a/src/stwo_backend/primitive_benchmark.rs
+++ b/src/stwo_backend/primitive_benchmark.rs
@@ -5924,7 +5924,7 @@ mod tests {
         ));
     }
 
-    #[ignore = "expensive publication proving path; keep the 4-step barrier in default CI"]
+    #[ignore = "expensive 5-step publication proving path; keep the 4-step barrier test in default CI"]
     #[test]
     fn phase71_handoff_receipt_benchmark_reports_publication_surface_overflow_barrier_above_first_blocked_point(
     ) {

--- a/src/stwo_backend/primitive_benchmark.rs
+++ b/src/stwo_backend/primitive_benchmark.rs
@@ -145,7 +145,7 @@ const PHASE44D_SOURCE_EMISSION_EXPERIMENTAL_STEP_COUNTS: [usize; 10] =
 const PHASE44D_SOURCE_EMISSION_MAX_STEPS: usize = 512;
 const PHASE44D_SOURCE_EMISSION_EXPERIMENTAL_MAX_STEPS: usize = 1024;
 const PHASE71_HANDOFF_RECEIPT_STEP_COUNTS: [usize; 3] = [1, 2, 3];
-const PHASE71_HANDOFF_RECEIPT_MAX_STEP_COUNT: usize = 4;
+const PHASE71_HANDOFF_RECEIPT_MAX_STEP_COUNT: usize = 6;
 const PHASE71_HANDOFF_RECEIPT_MAX_TOTAL_STEPS: usize = 6;
 const PHASE12_ARITHMETIC_BUDGET_MAP_MAX_STEPS: usize = 64;
 const PHASE44D_RESCALED_EXPLORATORY_STEP_COUNTS: [usize; 6] = [2, 4, 8, 16, 32, 64];
@@ -5887,11 +5887,11 @@ mod tests {
 
     #[test]
     fn phase71_handoff_receipt_benchmark_rejects_step_count_above_supported_cap() {
-        let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[5], false)
+        let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[7], false)
             .expect_err("step counts above the supported cap must fail");
         assert!(error
             .to_string()
-            .contains("supports at most 4 steps per point"));
+            .contains("supports at most 6 steps per point"));
     }
 
     #[test]
@@ -5918,6 +5918,17 @@ mod tests {
     fn phase71_handoff_receipt_benchmark_reports_publication_surface_overflow_barrier() {
         let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[4], false).expect_err(
             "4-step Phase71 publication sweep should hit the current execution barrier",
+        );
+        assert!(error.to_string().contains(
+            "overflowing arithmetic is not supported by the current execution-proof surface"
+        ));
+    }
+
+    #[test]
+    fn phase71_handoff_receipt_benchmark_reports_publication_surface_overflow_barrier_above_first_blocked_point(
+    ) {
+        let error = run_stwo_phase71_handoff_receipt_benchmark_for_steps(&[5], false).expect_err(
+            "5-step Phase71 publication sweep should still hit the current execution barrier",
         );
         assert!(error.to_string().contains(
             "overflowing arithmetic is not supported by the current execution-proof surface"

--- a/src/stwo_backend/primitive_benchmark.rs
+++ b/src/stwo_backend/primitive_benchmark.rs
@@ -5924,6 +5924,7 @@ mod tests {
         ));
     }
 
+    #[ignore = "expensive publication proving path; keep the 4-step barrier in default CI"]
     #[test]
     fn phase71_handoff_receipt_benchmark_reports_publication_surface_overflow_barrier_above_first_blocked_point(
     ) {


### PR DESCRIPTION
## Summary
- add bounded custom step-count support for the Phase71 handoff-receipt benchmark
- encode the current first blocked publication-lane point at `4` as an explicit regression, while keeping the custom sweep surface bounded
- record the April 25 assessment that Phase71 is a compactness result on the default lane, not a second Tablero-style replay-elimination boundary

## Why
The current repo state had enough evidence to answer the Phase71 question cleanly, but that answer was still branch-local knowledge. This PR makes the result durable:
- the checked-in paper evidence already shows Phase71 is smaller on bytes but slower on verify time at `1..=3`
- the source verifier still rebuilds the receipt from the full proof-checked Phase12 chain plus the full ordered Phase30 manifest
- the first blocked point on the carry-free publication surface is `4`, and the bounded follow-up keeps `5` on the same fail-closed proving path instead of silently reclassifying it as config rejection

## Validation
- `cargo +nightly-2025-07-14 fmt --check`
- `git diff --check`
- `cargo +nightly-2025-07-14 test --features stwo-backend --lib phase71_handoff_receipt_benchmark_`
- `cargo +nightly-2025-07-14 test --features stwo-backend --bin tvm phase71_handoff_receipt_benchmark_command_`
- `cargo +nightly-2025-07-14 check --features stwo-backend --lib --bin tvm`
- `cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- bench-stwo-phase71-handoff-receipt-reuse --step-counts 1,3 --capture-timings --output-tsv target/phase71-second-boundary/phase71-1-3.tsv --output-json target/phase71-second-boundary/phase71-1-3.json`
- `cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- bench-stwo-phase71-handoff-receipt-reuse --step-counts 4 --output-tsv target/phase71-second-boundary/phase71-4.tsv` (expected fail-closed overflow barrier)
- `cargo +nightly-2025-07-14 test --features stwo-backend --lib phase71_handoff_receipt_benchmark_reports_publication_surface_overflow_barrier_above_first_blocked_point -- --exact`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase71 second-boundary assessment with findings, reproduction commands, and guidance to stop treating the current publication surface as a second boundary.
* **New Features**
  * Added a CLI option to specify custom step-count sweeps and a corresponding benchmark entrypoint.
* **Improvements**
  * Enforced step-count caps with clearer error reporting for invalid or overflowing requests.
* **Tests**
  * Updated tests to cover step-count parsing, cap enforcement, duplicate-path handling, and overflow errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->