### PR TITLE
[codex] Add Tablero hardening packet and formal contracts

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -66,6 +66,10 @@ The active split is now:
   claiming backend transferability today because the carry-free Phase12 source
   family still cannot clear an honest proof-checked `4+` source chain, even
   under the bounded rescaling probe.
+- Gate 6: the repo now has an explicit Tablero statement-preservation note plus
+  an internal hardening packet and preflight script. These are the primary
+  entrypoints for closing fooling-ourselves risk on the Phase44D boundary and
+  its higher wrapper surfaces before any stronger promotion.
 
 At `1024` steps, the experimental shared path records:
 
@@ -95,15 +99,17 @@ Use these in order of authority for current state:
 5. `docs/engineering/phase12-carry-aware-arithmetic-subset-gate-2026-04-24.md`
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
 7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
-8. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-9. `docs/engineering/phase44d-carry-aware-experimental-2x2-scaling-gate-2026-04-25.md`
-10. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
-11. `docs/engineering/phase44d-carry-aware-experimental-family-matrix-gate-2026-04-25.md`
-12. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
-13. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
-14. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
-15. `docs/engineering/reproducibility.md`
-16. `git status --short --branch`
+8. `docs/engineering/tablero-soundness-note-2026-04-25.md`
+9. `docs/engineering/tablero-hardening-packet-2026-04-25.md`
+10. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+11. `docs/engineering/phase44d-carry-aware-experimental-2x2-scaling-gate-2026-04-25.md`
+12. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
+13. `docs/engineering/phase44d-carry-aware-experimental-family-matrix-gate-2026-04-25.md`
+14. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
+15. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
+16. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
+17. `docs/engineering/reproducibility.md`
+18. `git status --short --branch`
 
 ## Merge culture
 
@@ -131,28 +137,30 @@ Use these in order of authority for current state:
    lead with the growing-in-`N` curve shape rather than any one frontier ratio.
 3. Use issue `#255` only for the explanatory `2x2` constant-surface follow-up;
    it is not the highest-leverage next paper move ahead of the comparator.
-4. Track the heavier next-wave research separately:
-   - one SNIP-36 Sepolia deployment artifact
-   - only then revisit cross-backend Phase44D reproduction if a new honest
-     carry-free non-overflow source family or another bounded backend actually
-     exists
-5. Broaden review of the experimental backend beyond the current decoding-step
+4. Run the internal hardening packet before making stronger claims:
+   - `scripts/run_tablero_formal_contract_suite.sh`
+   - `scripts/run_tablero_hardening_preflight.sh --mode core`
+   - `scripts/run_tablero_hardening_preflight.sh --mode deep`
+5. Keep SNIP-36 parked until there is a real adapter path from local proof
+   objects to protocol-native proof facts. It is a deferred design lane, not a
+   current paper or hardening blocker.
+6. Broaden review of the experimental backend beyond the current decoding-step
    family, now that the disk-backed proof-file tamper matrix, serialized
    Phase12-chain tamper coverage, serialized Phase44D boundary/handoff/bridge/receipt
    coverage, serialized Phase47/48 wrapper coverage, and the honest `8`-step
    multiply/store carry patterns are all checked.
-6. Re-run the experimental Phase44D frontier only after any material AIR or
+7. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
-7. Keep the Phase43 second-boundary result in the explicit no-go bucket until
+8. Keep the Phase43 second-boundary result in the explicit no-go bucket until
    the source side emits the proof-native projection commitments, row
    commitments/openings, and public inputs listed in
    `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`.
-8. Keep the Phase44D second-backend question in the explicit no-go bucket until
+9. Keep the Phase44D second-backend question in the explicit no-go bucket until
    the shipped carry-free path can drive the same benchmark beyond `2` steps or
    another bounded backend lands first.
-9. Only after those steps decide whether any part of the experimental lane
+10. Only after those steps decide whether any part of the experimental lane
    should be promoted toward the paper/publication surface.
-10. Do not spend more time pushing the current publication/default Phase71
+11. Do not spend more time pushing the current publication/default Phase71
    surface as a second-boundary reproduction; if that question matters, move it
    to the experimental lane or a boundary that actually removes replay
    dependencies.

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -11,13 +11,15 @@ This is the fast local entrypoint for a fresh agent working in this repository.
 5. `docs/engineering/phase12-carry-aware-arithmetic-subset-gate-2026-04-24.md`
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
 7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
-8. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-9. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
-10. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
-11. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
-12. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
-13. `docs/engineering/reproducibility.md`
-14. `git status --short --branch`
+8. `docs/engineering/tablero-soundness-note-2026-04-25.md`
+9. `docs/engineering/tablero-hardening-packet-2026-04-25.md`
+10. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+11. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
+12. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
+13. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
+14. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
+15. `docs/engineering/reproducibility.md`
+16. `git status --short --branch`
 
 ## What this repository is now
 
@@ -85,15 +87,19 @@ The repo now also has one explicit answer on the second-backend question:
 4. Keep the cross-backend question in the explicit no-go bucket until a new
    honest non-overflow carry-free source family or another bounded backend can
    drive the same benchmark beyond `2` steps.
-5. Move the next-wave exploratory focus to one narrow SNIP-36 Sepolia
-   deployment artifact, then back to broader experimental carry-aware review if
-   the deployment path stays honest.
-6. Re-run the Phase44D experimental frontier only after any material AIR or
+5. Run the internal hardening packet before making stronger claims:
+   - `scripts/run_tablero_formal_contract_suite.sh`
+   - `scripts/run_tablero_hardening_preflight.sh --mode core`
+   - `scripts/run_tablero_hardening_preflight.sh --mode deep`
+6. Keep SNIP-36 parked until there is a real adapter path from local proof
+   objects to protocol-native proof facts; treat it as a deferred design lane,
+   not a current paper or review blocker.
+7. Re-run the Phase44D experimental frontier only after any material AIR or
    verifier change.
-7. Keep Phase43 in the explicit no-go bucket until the source side emits the
+8. Keep Phase43 in the explicit no-go bucket until the source side emits the
    proof-native projection commitments, row commitments/openings, and public
    inputs that the feasibility gate lists as missing.
-8. Keep the experimental backend isolated from the default/publication lane
+9. Keep the experimental backend isolated from the default/publication lane
    until a deliberate promotion pass.
 
 ## What not to do

--- a/Justfile
+++ b/Justfile
@@ -9,6 +9,9 @@
 #   just fmt            # cargo fmt --all
 #   just clippy         # cargo clippy --lib --no-deps -- -D warnings
 #   just deps           # dependency check suite (cargo-audit + cargo-deny)
+#   just tablero-formal
+#   just tablero-hardening-core
+#   just tablero-hardening-deep
 #   just zizmor         # workflow-file lint
 #   just shellcheck     # shellcheck on tracked shell scripts
 #   just stwo-smoke     # nightly stwo backend smoke
@@ -84,6 +87,18 @@ spec-sync:
 #   cargo install --locked cargo-deny --version 0.19.4
 deps:
     bash scripts/run_dependency_audit_suite.sh
+
+# Narrow Kani suite for the Tablero theorem surface.
+tablero-formal:
+    bash scripts/run_tablero_formal_contract_suite.sh
+
+# Tablero internal hardening packet. `deep` adds dedicated fuzz smoke and Miri
+# on top of the deterministic theorem- and artifact-facing checks.
+tablero-hardening-core:
+    bash scripts/run_tablero_hardening_preflight.sh --mode core
+
+tablero-hardening-deep:
+    bash scripts/run_tablero_hardening_preflight.sh --mode deep
 
 # Workflow-file lint. Workflows are kept on disk for future re-enable; lint
 # them so they don't bit-rot.

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -13,13 +13,15 @@ If you are in a local checkout, prefer `AGENTS.md`, `.codex/START_HERE.md`, and
 5. `docs/engineering/phase12-carry-aware-arithmetic-subset-gate-2026-04-24.md`
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
 7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
-8. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-9. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
-10. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
-11. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
-12. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
-13. `docs/engineering/reproducibility.md`
-14. `git status --short --branch`
+8. `docs/engineering/tablero-soundness-note-2026-04-25.md`
+9. `docs/engineering/tablero-hardening-packet-2026-04-25.md`
+10. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+11. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
+12. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
+13. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
+14. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
+15. `docs/engineering/reproducibility.md`
+16. `git status --short --branch`
 
 ## Current lane split
 
@@ -135,24 +137,30 @@ Tablero boundary.
    curve shape rather than any one frontier ratio.
 3. Treat the `2x2` constant-surface explanation as landed and use follow-up
    issue `#257` only if a deeper replay-only decomposition still looks useful.
-4. Move the next-wave exploratory focus to one narrow SNIP-36 Sepolia
-   deployment artifact.
-5. Keep the cross-backend Phase44D question in the explicit no-go bucket until
+4. Run the internal hardening packet before making stronger claims:
+   - `scripts/run_tablero_formal_contract_suite.sh`
+   - `scripts/run_tablero_hardening_preflight.sh --mode core`
+   - `scripts/run_tablero_hardening_preflight.sh --mode deep`
+5. Keep SNIP-36 parked until there is a real adapter path from local proof
+   objects to protocol-native proof facts; it is not a current hardening
+   blocker.
+6. Keep the cross-backend Phase44D question in the explicit no-go bucket until
    a new honest non-overflow carry-free source family or another bounded
    backend can drive the same benchmark beyond `2` steps.
-6. Re-run the experimental Phase44D frontier only after any material AIR or
+7. Re-run the experimental Phase44D frontier only after any material AIR or
    verifier change.
-7. Broaden review of the experimental backend beyond the current decoding-step
+8. Broaden review of the experimental backend beyond the current decoding-step
    family, now that the disk-backed proof-file tamper matrix, serialized
    Phase12-chain tamper coverage, serialized Phase44D boundary/handoff/bridge/receipt
    coverage, serialized Phase47/48 wrapper coverage, and the honest `8`-step
    multiply/store carry patterns are both checked.
-8. Keep the Phase43 second-boundary result in the explicit no-go bucket until
+9. Keep the Phase43 second-boundary result in the explicit no-go bucket until
    the source side emits the proof-native projection commitments, row
    commitments/openings, and public inputs listed in
    `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`.
-9. Only after those steps decide whether any part of the experimental lane should be promoted toward the paper/publication surface.
-10. Do not spend more time pushing the current publication/default Phase71
+10. Only after those steps decide whether any part of the experimental lane
+    should be promoted toward the paper/publication surface.
+11. Do not spend more time pushing the current publication/default Phase71
    surface as a second-boundary reproduction; if that question matters, move it
    to the experimental lane or a boundary that actually removes replay
    dependencies.

--- a/docs/engineering/phase44d-carry-aware-2x2-constant-surface-note-2026-04-25.md
+++ b/docs/engineering/phase44d-carry-aware-2x2-constant-surface-note-2026-04-25.md
@@ -49,6 +49,14 @@ So the honest sentence is:
 
 - “The `2x2` family wins because the underlying per-step layout geometry is much smaller, and both the compact-proof path and the typed-boundary binding path inherit that lighter surface even when the final serialized artifacts are nearly the same size.”
 
+The phrase "constant surface" in this note should be read narrowly. What is
+close to constant across the checked family frontiers is the **serialized
+boundary artifact size**, not the full verifier-side cost. The frontier
+`binding_serialized_bytes` rows stay within a few hundred bytes across families,
+while `binding_verify_ms` and `binding_emit_ms` still vary materially with the
+family-specific layout geometry. The transferable property here is
+constant-size boundary packaging; the time savings remain family-dependent.
+
 ## Layout geometry
 
 The source-level layout difference is large before Phase43 or Phase44D enters.

--- a/docs/engineering/tablero-hardening-packet-2026-04-25.md
+++ b/docs/engineering/tablero-hardening-packet-2026-04-25.md
@@ -1,0 +1,234 @@
+# Tablero Hardening Packet (April 25, 2026)
+
+This packet is the internal hardening entrypoint for reviewing the repository's
+Tablero claim and the carry-aware execution-proof hardening that underpins the
+experimental replay-avoidance line.
+
+It is designed to answer the stricter internal question first: what can the
+repository itself check, falsify, and bound before any external review matters?
+The goal is to reduce fooling-ourselves risk, not to manufacture audit theater.
+
+## Review objective
+
+Answer four questions cleanly:
+
+1. Does the current repository make an honest statement-preservation claim for
+   the Phase44D typed boundary?
+2. Are the carry-aware M31 `wrap_delta` witnesses range-bound inside the AIR,
+   rather than only in host-side trace construction?
+3. Do the higher wrapper objects (Phase45-48) stay boundary-width, or do they
+   silently reintroduce replay dependencies or stale-commitment acceptance?
+4. Does the local assurance stack exercise the right failure modes before any
+   stronger claim is made?
+
+## Read order
+
+1. `docs/engineering/tablero-soundness-note-2026-04-25.md`
+2. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
+3. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
+4. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+5. `docs/engineering/phase44d-carry-aware-experimental-2x2-scaling-gate-2026-04-25.md`
+6. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
+7. `docs/engineering/phase44d-carry-aware-experimental-family-matrix-gate-2026-04-25.md`
+8. `docs/paper/stark-transformer-alignment-2026.md`
+
+## Exact code surfaces to review
+
+### Carry-aware AIR and proof routing
+
+- `src/stwo_backend/arithmetic_subset_prover.rs`
+- `src/stwo_backend/decoding.rs`
+- `src/proof.rs`
+
+Key properties to confirm:
+
+- `wrap_delta` range is AIR-constrained by magnitude bits, sign, square, and
+  ADD/SUB unit-range checks.
+- default/publication verifier still rejects experimental backend proofs.
+- proof-checked Phase12 chain verification is safe-by-default.
+
+### Tablero core boundary
+
+- `src/stwo_backend/history_replay_projection_prover.rs`
+
+Key properties to confirm:
+
+- Phase44D typed boundary acceptance verifies the real compact proof and the
+  source-root/public-output binding.
+- boundary validation rejects replay reintroduction.
+- serialized artifacts fail closed under stale-commitment and field-drift
+  tampering.
+
+### Higher wrapper surfaces
+
+- `src/stwo_backend/recursion.rs`
+
+Key properties to confirm:
+
+- Phase45 bridge remains ordered-public-input binding, not replay.
+- Phase46 adapter receipt remains a compact verifier-input receipt, not a new
+  proof.
+- Phase47 wrapper candidate remains boundary-width and explicitly non-recursive.
+- Phase48 remains an explicit no-go wrapper attempt with blocker preservation.
+
+## Claim boundary
+
+### Strong claims supported today
+
+1. The carry-aware experimental backend now range-binds `wrap_delta` inside the
+   AIR.
+2. The Phase44D typed boundary preserves the same source-bound compact statement
+   as the replay baseline, under upstream S-two soundness and local hash-binding
+   assumptions.
+3. Default, `2x2`, and `3x3` layout families all reproduce the same
+   replay-avoidance mechanism on the experimental lane.
+4. Phase43 is a bounded no-go for a second boundary today because the source
+   side still lacks proof-native emission.
+
+### Claims not supported today
+
+1. No new STARK soundness theorem.
+2. No recursive compression theorem.
+3. No backend-independent empirical proof of Tablero.
+4. No SNIP-36 deployment claim.
+5. No claim that the large replay-avoidance ratios are implementation-independent
+   lower bounds for all manifest replay designs.
+
+## Tooling stack to run before stronger claims
+
+The current strongest practical stack is:
+
+| Tool | Role in this packet | Why it belongs here |
+| --- | --- | --- |
+| `cargo test` / `cargo-nextest` | deterministic regression and tamper checks | reproducible exact test filters and CI-friendly isolation |
+| `cargo-fuzz` | bounded adversarial parser/verifier input exploration | exercises malformed or unexpected serialized surfaces under an explicit wall-clock smoke budget |
+| `Kani` | bounded model checking | checks safety/correctness properties exhaustively within bounds |
+| `Miri` | undefined-behavior detection | catches UB that ordinary tests can miss |
+| `cargo-audit` + `cargo-deny` | dependency and policy drift | catches supply-chain issues before harder promotion |
+| optional `cargo-careful` | faster extra UB-oriented runtime checking | complements Miri when FFI/full-speed execution matters |
+| optional `cargo-llvm-cov` | coverage reporting | useful for audit packets, not a proof by itself |
+
+The repo already ships the first five. The last two are worth enabling when a
+deeper audit pass wants more artifacts, but they are not required for the
+minimal honest packet.
+
+For this packet, Kani is intentionally scoped to a narrow Tablero contract set
+rather than the entire repository-wide formal suite. That keeps the command
+disk-feasible and tied to the exact theorem surface instead of conflating it
+with unrelated historical harnesses.
+
+## Preflight commands
+
+### Core packet
+
+```bash
+scripts/run_tablero_hardening_preflight.sh --mode core
+```
+
+This runs:
+
+- formatting and diff hygiene,
+- targeted carry-aware AIR and proof-route tests,
+- targeted Phase44D/45/46/47/48 verifier and tamper tests,
+- the narrow Tablero formal-contract suite,
+- dependency audit.
+
+### Deep packet
+
+```bash
+scripts/run_tablero_hardening_preflight.sh --mode deep
+```
+
+This adds:
+
+- Tablero-focused fuzz smoke on Phase44D boundary binding and Phase45-48 wrapper
+  verifiers, bounded by an outer wall-clock budget and treated as a pass only
+  if no crash artifacts are emitted,
+- the repo's Miri suite.
+
+### Optional extras
+
+If installed locally, the recommended extra checks are:
+
+```bash
+cargo +nightly careful test --features stwo-backend --lib phase45_public_input_bridge_
+cargo llvm-cov --features stwo-backend --lib --lcov --output-path target/tablero-hardening/lcov.info
+```
+
+These are intentionally optional because the repository does not yet rely on
+those tools in the default merge flow.
+
+## Narrow formal-contract surface
+
+The core packet uses:
+
+```bash
+scripts/run_tablero_formal_contract_suite.sh
+```
+
+This runs the Kani harnesses most directly tied to the theorem:
+
+- Phase33 canonical public-input ordering
+- Phase36 and Phase37 non-claim / source-bound receipt flag surfaces
+- Phase45 boundary-width and canonical lane metadata
+- Phase47 receipt-only / no-replay / no-false-compression wrapper surface
+- Phase48 no-go / no-replay / no-false-recursion wrapper surface
+
+The broader `scripts/run_formal_contract_suite.sh` still exists for repository-
+wide work, but it is not required for this packet.
+
+## New fuzz surfaces in this packet
+
+This packet adds dedicated fuzz targets for:
+
+- Phase44D source-chain public-output boundary binding
+- Phase45 recursive-verifier public-input bridge
+- Phase46 Stwo proof-adapter receipt
+- Phase47 recursive-verifier wrapper candidate
+- Phase48 recursive proof-wrapper attempt
+
+This closes the earlier gap where the newer Tablero-shaped surfaces had strong
+deterministic tamper tests but no dedicated fuzz smoke.
+The smoke contract is intentionally modest: the targets are exercised under a
+bounded wall-clock budget, and timeout itself is treated as normal completion
+as long as libFuzzer emits no crash artifact.
+
+## Exact hardening questions
+
+1. Is the theorem in `docs/engineering/tablero-soundness-note-2026-04-25.md`
+   correctly scoped as a statement-preservation theorem rather than a new proof-
+   system theorem?
+2. Are the local binding assumptions explicit enough, especially around the
+   Blake2b commitment surfaces?
+3. Do the Phase44D/45/46/47/48 verifiers leave any replay-reintroduction or
+   stale-commitment gaps that the current tests miss?
+4. Are the carry-aware AIR constraints on `wrap_delta` complete enough for the
+   current experimental claim boundary?
+5. Is any additional bounded-model-checking harness obviously worth adding for
+   the exact binding predicates that replace replay?
+
+## Longer-term escalation path
+
+If the current packet is still not enough, the next honest escalation is:
+
+1. add more bounded Kani harnesses directly on Tablero binding predicates,
+2. widen the fuzz corpus for the new artifact surfaces,
+3. add optional `cargo-careful` and coverage artifacts into the hardening packet,
+4. if theorem-grade certainty is still required, formalize the typed-boundary
+   statement in Lean.
+
+That is a real escalation ladder. It is stronger than saying “we tested it a
+lot,” and it is more honest than pretending the repository already has proof-
+assistant closure.
+
+## External references for the tooling choices
+
+- cargo-nextest: <https://nexte.st/>
+- Rust Fuzz Book / cargo-fuzz: <https://rust-fuzz.github.io/book/>
+- Kani Rust Verifier: <https://model-checking.github.io/kani/>
+- Miri: <https://github.com/rust-lang/miri>
+- cargo-careful: <https://docs.rs/crate/cargo-careful/latest>
+- cargo-llvm-cov: <https://github.com/taiki-e/cargo-llvm-cov>
+- RustSec / cargo-audit / cargo-deny: <https://rustsec.org/>
+- StarkWare on proof assistants and S-two soundness work:
+  <https://starkware.co/blog/starkwares-gold-standard-of-soundness-with-formal-verification/>

--- a/docs/engineering/tablero-soundness-note-2026-04-25.md
+++ b/docs/engineering/tablero-soundness-note-2026-04-25.md
@@ -1,0 +1,237 @@
+# Tablero Soundness Note (April 25, 2026)
+
+This note states the strongest soundness claim the repository can currently make
+about the Tablero pattern.
+
+It is intentionally narrower than a new STARK theorem. The repository does **not**
+claim a new proof-system soundness result independent of upstream S-two. The
+claim here is statement preservation: when a verifier replaces an expensive
+replay surface with a typed boundary object, under what assumptions does that
+replacement preserve the same accepted statement set?
+
+## Scope
+
+- Primary demonstrated boundary: Phase44D typed source-chain public-output
+  boundary
+- Higher wrapper surfaces covered by the same statement-preservation shape:
+  Phase45 public-input bridge, Phase46 proof-adapter receipt, Phase47 wrapper
+  candidate, and Phase48 no-go wrapper attempt
+- Underlying cryptographic backend: upstream S-two `verify` plus repository-local
+  metadata, commitment, and replay-elimination checks
+- Claim boundary: the pattern is structurally broader than zkML, but the checked
+  empirical demonstrations in this repository remain in the transformer-VM lane
+
+## Threat model
+
+The adversary may:
+
+- choose arbitrary serialized artifacts,
+- splice stale nested artifacts into newer wrappers,
+- mutate version strings, flags, or commitments,
+- reorder public inputs or claimed rows,
+- substitute a different compact claim under a boundary-width object,
+- present a malformed or adversarial proof payload.
+
+The adversary does **not** break the collision resistance of the local
+Blake2b-based commitment functions and does not break the soundness of the
+upstream S-two proof system.
+
+## Objects and notation
+
+Let:
+
+- `R` be the underlying compact-proof relation checked by upstream S-two.
+- `V_R(c, π)` be the compact verifier for claim `c` and proof `π`.
+- `σ` be the heavier source surface that a replay baseline would inspect
+  directly, such as a proof-checked Phase12 chain plus ordered Phase30 manifest.
+- `U(σ, c)` be the replay-derived public surface that the baseline verifier would
+  reconstruct from `σ` and compare against `c`.
+- `Emit(σ, c)` be the deterministic source-side emission function that produces a
+  typed boundary object `β` plus any nested commitments needed for later wrapper
+  layers.
+- `Bind(β, c)` be the repository-local binding predicate that checks that `β`
+  carries the same source-root, public-output, ordering, flag, and commitment
+  facts that the replay baseline would have derived from `σ` for `c`.
+
+The Tablero verifier shape is:
+
+```text
+TableroVerify(β, c, π) :=
+  Validate(β)
+  and V_R(c, π)
+  and Bind(β, c)
+```
+
+where `Validate(β)` is the typed-object schema/version/flag/commitment check for
+that layer.
+
+## Assumptions
+
+### A1. Upstream compact-proof soundness
+
+If `V_R(c, π) = 1`, then except with negligible probability `ε_R`, the claim `c`
+is a true statement in relation `R` under the upstream S-two soundness model.
+
+This note inherits that assumption; it does not reprove it.
+
+### A2. Local commitment binding
+
+The repository-local commitment functions used to bind nested artifacts,
+public-input lanes, source roots, and wrapper objects are collision resistant up
+to negligible probability `ε_H`.
+
+This note treats those hash commitments as binding commitments, not as a new
+cryptographic construction.
+
+### A3. Proof-native emission completeness
+
+For a Tablero boundary to replace replay honestly, the source side must emit the
+proof-native fields that `Bind(β, c)` checks.
+
+This assumption is exactly why Phase44D clears and Phase43 currently does not:
+Phase43's feasibility gate records a real mechanism but a current no-go because
+its source side does not yet emit the proof-native inputs needed to drop the full
+trace honestly.
+
+## The statement-preservation theorem
+
+**Theorem 1 (Tablero statement preservation).** Let `β = Emit(σ, c)` be a typed
+boundary object for compact claim `c` over source surface `σ`. Suppose:
+
+1. `Validate(β)` succeeds,
+2. `V_R(c, π)` succeeds,
+3. `Bind(β, c)` succeeds, and
+4. Assumptions A1-A3 hold.
+
+Then, except with probability at most `ε_R + ε_H`, accepting `(β, c, π)` does
+not widen the accepted statement set relative to the replay verifier that checks
+`V_R(c, π)` and reconstructs the same public surface from `σ` directly.
+
+Equivalently: the typed boundary may remove verifier-side replay work, but it
+cannot change the accepted compact statement unless either the upstream proof
+system is unsound, the local commitments collide, or the source side failed to
+emit the proof-native data required by the binding predicate.
+
+## Proof sketch
+
+1. `V_R(c, π)` succeeds, so by A1 the compact claim `c` is valid for relation
+   `R`, except with probability `ε_R`.
+2. `Validate(β)` succeeds, so the typed boundary object satisfies its local
+   object-level invariants: canonical version/scope, no replay-reintroduction
+   flags, structurally well-formed commitments, and object self-commitment.
+3. `Bind(β, c)` succeeds, so the fields of `β` that replace replay work match the
+   compact claim `c` and the typed boundary's nested commitments. In this repo,
+   this includes source-root binding, canonical public-output binding, ordered
+   public-input binding, wrapper-commitment binding, and stale-commitment
+   rejection on serialized artifacts.
+4. By A2, the nested commitment checks are binding except with probability
+   `ε_H`, so the adversary cannot splice a semantically different nested object
+   under the same commitment except with negligible probability.
+5. Therefore the verifier that accepts `β` is accepting the same compact claim
+   `c` together with the same boundary facts that the replay baseline would have
+   derived, but without recomputing those facts from `σ` inside the verifier.
+6. So the accepted statement set is preserved up to `ε_R + ε_H`.
+
+## Corollary for this repository
+
+For the checked Phase44D path, the theorem says the following narrower sentence:
+
+> If the compact Phase43 proof verifies, and the Phase44D typed boundary passes
+> its source-root/public-output/commitment checks, then replacing ordered Phase30
+> manifest replay with Phase44D boundary acceptance preserves the same
+> source-bound compact statement up to upstream S-two soundness and local hash
+> binding assumptions.
+
+This is the strongest soundness sentence the current repository can defend for
+Tablero today.
+
+## Why Phase43 currently remains a no-go
+
+The theorem has a real precondition: the source side must emit the proof-native
+inputs that the binding predicate checks.
+
+Phase43 fails that precondition today. The source-root mechanism is real, but the
+current source surface does not emit the proof-native commitments and public
+inputs required to drop the full Phase43 trace honestly. So Phase43 is a valid
+engineering no-go, not a contradiction of the theorem.
+
+## What this theorem does not claim
+
+This note does **not** claim:
+
+- a new STARK soundness theorem,
+- a new S-two soundness theorem,
+- recursive-proof compression soundness,
+- knowledge soundness beyond the upstream proof system,
+- backend-independent empirical validation,
+- universal replay-elimination for every wrapper layer,
+- any claim that the large Phase44D ratios are independent of the repository's
+  current manifest serialization and hashing implementation.
+
+The theorem is about statement preservation under typed replay replacement, not
+about asymptotic optimality or universal speedups.
+
+## Code mapping
+
+The current repository surfaces this theorem through the following code paths.
+
+### Core Phase44D boundary
+
+- typed boundary validation and acceptance:
+  `src/stwo_backend/history_replay_projection_prover.rs`
+  - `verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance`
+  - `verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding`
+- nested source-emission and source-root checks:
+  `src/stwo_backend/history_replay_projection_prover.rs`
+  - `verify_phase44d_history_replay_projection_source_emission_public_output_acceptance`
+  - `verify_phase44d_history_replay_projection_external_source_root_binding`
+
+### Higher wrapper layers
+
+- Phase45 bridge verification:
+  `src/stwo_backend/recursion.rs`
+  - `verify_phase45_recursive_verifier_public_input_bridge`
+  - `verify_phase45_recursive_verifier_public_input_bridge_against_sources`
+- Phase46 receipt verification:
+  `src/stwo_backend/recursion.rs`
+  - `verify_phase46_stwo_proof_adapter_receipt`
+  - `verify_phase46_stwo_proof_adapter_receipt_against_sources`
+- Phase47 candidate verification:
+  `src/stwo_backend/recursion.rs`
+  - `verify_phase47_recursive_verifier_wrapper_candidate`
+  - `verify_phase47_recursive_verifier_wrapper_candidate_against_phase46`
+- Phase48 no-go wrapper verification:
+  `src/stwo_backend/recursion.rs`
+  - `verify_phase48_recursive_proof_wrapper_attempt`
+  - `verify_phase48_recursive_proof_wrapper_attempt_against_phase47`
+
+## Current evidence classes behind the theorem
+
+1. deterministic unit and tamper tests on the carry-aware proof surface,
+2. disk-backed JSON round-trip and stale-commitment rejection for Phase44D/45/46/47/48,
+3. bounded Kani harnesses for canonical public-input ordering plus Phase45/47/48
+   replay-free flag and wrapper surfaces,
+4. bounded fuzz smoke on manifest-style artifact loaders and Tablero artifact
+   acceptors,
+5. Miri/UB/sanitizer coverage through the repo hardening stack,
+6. dependency audit and merge-gate evidence.
+
+This is a strong engineering evidence stack. It is still weaker than a proof-assistant
+formalization.
+
+## Next honest escalation
+
+If the repo needs stronger closure than this note provides, the next honest
+escalation is not to widen the theorem informally. It is to move one step up
+the rigor ladder:
+
+1. keep the current deterministic and adversarial test stack,
+2. add stronger seeded fuzz corpora on the newer Tablero surfaces,
+3. add bounded model-checking for the exact binding predicates that replace
+   replay, and only then
+4. if the claim needs proof-assistant-grade certainty, formalize the typed
+   boundary statement in Lean or a similar assistant.
+
+That sequence matches the way StarkWare now describes its own formal-soundness
+roadmap for S-two-adjacent systems: proof assistants are the end of the
+escalation ladder, not the first step.

--- a/docs/paper/evidence/published-zkml-calibration-note-2026-04-24.md
+++ b/docs/paper/evidence/published-zkml-calibration-note-2026-04-24.md
@@ -107,6 +107,14 @@ So the Obelyzk row now strengthens deployment/on-chain calibration and public
 STARK-native posture, but it does not turn the table into a same-regime verifier
 race.
 
+One further caveat matters for the repository's own large replay-avoidance
+ratios. On the current local path, the dominant lower-layer baseline cost is the
+ordered Phase30 manifest replay that this codebase actually pays, including
+canonical JSON serialization and Blake2b hashing inside that replay flow. That
+cost is real for this implementation, and it is exactly the work the typed
+boundary removes here, but it should not be read as a universal lower bound on
+manifest replay cost across every possible STARK stack or serialization design.
+
 ## Immediate consequence for paper positioning
 
 The defensible public claim is narrower than “STARKs are already faster for

--- a/docs/paper/stark-transformer-alignment-2026.md
+++ b/docs/paper/stark-transformer-alignment-2026.md
@@ -732,6 +732,53 @@ artifact structure, typed public-output binding, and receipt/source consistency.
 not claim recursive compression, full standard-softmax inference soundness, or a
 universal security theorem for every row in the experimental S-two tier.
 
+#### Tablero statement-preservation theorem
+
+The current paper can make one stronger formal claim about the typed-boundary
+pattern without overclaiming a new proof-system theorem.
+
+Let `R` be the underlying compact-proof relation, `V_R(c, π)` the upstream S-two
+verifier for compact claim `c` and proof `π`, `σ` the heavier replay surface
+that the baseline verifier would inspect directly, `U(σ, c)` the replay-derived
+public surface reconstructed from `σ`, and `β = Emit(σ, c)` a typed boundary
+artifact emitted from that same source surface. Let `Bind(β, c)` be the
+repository-local binding predicate that checks the fields of `β` which replace
+replay work: source-root binding, typed public-output binding, ordered
+public-input binding where applicable, replay-flag checks, and nested
+commitment consistency. The Tablero verifier shape is then
+
+```text
+TableroVerify(β, c, π) := Validate(β) and V_R(c, π) and Bind(β, c).
+```
+
+**Theorem 3 (Tablero statement preservation).** Assume: (1) upstream S-two
+soundness for `V_R`, (2) binding of the local Blake2b-based commitment surfaces,
+and (3) that the source side emits the proof-native fields that `Bind(β, c)`
+checks. Then accepting `(β, c, π)` through `TableroVerify` does not widen the
+accepted statement set relative to the replay verifier that checks `V_R(c, π)`
+and reconstructs the same public surface from `σ` directly, except with the sum
+of the upstream proof-system soundness error and the local commitment-collision
+probability.
+
+**Proof sketch.** If `V_R(c, π)` accepts, then by upstream S-two soundness the
+compact claim `c` is valid except with negligible probability. `Validate(β)`
+ensures the typed object itself is canonical for its layer: version, semantic
+scope, replay-elimination flags, and self-commitment are all checked. `Bind(β,
+c)` then checks that the fields of `β` that replace replay are the same fields
+the replay baseline would have derived from `σ` for the same compact claim `c`.
+Under the local commitment-binding assumption, the adversary cannot splice a
+different nested object under the same commitments except with negligible
+probability. So replacing replay with `β` changes verifier cost, but not the
+accepted compact statement. This is a statement-preservation theorem, not a new
+recursive-compression or proof-system soundness theorem.
+
+That final precondition matters. The theorem does not automatically make every
+candidate boundary real. Phase43 remains a recorded no-go because the current
+source side still does not emit the proof-native commitments and public inputs
+needed to make `Bind(β, c)` complete without full-trace replay. So the theorem
+explains both outcomes in the repository: why Phase44D is a real typed-boundary
+result today, and why Phase43 is not yet one.
+
 For shared lookup evidence, the artifact binds normalization and activation table
 identity into a static lookup-table registry commitment inside the shared lookup
 artifact; this is table-identity and provenance binding, not recursive cross-step

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -104,5 +104,40 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "phase44d_source_chain_public_output_boundary_binding"
+path = "fuzz_targets/phase44d_source_chain_public_output_boundary_binding.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "phase45_recursive_verifier_public_input_bridge"
+path = "fuzz_targets/phase45_recursive_verifier_public_input_bridge.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "phase46_stwo_proof_adapter_receipt"
+path = "fuzz_targets/phase46_stwo_proof_adapter_receipt.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "phase47_recursive_verifier_wrapper_candidate"
+path = "fuzz_targets/phase47_recursive_verifier_wrapper_candidate.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "phase48_recursive_proof_wrapper_attempt"
+path = "fuzz_targets/phase48_recursive_proof_wrapper_attempt.rs"
+test = false
+doc = false
+bench = false
+
 [workspace]
 members = ["."]

--- a/fuzz/fuzz_targets/phase44d_source_chain_public_output_boundary_binding.rs
+++ b/fuzz/fuzz_targets/phase44d_source_chain_public_output_boundary_binding.rs
@@ -1,0 +1,32 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use llm_provable_computer::{
+    Phase43HistoryReplayProjectionCompactClaim,
+    Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary,
+};
+use llm_provable_computer::stwo_backend::
+    verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Phase44DBoundaryBindingInput {
+    boundary: Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary,
+    compact_claim: Phase43HistoryReplayProjectionCompactClaim,
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 1024 * 1024 {
+        return;
+    }
+    let Ok(json) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(input) = serde_json::from_str::<Phase44DBoundaryBindingInput>(json) else {
+        return;
+    };
+    let _ = verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding(
+        &input.boundary,
+        &input.compact_claim,
+    );
+});

--- a/fuzz/fuzz_targets/phase45_recursive_verifier_public_input_bridge.rs
+++ b/fuzz/fuzz_targets/phase45_recursive_verifier_public_input_bridge.rs
@@ -1,0 +1,19 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use llm_provable_computer::{
+    verify_phase45_recursive_verifier_public_input_bridge, Phase45RecursiveVerifierPublicInputBridge,
+};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 1024 * 1024 {
+        return;
+    }
+    let Ok(json) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(bridge) = serde_json::from_str::<Phase45RecursiveVerifierPublicInputBridge>(json) else {
+        return;
+    };
+    let _ = verify_phase45_recursive_verifier_public_input_bridge(&bridge);
+});

--- a/fuzz/fuzz_targets/phase46_stwo_proof_adapter_receipt.rs
+++ b/fuzz/fuzz_targets/phase46_stwo_proof_adapter_receipt.rs
@@ -1,0 +1,19 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use llm_provable_computer::{
+    verify_phase46_stwo_proof_adapter_receipt, Phase46StwoProofAdapterReceipt,
+};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 1024 * 1024 {
+        return;
+    }
+    let Ok(json) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(receipt) = serde_json::from_str::<Phase46StwoProofAdapterReceipt>(json) else {
+        return;
+    };
+    let _ = verify_phase46_stwo_proof_adapter_receipt(&receipt);
+});

--- a/fuzz/fuzz_targets/phase47_recursive_verifier_wrapper_candidate.rs
+++ b/fuzz/fuzz_targets/phase47_recursive_verifier_wrapper_candidate.rs
@@ -1,0 +1,19 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use llm_provable_computer::{
+    verify_phase47_recursive_verifier_wrapper_candidate, Phase47RecursiveVerifierWrapperCandidate,
+};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 1024 * 1024 {
+        return;
+    }
+    let Ok(json) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(candidate) = serde_json::from_str::<Phase47RecursiveVerifierWrapperCandidate>(json) else {
+        return;
+    };
+    let _ = verify_phase47_recursive_verifier_wrapper_candidate(&candidate);
+});

--- a/fuzz/fuzz_targets/phase48_recursive_proof_wrapper_attempt.rs
+++ b/fuzz/fuzz_targets/phase48_recursive_proof_wrapper_attempt.rs
@@ -1,0 +1,19 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use llm_provable_computer::{
+    verify_phase48_recursive_proof_wrapper_attempt, Phase48RecursiveProofWrapperAttempt,
+};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 1024 * 1024 {
+        return;
+    }
+    let Ok(json) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(attempt) = serde_json::from_str::<Phase48RecursiveProofWrapperAttempt>(json) else {
+        return;
+    };
+    let _ = verify_phase48_recursive_proof_wrapper_attempt(&attempt);
+});

--- a/scripts/run_formal_contract_suite.sh
+++ b/scripts/run_formal_contract_suite.sh
@@ -105,6 +105,22 @@ KANI_ARGS=(
   kani_phase33_public_input_lane_payload_wires_canonical_fields
   --harness
   kani_phase33_public_input_ordering_rejects_any_lane_drift
+  --harness
+  kani_phase45_bridge_flags_accept_canonical_boundary_width_bridge
+  --harness
+  kani_phase45_bridge_flags_reject_any_claim_replay_or_missing_verification
+  --harness
+  kani_phase45_public_input_lane_metadata_accepts_canonical_examples
+  --harness
+  kani_phase45_public_input_lane_metadata_rejects_index_or_label_drift
+  --harness
+  kani_phase47_wrapper_flags_accept_canonical_receipt_only_candidate
+  --harness
+  kani_phase47_wrapper_flags_reject_any_replay_or_false_claim
+  --harness
+  kani_phase48_attempt_flags_accept_canonical_no_go
+  --harness
+  kani_phase48_attempt_flags_reject_any_replay_or_false_claim
 )
 
 "${KANI_ARGS[@]}"

--- a/scripts/run_tablero_acceptance_fuzz_suite.sh
+++ b/scripts/run_tablero_acceptance_fuzz_suite.sh
@@ -7,23 +7,19 @@ cd "$ROOT_DIR"
 FUZZ_TOOLCHAIN="${FUZZ_TOOLCHAIN:-nightly-2025-07-14}"
 FUZZ_TIME_PER_TARGET="${FUZZ_TIME_PER_TARGET:-20}"
 FUZZ_INPUT_TIMEOUT_SECONDS="${FUZZ_INPUT_TIMEOUT_SECONDS:-5}"
-FUZZ_WORK_DIR="${FUZZ_WORK_DIR:-target/fuzz-smoke}"
-FUZZ_SOURCE_CORPUS_DIR="${FUZZ_SOURCE_CORPUS_DIR:-fuzz/corpus}"
-SAFE_TARGET_ROOT="${ROOT_DIR}/target"
 FUZZ_WALL_CLOCK_GRACE_SECONDS="${FUZZ_WALL_CLOCK_GRACE_SECONDS:-10}"
-# Keep this list to fast manifest-style targets. The phase12 shared-lookup
-# artifact verifier consumes full proof payloads and is too expensive for a
-# bounded smoke loop; it remains available for manual fuzzing.
+FUZZ_WORK_DIR="${FUZZ_WORK_DIR:-target/tablero-fuzz}"
+SAFE_TARGET_ROOT="${ROOT_DIR}/target"
 FUZZ_TARGETS=(
-  phase29_recursive_compression_input_contract
-  phase30_decoding_step_proof_envelope_manifest
-  phase35_recursive_compression_target_manifest
-  phase36_recursive_verifier_harness_receipt
-  phase37_recursive_artifact_chain_harness_receipt
+  phase44d_source_chain_public_output_boundary_binding
+  phase45_recursive_verifier_public_input_bridge
+  phase46_stwo_proof_adapter_receipt
+  phase47_recursive_verifier_wrapper_candidate
+  phase48_recursive_proof_wrapper_attempt
 )
 
 if ! command -v cargo-fuzz >/dev/null 2>&1 && ! cargo fuzz --version >/dev/null 2>&1; then
-  echo "cargo-fuzz is required; install it with \`cargo install cargo-fuzz\`" >&2
+  echo "cargo-fuzz is required; install it with \\`cargo install cargo-fuzz\\`" >&2
   exit 1
 fi
 
@@ -31,7 +27,6 @@ canonicalize_path() {
   python3 - "$1" <<'PY'
 import os
 import sys
-
 print(os.path.realpath(sys.argv[1]))
 PY
 }
@@ -42,7 +37,7 @@ require_safe_path_under() {
   local description="$3"
 
   if [[ -z "$candidate" || "$candidate" == "/" ]]; then
-    echo "refusing unsafe ${description} path: \`${candidate}\`" >&2
+    echo "refusing unsafe ${description} path: \\`${candidate}\\`" >&2
     exit 1
   fi
 
@@ -54,7 +49,7 @@ require_safe_path_under() {
   case "$resolved_candidate" in
     "$resolved_safe_root"|"$resolved_safe_root"/*) ;;
     *)
-      echo "refusing unsafe ${description} path: \`${resolved_candidate}\` is outside \`${resolved_safe_root}\`" >&2
+      echo "refusing unsafe ${description} path: \\`${resolved_candidate}\\` is outside \\`${resolved_safe_root}\\`" >&2
       exit 1
       ;;
   esac
@@ -73,35 +68,27 @@ require_strict_subpath_under() {
   resolved_safe_root="$(canonicalize_path "$safe_root")"
 
   if [[ "$resolved_candidate" == "$resolved_safe_root" ]]; then
-    echo "refusing unsafe ${description} path: \`${resolved_candidate}\` must be a strict child of \`${resolved_safe_root}\`" >&2
+    echo "refusing unsafe ${description} path: \\`${resolved_candidate}\\` must be a strict child of \\`${resolved_safe_root}\\`" >&2
     exit 1
   fi
 }
 
-require_safe_path_under "$FUZZ_WORK_DIR" "$SAFE_TARGET_ROOT" "fuzz work"
-require_safe_path_under "$FUZZ_SOURCE_CORPUS_DIR" "${ROOT_DIR}/fuzz/corpus" "source corpus"
+require_safe_path_under "$FUZZ_WORK_DIR" "$SAFE_TARGET_ROOT" "tablero fuzz work"
 
-FUZZ_HOST_TRIPLE="$(
-  rustc +"${FUZZ_TOOLCHAIN}" -vV | sed -n 's/^host: //p'
-)"
+FUZZ_HOST_TRIPLE="$({ rustc +"${FUZZ_TOOLCHAIN}" -vV | sed -n 's/^host: //p'; } )"
 if [[ -z "$FUZZ_HOST_TRIPLE" ]]; then
   echo "could not determine host triple for ${FUZZ_TOOLCHAIN}" >&2
   exit 1
 fi
 
 for target in "${FUZZ_TARGETS[@]}"; do
-  corpus_dir="${FUZZ_SOURCE_CORPUS_DIR}/${target}"
-  if [[ ! -d "$corpus_dir" ]]; then
-    echo "missing fuzz corpus directory: ${corpus_dir}" >&2
-    exit 1
-  fi
   run_dir="${FUZZ_WORK_DIR}/${target}"
   run_corpus_dir="${run_dir}/corpus"
   artifact_dir="${run_dir}/artifacts"
   require_strict_subpath_under "$run_dir" "$FUZZ_WORK_DIR" "target run"
   rm -rf -- "$run_dir"
   mkdir -p "$run_corpus_dir" "$artifact_dir"
-  cp -R "${corpus_dir}/." "$run_corpus_dir/"
+
   cargo +"${FUZZ_TOOLCHAIN}" fuzz build "$target"
   fuzz_binary="fuzz/target/${FUZZ_HOST_TRIPLE}/release/${target}"
   if [[ ! -x "$fuzz_binary" ]]; then
@@ -109,16 +96,12 @@ for target in "${FUZZ_TARGETS[@]}"; do
     exit 1
   fi
 
-  # libFuzzer's own time budget is not a reliable outer wall-clock bound here,
-  # so run the built binary under a short external alarm as well. Treat the
-  # outer timeout as a bounded smoke completion if no crash artifacts were
-  # emitted.
   set +e
   perl -e 'alarm shift @ARGV; exec @ARGV' \
     "$((FUZZ_TIME_PER_TARGET + FUZZ_INPUT_TIMEOUT_SECONDS + FUZZ_WALL_CLOCK_GRACE_SECONDS))" \
     "$fuzz_binary" \
     -artifact_prefix="${artifact_dir}/" \
-    -max_len=8388608 \
+    -max_len=1048576 \
     -timeout="${FUZZ_INPUT_TIMEOUT_SECONDS}" \
     -rss_limit_mb=4096 \
     -print_final_stats=1 \

--- a/scripts/run_tablero_formal_contract_suite.sh
+++ b/scripts/run_tablero_formal_contract_suite.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ "${CLEAN_KANI_TARGET:-1}" == "1" ]]; then
+  rm -rf target/kani
+fi
+
+KANI_ARGS=(
+  cargo
+  kani
+  --features
+  stwo-backend
+  --output-format
+  terse
+  --harness
+  kani_phase33_public_input_ordering_accepts_canonical_order
+  --harness
+  kani_phase33_public_input_lane_payload_wires_canonical_fields
+  --harness
+  kani_phase33_public_input_ordering_rejects_any_lane_drift
+  --harness
+  kani_phase36_receipt_flags_accept_canonical_nonclaim_receipt
+  --harness
+  kani_phase36_receipt_flags_reject_any_claim_or_missing_source_check
+  --harness
+  kani_phase37_receipt_flags_accept_canonical_source_bound_receipt
+  --harness
+  kani_phase37_receipt_flags_reject_any_claim_or_missing_source_check
+  --harness
+  kani_phase45_bridge_flags_accept_canonical_boundary_width_bridge
+  --harness
+  kani_phase45_bridge_flags_reject_any_claim_replay_or_missing_verification
+  --harness
+  kani_phase45_public_input_lane_metadata_accepts_canonical_examples
+  --harness
+  kani_phase45_public_input_lane_metadata_rejects_index_or_label_drift
+  --harness
+  kani_phase47_wrapper_flags_accept_canonical_receipt_only_candidate
+  --harness
+  kani_phase47_wrapper_flags_reject_any_replay_or_false_claim
+  --harness
+  kani_phase48_attempt_flags_accept_canonical_no_go
+  --harness
+  kani_phase48_attempt_flags_reject_any_replay_or_false_claim
+)
+
+"${KANI_ARGS[@]}"

--- a/scripts/run_tablero_hardening_preflight.sh
+++ b/scripts/run_tablero_hardening_preflight.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+MODE="core"
+HARDENING_TOOLCHAIN="${HARDENING_TOOLCHAIN:-nightly-2025-07-14}"
+FUZZ_TIME_PER_TARGET="${FUZZ_TIME_PER_TARGET:-20}"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+ARTIFACT_DIR="${ARTIFACT_DIR:-target/tablero-hardening/${RUN_ID}}"
+SUMMARY_TSV="${ARTIFACT_DIR}/summary.tsv"
+
+usage() {
+  cat <<USAGE
+Usage: scripts/run_tablero_hardening_preflight.sh [--mode core|deep]
+
+Modes:
+  core  deterministic theorem- and artifact-facing checks
+  deep  core plus Tablero-focused fuzz smoke and Miri
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$MODE" in
+  core|deep) ;;
+  *)
+    echo "unsupported mode: ${MODE}" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$ARTIFACT_DIR"
+printf 'step\tstatus\tlog\n' > "$SUMMARY_TSV"
+
+run_logged() {
+  local label="$1"
+  shift
+  local log_path="${ARTIFACT_DIR}/${label}.log"
+  echo "[tablero-hardening] ${label}"
+  if "$@" 2>&1 | tee "$log_path"; then
+    printf '%s\tpass\t%s\n' "$label" "$log_path" >> "$SUMMARY_TSV"
+  else
+    printf '%s\tfail\t%s\n' "$label" "$log_path" >> "$SUMMARY_TSV"
+    return 1
+  fi
+}
+
+run_logged fmt cargo fmt --check
+run_logged diff-check git diff --check
+run_logged carry-aware-air cargo +"${HARDENING_TOOLCHAIN}" test --features stwo-backend --lib carry_aware_
+run_logged experimental-proof-route cargo +"${HARDENING_TOOLCHAIN}" test --features stwo-backend --lib experimental_phase12_carry_aware_
+run_logged phase44d-boundary cargo +"${HARDENING_TOOLCHAIN}" test --features stwo-backend --lib phase44d_source_emission_public_output_boundary_
+run_logged phase44d-handoff cargo +"${HARDENING_TOOLCHAIN}" test --features stwo-backend --lib phase44d_source_emission_recursive_handoff_
+run_logged phase45-bridge cargo +"${HARDENING_TOOLCHAIN}" test --features stwo-backend --lib phase45_public_input_bridge_
+run_logged phase46-receipt cargo +"${HARDENING_TOOLCHAIN}" test --features stwo-backend --lib phase46_stwo_proof_adapter_receipt_
+run_logged phase47-candidate cargo +"${HARDENING_TOOLCHAIN}" test --features stwo-backend --lib phase47_recursive_verifier_wrapper_candidate_
+run_logged phase48-wrapper-attempt cargo +"${HARDENING_TOOLCHAIN}" test --features stwo-backend --lib phase48_recursive_proof_wrapper_attempt_
+
+# This machine runs close to disk pressure. Clear heavyweight build products
+# before the more expensive bounded-model-checking and sanitizer phases so the
+# integrated hardening gate stays runnable instead of failing on storage churn.
+rm -rf target/debug target/miri target/kani fuzz/target
+run_logged formal-contracts scripts/run_tablero_formal_contract_suite.sh
+rm -rf target/kani
+run_logged dependency-audit scripts/run_dependency_audit_suite.sh
+
+if [[ "$MODE" == "deep" ]]; then
+  run_logged tablero-fuzz env FUZZ_TIME_PER_TARGET="$FUZZ_TIME_PER_TARGET" FUZZ_TOOLCHAIN="$HARDENING_TOOLCHAIN" scripts/run_tablero_acceptance_fuzz_suite.sh
+  rm -rf fuzz/target target/debug target/kani target/miri
+  run_logged miri env HARDENING_TOOLCHAIN="$HARDENING_TOOLCHAIN" scripts/run_miri_suite.sh
+fi
+
+echo "[tablero-hardening] summary: ${SUMMARY_TSV}"

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -204,6 +204,7 @@ pub use history_replay_projection_prover::{
     verify_phase44d_history_replay_projection_emitted_root_artifact_acceptance,
     verify_phase44d_history_replay_projection_external_source_root_acceptance,
     verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance,
+    verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding,
     verify_phase44d_history_replay_projection_source_emission_acceptance,
     verify_phase44d_history_replay_projection_source_emission_public_output_acceptance,
     verify_phase44d_history_replay_projection_terminal_boundary_logup_closure,

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -5197,6 +5197,96 @@ fn phase37_receipt_flag_surface_is_valid(
 }
 
 #[cfg(feature = "stwo-backend")]
+fn phase45_bridge_flag_surface_is_valid(
+    public_output_boundary_verified: bool,
+    compact_envelope_verified: bool,
+    terminal_boundary_logup_closure_verified: bool,
+    recursive_verification_claimed: bool,
+    cryptographic_compression_claimed: bool,
+    verifier_requires_phase43_trace: bool,
+    verifier_requires_phase30_manifest: bool,
+    verifier_embeds_expected_rows: bool,
+    public_input_count: usize,
+    ordered_lane_count: usize,
+) -> bool {
+    public_output_boundary_verified
+        && compact_envelope_verified
+        && terminal_boundary_logup_closure_verified
+        && !recursive_verification_claimed
+        && !cryptographic_compression_claimed
+        && !verifier_requires_phase43_trace
+        && !verifier_requires_phase30_manifest
+        && !verifier_embeds_expected_rows
+        && public_input_count == ordered_lane_count
+        && public_input_count == PHASE45_PUBLIC_INPUT_LANE_LABELS.len()
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase45_public_input_lane_metadata_is_canonical(
+    expected_index: usize,
+    observed_index: usize,
+    observed_label: &str,
+) -> bool {
+    expected_index < PHASE45_PUBLIC_INPUT_LANE_LABELS.len()
+        && observed_index == expected_index
+        && observed_label == PHASE45_PUBLIC_INPUT_LANE_LABELS[expected_index]
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase47_wrapper_flag_surface_is_valid(
+    phase46_receipt_verified: bool,
+    stwo_core_verify_succeeded: bool,
+    terminal_logup_closed: bool,
+    consumes_phase46_receipt_only: bool,
+    wrapper_requires_phase43_trace: bool,
+    wrapper_requires_phase30_manifest: bool,
+    wrapper_embeds_expected_rows: bool,
+    recursive_proof_available: bool,
+    recursive_verification_claimed: bool,
+    cryptographic_compression_claimed: bool,
+) -> bool {
+    phase46_receipt_verified
+        && stwo_core_verify_succeeded
+        && terminal_logup_closed
+        && consumes_phase46_receipt_only
+        && !wrapper_requires_phase43_trace
+        && !wrapper_requires_phase30_manifest
+        && !wrapper_embeds_expected_rows
+        && !recursive_proof_available
+        && !recursive_verification_claimed
+        && !cryptographic_compression_claimed
+}
+
+#[cfg(feature = "stwo-backend")]
+fn phase48_attempt_flag_surface_is_valid(
+    phase47_candidate_verified: bool,
+    local_stwo_core_verifier_detected: bool,
+    local_stwo_cairo_verifier_core_detected: bool,
+    local_stwo_cairo_air_verifier_detected: bool,
+    local_phase43_projection_cairo_air_detected: bool,
+    actual_recursive_wrapper_available: bool,
+    recursive_proof_constructed: bool,
+    recursive_verification_claimed: bool,
+    cryptographic_compression_claimed: bool,
+    wrapper_requires_phase43_trace: bool,
+    wrapper_requires_phase30_manifest: bool,
+    wrapper_embeds_expected_rows: bool,
+) -> bool {
+    phase47_candidate_verified
+        && local_stwo_core_verifier_detected
+        && local_stwo_cairo_verifier_core_detected
+        && local_stwo_cairo_air_verifier_detected
+        && !local_phase43_projection_cairo_air_detected
+        && !actual_recursive_wrapper_available
+        && !recursive_proof_constructed
+        && !recursive_verification_claimed
+        && !cryptographic_compression_claimed
+        && !wrapper_requires_phase43_trace
+        && !wrapper_requires_phase30_manifest
+        && !wrapper_embeds_expected_rows
+}
+
+#[cfg(feature = "stwo-backend")]
 fn phase37_require_hash32(label: &str, value: &str) -> Result<()> {
     if !phase37_is_hash32_lower_hex(value) {
         return Err(VmError::InvalidConfig(format!(
@@ -5221,9 +5311,12 @@ mod kani_phase36_phase37_proofs {
     use super::{
         phase33_public_input_lane_payload, phase33_public_input_lanes_are_canonical,
         phase36_receipt_flag_surface_is_valid, phase37_is_hash32_lower_hex,
-        phase37_is_lower_hex_byte, phase37_receipt_flag_surface_is_valid, Phase33PublicInputLane,
-        Phase33PublicInputLanePayload, Phase33RecursiveCompressionPublicInputManifest,
-        PHASE33_PUBLIC_INPUT_LANES,
+        phase37_is_lower_hex_byte, phase37_receipt_flag_surface_is_valid,
+        phase45_bridge_flag_surface_is_valid, phase45_public_input_lane_metadata_is_canonical,
+        phase47_wrapper_flag_surface_is_valid, phase48_attempt_flag_surface_is_valid,
+        Phase33PublicInputLane, Phase33PublicInputLanePayload,
+        Phase33RecursiveCompressionPublicInputManifest, PHASE33_PUBLIC_INPUT_LANES,
+        PHASE45_PUBLIC_INPUT_LANE_LABELS,
     };
     use crate::proof::StarkProofBackend;
 
@@ -5459,6 +5552,184 @@ mod kani_phase36_phase37_proofs {
             };
 
         assert!(!phase33_public_input_lanes_are_canonical(&observed));
+    }
+
+    #[kani::proof]
+    fn kani_phase45_bridge_flags_accept_canonical_boundary_width_bridge() {
+        assert!(phase45_bridge_flag_surface_is_valid(
+            true, true, true, false, false, false, false, false, 24, 24,
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase45_bridge_flags_reject_any_claim_replay_or_missing_verification() {
+        let public_output_boundary_verified = kani::any::<bool>();
+        let compact_envelope_verified = kani::any::<bool>();
+        let terminal_boundary_logup_closure_verified = kani::any::<bool>();
+        let recursive_verification_claimed = kani::any::<bool>();
+        let cryptographic_compression_claimed = kani::any::<bool>();
+        let verifier_requires_phase43_trace = kani::any::<bool>();
+        let verifier_requires_phase30_manifest = kani::any::<bool>();
+        let verifier_embeds_expected_rows = kani::any::<bool>();
+        let count_ok = kani::any::<bool>();
+        let public_input_count = if count_ok { 24 } else { 23 };
+        let ordered_lane_count = if count_ok { 24 } else { 25 };
+        kani::assume(
+            !public_output_boundary_verified
+                || !compact_envelope_verified
+                || !terminal_boundary_logup_closure_verified
+                || recursive_verification_claimed
+                || cryptographic_compression_claimed
+                || verifier_requires_phase43_trace
+                || verifier_requires_phase30_manifest
+                || verifier_embeds_expected_rows
+                || public_input_count != ordered_lane_count
+                || public_input_count != PHASE45_PUBLIC_INPUT_LANE_LABELS.len(),
+        );
+
+        assert!(!phase45_bridge_flag_surface_is_valid(
+            public_output_boundary_verified,
+            compact_envelope_verified,
+            terminal_boundary_logup_closure_verified,
+            recursive_verification_claimed,
+            cryptographic_compression_claimed,
+            verifier_requires_phase43_trace,
+            verifier_requires_phase30_manifest,
+            verifier_embeds_expected_rows,
+            public_input_count,
+            ordered_lane_count,
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase45_public_input_lane_metadata_accepts_canonical_examples() {
+        assert!(phase45_public_input_lane_metadata_is_canonical(
+            0,
+            0,
+            PHASE45_PUBLIC_INPUT_LANE_LABELS[0],
+        ));
+        assert!(phase45_public_input_lane_metadata_is_canonical(
+            PHASE45_PUBLIC_INPUT_LANE_LABELS.len() - 1,
+            PHASE45_PUBLIC_INPUT_LANE_LABELS.len() - 1,
+            PHASE45_PUBLIC_INPUT_LANE_LABELS[PHASE45_PUBLIC_INPUT_LANE_LABELS.len() - 1],
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase45_public_input_lane_metadata_rejects_index_or_label_drift() {
+        assert!(!phase45_public_input_lane_metadata_is_canonical(
+            0,
+            1,
+            PHASE45_PUBLIC_INPUT_LANE_LABELS[0],
+        ));
+        assert!(!phase45_public_input_lane_metadata_is_canonical(
+            0,
+            0,
+            PHASE45_PUBLIC_INPUT_LANE_LABELS[1],
+        ));
+        assert!(!phase45_public_input_lane_metadata_is_canonical(
+            PHASE45_PUBLIC_INPUT_LANE_LABELS.len() - 1,
+            PHASE45_PUBLIC_INPUT_LANE_LABELS.len() - 2,
+            PHASE45_PUBLIC_INPUT_LANE_LABELS[PHASE45_PUBLIC_INPUT_LANE_LABELS.len() - 1],
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase47_wrapper_flags_accept_canonical_receipt_only_candidate() {
+        assert!(phase47_wrapper_flag_surface_is_valid(
+            true, true, true, true, false, false, false, false, false, false,
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase47_wrapper_flags_reject_any_replay_or_false_claim() {
+        let phase46_receipt_verified = kani::any::<bool>();
+        let stwo_core_verify_succeeded = kani::any::<bool>();
+        let terminal_logup_closed = kani::any::<bool>();
+        let consumes_phase46_receipt_only = kani::any::<bool>();
+        let wrapper_requires_phase43_trace = kani::any::<bool>();
+        let wrapper_requires_phase30_manifest = kani::any::<bool>();
+        let wrapper_embeds_expected_rows = kani::any::<bool>();
+        let recursive_proof_available = kani::any::<bool>();
+        let recursive_verification_claimed = kani::any::<bool>();
+        let cryptographic_compression_claimed = kani::any::<bool>();
+        kani::assume(
+            !phase46_receipt_verified
+                || !stwo_core_verify_succeeded
+                || !terminal_logup_closed
+                || !consumes_phase46_receipt_only
+                || wrapper_requires_phase43_trace
+                || wrapper_requires_phase30_manifest
+                || wrapper_embeds_expected_rows
+                || recursive_proof_available
+                || recursive_verification_claimed
+                || cryptographic_compression_claimed,
+        );
+
+        assert!(!phase47_wrapper_flag_surface_is_valid(
+            phase46_receipt_verified,
+            stwo_core_verify_succeeded,
+            terminal_logup_closed,
+            consumes_phase46_receipt_only,
+            wrapper_requires_phase43_trace,
+            wrapper_requires_phase30_manifest,
+            wrapper_embeds_expected_rows,
+            recursive_proof_available,
+            recursive_verification_claimed,
+            cryptographic_compression_claimed,
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase48_attempt_flags_accept_canonical_no_go() {
+        assert!(phase48_attempt_flag_surface_is_valid(
+            true, true, true, true, false, false, false, false, false, false, false, false,
+        ));
+    }
+
+    #[kani::proof]
+    fn kani_phase48_attempt_flags_reject_any_replay_or_false_claim() {
+        let phase47_candidate_verified = kani::any::<bool>();
+        let local_stwo_core_verifier_detected = kani::any::<bool>();
+        let local_stwo_cairo_verifier_core_detected = kani::any::<bool>();
+        let local_stwo_cairo_air_verifier_detected = kani::any::<bool>();
+        let local_phase43_projection_cairo_air_detected = kani::any::<bool>();
+        let actual_recursive_wrapper_available = kani::any::<bool>();
+        let recursive_proof_constructed = kani::any::<bool>();
+        let recursive_verification_claimed = kani::any::<bool>();
+        let cryptographic_compression_claimed = kani::any::<bool>();
+        let wrapper_requires_phase43_trace = kani::any::<bool>();
+        let wrapper_requires_phase30_manifest = kani::any::<bool>();
+        let wrapper_embeds_expected_rows = kani::any::<bool>();
+        kani::assume(
+            !phase47_candidate_verified
+                || !local_stwo_core_verifier_detected
+                || !local_stwo_cairo_verifier_core_detected
+                || !local_stwo_cairo_air_verifier_detected
+                || local_phase43_projection_cairo_air_detected
+                || actual_recursive_wrapper_available
+                || recursive_proof_constructed
+                || recursive_verification_claimed
+                || cryptographic_compression_claimed
+                || wrapper_requires_phase43_trace
+                || wrapper_requires_phase30_manifest
+                || wrapper_embeds_expected_rows,
+        );
+
+        assert!(!phase48_attempt_flag_surface_is_valid(
+            phase47_candidate_verified,
+            local_stwo_core_verifier_detected,
+            local_stwo_cairo_verifier_core_detected,
+            local_stwo_cairo_air_verifier_detected,
+            local_phase43_projection_cairo_air_detected,
+            actual_recursive_wrapper_available,
+            recursive_proof_constructed,
+            recursive_verification_claimed,
+            cryptographic_compression_claimed,
+            wrapper_requires_phase43_trace,
+            wrapper_requires_phase30_manifest,
+            wrapper_embeds_expected_rows,
+        ));
     }
 }
 
@@ -10096,6 +10367,22 @@ pub fn verify_phase45_recursive_verifier_public_input_bridge(
                 .to_string(),
         ));
     }
+    if !phase45_bridge_flag_surface_is_valid(
+        bridge.public_output_boundary_verified,
+        bridge.compact_envelope_verified,
+        bridge.terminal_boundary_logup_closure_verified,
+        bridge.recursive_verification_claimed,
+        bridge.cryptographic_compression_claimed,
+        bridge.verifier_requires_phase43_trace,
+        bridge.verifier_requires_phase30_manifest,
+        bridge.verifier_embeds_expected_rows,
+        bridge.public_input_count,
+        bridge.ordered_public_input_lanes.len(),
+    ) {
+        return Err(VmError::InvalidConfig(
+            "Phase 45 public-input bridge has non-canonical public-input count".to_string(),
+        ));
+    }
     if bridge.verifier_side_complexity
         != STWO_RECURSIVE_VERIFIER_PUBLIC_INPUT_BRIDGE_COMPLEXITY_PHASE45
     {
@@ -10103,15 +10390,8 @@ pub fn verify_phase45_recursive_verifier_public_input_bridge(
             "Phase 45 public-input bridge complexity drift".to_string(),
         ));
     }
-    if bridge.public_input_count != bridge.ordered_public_input_lanes.len()
-        || bridge.public_input_count != PHASE45_PUBLIC_INPUT_LANE_LABELS.len()
-    {
-        return Err(VmError::InvalidConfig(
-            "Phase 45 public-input bridge has non-canonical public-input count".to_string(),
-        ));
-    }
     for (index, lane) in bridge.ordered_public_input_lanes.iter().enumerate() {
-        if lane.index != index || lane.label != PHASE45_PUBLIC_INPUT_LANE_LABELS[index] {
+        if !phase45_public_input_lane_metadata_is_canonical(index, lane.index, &lane.label) {
             return Err(VmError::InvalidConfig(
                 "Phase 45 public-input bridge lane order is not canonical".to_string(),
             ));
@@ -10714,6 +10994,18 @@ pub fn verify_phase47_recursive_verifier_wrapper_candidate(
                 .to_string(),
         ));
     }
+    debug_assert!(phase47_wrapper_flag_surface_is_valid(
+        candidate.phase46_receipt_verified,
+        candidate.stwo_core_verify_succeeded,
+        candidate.terminal_logup_closed,
+        candidate.consumes_phase46_receipt_only,
+        candidate.wrapper_requires_phase43_trace,
+        candidate.wrapper_requires_phase30_manifest,
+        candidate.wrapper_embeds_expected_rows,
+        candidate.recursive_proof_available,
+        candidate.recursive_verification_claimed,
+        candidate.cryptographic_compression_claimed,
+    ));
     if candidate.verifier_side_complexity
         != STWO_RECURSIVE_VERIFIER_WRAPPER_CANDIDATE_COMPLEXITY_PHASE47
     {
@@ -10977,6 +11269,20 @@ pub fn verify_phase48_recursive_proof_wrapper_attempt(
                 .to_string(),
         ));
     }
+    debug_assert!(phase48_attempt_flag_surface_is_valid(
+        attempt.phase47_candidate_verified,
+        attempt.local_stwo_core_verifier_detected,
+        attempt.local_stwo_cairo_verifier_core_detected,
+        attempt.local_stwo_cairo_air_verifier_detected,
+        attempt.local_phase43_projection_cairo_air_detected,
+        attempt.actual_recursive_wrapper_available,
+        attempt.recursive_proof_constructed,
+        attempt.recursive_verification_claimed,
+        attempt.cryptographic_compression_claimed,
+        attempt.wrapper_requires_phase43_trace,
+        attempt.wrapper_requires_phase30_manifest,
+        attempt.wrapper_embeds_expected_rows,
+    ));
     if attempt.compact_proof_channel
         != STWO_RECURSIVE_PROOF_WRAPPER_ATTEMPT_COMPACT_PROOF_CHANNEL_PHASE48
         || attempt.recursive_verifier_channel


### PR DESCRIPTION
## Summary
- add a scoped Tablero statement-preservation note and internal hardening packet
- add narrow Kani contracts plus new Phase44D/45/46/47/48 fuzz targets and hardening scripts
- harden the fuzz smoke wrappers and deep preflight so the full assurance stack is actually runnable under local disk pressure

## Validation
- `bash scripts/run_tablero_formal_contract_suite.sh`
- `bash scripts/run_tablero_hardening_preflight.sh --mode core`
- `bash scripts/run_tablero_hardening_preflight.sh --mode deep`
- `bash scripts/run_shellcheck_suite.sh`
- push hook local release gate: `14 / 14 steps OK`

## Artifacts
- deep preflight summary: `target/tablero-hardening/20260425T215057Z/summary.tsv`
- formal contracts log: `target/tablero-hardening/20260425T215057Z/formal-contracts.log`
- fuzz smoke log: `target/tablero-hardening/20260425T215057Z/tablero-fuzz.log`
- miri log: `target/tablero-hardening/20260425T215057Z/miri.log`

## Notes
- the Tablero fuzz smoke is now explicitly wall-clock bounded; timeout is treated as normal smoke completion only when no crash artifacts are emitted
- the deep hardening preflight now clears heavyweight build products between deterministic tests, Kani, fuzz, and Miri so the command stays runnable under local disk pressure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated engineering handoff guide with new Tablero hardening procedures
  * Added formal soundness specification for Tablero verification boundary
  * New hardening packet document with verification and tooling guidance

* **Testing**
  * Extended formal contract verification with new Phase 45, 47, and 48 harnesses
  * Added Tablero acceptance fuzzing suite with configurable timeouts
  * New hardening preflight runner supporting core and deep verification modes

* **Improvements**
  * Enhanced validation for Phase 45/47/48 flag surfaces and public-input lane metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->