### PR TITLE
[codex] Record Phase44D second-backend feasibility gate

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -61,6 +61,11 @@ The active split is now:
   source-root binding mechanism but an explicit **NO-GO** for claiming a second
   Tablero boundary today because the source side still does not emit the
   proof-native inputs needed to drop the full Phase43 trace honestly.
+- Gate 5: the Phase44D second-backend feasibility gate records a real carry-free
+  `2`-step checkpoint on the shipped backend but an explicit **NO-GO** for
+  claiming backend transferability today because the carry-free Phase12 source
+  family still cannot clear an honest proof-checked `4+` source chain, even
+  under the bounded rescaling probe.
 
 At `1024` steps, the experimental shared path records:
 
@@ -96,8 +101,9 @@ Use these in order of authority for current state:
 11. `docs/engineering/phase44d-carry-aware-experimental-family-matrix-gate-2026-04-25.md`
 12. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
 13. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
-14. `docs/engineering/reproducibility.md`
-15. `git status --short --branch`
+14. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
+15. `docs/engineering/reproducibility.md`
+16. `git status --short --branch`
 
 ## Merge culture
 
@@ -126,8 +132,10 @@ Use these in order of authority for current state:
 3. Use issue `#255` only for the explanatory `2x2` constant-surface follow-up;
    it is not the highest-leverage next paper move ahead of the comparator.
 4. Track the heavier next-wave research separately:
-   - cross-backend Phase44D reproduction after the comparator lands
-   - one SNIP-36 Sepolia deployment artifact after the comparator lands
+   - one SNIP-36 Sepolia deployment artifact
+   - only then revisit cross-backend Phase44D reproduction if a new honest
+     carry-free non-overflow source family or another bounded backend actually
+     exists
 5. Broaden review of the experimental backend beyond the current decoding-step
    family, now that the disk-backed proof-file tamper matrix, serialized
    Phase12-chain tamper coverage, serialized Phase44D boundary/handoff/bridge/receipt
@@ -139,9 +147,12 @@ Use these in order of authority for current state:
    the source side emits the proof-native projection commitments, row
    commitments/openings, and public inputs listed in
    `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`.
-8. Only after those steps decide whether any part of the experimental lane
+8. Keep the Phase44D second-backend question in the explicit no-go bucket until
+   the shipped carry-free path can drive the same benchmark beyond `2` steps or
+   another bounded backend lands first.
+9. Only after those steps decide whether any part of the experimental lane
    should be promoted toward the paper/publication surface.
-9. Do not spend more time pushing the current publication/default Phase71
+10. Do not spend more time pushing the current publication/default Phase71
    surface as a second-boundary reproduction; if that question matters, move it
    to the experimental lane or a boundary that actually removes replay
    dependencies.

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -15,8 +15,9 @@ This is the fast local entrypoint for a fresh agent working in this repository.
 9. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
 10. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
 11. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
-12. `docs/engineering/reproducibility.md`
-13. `git status --short --branch`
+12. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
+13. `docs/engineering/reproducibility.md`
+14. `git status --short --branch`
 
 ## What this repository is now
 
@@ -57,28 +58,36 @@ The repo now has one explicit answer on the next-boundary question:
 - The bounded engineering gate is recorded in `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`.
 - Do not describe Phase43 as a second Tablero demonstration until a source-emission patch lands and the same gate reruns cleanly.
 
+## Current cross-backend read
+
+The repo now also has one explicit answer on the second-backend question:
+
+- The shipped carry-free backend reproduces the Phase44D replay-avoidance
+  mechanism at the single checked `2`-step point.
+- It still does **not** support an honest `4+` proof-checked source chain, even
+  under the bounded carry-free rescaling search.
+- The bounded engineering gate is recorded in
+  `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`.
+- Do not describe Phase44D as backend-independent today; the scalable
+  growing-in-`N` result is still limited to the experimental carry-aware lane.
+
 ## Next likely technical steps
 
-1. Add one narrow matched external comparator on the already-supported compact
-   artifact regime, with a source-backed Obelyzk Sepolia verifier-object row as
-   the first target and an explicit no-go note if that row cannot be aligned
-   honestly enough for the paper.
+1. Treat the narrow source-backed Obelyzk Sepolia comparator as landed and keep
+   it in the paper lane as a deployment calibration, not a matched local
+   verifier-time row.
 2. Use the family-matrix gate note now that default, `2x2`, and `3x3` all
    reproduce the same replay-avoidance mechanism on the experimental lane, and
    treat the curve shape as the main experimental takeaway rather than any one
    frontier ratio.
-3. Treat issue `#255` as the next explanatory follow-up on the unexpectedly
-   strong `2x2` constants, not as the main paper-strengthening move ahead of
-   the external comparator.
-4. Track the heavier next-wave research separately:
-   - cross-backend Phase44D reproduction after the comparator lands
-   - one SNIP-36 Sepolia deployment artifact after the comparator lands
-5. Broaden experimental carry-aware review beyond the current decoding-step
-   family, now that the honest `8`-step multiply/store carry patterns, the
-   proof-file tamper matrix, the serialized proof-checked Phase12-chain tamper
-   matrix, the serialized Phase44D boundary / handoff / bridge / receipt
-   tamper checks, and the serialized Phase47 / Phase48 wrapper checks are
-   covered.
+3. Treat the `2x2` constant-surface explanation as landed and use follow-up
+   issue `#257` only if a deeper replay-only decomposition still looks useful.
+4. Keep the cross-backend question in the explicit no-go bucket until a new
+   honest non-overflow carry-free source family or another bounded backend can
+   drive the same benchmark beyond `2` steps.
+5. Move the next-wave exploratory focus to one narrow SNIP-36 Sepolia
+   deployment artifact, then back to broader experimental carry-aware review if
+   the deployment path stays honest.
 6. Re-run the Phase44D experimental frontier only after any material AIR or
    verifier change.
 7. Keep Phase43 in the explicit no-go bucket until the source side emits the

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -17,8 +17,9 @@ If you are in a local checkout, prefer `AGENTS.md`, `.codex/START_HERE.md`, and
 9. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
 10. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
 11. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
-12. `docs/engineering/reproducibility.md`
-13. `git status --short --branch`
+12. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
+13. `docs/engineering/reproducibility.md`
+14. `git status --short --branch`
 
 ## Current lane split
 
@@ -88,6 +89,11 @@ This repository now has two live lanes.
   binding mechanism but an explicit **NO-GO** for claiming a second Tablero
   boundary today because the source side still does not emit the proof-native
   inputs needed to drop the full Phase43 trace honestly.
+- The Phase44D second-backend feasibility gate records a real carry-free
+  `2`-step checkpoint on the shipped backend but an explicit **NO-GO** for
+  claiming backend transferability today because the carry-free Phase12 source
+  family still cannot clear an honest proof-checked `4+` source chain, even
+  under the bounded rescaling probe.
 - At `1024` steps, the experimental shared path records `427.209 ms` verification versus
   `133430.237 ms` for the Phase30 replay baseline, with `156,614` bytes versus `1,464,721` bytes.
 - At `256` steps on the `3x3` family, the experimental shared path records
@@ -122,30 +128,31 @@ Tablero boundary.
 
 ## Next sensible moves
 
-1. Add one narrow matched external comparator on the already-supported compact
-   artifact regime, with a source-backed Obelyzk Sepolia verifier-object row as
-   the first target and an explicit no-go note if that row cannot be aligned
-   honestly enough for the paper.
+1. Treat the narrow source-backed Obelyzk Sepolia comparator as landed and keep
+   it in the paper lane as a deployment calibration, not a matched local
+   verifier-time row.
 2. Treat the family-matrix result as landed and lead with the growing-in-`N`
    curve shape rather than any one frontier ratio.
-3. Use issue `#255` only for the explanatory `2x2` constant-surface follow-up;
-   it is not the highest-leverage next paper move ahead of the comparator.
-4. Track the heavier next-wave research separately:
-   - cross-backend Phase44D reproduction after the comparator lands
-   - one SNIP-36 Sepolia deployment artifact after the comparator lands
-5. Re-run the experimental Phase44D frontier only after any material AIR or
+3. Treat the `2x2` constant-surface explanation as landed and use follow-up
+   issue `#257` only if a deeper replay-only decomposition still looks useful.
+4. Move the next-wave exploratory focus to one narrow SNIP-36 Sepolia
+   deployment artifact.
+5. Keep the cross-backend Phase44D question in the explicit no-go bucket until
+   a new honest non-overflow carry-free source family or another bounded
+   backend can drive the same benchmark beyond `2` steps.
+6. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
-6. Broaden review of the experimental backend beyond the current decoding-step
+7. Broaden review of the experimental backend beyond the current decoding-step
    family, now that the disk-backed proof-file tamper matrix, serialized
    Phase12-chain tamper coverage, serialized Phase44D boundary/handoff/bridge/receipt
    coverage, serialized Phase47/48 wrapper coverage, and the honest `8`-step
    multiply/store carry patterns are both checked.
-7. Keep the Phase43 second-boundary result in the explicit no-go bucket until
+8. Keep the Phase43 second-boundary result in the explicit no-go bucket until
    the source side emits the proof-native projection commitments, row
    commitments/openings, and public inputs listed in
    `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`.
-8. Only after those steps decide whether any part of the experimental lane should be promoted toward the paper/publication surface.
-9. Do not spend more time pushing the current publication/default Phase71
+9. Only after those steps decide whether any part of the experimental lane should be promoted toward the paper/publication surface.
+10. Do not spend more time pushing the current publication/default Phase71
    surface as a second-boundary reproduction; if that question matters, move it
    to the experimental lane or a boundary that actually removes replay
    dependencies.

--- a/docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md
+++ b/docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md
@@ -1,0 +1,163 @@
+# Phase44D Second-Backend Feasibility Gate (April 25, 2026)
+
+Date: 2026-04-25
+
+## Scope
+
+This note closes issue `#259`:
+
+> does the Phase44D replay-avoidance pattern survive a second execution-proof
+> backend, or are the current transferability claims still limited to multiple
+> layout families on the same carry-aware backend?
+
+The goal here is not to force a positive result. The goal is to record an
+honest backend-transferability verdict without smoothing over the blocker.
+
+## Evidence base
+
+Checked evidence already in the repository:
+
+- `docs/paper/evidence/stwo-phase44d-source-emission-2026-04.tsv`
+- `docs/paper/evidence/stwo-phase44d-source-emission-2026-04.json`
+- `docs/engineering/evidence/phase44d-rescaling-frontier-2026-04.tsv`
+- `docs/engineering/evidence/phase44d-rescaling-frontier-2026-04.json`
+- `docs/engineering/phase44d-core-proving-lane-decision-gate-2026-04-24.md`
+
+Fresh spot checks on current `origin/main`:
+
+```bash
+cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
+  bench-stwo-phase44d-source-emission-reuse \
+  --output-tsv target/issue259-default-2.tsv \
+  --output-json target/issue259-default-2.json \
+  --step-counts 2 \
+  --capture-timings
+
+cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- \
+  bench-stwo-phase44d-rescaled-exploratory \
+  --output-tsv target/issue259-rescaled-2-4.tsv \
+  --output-json target/issue259-rescaled-2-4.json \
+  --step-counts 2,4 \
+  --capture-timings
+```
+
+The first command reran the shipped carry-free Phase44D surface at the checked
+`2`-step point. The second command reran the bounded carry-free rescaling probe
+at `2,4` steps and reproduced the exact `4`-step blocker.
+
+## What is real on the shipped carry-free backend
+
+The shipped carry-free backend already shows the same Phase44D mechanism at the
+checked `2`-step point. The checked median-of-5 publication evidence records:
+
+| Surface | Verify time |
+|---|---:|
+| Typed Phase44D boundary + compact proof | `0.957 ms` |
+| Phase30 manifest replay baseline + compact proof | `16.688 ms` |
+| Compact Phase43 proof only | `0.456 ms` |
+| Phase30 replay only | `15.856 ms` |
+| Phase44D boundary binding only | `0.399 ms` |
+
+So the mechanism itself is not experimental-only. Even on the shipped carry-free
+backend, the typed boundary avoids a real verifier-side replay surface and the
+causal split is the same one seen on the experimental lane:
+
+- compact proof verification remains in both paths;
+- the skipped work is the Phase30 replay surface;
+- the saved work is not a faster FRI or faster cryptographic verifier.
+
+The fresh single-run spot check on current `origin/main` reproduced the same
+qualitative split with the current binary:
+
+| Surface | Verify time |
+|---|---:|
+| Typed Phase44D boundary + compact proof | `15.238 ms` |
+| Phase30 manifest replay baseline + compact proof | `269.882 ms` |
+| Compact Phase43 proof only | `6.251 ms` |
+| Phase30 replay only | `256.365 ms` |
+| Phase44D boundary binding only | `6.237 ms` |
+
+Those single-run timings are host-dependent and not paper-facing numbers.
+They matter here only because they confirm that the mechanism still exists on
+the current mainline checkout.
+
+## What does not survive today
+
+There is still no honest growing-in-`N` reproduction on the carry-free backend.
+
+The checked rescaling frontier already records:
+
+- `steps=2`: verified with the identity profile
+- `steps=4,8,16,32,64`: blocked
+
+The exact blocker is unchanged:
+
+> `phase44d rescaled exploratory benchmark could not find a carry-free rescaling profile that supports a proof-checked 4-step Phase12 source chain`
+
+The fresh `2,4` rerun on current `origin/main` reproduced that same blocker
+verbatim.
+
+So the honest cross-backend picture is:
+
+- the carry-free backend does reproduce the Phase44D replay-avoidance mechanism
+  at one narrow checked point;
+- it does **not** currently reproduce the growing verifier-latency curve shape
+  that makes the experimental carry-aware result interesting;
+- the blocker is still the underlying carry-free Phase12 execution-proof
+  surface, not the Phase44D typed-boundary logic.
+
+## Honest read
+
+### What this gate proves
+
+- Phase44D replay avoidance is not unique to the carry-aware backend.
+- The typed boundary is architecturally real on the shipped carry-free route.
+- The causal story still holds on the second backend: compact proof stays,
+  Phase30 replay goes away.
+
+### What this gate does not prove
+
+- It does **not** justify calling Tablero backend-independent today.
+- It does **not** justify quoting the experimental growing-in-`N` curve as a
+  second-backend result.
+- It does **not** reopen the carry-free lane as a frontier-scaling program.
+
+## Decision
+
+### Verdict
+
+**NO-GO for claiming Phase44D backend transferability today.**
+
+### Reason
+
+The second backend only clears the single checked `2`-step point. It does not
+clear an honest `4+` proof-checked source chain, even under the bounded
+carry-free rescaling search. Without that, the repo cannot support the real
+backend-transferability claim that matters here:
+
+> the same replay-avoidance mechanism opens a widening verifier-latency gap on
+> a second execution-proof backend.
+
+### Narrow positive result worth keeping
+
+The carry-free `2`-step checkpoint is still useful. It shows that the typed
+boundary mechanism itself is not tied to the experimental backend. What is tied
+to the experimental backend today is the scalable `4+` source-chain family.
+
+## Next move
+
+Do not spend more time trying to squeeze a positive backend-transferability
+claim out of the current carry-free Phase12 family.
+
+Reopen this question only if one of these happens:
+
+1. a new honest non-overflow carry-free source family lands and can drive the
+   same Phase44D benchmark beyond `2` steps, or
+2. another explicitly bounded execution-proof backend lands first.
+
+Until then, treat the backend-transferability question as bounded and closed,
+and keep the next wave pointed at:
+
+- SNIP-36 deployment viability on a narrow proof object; and
+- explanation of the already-landed family-matrix constants rather than more
+  carry-free frontier chasing.


### PR DESCRIPTION
## Summary
- add a checked-in Phase44D second-backend feasibility gate note for the carry-free backend
- record the honest NO-GO verdict: the shipped carry-free backend reproduces the 2-step mechanism but still cannot clear an honest 4+ source chain
- update local and tracked handoff notes so the next-wave focus shifts from backend transferability to the SNIP-36 deployment slice

## Validation
- git diff --check
- cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- bench-stwo-phase44d-source-emission-reuse --output-tsv target/issue259-default-2.tsv --output-json target/issue259-default-2.json --step-counts 2 --capture-timings
- cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- bench-stwo-phase44d-rescaled-exploratory --output-tsv target/issue259-rescaled-2-4.tsv --output-json target/issue259-rescaled-2-4.json --step-counts 2,4 --capture-timings
- scripts/local_release_gate.sh

Closes #259.
