### PR TITLE
[codex] Harden wrap-delta and serialized chain checks

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -53,6 +53,9 @@ The active split is now:
 - Gate 2e: the honest `8`-step family now has explicit coverage for signed and
   non-unit `MulMemory` wrap deltas, the sticky-carry `Store` rows that follow
   them, and a full positive trace-constraint sweep across all eight seeds.
+- Gate 2i: the carry-aware lane now has a narrow theorem-style note for the
+  `wrap_delta` witness discipline, plus exhaustive deterministic checks for the
+  full supported range-witness and quotient / divisibility surface.
 - Gate 3: the experimental Phase44D typed-boundary reuse sweep clears `2,4,8,16,32,64,128,256,512,1024`.
 - Gate 3b: the same Phase44D replay-avoidance mechanism now reproduces on the
   non-default `3x3` layout family through `2,4,8,16,32,64,128,256` under the
@@ -70,6 +73,10 @@ The active split is now:
   an internal hardening packet and preflight script. These are the primary
   entrypoints for closing fooling-ourselves risk on the Phase44D boundary and
   its higher wrapper surfaces before any stronger promotion.
+- Gate 6b: the Tablero hardening stack now also includes one bounded
+  differential serialized-artifact mutator across Phase44D/45/46/47/48, plus
+  release-mode canonical-flag checks on the Phase47/48 verifiers where the
+  repo previously relied on `debug_assert!` only.
 
 At `1024` steps, the experimental shared path records:
 
@@ -99,17 +106,18 @@ Use these in order of authority for current state:
 5. `docs/engineering/phase12-carry-aware-arithmetic-subset-gate-2026-04-24.md`
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
 7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
-8. `docs/engineering/tablero-soundness-note-2026-04-25.md`
-9. `docs/engineering/tablero-hardening-packet-2026-04-25.md`
-10. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-11. `docs/engineering/phase44d-carry-aware-experimental-2x2-scaling-gate-2026-04-25.md`
-12. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
-13. `docs/engineering/phase44d-carry-aware-experimental-family-matrix-gate-2026-04-25.md`
-14. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
-15. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
-16. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
-17. `docs/engineering/reproducibility.md`
-18. `git status --short --branch`
+8. `docs/engineering/phase12-carry-aware-wrap-delta-witness-discipline-2026-04-26.md`
+9. `docs/engineering/tablero-soundness-note-2026-04-25.md`
+10. `docs/engineering/tablero-hardening-packet-2026-04-25.md`
+11. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+12. `docs/engineering/phase44d-carry-aware-experimental-2x2-scaling-gate-2026-04-25.md`
+13. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
+14. `docs/engineering/phase44d-carry-aware-experimental-family-matrix-gate-2026-04-25.md`
+15. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
+16. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
+17. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
+18. `docs/engineering/reproducibility.md`
+19. `git status --short --branch`
 
 ## Merge culture
 
@@ -141,6 +149,9 @@ Use these in order of authority for current state:
    - `scripts/run_tablero_formal_contract_suite.sh`
    - `scripts/run_tablero_hardening_preflight.sh --mode core`
    - `scripts/run_tablero_hardening_preflight.sh --mode deep`
+  - The hardening packet now includes exhaustive deterministic `wrap_delta`
+    witness/divisibility checks, and the fuzz suite now includes a
+    serialized-artifact differential mutator across Phase44D→48.
 5. Keep SNIP-36 parked until there is a real adapter path from local proof
    objects to protocol-native proof facts. It is a deferred design lane, not a
    current paper or hardening blocker.

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -11,15 +11,16 @@ This is the fast local entrypoint for a fresh agent working in this repository.
 5. `docs/engineering/phase12-carry-aware-arithmetic-subset-gate-2026-04-24.md`
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
 7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
-8. `docs/engineering/tablero-soundness-note-2026-04-25.md`
-9. `docs/engineering/tablero-hardening-packet-2026-04-25.md`
-10. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-11. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
-12. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
-13. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
-14. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
-15. `docs/engineering/reproducibility.md`
-16. `git status --short --branch`
+8. `docs/engineering/phase12-carry-aware-wrap-delta-witness-discipline-2026-04-26.md`
+9. `docs/engineering/tablero-soundness-note-2026-04-25.md`
+10. `docs/engineering/tablero-hardening-packet-2026-04-25.md`
+11. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+12. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
+13. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
+14. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
+15. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
+16. `docs/engineering/reproducibility.md`
+17. `git status --short --branch`
 
 ## What this repository is now
 
@@ -32,7 +33,7 @@ This repository currently has two live lanes.
 2. Experimental core-proving lane
    - The carry-aware backend `stwo-phase12-decoding-family-v10-carry-aware-experimental` is the active upside research lane.
    - It clears the honest `8`-step Phase12 family, has AIR-level `wrap_delta` range constraints, and the experimental Phase44D scaling sweep currently clears through `2,4,8,16,32,64,128,256,512,1024`.
-   - The focused April 25 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, serialized Phase44D typed-boundary tamper coverage, serialized Phase44D handoff / Phase45 bridge / Phase46 receipt tamper coverage, and serialized Phase47 wrapper-candidate / Phase48 wrapper-attempt tamper coverage including stale-commitment rejection.
+   - The focused April 25-26 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, serialized Phase44D typed-boundary tamper coverage, serialized Phase44D handoff / Phase45 bridge / Phase46 receipt tamper coverage, serialized Phase47 wrapper-candidate / Phase48 wrapper-attempt tamper coverage including stale-commitment rejection, and one bounded differential serialized-artifact mutator across the full Phase44D→48 chain.
 
 Do not collapse these two lanes into one claim.
 
@@ -91,6 +92,7 @@ The repo now also has one explicit answer on the second-backend question:
    - `scripts/run_tablero_formal_contract_suite.sh`
    - `scripts/run_tablero_hardening_preflight.sh --mode core`
    - `scripts/run_tablero_hardening_preflight.sh --mode deep`
+   - The hardening packet now includes exhaustive deterministic checks for the carry-aware `wrap_delta` witness/divisibility surface, not only the Tablero flag surfaces.
 6. Keep SNIP-36 parked until there is a real adapter path from local proof
    objects to protocol-native proof facts; treat it as a deferred design lane,
    not a current paper or review blocker.

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -13,15 +13,16 @@ If you are in a local checkout, prefer `AGENTS.md`, `.codex/START_HERE.md`, and
 5. `docs/engineering/phase12-carry-aware-arithmetic-subset-gate-2026-04-24.md`
 6. `docs/engineering/phase12-carry-aware-soundness-hardening-2026-04-24.md`
 7. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
-8. `docs/engineering/tablero-soundness-note-2026-04-25.md`
-9. `docs/engineering/tablero-hardening-packet-2026-04-25.md`
-10. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-11. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
-12. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
-13. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
-14. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
-15. `docs/engineering/reproducibility.md`
-16. `git status --short --branch`
+8. `docs/engineering/phase12-carry-aware-wrap-delta-witness-discipline-2026-04-26.md`
+9. `docs/engineering/tablero-soundness-note-2026-04-25.md`
+10. `docs/engineering/tablero-hardening-packet-2026-04-25.md`
+11. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+12. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
+13. `docs/engineering/phase71-second-boundary-assessment-2026-04-25.md`
+14. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
+15. `docs/engineering/phase44d-second-backend-feasibility-gate-2026-04-25.md`
+16. `docs/engineering/reproducibility.md`
+17. `git status --short --branch`
 
 ## Current lane split
 
@@ -63,6 +64,11 @@ This repository now has two live lanes.
 - A second April 25 follow-up covers signed/non-unit `MulMemory` wrap patterns,
   sticky-carry `Store` preservation, and a full positive trace sweep on the
   honest `8`-step family.
+- The April 26 follow-up adds a narrow witness-discipline note for `wrap_delta`,
+  exhaustive deterministic tests for the full supported range-witness and
+  quotient/divisibility family, one bounded differential serialized-artifact
+  mutator across Phase44D/45/46/47/48, and release-mode canonical-flag checks
+  on the Phase47/48 verifiers.
 - The experimental Phase44D typed-boundary sweep clears `2,4,8,16,32,64,128,256,512,1024`.
 - The experimental Phase44D typed-boundary sweep over the `2x2` family also
   clears `2,4,8,16,32,64,128,256,512,1024`
@@ -141,6 +147,9 @@ Tablero boundary.
    - `scripts/run_tablero_formal_contract_suite.sh`
    - `scripts/run_tablero_hardening_preflight.sh --mode core`
    - `scripts/run_tablero_hardening_preflight.sh --mode deep`
+   - The hardening packet now includes exhaustive deterministic `wrap_delta`
+     witness/divisibility checks, and the fuzz suite now includes a
+     serialized-artifact differential mutator across Phase44D→48.
 5. Keep SNIP-36 parked until there is a real adapter path from local proof
    objects to protocol-native proof facts; it is not a current hardening
    blocker.

--- a/docs/engineering/phase12-carry-aware-wrap-delta-witness-discipline-2026-04-26.md
+++ b/docs/engineering/phase12-carry-aware-wrap-delta-witness-discipline-2026-04-26.md
@@ -1,0 +1,199 @@
+# Carry-Aware `wrap_delta` Witness Discipline (April 26, 2026)
+
+This note narrows one specific soundness surface in the experimental
+carry-aware Phase12 arithmetic-subset AIR: the witness discipline around
+`wrap_delta`.
+
+It is not a proof of the full execution proof. It states the smaller property
+we actually need to avoid fooling ourselves about overflow handling:
+
+- host-side trace construction emits only integer `wrap_delta` values whose
+  quotient interpretation is well-defined;
+- the AIR constrains the auxiliary witness columns so an accepted row cannot
+  reinterpret that quotient as an arbitrary M31 field element;
+- ADD/SUB rows are further pinned to the unit range `{ -1, 0, 1 }`.
+
+## Scope
+
+This note covers the experimental backend surface in
+`src/stwo_backend/arithmetic_subset_prover.rs`:
+
+- `carry_aware_wrap_delta`
+- `carry_aware_wrap_delta_range_witness`
+- the AIR constraints over
+  `wrap_delta`, `wrap_delta_inv`, `wrap_delta_square`, `wrap_delta_abs`,
+  `wrap_delta_sign`, and `wrap_delta_abs_bits[*]`
+
+It does **not** claim:
+
+- full correctness of the VM transition relation;
+- soundness of unrelated witness columns;
+- backend-independence;
+- promotion of the experimental carry-aware lane into the default/publication
+  lane.
+
+## Notation
+
+Let:
+
+- `B = 2^16` be the carry wrap basis;
+- `raw_acc` be the unwrapped active accumulator for a carry-sensitive row;
+- `next_acc` be the wrapped `i16` accumulator stored in the next machine state;
+- `delta` be the integer quotient `(raw_acc - next_acc) / B` when divisible.
+
+The AIR stores this quotient as `wrap_delta` and introduces auxiliary columns:
+
+- `wrap_delta_inv`
+- `wrap_delta_square`
+- `wrap_delta_abs`
+- `wrap_delta_sign`
+- `wrap_delta_abs_bits[0..N)` with `N = 15`
+
+The maximum allowed magnitude is:
+
+- `CARRY_AWARE_WRAP_DELTA_ABS_MAX = 2^14`
+
+which matches the worst-case `i16 * i16` multiplication quotient under division
+by `2^16`.
+
+## Host-side discipline
+
+The host-side quotient constructor is:
+
+```text
+carry_aware_wrap_delta(raw_acc, wrapped_acc)
+```
+
+It rejects any row where:
+
+1. `raw_acc - wrapped_acc` is not divisible by `2^16`;
+2. the quotient magnitude exceeds `2^14`;
+3. the quotient does not fit in `i16`.
+
+The host-side range witness constructor is:
+
+```text
+carry_aware_wrap_delta_range_witness(delta)
+```
+
+It rejects any `delta` whose magnitude exceeds `2^14`, and otherwise returns:
+
+- `abs = |delta|`
+- `sign = (delta < 0)`
+- a little-endian bit decomposition of `abs`
+
+## AIR discipline
+
+For carry-sensitive rows, the AIR enforces all of the following:
+
+1. **Arithmetic wrap relation**
+
+```text
+raw_acc - next_acc = wrap_delta * 2^16
+```
+
+over the field.
+
+2. **Bitness of decomposition**
+
+Each `wrap_delta_abs_bits[i]` is boolean.
+
+3. **Magnitude reconstruction**
+
+`wrap_delta_abs = sum_i wrap_delta_abs_bits[i] * 2^i`.
+
+4. **High-bit exclusivity**
+
+If the top bit is set, all lower bits must be zero. Combined with
+reconstruction, this bounds `wrap_delta_abs <= 2^14`.
+
+5. **Signed reconstruction**
+
+`wrap_delta = wrap_delta_abs * (1 - 2 * wrap_delta_sign)`.
+
+6. **Quadratic pin**
+
+`wrap_delta_square = wrap_delta^2`.
+
+7. **Carry-activity gating**
+
+Non-carry rows must zero the carry witness surface.
+
+8. **Inverse discipline**
+
+`wrap_delta * wrap_delta_inv = next_carry_active`, so a non-zero active delta
+must have a valid inverse witness and an inactive carry row cannot float an
+arbitrary inverse.
+
+9. **ADD/SUB unit-range discipline**
+
+On ADD/SUB rows,
+
+```text
+wrap_delta_square = next_carry_active
+```
+
+so the only admissible active deltas are `-1` and `1`, while inactive rows pin
+`delta = 0`.
+
+## Statement
+
+### Theorem (carry-aware `wrap_delta` witness discipline)
+
+Assume a carry-sensitive experimental Phase12 row is accepted by the current
+AIR and its witness columns satisfy the constraints above.
+
+Then there exists an integer `delta` such that:
+
+1. `delta = wrap_delta` under the signed reconstruction induced by
+   `wrap_delta_abs`, `wrap_delta_sign`, and `wrap_delta_abs_bits`;
+2. `|delta| <= 2^14`;
+3. `raw_acc - next_acc = delta * 2^16` as an integer relation, not only as a
+   field relation;
+4. if the row is ADD or SUB, then `delta in { -1, 0, 1 }`.
+
+### Proof sketch
+
+- Bitness and reconstruction force `wrap_delta_abs_bits` to encode an actual
+  non-negative integer `wrap_delta_abs`.
+- High-bit exclusivity and the chosen bit width cap that magnitude at `2^14`.
+- Signed reconstruction forces `wrap_delta` to be exactly either
+  `wrap_delta_abs` or `-wrap_delta_abs`; it cannot float to another M31 value.
+- The square pin prevents inconsistent sign/magnitude pairings from surviving.
+- The arithmetic wrap relation then identifies the only admissible integer
+  quotient between `raw_acc` and `next_acc`.
+- On ADD/SUB rows, `wrap_delta_square = next_carry_active` collapses the active
+  magnitude to `1`, while inactive carry rows already force `wrap_delta = 0`.
+
+So the accepted witness surface cannot encode an arbitrary field solution to the
+wrap equation. It must encode a bounded signed integer quotient.
+
+## Executable checks tied to this note
+
+Deterministic tests already cover:
+
+- out-of-range `wrap_delta` witness rejection;
+- ADD/SUB deltas outside `{ -1, 0, 1 }`;
+- drift in `wrap_delta_abs_bits`, `wrap_delta_sign`, and `wrap_delta_square`;
+- full supported-range witness canonicality for every `wrap_delta` in
+  `[-2^14, 2^14]`;
+- full supported-range divisibility checks for representative wrapped
+  accumulators, including rejection of `+1` remainder drift on each supported
+  quotient;
+- honest positive, negative, and non-unit multiply/store carry patterns.
+
+These checks do not replace the AIR proof. They make the host-side
+range-witness constructor and quotient/divisibility helpers part of the
+executable contract surface through exhaustive deterministic tests that finish
+quickly enough to stay in the normal hardening loop.
+
+## Practical conclusion
+
+The April 24 range-hardening work did more than add tests. It closed the
+specific gap where `raw_acc - next_acc = wrap_delta * 2^16` could otherwise be
+satisfied by a spurious field element that was never bound back to an honest
+integer quotient.
+
+That is the property this repo now has stronger grounds to rely on when it says
+its experimental carry-aware overflow witness is not merely host-checked but AIR
+bound.

--- a/docs/engineering/tablero-hardening-packet-2026-04-25.md
+++ b/docs/engineering/tablero-hardening-packet-2026-04-25.md
@@ -23,14 +23,15 @@ Answer four questions cleanly:
 
 ## Read order
 
-1. `docs/engineering/tablero-soundness-note-2026-04-25.md`
-2. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
-3. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
-4. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
-5. `docs/engineering/phase44d-carry-aware-experimental-2x2-scaling-gate-2026-04-25.md`
-6. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
-7. `docs/engineering/phase44d-carry-aware-experimental-family-matrix-gate-2026-04-25.md`
-8. `docs/paper/stark-transformer-alignment-2026.md`
+1. `docs/engineering/phase12-carry-aware-wrap-delta-witness-discipline-2026-04-26.md`
+2. `docs/engineering/tablero-soundness-note-2026-04-25.md`
+3. `docs/engineering/phase12-carry-aware-soundness-review-2026-04-25.md`
+4. `docs/engineering/phase43-second-boundary-feasibility-gate-2026-04-25.md`
+5. `docs/engineering/phase44d-carry-aware-experimental-scaling-gate-2026-04-24.md`
+6. `docs/engineering/phase44d-carry-aware-experimental-2x2-scaling-gate-2026-04-25.md`
+7. `docs/engineering/phase44d-carry-aware-experimental-3x3-scaling-gate-2026-04-25.md`
+8. `docs/engineering/phase44d-carry-aware-experimental-family-matrix-gate-2026-04-25.md`
+9. `docs/paper/stark-transformer-alignment-2026.md`
 
 ## Exact code surfaces to review
 
@@ -174,6 +175,10 @@ This runs the Kani harnesses most directly tied to the theorem:
 - Phase47 receipt-only / no-replay / no-false-compression wrapper surface
 - Phase48 no-go / no-replay / no-false-recursion wrapper surface
 
+The carry-aware `wrap_delta` witness/divisibility properties are enforced in
+this packet by fast exhaustive Rust tests over the full supported `wrap_delta`
+range and representative wrapped-accumulator anchors, not by the Kani slice.
+
 The broader `scripts/run_formal_contract_suite.sh` still exists for repository-
 wide work, but it is not required for this packet.
 
@@ -186,6 +191,9 @@ This packet adds dedicated fuzz targets for:
 - Phase46 Stwo proof-adapter receipt
 - Phase47 recursive-verifier wrapper candidate
 - Phase48 recursive proof-wrapper attempt
+- one bounded differential mutator that starts from an accepted serialized
+  Phase44D→48 chain artifact, applies a semantic post-serialization drift, and
+  asserts verifier rejection at the mutated stage and its against-sources check
 
 This closes the earlier gap where the newer Tablero-shaped surfaces had strong
 deterministic tamper tests but no dedicated fuzz smoke.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -139,5 +139,12 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "phase44d_phase48_serialized_chain_differential"
+path = "fuzz_targets/phase44d_phase48_serialized_chain_differential.rs"
+test = false
+doc = false
+bench = false
+
 [workspace]
 members = ["."]

--- a/fuzz/fuzz_targets/phase44d_phase48_serialized_chain_differential.rs
+++ b/fuzz/fuzz_targets/phase44d_phase48_serialized_chain_differential.rs
@@ -1,0 +1,321 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use llm_provable_computer::{
+    commit_phase44d_recursive_verifier_public_output_handoff,
+    commit_phase45_recursive_verifier_public_input_bridge,
+    commit_phase45_recursive_verifier_public_inputs, commit_phase46_stwo_proof_adapter_receipt,
+    commit_phase47_recursive_verifier_wrapper_candidate,
+    commit_phase48_recursive_proof_wrapper_attempt,
+    emit_phase44d_history_replay_projection_source_chain_public_output_boundary,
+    phase29_prepare_recursive_compression_input_contract, phase43_prepare_history_replay_trace,
+    phase44d_prepare_recursive_verifier_public_output_handoff,
+    phase45_prepare_recursive_verifier_public_input_bridge,
+    phase46_prepare_stwo_proof_adapter_receipt,
+    phase47_prepare_recursive_verifier_wrapper_candidate,
+    phase48_prepare_recursive_proof_wrapper_attempt,
+    prove_phase42_boundary_preimage_shared_proof_demo,
+    prove_phase43_history_replay_projection_compact_claim_envelope,
+    verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance,
+    verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding,
+    verify_phase44d_recursive_verifier_public_output_handoff,
+    verify_phase44d_recursive_verifier_public_output_handoff_against_boundary,
+    verify_phase45_recursive_verifier_public_input_bridge,
+    verify_phase45_recursive_verifier_public_input_bridge_against_sources,
+    verify_phase46_stwo_proof_adapter_receipt, verify_phase46_stwo_proof_adapter_receipt_against_sources,
+    verify_phase47_recursive_verifier_wrapper_candidate,
+    verify_phase47_recursive_verifier_wrapper_candidate_against_phase46,
+    verify_phase48_recursive_proof_wrapper_attempt,
+    verify_phase48_recursive_proof_wrapper_attempt_against_phase47,
+    Phase43HistoryReplayProjectionCompactProofEnvelope,
+    Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary,
+    Phase44DRecursiveVerifierPublicOutputHandoff, Phase45RecursiveVerifierPublicInputBridge,
+    Phase46StwoProofAdapterReceipt, Phase47RecursiveVerifierWrapperCandidate,
+    Phase48RecursiveProofWrapperAttempt,
+};
+use std::sync::OnceLock;
+
+#[derive(Clone)]
+struct DifferentialFixture {
+    compact_envelope: Phase43HistoryReplayProjectionCompactProofEnvelope,
+    boundary: Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary,
+    handoff: Phase44DRecursiveVerifierPublicOutputHandoff,
+    bridge: Phase45RecursiveVerifierPublicInputBridge,
+    receipt: Phase46StwoProofAdapterReceipt,
+    candidate: Phase47RecursiveVerifierWrapperCandidate,
+    attempt: Phase48RecursiveProofWrapperAttempt,
+}
+
+fn hash32(hex: char) -> String {
+    hex.to_string().repeat(64)
+}
+
+fn fixture() -> &'static DifferentialFixture {
+    static FIXTURE: OnceLock<DifferentialFixture> = OnceLock::new();
+    FIXTURE.get_or_init(|| {
+        let (chain, phase28, phase30) =
+            prove_phase42_boundary_preimage_shared_proof_demo().expect("build shared-proof demo");
+        let contract = phase29_prepare_recursive_compression_input_contract(&phase28)
+            .expect("prepare phase29 contract");
+        let trace = phase43_prepare_history_replay_trace(&chain, &phase28, &contract, &phase30)
+            .expect("prepare phase43 trace");
+        let compact_envelope = prove_phase43_history_replay_projection_compact_claim_envelope(&trace)
+            .expect("prove compact envelope");
+        let boundary = emit_phase44d_history_replay_projection_source_chain_public_output_boundary(
+            &trace, &phase30,
+        )
+        .expect("emit phase44d boundary");
+        let handoff = phase44d_prepare_recursive_verifier_public_output_handoff(
+            &boundary,
+            &compact_envelope,
+        )
+        .expect("prepare phase44d handoff");
+        let bridge = phase45_prepare_recursive_verifier_public_input_bridge(
+            &boundary,
+            &compact_envelope,
+            &handoff,
+        )
+        .expect("prepare phase45 bridge");
+        let receipt = phase46_prepare_stwo_proof_adapter_receipt(&bridge, &compact_envelope)
+            .expect("prepare phase46 receipt");
+        let candidate = phase47_prepare_recursive_verifier_wrapper_candidate(&receipt)
+            .expect("prepare phase47 candidate");
+        let attempt = phase48_prepare_recursive_proof_wrapper_attempt(&candidate)
+            .expect("prepare phase48 attempt");
+
+        DifferentialFixture {
+            compact_envelope,
+            boundary,
+            handoff,
+            bridge,
+            receipt,
+            candidate,
+            attempt,
+        }
+    })
+}
+
+fn deserialize_tampered<T: serde::Serialize + serde::de::DeserializeOwned>(artifact: &T) -> serde_json::Value {
+    serde_json::to_value(artifact).expect("serialize accepted artifact")
+}
+
+fn boundary_case(variant: u8) {
+    let fixture = fixture();
+    let mut boundary_json = deserialize_tampered(&fixture.boundary);
+    match variant % 2 {
+        0 => {
+            boundary_json["verifier_requires_phase43_trace"] = serde_json::json!(true);
+            boundary_json["verifier_requires_phase30_manifest"] = serde_json::json!(true);
+        }
+        _ => {
+            let total_steps = boundary_json["source_emission_public_output"]["source_emission"]
+                ["source_claim"]["total_steps"]
+                .as_u64()
+                .expect("total_steps")
+                + 1;
+            boundary_json["source_emission_public_output"]["source_emission"]["source_claim"]
+                ["total_steps"] = serde_json::json!(total_steps);
+        }
+    }
+    let boundary: Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary =
+        serde_json::from_value(boundary_json).expect("deserialize tampered boundary");
+
+    assert!(verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance(
+        &boundary,
+        &fixture.compact_envelope,
+    )
+    .is_err());
+    assert!(verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding(
+        &boundary,
+        &fixture.compact_envelope.claim,
+    )
+    .is_err());
+}
+
+fn handoff_case(variant: u8) {
+    let fixture = fixture();
+    let mut handoff_json = deserialize_tampered(&fixture.handoff);
+    let handoff: Phase44DRecursiveVerifierPublicOutputHandoff = match variant % 2 {
+        0 => {
+            handoff_json["verifier_requires_phase43_trace"] = serde_json::json!(true);
+            handoff_json["verifier_requires_phase30_manifest"] = serde_json::json!(true);
+            let mut handoff: Phase44DRecursiveVerifierPublicOutputHandoff =
+                serde_json::from_value(handoff_json).expect("deserialize tampered handoff");
+            handoff.handoff_commitment = commit_phase44d_recursive_verifier_public_output_handoff(&handoff)
+                .expect("recommit tampered handoff");
+            handoff
+        }
+        _ => {
+            handoff_json["source_chain_public_output_boundary_commitment"] =
+                serde_json::json!(hash32('b'));
+            serde_json::from_value(handoff_json).expect("deserialize stale handoff")
+        }
+    };
+
+    assert!(verify_phase44d_recursive_verifier_public_output_handoff(&handoff).is_err());
+    assert!(verify_phase44d_recursive_verifier_public_output_handoff_against_boundary(
+        &handoff,
+        &fixture.boundary,
+        &fixture.compact_envelope,
+    )
+    .is_err());
+}
+
+fn bridge_case(variant: u8) {
+    let fixture = fixture();
+    let mut bridge_json = deserialize_tampered(&fixture.bridge);
+    let bridge: Phase45RecursiveVerifierPublicInputBridge = match variant % 2 {
+        0 => {
+            bridge_json["verifier_requires_phase43_trace"] = serde_json::json!(true);
+            bridge_json["verifier_requires_phase30_manifest"] = serde_json::json!(true);
+            let mut bridge: Phase45RecursiveVerifierPublicInputBridge =
+                serde_json::from_value(bridge_json).expect("deserialize tampered bridge");
+            bridge.bridge_commitment =
+                commit_phase45_recursive_verifier_public_input_bridge(&bridge)
+                    .expect("recommit tampered bridge");
+            bridge
+        }
+        _ => {
+            let lanes = bridge_json["ordered_public_input_lanes"]
+                .as_array_mut()
+                .expect("ordered lanes");
+            if lanes.len() >= 2 {
+                lanes.swap(0, 1);
+            }
+            let mut bridge: Phase45RecursiveVerifierPublicInputBridge =
+                serde_json::from_value(bridge_json).expect("deserialize reordered bridge");
+            bridge.ordered_public_inputs_commitment =
+                commit_phase45_recursive_verifier_public_inputs(&bridge.ordered_public_input_lanes)
+                    .expect("recommit reordered public inputs");
+            bridge.bridge_commitment =
+                commit_phase45_recursive_verifier_public_input_bridge(&bridge)
+                    .expect("recommit reordered bridge");
+            bridge
+        }
+    };
+
+    assert!(verify_phase45_recursive_verifier_public_input_bridge(&bridge).is_err());
+    assert!(verify_phase45_recursive_verifier_public_input_bridge_against_sources(
+        &bridge,
+        &fixture.boundary,
+        &fixture.compact_envelope,
+        &fixture.handoff,
+    )
+    .is_err());
+}
+
+fn receipt_case(variant: u8) {
+    let fixture = fixture();
+    let mut receipt_json = deserialize_tampered(&fixture.receipt);
+    let receipt: Phase46StwoProofAdapterReceipt = match variant % 2 {
+        0 => {
+            receipt_json["recursive_verification_claimed"] = serde_json::json!(true);
+            receipt_json["cryptographic_compression_claimed"] = serde_json::json!(true);
+            let mut receipt: Phase46StwoProofAdapterReceipt =
+                serde_json::from_value(receipt_json).expect("deserialize tampered receipt");
+            receipt.adapter_receipt_commitment = commit_phase46_stwo_proof_adapter_receipt(&receipt)
+                .expect("recommit tampered receipt");
+            receipt
+        }
+        _ => {
+            receipt_json["terminal_boundary_public_logup_sum_limbs"][0] = serde_json::json!(1);
+            let mut receipt: Phase46StwoProofAdapterReceipt =
+                serde_json::from_value(receipt_json).expect("deserialize tampered receipt sums");
+            receipt.adapter_receipt_commitment = commit_phase46_stwo_proof_adapter_receipt(&receipt)
+                .expect("recommit tampered receipt sums");
+            receipt
+        }
+    };
+
+    assert!(verify_phase46_stwo_proof_adapter_receipt(&receipt).is_err());
+    assert!(verify_phase46_stwo_proof_adapter_receipt_against_sources(
+        &receipt,
+        &fixture.bridge,
+        &fixture.boundary,
+        &fixture.compact_envelope,
+        &fixture.handoff,
+    )
+    .is_err());
+}
+
+fn candidate_case(variant: u8) {
+    let fixture = fixture();
+    let mut candidate_json = deserialize_tampered(&fixture.candidate);
+    let candidate: Phase47RecursiveVerifierWrapperCandidate = match variant % 2 {
+        0 => {
+            candidate_json["wrapper_requires_phase43_trace"] = serde_json::json!(true);
+            candidate_json["wrapper_requires_phase30_manifest"] = serde_json::json!(true);
+            let mut candidate: Phase47RecursiveVerifierWrapperCandidate = serde_json::from_value(candidate_json)
+                .expect("deserialize tampered candidate");
+            candidate.candidate_commitment =
+                commit_phase47_recursive_verifier_wrapper_candidate(&candidate)
+                    .expect("recommit tampered candidate");
+            candidate
+        }
+        _ => {
+            candidate_json["recursive_proof_available"] = serde_json::json!(true);
+            candidate_json["recursive_verification_claimed"] = serde_json::json!(true);
+            candidate_json["cryptographic_compression_claimed"] = serde_json::json!(true);
+            let mut candidate: Phase47RecursiveVerifierWrapperCandidate = serde_json::from_value(candidate_json)
+                .expect("deserialize false-claim candidate");
+            candidate.candidate_commitment =
+                commit_phase47_recursive_verifier_wrapper_candidate(&candidate)
+                    .expect("recommit false-claim candidate");
+            candidate
+        }
+    };
+
+    assert!(verify_phase47_recursive_verifier_wrapper_candidate(&candidate).is_err());
+    assert!(verify_phase47_recursive_verifier_wrapper_candidate_against_phase46(
+        &candidate,
+        &fixture.receipt,
+    )
+    .is_err());
+}
+
+fn attempt_case(variant: u8) {
+    let fixture = fixture();
+    let mut attempt_json = deserialize_tampered(&fixture.attempt);
+    let attempt: Phase48RecursiveProofWrapperAttempt = match variant % 2 {
+        0 => {
+            attempt_json["actual_recursive_wrapper_available"] = serde_json::json!(true);
+            attempt_json["recursive_proof_constructed"] = serde_json::json!(true);
+            attempt_json["recursive_verification_claimed"] = serde_json::json!(true);
+            attempt_json["cryptographic_compression_claimed"] = serde_json::json!(true);
+            let mut attempt: Phase48RecursiveProofWrapperAttempt = serde_json::from_value(attempt_json)
+                .expect("deserialize false-claim attempt");
+            attempt.attempt_commitment = commit_phase48_recursive_proof_wrapper_attempt(&attempt)
+                .expect("recommit false-claim attempt");
+            attempt
+        }
+        _ => {
+            attempt_json["blocking_reasons"] = serde_json::json!(["generic wrapper blocker"]);
+            let mut attempt: Phase48RecursiveProofWrapperAttempt = serde_json::from_value(attempt_json)
+                .expect("deserialize blocker-drift attempt");
+            attempt.attempt_commitment = commit_phase48_recursive_proof_wrapper_attempt(&attempt)
+                .expect("recommit blocker-drift attempt");
+            attempt
+        }
+    };
+
+    assert!(verify_phase48_recursive_proof_wrapper_attempt(&attempt).is_err());
+    assert!(verify_phase48_recursive_proof_wrapper_attempt_against_phase47(
+        &attempt,
+        &fixture.candidate,
+    )
+    .is_err());
+}
+
+fuzz_target!(|data: &[u8]| {
+    let selector = data.first().copied().unwrap_or(0);
+    let variant = data.get(1).copied().unwrap_or(0);
+
+    match selector % 6 {
+        0 => boundary_case(variant),
+        1 => handoff_case(variant),
+        2 => bridge_case(variant),
+        3 => receipt_case(variant),
+        4 => candidate_case(variant),
+        _ => attempt_case(variant),
+    }
+});

--- a/scripts/run_tablero_acceptance_fuzz_suite.sh
+++ b/scripts/run_tablero_acceptance_fuzz_suite.sh
@@ -16,10 +16,11 @@ FUZZ_TARGETS=(
   phase46_stwo_proof_adapter_receipt
   phase47_recursive_verifier_wrapper_candidate
   phase48_recursive_proof_wrapper_attempt
+  phase44d_phase48_serialized_chain_differential
 )
 
 if ! command -v cargo-fuzz >/dev/null 2>&1 && ! cargo fuzz --version >/dev/null 2>&1; then
-  echo "cargo-fuzz is required; install it with \\`cargo install cargo-fuzz\\`" >&2
+  echo "cargo-fuzz is required; install it with \`cargo install cargo-fuzz\`" >&2
   exit 1
 fi
 
@@ -37,7 +38,7 @@ require_safe_path_under() {
   local description="$3"
 
   if [[ -z "$candidate" || "$candidate" == "/" ]]; then
-    echo "refusing unsafe ${description} path: \\`${candidate}\\`" >&2
+    echo "refusing unsafe ${description} path: \`${candidate}\`" >&2
     exit 1
   fi
 
@@ -49,7 +50,7 @@ require_safe_path_under() {
   case "$resolved_candidate" in
     "$resolved_safe_root"|"$resolved_safe_root"/*) ;;
     *)
-      echo "refusing unsafe ${description} path: \\`${resolved_candidate}\\` is outside \\`${resolved_safe_root}\\`" >&2
+      echo "refusing unsafe ${description} path: \`${resolved_candidate}\` is outside \`${resolved_safe_root}\`" >&2
       exit 1
       ;;
   esac
@@ -68,7 +69,7 @@ require_strict_subpath_under() {
   resolved_safe_root="$(canonicalize_path "$safe_root")"
 
   if [[ "$resolved_candidate" == "$resolved_safe_root" ]]; then
-    echo "refusing unsafe ${description} path: \\`${resolved_candidate}\\` must be a strict child of \\`${resolved_safe_root}\\`" >&2
+    echo "refusing unsafe ${description} path: \`${resolved_candidate}\` must be a strict child of \`${resolved_safe_root}\`" >&2
     exit 1
   fi
 }

--- a/scripts/run_tablero_formal_contract_suite.sh
+++ b/scripts/run_tablero_formal_contract_suite.sh
@@ -45,6 +45,10 @@ KANI_ARGS=(
   kani_phase48_attempt_flags_accept_canonical_no_go
   --harness
   kani_phase48_attempt_flags_reject_any_replay_or_false_claim
+  --harness
+  kani_carry_aware_wrap_delta_range_witness_accepts_in_range_deltas
+  --harness
+  kani_carry_aware_wrap_delta_range_witness_rejects_out_of_range_deltas
 )
 
 "${KANI_ARGS[@]}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,7 @@ pub use stwo_backend::{
     verify_phase44d_history_replay_projection_emitted_root_artifact_acceptance,
     verify_phase44d_history_replay_projection_external_source_root_acceptance,
     verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance,
+    verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding,
     verify_phase44d_history_replay_projection_source_emission_acceptance,
     verify_phase44d_history_replay_projection_source_emission_public_output_acceptance,
     verify_phase44d_history_replay_projection_terminal_boundary_logup_closure,

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -3646,6 +3646,40 @@ fn carry_aware_wrap_delta_range_witness(
     Ok((abs, delta < 0, bits))
 }
 
+#[cfg(test)]
+fn wrap_delta_abs_bits_reconstruct(bits: &[bool; CARRY_AWARE_WRAP_DELTA_ABS_BITS]) -> u16 {
+    bits.iter().enumerate().fold(
+        0u16,
+        |acc, (bit_index, bit)| {
+            if *bit {
+                acc | (1u16 << bit_index)
+            } else {
+                acc
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+fn wrap_delta_range_witness_is_canonical(
+    delta: i16,
+    abs: u16,
+    sign: bool,
+    bits: &[bool; CARRY_AWARE_WRAP_DELTA_ABS_BITS],
+) -> bool {
+    let reconstructed_abs = wrap_delta_abs_bits_reconstruct(bits);
+    let reconstructed_delta = if sign {
+        -i32::from(abs)
+    } else {
+        i32::from(abs)
+    };
+
+    abs == reconstructed_abs
+        && i32::from(abs) <= i32::from(CARRY_AWARE_WRAP_DELTA_ABS_MAX)
+        && sign == (delta < 0)
+        && reconstructed_delta == i32::from(delta)
+}
+
 fn wrap_delta_inverse_base(delta: i16) -> BaseField {
     if delta == 0 {
         BaseField::zero()
@@ -4976,6 +5010,56 @@ mod tests {
             Ok(false) => {}
             Ok(true) => panic!("tampered carry-aware payload must not verify"),
             Err(_) => {}
+        }
+    }
+
+    #[test]
+    fn carry_aware_wrap_delta_range_witness_is_canonical_across_full_supported_range() {
+        for delta in
+            -i32::from(CARRY_AWARE_WRAP_DELTA_ABS_MAX)..=i32::from(CARRY_AWARE_WRAP_DELTA_ABS_MAX)
+        {
+            let delta = delta as i16;
+            let (abs, sign, bits) = carry_aware_wrap_delta_range_witness(delta)
+                .expect("supported delta should witness");
+            assert!(
+                abs <= CARRY_AWARE_WRAP_DELTA_ABS_MAX,
+                "witness abs drifted outside supported range for delta {delta}"
+            );
+            assert!(
+                wrap_delta_range_witness_is_canonical(delta, abs, sign, &bits),
+                "non-canonical wrap-delta witness for delta {delta}"
+            );
+        }
+
+        assert!(
+            carry_aware_wrap_delta_range_witness(CARRY_AWARE_WRAP_DELTA_ABS_MAX as i16 + 1)
+                .is_err()
+        );
+        assert!(
+            carry_aware_wrap_delta_range_witness(-(CARRY_AWARE_WRAP_DELTA_ABS_MAX as i16) - 1)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn carry_aware_wrap_delta_divisibility_checks_hold_across_full_supported_range() {
+        let wrapped_acc_cases = [i16::MIN, -12345, -1, 0, 1, 12345, i16::MAX];
+        for &wrapped_acc in &wrapped_acc_cases {
+            for delta in -i32::from(CARRY_AWARE_WRAP_DELTA_ABS_MAX)
+                ..=i32::from(CARRY_AWARE_WRAP_DELTA_ABS_MAX)
+            {
+                let raw_acc = i32::from(wrapped_acc) + delta * (CARRY_AWARE_WRAP_BASIS as i32);
+                assert_eq!(
+                    carry_aware_wrap_delta(raw_acc, wrapped_acc)
+                        .expect("divisible supported difference should verify"),
+                    delta as i16,
+                    "supported divisible difference drifted for wrapped_acc={wrapped_acc}, delta={delta}",
+                );
+                assert!(
+                    carry_aware_wrap_delta(raw_acc + 1, wrapped_acc).is_err(),
+                    "non-divisible difference should reject for wrapped_acc={wrapped_acc}, delta={delta}",
+                );
+            }
         }
     }
 

--- a/src/stwo_backend/history_replay_projection_prover.rs
+++ b/src/stwo_backend/history_replay_projection_prover.rs
@@ -7073,6 +7073,146 @@ mod tests {
         assert!(error.to_string().contains("commitment"));
     }
 
+    #[test]
+    fn phase44d_phase48_serialized_chain_rejects_post_serialization_semantic_drift() {
+        let fixture = sample_phase44d_composed_artifact_fixture();
+        let wrapper_fixture = sample_phase47_phase48_wrapper_fixture();
+
+        let boundary = load_tampered_serialized_artifact(
+            "phase44d-boundary-post-serialization-drift",
+            &fixture.boundary,
+            |boundary_json| {
+                boundary_json["source_emission_public_output"]["source_emission"]["source_claim"]
+                    ["total_steps"] = serde_json::json!(
+                    fixture
+                        .boundary
+                        .source_emission_public_output
+                        .source_emission
+                        .source_claim
+                        .total_steps
+                        + 1
+                );
+            },
+        );
+        assert!(
+            verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance(
+                &boundary,
+                &fixture.compact_envelope,
+            )
+            .is_err()
+        );
+        assert!(
+            verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding(
+                &boundary,
+                &fixture.compact_envelope.claim,
+            )
+            .is_err()
+        );
+
+        let mut handoff = load_tampered_serialized_artifact(
+            "phase44d-handoff-post-serialization-drift",
+            &fixture.handoff,
+            |handoff_json| {
+                handoff_json["verifier_requires_phase43_trace"] = serde_json::json!(true);
+                handoff_json["verifier_requires_phase30_manifest"] = serde_json::json!(true);
+            },
+        );
+        handoff.handoff_commitment =
+            commit_phase44d_recursive_verifier_public_output_handoff(&handoff)
+                .expect("recommit tampered Phase44D handoff");
+        assert!(verify_phase44d_recursive_verifier_public_output_handoff(&handoff).is_err());
+        assert!(
+            verify_phase44d_recursive_verifier_public_output_handoff_against_boundary(
+                &handoff,
+                &fixture.boundary,
+                &fixture.compact_envelope,
+            )
+            .is_err()
+        );
+
+        let mut bridge = load_tampered_serialized_artifact(
+            "phase45-bridge-post-serialization-drift",
+            &fixture.bridge,
+            |bridge_json| {
+                bridge_json["verifier_requires_phase43_trace"] = serde_json::json!(true);
+                bridge_json["verifier_requires_phase30_manifest"] = serde_json::json!(true);
+            },
+        );
+        bridge.bridge_commitment = commit_phase45_recursive_verifier_public_input_bridge(&bridge)
+            .expect("recommit tampered Phase45 bridge");
+        assert!(verify_phase45_recursive_verifier_public_input_bridge(&bridge).is_err());
+        assert!(
+            verify_phase45_recursive_verifier_public_input_bridge_against_sources(
+                &bridge,
+                &fixture.boundary,
+                &fixture.compact_envelope,
+                &fixture.handoff,
+            )
+            .is_err()
+        );
+
+        let mut receipt = load_tampered_serialized_artifact(
+            "phase46-receipt-post-serialization-drift",
+            &fixture.receipt,
+            |receipt_json| {
+                receipt_json["recursive_verification_claimed"] = serde_json::json!(true);
+                receipt_json["cryptographic_compression_claimed"] = serde_json::json!(true);
+            },
+        );
+        receipt.adapter_receipt_commitment = commit_phase46_stwo_proof_adapter_receipt(&receipt)
+            .expect("recommit tampered Phase46 receipt");
+        assert!(verify_phase46_stwo_proof_adapter_receipt(&receipt).is_err());
+        assert!(verify_phase46_stwo_proof_adapter_receipt_against_sources(
+            &receipt,
+            &fixture.bridge,
+            &fixture.boundary,
+            &fixture.compact_envelope,
+            &fixture.handoff,
+        )
+        .is_err());
+
+        let mut candidate = load_tampered_serialized_artifact(
+            "phase47-candidate-post-serialization-drift",
+            &wrapper_fixture.candidate,
+            |candidate_json| {
+                candidate_json["wrapper_requires_phase43_trace"] = serde_json::json!(true);
+                candidate_json["wrapper_requires_phase30_manifest"] = serde_json::json!(true);
+            },
+        );
+        candidate.candidate_commitment =
+            commit_phase47_recursive_verifier_wrapper_candidate(&candidate)
+                .expect("recommit tampered Phase47 candidate");
+        assert!(verify_phase47_recursive_verifier_wrapper_candidate(&candidate).is_err());
+        assert!(
+            verify_phase47_recursive_verifier_wrapper_candidate_against_phase46(
+                &candidate,
+                &fixture.receipt,
+            )
+            .is_err()
+        );
+
+        let mut attempt = load_tampered_serialized_artifact(
+            "phase48-attempt-post-serialization-drift",
+            &wrapper_fixture.attempt,
+            |attempt_json| {
+                attempt_json["actual_recursive_wrapper_available"] = serde_json::json!(true);
+                attempt_json["recursive_proof_constructed"] = serde_json::json!(true);
+                attempt_json["recursive_verification_claimed"] = serde_json::json!(true);
+                attempt_json["cryptographic_compression_claimed"] = serde_json::json!(true);
+            },
+        );
+        attempt.attempt_commitment = commit_phase48_recursive_proof_wrapper_attempt(&attempt)
+            .expect("recommit tampered Phase48 attempt");
+        assert!(verify_phase48_recursive_proof_wrapper_attempt(&attempt).is_err());
+        assert!(
+            verify_phase48_recursive_proof_wrapper_attempt_against_phase47(
+                &attempt,
+                &wrapper_fixture.candidate,
+            )
+            .is_err()
+        );
+    }
+
     fn sample_phase48_attempt_for_phase49() -> Phase48RecursiveProofWrapperAttempt {
         sample_phase47_phase48_wrapper_fixture().attempt.clone()
     }

--- a/src/stwo_backend/recursion.rs
+++ b/src/stwo_backend/recursion.rs
@@ -10994,7 +10994,7 @@ pub fn verify_phase47_recursive_verifier_wrapper_candidate(
                 .to_string(),
         ));
     }
-    debug_assert!(phase47_wrapper_flag_surface_is_valid(
+    if !phase47_wrapper_flag_surface_is_valid(
         candidate.phase46_receipt_verified,
         candidate.stwo_core_verify_succeeded,
         candidate.terminal_logup_closed,
@@ -11005,7 +11005,12 @@ pub fn verify_phase47_recursive_verifier_wrapper_candidate(
         candidate.recursive_proof_available,
         candidate.recursive_verification_claimed,
         candidate.cryptographic_compression_claimed,
-    ));
+    ) {
+        return Err(VmError::InvalidConfig(
+            "Phase 47 recursive-verifier wrapper candidate canonical flag surface drift"
+                .to_string(),
+        ));
+    }
     if candidate.verifier_side_complexity
         != STWO_RECURSIVE_VERIFIER_WRAPPER_CANDIDATE_COMPLEXITY_PHASE47
     {
@@ -11269,7 +11274,7 @@ pub fn verify_phase48_recursive_proof_wrapper_attempt(
                 .to_string(),
         ));
     }
-    debug_assert!(phase48_attempt_flag_surface_is_valid(
+    if !phase48_attempt_flag_surface_is_valid(
         attempt.phase47_candidate_verified,
         attempt.local_stwo_core_verifier_detected,
         attempt.local_stwo_cairo_verifier_core_detected,
@@ -11282,7 +11287,11 @@ pub fn verify_phase48_recursive_proof_wrapper_attempt(
         attempt.wrapper_requires_phase43_trace,
         attempt.wrapper_requires_phase30_manifest,
         attempt.wrapper_embeds_expected_rows,
-    ));
+    ) {
+        return Err(VmError::InvalidConfig(
+            "Phase 48 recursive proof-wrapper attempt canonical flag surface drift".to_string(),
+        ));
+    }
     if attempt.compact_proof_channel
         != STWO_RECURSIVE_PROOF_WRAPPER_ATTEMPT_COMPACT_PROOF_CHANNEL_PHASE48
         || attempt.recursive_verifier_channel


### PR DESCRIPTION
## Summary
- add exhaustive carry-aware `wrap_delta` witness/divisibility checks plus a narrow theorem-style engineering note
- add a differential serialized-artifact fuzz target across the Phase44D->48 chain and a deterministic regression covering the same post-serialization semantic drift family
- promote Phase47/48 canonical flag-surface checks from debug-only assertions to release-mode verifier guards and refresh the hardening packet/handoff notes

## Validation
- `cargo +nightly-2025-07-14 test phase44d_phase48_serialized_chain_rejects_post_serialization_semantic_drift --features stwo-backend --lib`
- `cargo +nightly-2025-07-14 test carry_aware_wrap_delta_ --features stwo-backend --lib`
- `cargo +nightly-2025-07-14 fuzz build phase44d_phase48_serialized_chain_differential`
- `bash scripts/run_tablero_formal_contract_suite.sh`
- `FUZZ_TIME_PER_TARGET=5 bash scripts/run_tablero_acceptance_fuzz_suite.sh`
- `bash scripts/run_tablero_hardening_preflight.sh --mode core`
- pre-push local release gate: `14 / 14` steps passed

## Evidence
- core hardening summary: `target/tablero-hardening/20260425T234228Z/summary.tsv`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new fuzzing and exhaustive regression tests covering serialized artifact drift and carry-aware witness discipline.

* **Documentation**
  * Added and reordered engineering notes and a hardening packet describing witness-discipline checks and fuzzing strategy.

* **Bug Fixes/Improvements**
  * Improved terminal error message formatting and moved key validity checks from debug-only assertions to guaranteed runtime validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->