### PR TITLE
[codex] Harden trace bundling and against-sources fuzz

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -151,7 +151,8 @@ Use these in order of authority for current state:
    - `scripts/run_tablero_hardening_preflight.sh --mode deep`
   - The hardening packet now includes exhaustive deterministic `wrap_delta`
     witness/divisibility checks, and the fuzz suite now includes a
-    serialized-artifact differential mutator across Phase44D→48.
+    serialized-artifact differential mutator across Phase44D→48 plus
+    raw serialized-bundle fuzzing of the full Phase44D→48 against-sources bundle.
 5. Keep SNIP-36 parked until there is a real adapter path from local proof
    objects to protocol-native proof facts. It is a deferred design lane, not a
    current paper or hardening blocker.

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -33,7 +33,7 @@ This repository currently has two live lanes.
 2. Experimental core-proving lane
    - The carry-aware backend `stwo-phase12-decoding-family-v10-carry-aware-experimental` is the active upside research lane.
    - It clears the honest `8`-step Phase12 family, has AIR-level `wrap_delta` range constraints, and the experimental Phase44D scaling sweep currently clears through `2,4,8,16,32,64,128,256,512,1024`.
-   - The focused April 25-26 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, serialized Phase44D typed-boundary tamper coverage, serialized Phase44D handoff / Phase45 bridge / Phase46 receipt tamper coverage, serialized Phase47 wrapper-candidate / Phase48 wrapper-attempt tamper coverage including stale-commitment rejection, and one bounded differential serialized-artifact mutator across the full Phase44D→48 chain.
+   - The focused April 25-26 follow-up now covers signed/non-unit `MulMemory` wrap patterns, sticky-carry `Store` preservation, a full honest `8`-step trace sweep, serialized experimental proof-file tamper coverage, serialized proof-checked Phase12-chain tamper coverage, serialized Phase44D typed-boundary tamper coverage, serialized Phase44D handoff / Phase45 bridge / Phase46 receipt tamper coverage, serialized Phase47 wrapper-candidate / Phase48 wrapper-attempt tamper coverage including stale-commitment rejection, one bounded differential serialized-artifact mutator across the full Phase44D→48 chain, and raw serialized-bundle fuzz coverage for the Phase44D→48 against-sources acceptance chain.
 
 Do not collapse these two lanes into one claim.
 
@@ -92,7 +92,7 @@ The repo now also has one explicit answer on the second-backend question:
    - `scripts/run_tablero_formal_contract_suite.sh`
    - `scripts/run_tablero_hardening_preflight.sh --mode core`
    - `scripts/run_tablero_hardening_preflight.sh --mode deep`
-   - The hardening packet now includes exhaustive deterministic checks for the carry-aware `wrap_delta` witness/divisibility surface, not only the Tablero flag surfaces.
+   - The hardening packet now includes exhaustive deterministic checks for the carry-aware `wrap_delta` witness/divisibility surface, raw serialized-bundle fuzzing for the Phase44D→48 against-sources bundle, and not only the Tablero flag surfaces.
 6. Keep SNIP-36 parked until there is a real adapter path from local proof
    objects to protocol-native proof facts; treat it as a deferred design lane,
    not a current paper or review blocker.

--- a/docs/engineering/tablero-hardening-packet-2026-04-25.md
+++ b/docs/engineering/tablero-hardening-packet-2026-04-25.md
@@ -156,6 +156,10 @@ cargo +nightly careful test --features stwo-backend --lib phase45_public_input_b
 cargo llvm-cov --features stwo-backend --lib --lcov --output-path target/tablero-hardening/lcov.info
 ```
 
+The fuzz suite accepts optional checked-in seed corpora under `fuzz/corpus/<target>/`,
+but the default hardening packet does not require a corpus-refresh script or any
+pre-generated accepted-chain bundle.
+
 These are intentionally optional because the repository does not yet rely on
 those tools in the default merge flow.
 
@@ -191,6 +195,9 @@ This packet adds dedicated fuzz targets for:
 - Phase46 Stwo proof-adapter receipt
 - Phase47 recursive-verifier wrapper candidate
 - Phase48 recursive proof-wrapper attempt
+- one raw serialized Phase44D→48 against-sources bundle fuzzer that parses
+  an arbitrary artifact bundle and exercises every standalone and
+  `*_against_sources` acceptance step in the chain
 - one bounded differential mutator that starts from an accepted serialized
   Phase44D→48 chain artifact, applies a semantic post-serialization drift, and
   asserts verifier rejection at the mutated stage and its against-sources check

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -140,6 +140,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "phase44d_phase48_against_sources_chain"
+path = "fuzz_targets/phase44d_phase48_against_sources_chain.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "phase44d_phase48_serialized_chain_differential"
 path = "fuzz_targets/phase44d_phase48_serialized_chain_differential.rs"
 test = false

--- a/fuzz/fuzz_targets/phase44d_phase48_against_sources_chain.rs
+++ b/fuzz/fuzz_targets/phase44d_phase48_against_sources_chain.rs
@@ -1,0 +1,83 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use llm_provable_computer::{
+    verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance,
+    verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding,
+    verify_phase44d_recursive_verifier_public_output_handoff,
+    verify_phase44d_recursive_verifier_public_output_handoff_against_boundary,
+    verify_phase45_recursive_verifier_public_input_bridge,
+    verify_phase45_recursive_verifier_public_input_bridge_against_sources,
+    verify_phase46_stwo_proof_adapter_receipt,
+    verify_phase46_stwo_proof_adapter_receipt_against_sources,
+    verify_phase47_recursive_verifier_wrapper_candidate,
+    verify_phase47_recursive_verifier_wrapper_candidate_against_phase46,
+    verify_phase48_recursive_proof_wrapper_attempt,
+    verify_phase48_recursive_proof_wrapper_attempt_against_phase47,
+    Phase43HistoryReplayProjectionCompactProofEnvelope,
+    Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary,
+    Phase44DRecursiveVerifierPublicOutputHandoff, Phase45RecursiveVerifierPublicInputBridge,
+    Phase46StwoProofAdapterReceipt, Phase47RecursiveVerifierWrapperCandidate,
+    Phase48RecursiveProofWrapperAttempt,
+};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Phase44DPhase48AgainstSourcesChainInput {
+    compact_envelope: Phase43HistoryReplayProjectionCompactProofEnvelope,
+    boundary: Phase44DHistoryReplayProjectionSourceChainPublicOutputBoundary,
+    handoff: Phase44DRecursiveVerifierPublicOutputHandoff,
+    bridge: Phase45RecursiveVerifierPublicInputBridge,
+    receipt: Phase46StwoProofAdapterReceipt,
+    candidate: Phase47RecursiveVerifierWrapperCandidate,
+    attempt: Phase48RecursiveProofWrapperAttempt,
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 8 * 1024 * 1024 {
+        return;
+    }
+    let Ok(input) = serde_json::from_slice::<Phase44DPhase48AgainstSourcesChainInput>(data) else {
+        return;
+    };
+
+    let _ = verify_phase44d_history_replay_projection_source_chain_public_output_boundary_acceptance(
+        &input.boundary,
+        &input.compact_envelope,
+    );
+    let _ = verify_phase44d_history_replay_projection_source_chain_public_output_boundary_binding(
+        &input.boundary,
+        &input.compact_envelope.claim,
+    );
+    let _ = verify_phase44d_recursive_verifier_public_output_handoff(&input.handoff);
+    let _ = verify_phase44d_recursive_verifier_public_output_handoff_against_boundary(
+        &input.handoff,
+        &input.boundary,
+        &input.compact_envelope,
+    );
+    let _ = verify_phase45_recursive_verifier_public_input_bridge(&input.bridge);
+    let _ = verify_phase45_recursive_verifier_public_input_bridge_against_sources(
+        &input.bridge,
+        &input.boundary,
+        &input.compact_envelope,
+        &input.handoff,
+    );
+    let _ = verify_phase46_stwo_proof_adapter_receipt(&input.receipt);
+    let _ = verify_phase46_stwo_proof_adapter_receipt_against_sources(
+        &input.receipt,
+        &input.bridge,
+        &input.boundary,
+        &input.compact_envelope,
+        &input.handoff,
+    );
+    let _ = verify_phase47_recursive_verifier_wrapper_candidate(&input.candidate);
+    let _ = verify_phase47_recursive_verifier_wrapper_candidate_against_phase46(
+        &input.candidate,
+        &input.receipt,
+    );
+    let _ = verify_phase48_recursive_proof_wrapper_attempt(&input.attempt);
+    let _ = verify_phase48_recursive_proof_wrapper_attempt_against_phase47(
+        &input.attempt,
+        &input.candidate,
+    );
+});

--- a/scripts/run_tablero_acceptance_fuzz_suite.sh
+++ b/scripts/run_tablero_acceptance_fuzz_suite.sh
@@ -9,6 +9,7 @@ FUZZ_TIME_PER_TARGET="${FUZZ_TIME_PER_TARGET:-20}"
 FUZZ_INPUT_TIMEOUT_SECONDS="${FUZZ_INPUT_TIMEOUT_SECONDS:-5}"
 FUZZ_WALL_CLOCK_GRACE_SECONDS="${FUZZ_WALL_CLOCK_GRACE_SECONDS:-10}"
 FUZZ_WORK_DIR="${FUZZ_WORK_DIR:-target/tablero-fuzz}"
+FUZZ_SOURCE_CORPUS_DIR="${FUZZ_SOURCE_CORPUS_DIR:-fuzz/corpus}"
 SAFE_TARGET_ROOT="${ROOT_DIR}/target"
 FUZZ_TARGETS=(
   phase44d_source_chain_public_output_boundary_binding
@@ -16,6 +17,7 @@ FUZZ_TARGETS=(
   phase46_stwo_proof_adapter_receipt
   phase47_recursive_verifier_wrapper_candidate
   phase48_recursive_proof_wrapper_attempt
+  phase44d_phase48_against_sources_chain
   phase44d_phase48_serialized_chain_differential
 )
 
@@ -75,6 +77,7 @@ require_strict_subpath_under() {
 }
 
 require_safe_path_under "$FUZZ_WORK_DIR" "$SAFE_TARGET_ROOT" "tablero fuzz work"
+require_safe_path_under "$FUZZ_SOURCE_CORPUS_DIR" "${ROOT_DIR}/fuzz/corpus" "source corpus"
 
 FUZZ_HOST_TRIPLE="$({ rustc +"${FUZZ_TOOLCHAIN}" -vV | sed -n 's/^host: //p'; } )"
 if [[ -z "$FUZZ_HOST_TRIPLE" ]]; then
@@ -83,12 +86,16 @@ if [[ -z "$FUZZ_HOST_TRIPLE" ]]; then
 fi
 
 for target in "${FUZZ_TARGETS[@]}"; do
+  corpus_dir="${FUZZ_SOURCE_CORPUS_DIR}/${target}"
   run_dir="${FUZZ_WORK_DIR}/${target}"
   run_corpus_dir="${run_dir}/corpus"
   artifact_dir="${run_dir}/artifacts"
   require_strict_subpath_under "$run_dir" "$FUZZ_WORK_DIR" "target run"
   rm -rf -- "$run_dir"
   mkdir -p "$run_corpus_dir" "$artifact_dir"
+  if [[ -d "$corpus_dir" ]]; then
+    cp -R "${corpus_dir}/." "$run_corpus_dir/"
+  fi
 
   cargo +"${FUZZ_TOOLCHAIN}" fuzz build "$target"
   fuzz_binary="fuzz/target/${FUZZ_HOST_TRIPLE}/release/${target}"

--- a/src/stwo_backend/arithmetic_subset_prover.rs
+++ b/src/stwo_backend/arithmetic_subset_prover.rs
@@ -2949,6 +2949,7 @@ fn build_trace_bundle_with_mode(
     states: &[MachineState],
     mode: ArithmeticSubsetProofMode,
 ) -> Result<TraceBundle> {
+    validate_trace_bundle_state_trace(states)?;
     let real_rows = states.len().max(1);
     let row_count = real_rows.next_power_of_two();
     let log_size = row_count.ilog2();
@@ -2971,12 +2972,25 @@ fn build_trace_bundle_with_mode(
     })
 }
 
+fn validate_trace_bundle_state_trace(states: &[MachineState]) -> Result<()> {
+    let Some(last_state) = states.last() else {
+        return Err(VmError::UnsupportedProof(
+            "arithmetic subset trace bundling requires a non-empty state trace".to_string(),
+        ));
+    };
+    if !last_state.halted {
+        return Err(VmError::UnsupportedProof(
+            "arithmetic subset trace bundling requires a halted final state".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn build_preprocessed_rows(
     program: &Program,
     states: &[MachineState],
     row_count: usize,
 ) -> Result<Vec<PreprocessedRow>> {
-    let last_state = states.last().expect("non-empty state trace");
     let mut rows = Vec::with_capacity(row_count);
     for row_index in 0..row_count {
         let row = if row_index + 1 < states.len() {
@@ -2997,7 +3011,6 @@ fn build_preprocessed_rows(
         };
         rows.push(row);
     }
-    debug_assert!(last_state.halted);
     Ok(rows)
 }
 
@@ -5154,6 +5167,40 @@ mod tests {
         };
         assert!(
             err.to_string().contains("expected next carry true"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn trace_bundle_builder_rejects_empty_state_trace() {
+        let err = match build_trace_bundle(&compile_program("programs/addition.tvm"), &[]) {
+            Ok(_) => panic!("empty state trace must fail"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("arithmetic subset trace bundling requires a non-empty state trace"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn carry_aware_trace_builder_rejects_non_halted_final_state() {
+        let (program, mut states, _) = phase12_carry_aware_family_fixture(8, 0);
+        let last_state = states.last_mut().expect("non-empty states");
+        last_state.halted = false;
+
+        let err = match build_trace_bundle_with_mode(
+            &program,
+            &states,
+            ArithmeticSubsetProofMode::Phase12CarryAwareExperimental,
+        ) {
+            Ok(_) => panic!("non-halted final state must fail"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("arithmetic subset trace bundling requires a halted final state"),
             "{err}"
         );
     }


### PR DESCRIPTION
## Summary
- harden arithmetic-subset trace bundling by rejecting empty or non-halted state traces before preprocessed-row construction
- add a raw serialized `Phase44D -> Phase48` `*_against_sources` fuzz target and include it in the Tablero acceptance fuzz suite
- refresh the internal hardening packet / handoff notes so the documented packet matches the actual optional-corpus workflow

## Validation
- `cargo +nightly-2025-07-14 test --features stwo-backend --lib trace_bundle_builder_rejects_empty_state_trace`
- `cargo +nightly-2025-07-14 test --features stwo-backend --lib carry_aware_trace_builder_rejects_non_halted_final_state`
- `cargo +nightly-2025-07-14 fuzz build phase44d_phase48_against_sources_chain`
- `FUZZ_TIME_PER_TARGET=5 bash scripts/run_tablero_acceptance_fuzz_suite.sh`
- `bash scripts/run_tablero_hardening_preflight.sh --mode core`
- pre-push local release gate: `14 / 14` steps passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that checked-in fuzz seed corpora are optional in the default hardening packet configuration.

* **New Features**
  * Fuzz suite now supports seeding runs from a configurable source corpus directory with safety validation.

* **Bug Fixes**
  * Added validation to reject empty state traces and non-halted machine states during proof generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->