### PR TITLE
[codex] Write presentation-facing Tablero paper package

### DIFF
--- a/docs/paper/PUBLICATION_RELEASE.md
+++ b/docs/paper/PUBLICATION_RELEASE.md
@@ -1,147 +1,57 @@
 # Publication Release Package
 
-Snapshot date: **April 24, 2026**
+Snapshot date: **April 26, 2026**
 
-Planned publication tag after repository transfer: `paper-publication-v6-2026-04-24`
+Primary presentation title:
 
-Canonical publication snapshot after transfer: The canonical v6 publication snapshot is
-the release tag `paper-publication-v6-2026-04-24` once cut in the final publication
-repository. Until that transfer and tag cut happen, the paper keeps Reference `[30]`
-pointed at the staging commit-pinned snapshot below. The final publication tag
-intentionally need not match the pinned carried-state evidence commit used by the
-aggregation bundle. Before upload, that tag still needs to be cut in the final
-publication repository and Reference `[30]` needs to be retargeted to it.
+`Tablero: Typed Verifier Boundaries for Layered STARK Systems, with Evidence from STARK-zkML`
 
-Pinned Phase63-65 proof-carrying artifact checkpoint:
-`03cc77f371275c8d9ef5f4244a23d3e35c98a41b`
+Primary presentation files:
 
-Pinned carried-state aggregation provenance checkpoint:
-`6ff972ddda4051d73dc65c92a88c0d00683ec8c7`
+- `docs/paper/tablero-typed-verifier-boundaries-2026.md`
+- `docs/paper/appendix-tablero-claim-boundary.md`
+- `docs/paper/appendix-system-comparison.md`
 
-Dedicated proof-carrying aggregation bundle index cited by Reference `[46]`:
-`6bb8cab99092203217d64951c3af61488aa2c58e`
+Supporting package directories:
 
-Current staging repository: `https://github.com/omarespejel/provable-transformer-vm`
-(earlier iterations of this research line used the `llm-provable-computer` project
-name). The final publication repository may move before the canonical tag is cut.
-
-Formal paper author line in the draft:
-
-- Abdelhamid Bakhta - StarkWare
-- Omar Espejel - Starknet Foundation
-
-This repository state is the publication-facing package for the paper and its supporting
-artifacts. The package is intentionally split into evidence tiers rather than treated as
-one monolithic benchmark claim.
-
-## Included materials
-
-- Main paper:
-  - `docs/paper/stark-transformer-alignment-2026.md`
-  - Title: `On the Structural Fit of Transformer Workloads and STARK Proof Systems`
-- Supporting appendices:
-  - `docs/paper/appendix-system-comparison.md`
-  - `docs/paper/appendix-scaling-companion.md`
-  - `docs/paper/appendix-influence-realization.md`
-- Frozen artifact bundles:
-  - `docs/paper/artifacts/stwo-proof-carrying-aggregation-v1-2026-04-11/`
-  - `docs/paper/artifacts/phase63-65-proof-carrying-artifact-v1-2026-04-20/`
-  - `docs/paper/artifacts/stwo-transformer-shaped-v1-2026-04-21/`
-  - `docs/paper/artifacts/stwo-shared-normalization-primitive-v1-2026-04-21/`
-- Figure sources:
-  - `docs/paper/figures/section4-ratio-vs-context.tsv`
-  - `docs/paper/figures/section4-decomposition-vs-context.tsv`
-  - `docs/paper/figures/section5-carried-state-ladder.svg`
-  - `docs/paper/figures/stwo-phase44d-source-emission-2026-04.svg`
-  - `docs/paper/figures/stwo-phase71-handoff-receipt-2026-04.svg`
-  - `scripts/paper/generate_section4_ratio_figure.py`
-  - `scripts/paper/generate_section4_decomposition_figure.py`
-  - `scripts/paper/generate_stwo_phase44d_source_emission_benchmark.sh`
-  - `scripts/paper/generate_stwo_phase44d_source_emission_figure.py`
-  - `scripts/paper/generate_stwo_phase71_handoff_receipt_benchmark.sh`
-  - `scripts/paper/generate_stwo_phase71_handoff_receipt_figure.py`
-- External evidence snapshots:
-  - `docs/paper/evidence/web-2026-04-06/`
-  - `docs/paper/evidence/gemma-config-snapshots/`
-  - `docs/paper/evidence/published-zkml-numbers-2026-04.tsv`
-  - `docs/paper/evidence/published-zkml-calibration-note-2026-04-24.md`
-  - `docs/paper/evidence/obelyzk-sepolia-comparator-note-2026-04-25.md`
+- `docs/paper/evidence/`
+- `docs/paper/figures/`
+- `docs/paper/artifacts/`
+- `docs/paper/submission-v4-2026-04-11/`
 
 ## Claim posture
 
-- `stwo-transformer-shaped-v1` and `stwo-shared-normalization-primitive-v1` are the
-  current narrow evidence tiers for the experimental S-two path.
-- Post-freeze commit-pinned evidence now includes the merged pre-recursive carried-state
-  aggregation bundle, including proof-carrying outer aggregation over chained artifacts.
-- The April 20 Phase63-65 verifier-surface index pins the current paper's stronger
-  proof-carrying bridge: shared lookup identity and typed carried state are now
-  verifier-visible across a transformer-shaped artifact line.
-- The April 21 `stwo-transformer-shaped-v1` bundle freezes one reproducible
-  transformer-shaped `stwo` artifact with `28s` prepare, `9s` verify, `9,348,044`
-  artifact bytes, a five-step source chain, and two translated segment manifests.
-- The April 24 evidence set adds two higher-layer verifier-bound calibration rows:
-  a Phase44D typed source-emission boundary that wins on local verification latency
-  but not serialized bytes, now with causal decomposition and an explicit `4+` step
-  overflow barrier on the current execution-proof surface, and a Phase71 handoff
-  receipt compactness row that wins on serialized surface but not on verification
-  time.
-- The April 24 literature-facing calibration snapshot now records three distinct
-  local regimes rather than one catch-all internal row: the Phase12 proving bundle,
-  the Phase44D typed-boundary latency row, and the Phase71 handoff-receipt
-  compactness row.
-- The April 25 comparator refresh upgrades the public STARK-native calibration
-  from a README-only Obelyzk benchmark line to a source-backed Starknet Sepolia
-  verifier-object note with exact contract, transaction, calldata, and paper
-  gas references; it still does **not** create a matched local verifier-time row.
-- Older carried-state artifact bundles are retained as archival provenance; see
-  `docs/paper/artifacts/README.md`. The proof-carrying aggregation bundle is the
-  publication-facing artifact bundle for the carried-state aggregation line.
-- The repo still does **not** claim full standard-softmax transformer inference on
-  S-two, recursive cross-step shared-table accumulation beyond the public
-  lookup-accumulator artifact, recursive cryptographic compression/verification closure,
-  or production-scale zkML deployment.
+This package is intentionally narrower than a full zkML performance paper.
 
-## Regeneration
+It supports the following presentation posture:
 
-- Local reproducibility bundle:
-  - `./scripts/generate_repro_bundle.sh`
-  - optional stronger profile: `STARK_PROFILE=publication-v1 ./scripts/generate_repro_bundle.sh`
-- Transformer-shaped `stwo` bundle:
-  - `./scripts/paper/generate_stwo_transformer_shaped_bundle.sh`
-- Tensor-native shared-normalization primitive bundle:
-  - `./scripts/paper/generate_stwo_shared_normalization_primitive_bundle.sh`
-- Proof-carrying aggregation bundle:
-  - `./scripts/paper/generate_stwo_proof_carrying_aggregation_bundle.sh`
-- Phase63-65 verifier-surface checkpoint:
-  - validate with `cargo +nightly-2025-07-14 test -q --features stwo-backend --lib phase63 -- --nocapture`
-  - validate with `cargo +nightly-2025-07-14 test -q --features stwo-backend --lib phase64 -- --nocapture`
-  - validate with `cargo +nightly-2025-07-14 test -q --features stwo-backend --lib phase65 -- --nocapture`
-- Archived web evidence:
-  - `python3 scripts/paper/archive_supporting_web_evidence.py`
-- Gemma config extracts:
-  - `python3 scripts/paper/extract_gemma_config_snapshots.py`
-- Paper preflight checks:
+- the paper's main contribution is a typed verifier-boundary pattern,
+- the formal core is a statement-preservation theorem under explicit assumptions,
+- the empirical lab is one transformer-shaped STARK-zkML stack,
+- the main positive evidence is replay avoidance across three layout families,
+- the main negative evidence is one bounded no-go on a second candidate boundary,
+- the external calibration is source-backed but not presented as a matched verifier race.
+
+It does **not** support the following claims:
+
+- a new STARK theorem,
+- backend independence,
+- recursive compression,
+- full end-to-end transformer benchmarking,
+- onchain deployment of the typed-boundary path.
+
+## Package hygiene
+
+For presentation use, prefer the paper and appendix prose over internal artifact naming.
+Tracked evidence files and artifact directories may retain older internal labels for
+provenance stability; the presentation copy should use the external names introduced in
+this package.
+
+## Regeneration and checks
+
+- package preflight:
   - `python3 scripts/paper/paper_preflight.py --repo-root .`
-- Higher-layer benchmark evidence:
-  - `mkdir -p ./out/paper-bench`
-  - `BENCH_RUNS=5 CAPTURE_TIMINGS=1 TSV_OUT=./out/paper-bench/stwo-phase44d-source-emission-2026-04.tsv JSON_OUT=./out/paper-bench/stwo-phase44d-source-emission-2026-04.json SVG_OUT=./out/paper-bench/stwo-phase44d-source-emission-2026-04.svg PNG_OUT= PDF_OUT= ./scripts/paper/generate_stwo_phase44d_source_emission_benchmark.sh`
-  - `BENCH_RUNS=5 CAPTURE_TIMINGS=1 TSV_OUT=./out/paper-bench/stwo-phase71-handoff-receipt-2026-04.tsv JSON_OUT=./out/paper-bench/stwo-phase71-handoff-receipt-2026-04.json SVG_OUT=./out/paper-bench/stwo-phase71-handoff-receipt-2026-04.svg PNG_OUT= PDF_OUT= ./scripts/paper/generate_stwo_phase71_handoff_receipt_benchmark.sh`
-  - `ALLOW_HOST_DEPENDENT_OUTPUTS` stays unset here on purpose so scratch captures cannot overwrite the frozen tracked evidence under `docs/paper/`.
-
-## Publication check
-
-Before cutting a release tag, verify:
-
-1. the frozen bundle directories exist and their `sha256sums.txt` files validate, and
-   the aggregation bundle's `provenance_sha256sums.txt` also validates,
-2. the main paper and appendices refer to the same repo state and evidence tiers,
-3. the design note matches the current experimental `stwo` status,
-4. no stale top-level README language still describes S-two as merely prospective,
-5. Reference `[30]` remains commit-pinned until the repository transfer and v6
-   publication tag exist; after that tag is cut in the final publication repository,
-   update `[30]` to the v6 publication tag while keeping the aggregation bundle directly
-   pinned by Reference `[46]`,
-6. the formal author line and affiliation text are confirmed before public release,
-7. `paper preflight` passes (citation integrity, immutable local repo links, figure/link
-   paths, appendix source note, and unresolved publication snapshot placeholder
-   detection).
+- supporting evidence regeneration stays under the existing checked scripts in
+  `scripts/paper/` and `scripts/engineering/`
+- the machine-readable evidence files in `docs/paper/evidence/` remain the source of
+  exact numeric values used in the presentation draft

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -1,56 +1,32 @@
 # Paper Package
 
-This directory contains the publication-facing package for:
+This directory contains the presentation-facing paper package for:
 
-`On the Structural Fit of Transformer Workloads and STARK Proof Systems`
+`Tablero: Typed Verifier Boundaries for Layered STARK Systems, with Evidence from STARK-zkML`
 
-Primary files:
+Primary presentation files:
 
-- `stark-transformer-alignment-2026.md`
+- `tablero-typed-verifier-boundaries-2026.md`
+- `appendix-tablero-claim-boundary.md`
 - `appendix-system-comparison.md`
-- `appendix-scaling-companion.md`
-- `appendix-influence-realization.md`
 - `PUBLICATION_RELEASE.md`
 
 Supporting publication assets:
 
 - `figures/`
 - `evidence/`
-- `submission-v4-2026-04-11/`
 - `artifacts/`
+- `submission-v4-2026-04-11/`
 
-Current paper-freeze addendum (April 24 freeze + April 25 comparator refresh):
+Package posture:
 
-- `artifacts/phase63-65-proof-carrying-artifact-v1-2026-04-20/`
-- `artifacts/phase66-69-proof-carrying-hardening-v1-2026-04-21/`
-- `artifacts/phase70-80-proof-checked-decode-bridge-v1-2026-04-21/`
-- `artifacts/stwo-transformer-shaped-v1-2026-04-21/`
-- `figures/stwo-phase44d-source-emission-2026-04.svg`
-- `figures/stwo-phase71-handoff-receipt-2026-04.svg`
-- `evidence/stwo-phase44d-source-emission-2026-04.tsv`
-- `evidence/stwo-phase71-handoff-receipt-2026-04.tsv`
-- `evidence/published-zkml-numbers-2026-04.tsv`
-- `evidence/published-zkml-calibration-note-2026-04-24.md`
-- `evidence/obelyzk-sepolia-comparator-note-2026-04-25.md`
+- The presentation paper is about typed verifier boundaries, statement preservation,
+  replay avoidance, and explicit claim boundaries.
+- The transformer-shaped STARK-zkML stack is the empirical laboratory, not the scope of
+  the entire design claim.
+- The package keeps external language in the paper and appendices even when the tracked
+  evidence files and artifact directories retain older internal names for checksum and
+  provenance stability.
 
-This package keeps the April 24 freeze intact while adding an April 25 comparator
-refresh that sharpens the external calibration snapshot without promoting a new matched
-benchmark claim.
-
-Later bridge work remains implemented in-repo but is not yet part of the frozen
-publication-facing artifact bundle:
-
-- Phase81-84 translated Paper 3 seam surfaces
-
-Draft next-paper package:
-
-- `paper2/README.md`
-- `paper2/proof-carrying-decode-surfaces-2026.md`
-- `paper2/appendix-claim-boundary.md`
-- `paper2/appendix-ivc-positioning.md`
-- `paper2/appendix-engineering-gaps.md`
-- `paper2/appendix-artifact-map.md`
-
-For artifact-bundle scope, cited bundles, and archival provenance bundles, see:
-
-- `artifacts/README.md`
+Archived earlier drafts remain in this directory for provenance, but they are not the
+primary presentation path.

--- a/docs/paper/appendix-system-comparison.md
+++ b/docs/paper/appendix-system-comparison.md
@@ -1,50 +1,35 @@
 # Appendix: Public System Comparison Snapshot
 
-Snapshot date: **April 24, 2026** with an **April 25, 2026** comparator refresh
+Snapshot date: **April 26, 2026**
 
-This appendix is a compact comparison table for the three systems most relevant to the
-argument in the main paper. It inherits its source posture from Sections 6 and 7:
-archival papers, official engineering/product materials, and commit-pinned repository
-artifacts are used for different claim types and should not be read as a single matched
-benchmark class.
+Sources: this appendix compares three systems using a mixed source posture: archival papers, official public engineering materials, and pinned local evidence artifacts. It is not a matched benchmark table on identical workloads.
 
-Sources: rows inherit the main paper’s source set from Sections 6 and 7, especially
-References 24-31, 35-40, 46, and 49.
+## Table A1. DeepProve vs. Obelyzk vs. this paper's local evidence package
 
-It should be read with one rule in mind: these are **not** matched end-to-end benchmarks
-on identical workloads. They are a structured comparison of public claims, committed
-artifacts, and implementation scope.
-
-## Table A1. DeepProve vs. BitSage Obelyzk (obelyzk.rs) vs. `provable-transformer-vm`
-
-| Dimension                 | Lagrange DeepProve                                                                               | BitSage Obelyzk (obelyzk.rs)                                                                                                                                                        | `provable-transformer-vm`                                                                                                                                                      |
-| ------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Primary role              | Production-oriented zkML system                                                                  | Public STARK-native zkML stack                                                                                                                                                      | Semantics-and-proof research artifact                                                                                                                                          |
-| Proof family              | SNARK / SNARK-hybrid                                                                             | STARK-native on S-two / STWO                                                                                                                                                        | S-two / STWO only; narrow artifact-backed transformer and repeated-reuse research line                                                                                         |
-| Public transformer scope  | Public claims of full GPT-2 inference and later Gemma-class progress                             | Public repo/verifier claims transformer-block support, recursive verifier milestones, and aggressive single-block benchmarks                                                        | Deterministic transformer-shaped VM, not full learned transformer inference                                                                                                    |
-| Strongest public evidence | Official Lagrange product/blog materials                                                         | Docs.rs verifier page, Obelyzk paper, and Starknet Sepolia verification path                                                                                                        | Checked evidence files under `docs/paper/evidence/`, publication figures under `docs/paper/figures/`, and statement-versioned repo outputs                                  |
-| Non-arithmetic handling   | Custom circuits and lookup-oriented techniques                                                   | LogUp-style lookup machinery on STWO                                                                                                                                                | Lookup-backed calibration rows now exist for normalization, softmax-exp, and binary-step activation; full learned softmax/inference remains out of scope                      |
-| Backend maturity          | Strongest public deployment maturity of the three                                                | Strongest public STARK-native zkML signal                                                                                                                                           | Strongest semantics-portability story among the three                                                                                                                          |
-| Public onchain posture    | Production/prover maturity emphasized more than public Starknet verification demos               | Starknet verification path and public demos emphasized                                                                                                                              | No onchain verifier integration yet                                                                                                                                            |
-| Public onchain evidence   | Public materials emphasize production deployment more than named Starknet proof-demo identifiers | Pinned Starknet Sepolia recursive verifier object; exact contract, tx, calldata, and gas figures are recorded in `docs/paper/evidence/obelyzk-sepolia-comparator-note-2026-04-25.md` | No public onchain proof-verification artifact set                                                                                                                              |
-| Recursion posture         | Present in system architecture, but details vary by release                                      | Publicly aligned with S-two / STWO recursion path                                                                                                                                   | Recursive cryptographic compression not implemented; repo stops at frozen narrow S-two execution proofs, proof-carrying decoding demos, and a pre-recursive aggregation ladder |
-| Paper relevance           | Main counterexample to categorical anti-SNARK claims                                             | Closest STARK-native comparator to the paper thesis                                                                                                                                 | Concrete local calibration and carried-state artifact surface that the paper can describe precisely                                                                             |
-| Main caveat               | Strong public claims, but not directly comparable to STARK systems on identical workloads        | Public deployment evidence is stronger than the old README-only posture, but the public verifier object is still not a matched local comparator to this repo's pre-recursive artifacts; verifier docs still show uneven component maturity (`Attention` remains `Prover only`) | Narrow scope: local S-two wins now split by regime (`Phase12` proving, `Phase44D` typed-boundary latency, and `Phase71` handoff-receipt compactness), not a matched full-model benchmark or universal win |
+| Dimension | DeepProve | Obelyzk | This paper's local package |
+| --- | --- | --- | --- |
+| Primary role | Production-oriented zkML system | Public STARK-native recursive deployment stack | Research paper on typed verifier boundaries |
+| Proof family | SNARK / SNARK-hybrid | STARK-native recursive stack | STARK-native compact-proof plus typed-boundary settlement layer |
+| Public transformer scope | Strong public full-model posture | Strong public recursive deployment posture | Transformer-shaped empirical laboratory, not a full-model benchmark |
+| Strongest public evidence | Official product and engineering materials | Public docs.rs verifier page, public paper, and Starknet Sepolia verifier object | Checked evidence package with typed-boundary, compact-object, and proving-surface calibration rows |
+| What is most relevant here | Counterexample to categorical anti-SNARK claims | Strongest public STARK-native deployment comparator | Strongest formal and empirical replay-avoidance study in this package |
+| Public onchain posture | Not the main emphasis of the public materials | Explicit Starknet Sepolia verifier path | No typed-boundary onchain artifact claimed |
+| Best use in this paper | Broad external context | Source-backed deployment calibration | Main formal and empirical object |
+| Main caveat | Not directly matched to the local typed-boundary laboratory | Strong deployment evidence, but not a matched verifier-time comparator to the local typed-boundary path | Narrow claim boundary: one experimental backend, three layout families, explicit non-claims |
 
 ## How to use this appendix
 
-Use this appendix when the main paper needs one concise comparison object, but keep the
-stronger qualifications in the main text:
+This appendix is useful only if it is read conservatively.
 
-- DeepProve is the strongest counterexample to categorical anti-SNARK claims.
-- BitSage is the strongest public STARK-native comparator, and the pinned
-  evidence is now a source-backed Starknet Sepolia recursive verifier object
-  rather than a README-only benchmark line; it still needs to be separated into
-  benchmark claims, onchain demos, and broader roadmap scope.
-- `provable-transformer-vm` is not a frontier zkML prover; it is a trace-semantics and
-  proof-architecture artifact with reproducible evidence and an explicit pre-recursive
-  aggregation boundary.
-- If you need one narrow verifier-object comparison rather than another full-model row,
-  the only honest cross-system pairing in the pinned snapshot is `NANOZK`'s abstract
-  `d <= 128` layer-proof row against this repo's `Phase71` handoff-receipt row. Use it
-  as compact-object calibration only. It is explicitly not a matched benchmark.
+- DeepProve matters because it prevents the paper from turning into a simplistic
+  STARK-versus-SNARK slogan.
+- Obelyzk matters because it provides the strongest public STARK-native deployment
+  calibration currently available to this package.
+- The local paper package matters because it provides a theorem, a hardening stack, and a
+  replay-avoidance experiment, not because it wins a matched end-to-end system race.
+
+A narrower public comparator also exists in the compact-object regime. Public NANOZK
+materials report a small verifier-facing proof object with fast verification. The
+closest local compact handoff object is smaller but slower on its present path. That is
+useful precisely because it reinforces the paper's main lesson: different layers improve
+different costs.

--- a/docs/paper/appendix-tablero-claim-boundary.md
+++ b/docs/paper/appendix-tablero-claim-boundary.md
@@ -1,0 +1,43 @@
+# Appendix: Claim Boundary for the Presentation Draft
+
+This appendix makes the paper's positive and negative claim surfaces explicit.
+
+## Positive claim surface
+
+The paper claims only the following.
+
+| Surface | Honest claim |
+| --- | --- |
+| Typed verifier boundary | A verifier can replace an expensive replay surface with a typed boundary object when that object is complete, well formed, and commitment-bound to the same compact claim. |
+| Formal guarantee | Under upstream compact-proof soundness, commitment binding, and source-emission completeness, Tablero preserves the same accepted statement set as the replay verifier. |
+| Empirical evidence | In the current transformer-shaped empirical lab, the main typed boundary reproduces across three layout families with a growing-in-`N` replay-avoidance curve. |
+| Negative evidence | A second candidate boundary is reported honestly as a no-go because the required source emission and replay-cost conditions were not both satisfied. |
+| Assurance posture | Deterministic tamper tests, bounded model checking, differential fuzzing, and fail-closed runtime guards materially reduce implementation-side self-deception risk. |
+
+## Negative claim surface
+
+The paper does **not** claim the following.
+
+| Surface | Explicit non-claim |
+| --- | --- |
+| New STARK theorem | No new soundness theorem for STARKs or for S-two itself. |
+| Backend independence | No empirical proof that the pattern is backend independent today. |
+| Recursive compression | No recursive verifier, no proof-carrying data theorem, and no incrementally verifiable computation construction. |
+| Universal speedup | No claim that typed boundaries always improve verifier performance. |
+| Implementation-invariant baseline | No claim that every manifest implementation in every system would pay the same replay cost as this codebase. |
+| Full zkML frontier result | No claim of full end-to-end transformer inference proving or a matched full-model benchmark against public competitors. |
+| Onchain deployment | No claim that the typed-boundary path itself has already been deployed onchain. |
+
+## Talk-safe summary
+
+If this paper is presented orally, the safest one-sentence summary is:
+
+> Tablero is a typed verifier-boundary pattern for layered STARK systems: when the
+> source side emits the right proof-native facts, the verifier can replace an expensive
+> replay path with a compact boundary object without widening what it accepts.
+
+The safest one-sentence warning is:
+
+> The large latency ratios in this paper are replay-avoidance results on the current
+> implementation, not claims that cryptographic STARK verification itself became
+> hundreds of times faster.

--- a/docs/paper/evidence/published-zkml-calibration-note-2026-04-24.md
+++ b/docs/paper/evidence/published-zkml-calibration-note-2026-04-24.md
@@ -1,152 +1,82 @@
-# Published zkML Calibration Note (2026-04-24)
+# Published zkML Calibration Note (2026-04-24, refreshed for the Tablero presentation package)
 
-This note records the current literature-facing calibration pass for the repository's
-STARK-vs-SNARK transformer positioning after the checked one-shot, shared-table,
-Phase12-style shared-bundle, Phase44D typed-boundary, and Phase71 handoff-receipt rows
-landed in the paper evidence set.
+This note records the literature-facing calibration posture for the presentation paper.
+It is a workload-scope and claim-scope note, not a matched benchmark claim.
 
-Primary-source table:
+Primary source table:
 
 - `docs/paper/evidence/published-zkml-numbers-2026-04.tsv`
 
 ## What this table is for
 
-It is a ground-truth extraction pass and workload-scope snapshot, not a claim of
-matched benchmarking.
+The table is a structured extraction of public numbers and local evidence rows.
+It is meant to support disciplined positioning, not backend branding.
 
-The repository's symbolic model is still useful as a structural model, but these
-published numbers make three boundaries explicit:
+Three points matter most.
 
-1. current public 2026 zkML winners are lookup-aware systems, regardless of
-   whether they sit on a SNARK or STARK stack,
-2. this repository does not yet have a matched full-transformer `stwo` result on
-   the same workload/hardware envelope as the strongest public SNARK papers, and
-3. the symbolic ratio (`1.48x` for the GPT-2-small worked example) is therefore
-   not yet an empirical wall-clock claim.
+1. The strongest current zkML systems are already lookup-aware, regardless of whether
+   they sit on SNARK or STARK stacks.
+2. This repository does not yet have a matched full-model transformer benchmark against
+   those public systems.
+3. The local evidence is therefore split by verifier-facing regime rather than smoothed
+   into a fake universal win story.
 
-## What the extracted rows already show
+## The three local regimes that matter
 
-- `NANOZK` reports `6.3s` prove time, `23ms` verify time, and `6.9 KB` proof
-  size for a GPT-2-scale transformer block at `d = 768`.
-- `NANOZK` also gives one narrower public verifier-object row directly in the
-  abstract: for transformer models up to `d = 128`, it reports a `5.5 KB`
-  layer proof with `24 ms` verification time.
-- `Jolt Atlas` reports `14s` prove time and `0.517s` verify time for a
-  `~0.25M`-parameter `nanoGPT` model, and `~38s` end-to-end for `GPT-2 (125M)`.
-- `EZKL`, as quoted by `Jolt Atlas` on the same `nanoGPT` workload, reports
-  `237s` proof time and `0.34s` verify time.
-- `BitSage Obelyzk` now has a source-backed Starknet Sepolia verifier-object row:
-  docs.rs pins recursive verifier contract
-  `0x1c208a5fe731c0d03b098b524f274c537587ea1d43d903838cc4a2bf90c40c7`,
-  verified tx
-  `0x276c6a448829c0f3975080914a89c2a9611fc41912aff1fddfe29d8f3364ddc`,
-  and `942` felt calldata for a 30-layer `SmolLM2-135M` recursive proof; the
-  same page reports `3.55s` recursive compression on top of a `102s` GKR proof
-  on `A10G`, and the accompanying paper reports `~280K` gas for one-layer GKR
-  verify and `~2.5M` gas (`~$0.01`) for the full 40-layer Starknet Sepolia
-  path. This sharpens deployment calibration, not a matched local verifier row.
-- the current repository now exposes **three** literature-facing local calibration rows,
-  each for a different regime:
-  - the checked `Phase12`-style shared lookup bundle as the local proving-surface row at
-    three paired rows:
-    `4,968` raw proof bytes, `14.939 ms` prove, and `6.745 ms` verify from
-    `docs/paper/evidence/stwo-phase12-shared-lookup-bundle-reuse-2026-04.tsv`;
-  - the checked `Phase44D` typed source-emission boundary as the local latency row at
-    the current two-step power-of-two point: `61,238` serialized bytes, `1.034 ms` boundary emission,
-    and `0.957 ms` verify from
-    `docs/paper/evidence/stwo-phase44d-source-emission-2026-04.tsv`; the same
-    evidence file also records the causal split showing `0.456 ms` for the compact
-    Phase43 proof alone, `15.856 ms` for ordered Phase30 manifest replay alone,
-    and `0.399 ms` for typed-boundary binding after prior compact-proof verification;
-  - the checked `Phase71` handoff receipt as the local compact-object row at three
-    steps: `1,533` serialized bytes and `34.613 ms` verify from
-    `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.tsv`.
-  These are still not full transformer benchmarks, but they now cover a proving-surface
-  row, a latency-oriented typed boundary row, and a compactness-oriented receipt row
-  rather than a single local artifact line.
+The local package currently exposes three different verifier-facing regimes.
 
-## One narrow external comparator that is actually useful
+1. **Proving surface.** A narrow proving-bound calibration row for a compact reusable
+   proof bundle.
+2. **Typed-boundary latency surface.** The main Tablero row: verify a compact proof,
+   accept a typed boundary, and avoid replaying the ordered manifest baseline.
+3. **Compact-object surface.** A smaller handoff object that improves serialized size but
+   does not win on local verifier latency.
 
-If the paper needs exactly one narrower external comparator rather than another
-full-model row, the only honest pairing in the current snapshot is the compact
-verifier-object regime, and it should be used only as compact-object calibration:
+Those rows should not be collapsed into one slogan because they improve different costs.
 
-- external row: `NANOZK` abstract layer proof at `d <= 128` -> `5.5 KB`, `24 ms`
-  verification;
-- closest local row: `Phase71` handoff receipt at three steps ->
-  `1,533` serialized bytes, `34.613 ms` verification from
-  `docs/paper/evidence/stwo-phase71-handoff-receipt-2026-04.tsv`.
+## What the typed-boundary row actually means
 
-That comparison is interesting because it splits cleanly:
+The large local ratios in the presentation paper come from the typed-boundary latency
+surface. The baseline in that experiment is the verifier-side replay path that this
+codebase actually pays today, especially ordered canonical serialization, hashing, and
+manifest reconstruction.
 
-- the current local `Phase71` object is **smaller** than the public `NANOZK`
-  compact proof object, but
-- it is **slower to verify** on the current path.
+That is a real cost and a real result. But it is still implementation grounded. The
+paper should say explicitly that the ratios measure replay avoidance against the current
+manifest implementation, not a universal lower bound on every possible replay design.
 
-This is explicitly not a matched benchmark. The workloads and proof objects differ.
-But it is still the most honest narrow comparator now available in public sources, and
-it reinforces the paper's actual position: different verifier-facing layers improve
-different costs.
+## External calibration that is actually useful
 
-## What the Obelyzk row now does and does not buy us
+The strongest public STARK-native deployment calibration in this package is the Obelyzk
+Starknet Sepolia verifier object.
 
-The refreshed `BitSage Obelyzk` row is useful because it upgrades the public
-STARK-native comparator from a repo-reported README benchmark to a source-backed
-Starknet Sepolia verifier-object record with an exact contract address, an exact
-verified transaction hash, and an exact recursive calldata width.
+It is useful because it pins:
 
-What it still does **not** buy us is a matched local verifier-time row:
+- a concrete verifier contract,
+- a concrete verified transaction,
+- a concrete calldata width, and
+- public gas numbers for a deployed recursive path.
 
-- the public Obelyzk object is a recursive STARK settlement proof over a GKR
-  stack,
-- the local `Phase44D` row is a pre-recursive typed-boundary latency surface,
-  and
-- the local `Phase71` row is a pre-recursive compact handoff surface.
+It is **not** a matched local verifier-time comparator to the typed-boundary experiment.
+The objects live at different layers of the stack.
 
-So the Obelyzk row now strengthens deployment/on-chain calibration and public
-STARK-native posture, but it does not turn the table into a same-regime verifier
-race.
+A narrower compact-object comparison is also honest:
 
-One further caveat matters for the repository's own large replay-avoidance
-ratios. On the current local path, the dominant lower-layer baseline cost is the
-ordered Phase30 manifest replay that this codebase actually pays, including
-canonical JSON serialization and Blake2b hashing inside that replay flow. That
-cost is real for this implementation, and it is exactly the work the typed
-boundary removes here, but it should not be read as a universal lower bound on
-manifest replay cost across every possible STARK stack or serialization design.
+- public NANOZK material reports a small verifier-facing proof object with fast
+  verification, and
+- the local compact handoff object is smaller but slower on its current path.
 
-## Immediate consequence for paper positioning
+Again, the point is not that one system categorically wins. The point is that the right
+comparison depends on which verifier-facing layer is being discussed.
 
-The defensible public claim is narrower than “STARKs are already faster for
-transformers.”
+## Immediate consequence for the paper
 
-The current defensible claim is:
+The safest public claim is:
 
-- lookup-friendly proof systems align with transformer non-arithmetic pressure,
-- the repository now provides one-shot and reuse-sensitive `stwo` calibration rows
-  across three different local surfaces: `Phase12` proving, `Phase44D` typed-boundary
-  latency, and `Phase71` handoff-receipt compactness, and
-- external calibration should be read by workload regime, not as a matched wall-clock
-  race.
+- lookup-friendly proof systems align well with transformer workloads,
+- this repository contributes a typed verifier-boundary pattern plus a formal
+  statement-preservation criterion, and
+- the local evidence should be read by verifier-facing regime: proving surface, typed
+  boundary latency surface, and compact-object surface.
 
-## What remains to calibrate
-
-This table is necessary but not sufficient. It does not normalize:
-
-- security level,
-- hardware,
-- exact sequence length,
-- whether the workload is one layer, one block, or a full model,
-- setup/keygen amortization,
-- approximation strategy for non-arithmetic operations.
-
-The next calibration step must therefore preserve the same standard:
-
-1. keep adding only verifier-bound local rows whose reuse claim is enforced by the
-   proof statement rather than by artifact deduplication,
-2. keep the local calibration rows split by cost regime instead of collapsing them into
-   a fake universal win story,
-3. widen that reuse-sensitive measurement discipline to richer kernels before making
-   the headline broader, and
-4. add narrower external comparator rows only when workload boundary, hardware, and
-   proof object are explicit enough to avoid backend-slogan comparisons.
+That is strong enough to be interesting and narrow enough to remain defensible.

--- a/docs/paper/tablero-typed-verifier-boundaries-2026.md
+++ b/docs/paper/tablero-typed-verifier-boundaries-2026.md
@@ -1,0 +1,502 @@
+# Tablero: Typed Verifier Boundaries for Layered STARK Systems, with Evidence from STARK-zkML
+
+<p><strong>Abdelhamid Bakhta</strong><br>
+StarkWare</p>
+
+<p><strong>Omar Espejel</strong><br>
+Starknet Foundation</p>
+
+*April 2026 draft*
+
+## Abstract
+
+Layered proof systems often pay a verifier-side replay cost long after the core
+cryptographic statement has already been fixed. In practice, a verifier may first
+check a compact proof and then still spend most of its wall-clock budget
+reconstructing ordered manifests, public-input tables, or source-chain summaries.
+This paper isolates a design pattern for removing that replay cost without widening
+what the verifier accepts. We call the pattern **Tablero**: a typed verifier boundary
+that binds the same public facts the replay path would have reconstructed, but does
+so through a compact boundary object and explicit commitment checks.
+
+The main technical claim is a statement-preservation theorem: if the underlying
+compact proof system is sound, the boundary object is well formed, and the boundary
+binding checks are complete for the emitted source facts, then accepting the typed
+boundary preserves the same accepted statement set as replaying the heavier source
+surface directly. This is not a new STARK theorem and not a recursive-compression
+result. It is a theorem about when replay replacement is honest.
+
+We then study the pattern in a transformer-shaped STARK-zkML laboratory. On the
+current experimental backend, the main typed-boundary path reproduces across three
+layout families. At the checked frontier, the replay-avoidance ratio grows from
+`19.2x` to `250.6x` on the `3x3` family and reaches `312.3x` on the default family and
+`925.1x` on the `2x2` family at `1024` checked steps. The dominant avoided cost is not
+faster FRI verification; it is the verifier-side replay path itself, especially
+ordered canonical serialization and hashing in the manifest baseline. A second
+candidate boundary is also reported honestly as a negative result: it did not clear
+as a meaningful replay-elimination boundary under the current source-emission and cost
+structure.
+
+The contribution is therefore threefold: a reusable verifier-boundary pattern, a
+formal statement-preservation criterion for deploying it safely, and an empirical
+study showing when and why replay elimination opens a growing latency gap in a layered
+STARK stack.
+
+______________________________________________________________________
+
+## 1. Introduction
+
+The hardest systems problems in proof engineering often arise above the core proof.
+A stack can already have a cryptographically meaningful compact statement and still
+force the verifier to replay heavy structure around it: ordered manifests,
+derived public-input vectors, source-chain commitments, or receipt wrappers.
+Those replay surfaces matter because they are where wall-clock latency,
+serialization overhead, and implementation complexity can pile up even when the
+core proof relation is already fixed.
+
+This paper studies that layer. The question is not whether recursive STARK systems,
+lookup-heavy verifiers, or zkML stacks are possible in principle. The question is
+more operational:
+
+**When can a verifier replace an expensive replay surface with a typed boundary object
+without changing what it accepts?**
+
+That question matters well beyond zkML. Any layered STARK system with a compact proof
+at one layer and replay-heavy verification logic at the next layer can face the same
+tradeoff. A typed boundary is attractive because it can compress the verifier-facing
+object and remove replay work. But it is only honest if the boundary object is bound
+to the same statement the replay path would have enforced.
+
+We use a transformer-shaped STARK-zkML stack as the empirical lab because it makes
+these replay surfaces unusually visible. The stack already exposes compact proofs,
+source-bound verification paths, bridge objects, handoff receipts, wrapper candidates,
+and a hardening program aimed at malformed or stale serialized artifacts. That gives us
+a realistic setting in which the replay surface is both large enough to matter and
+formal enough to study.
+
+The paper makes four claims.
+
+1. **Design claim.** Tablero is a reusable settlement-layer pattern for layered STARK
+   systems: replace verifier-side replay with a typed boundary whose fields are
+   commitment-bound to the compact statement.
+2. **Formal claim.** Under explicit assumptions, accepting the typed boundary preserves
+   the same accepted statement set as replaying the heavier source surface.
+3. **Empirical claim.** In the current transformer-shaped empirical lab, the main typed
+   boundary reproduces across three layout families and exhibits a growing-in-`N`
+   replay-avoidance curve.
+4. **Boundary claim.** The pattern is not universal. It only applies where the source
+   side emits enough proof-native material and where the replay surface is expensive
+   enough to be worth removing. We include one bounded negative result to mark that
+   boundary explicitly.
+
+We also state the non-claims up front. This paper does **not** claim a new STARK
+soundness theorem, backend independence, recursive proof compression, a full end-to-end
+transformer benchmark, or a universal lower bound on replay cost across all
+implementations. The empirical demonstrations remain in one transformer-shaped STARK-zkML
+lane, and the large latency ratios are implementation-grounded replay-avoidance ratios,
+not claims that cryptographic verification itself became hundreds of times faster.
+
+______________________________________________________________________
+
+## 2. Replay Surfaces in Layered STARK Systems
+
+Consider a layered verifier with two kinds of work.
+
+- **Compact-proof work.** Verify the claim and proof that define the compact
+  cryptographic statement.
+- **Replay work.** Reconstruct or recheck heavier source-side structure around that
+  compact statement: ordered manifests, source-chain objects, public-input lists,
+  receipt wrappers, or other derived commitments.
+
+A verifier that performs both is often logically correct but architecturally
+inefficient. The replay path may dominate wall-clock cost even when the compact proof
+is relatively small.
+
+That distinction motivates a cleaner abstraction.
+
+A **typed verifier boundary** is a compact object emitted by the source side that carries
+exactly the boundary facts the verifier would otherwise derive by replaying the heavier
+surface. The verifier then accepts the compact proof together with the typed boundary,
+provided it can validate the object and prove that the object's fields bind to the same
+compact statement.
+
+The question is not whether a smaller object exists. The question is whether accepting
+that smaller object preserves the same statement.
+
+______________________________________________________________________
+
+## 3. The Tablero Pattern
+
+We now define the pattern in abstract form.
+
+### 3.1 Objects and notation
+
+Let:
+
+- `R` be the underlying compact-proof relation;
+- `c` be a public compact claim in relation `R`;
+- `π` be a proof for `c`;
+- `V_R(c, π)` be the verifier for `R`;
+- `σ` be the heavier source surface that a replay baseline would inspect directly;
+- `β` be a typed boundary object emitted from `σ` and `c`.
+
+The source surface `σ` can be any structured object whose replay path yields public
+facts that the verifier currently depends on: ordered manifests, source-chain summaries,
+bridge commitments, or receipt-level derived public inputs.
+
+### 3.2 Definition: typed verifier boundary
+
+**Definition 1 (Typed verifier boundary).** A typed verifier boundary `β` for compact
+claim `c` over source surface `σ` is a compact object emitted by the source side such
+that:
+
+1. `β` is schema-valid and version-valid,
+2. `β` exposes the public boundary facts the replay verifier would otherwise derive
+   from `σ`, and
+3. `β` carries enough commitment-bound information for the verifier to check that
+   those facts belong to the same compact claim `c`.
+
+### 3.3 Definition: Tablero acceptance rule
+
+Let `Validate(β)` be the object-level validation predicate for the typed boundary, and
+let `Bind(β, c)` be the repository-local binding predicate that checks boundary-to-claim
+consistency.
+
+Then the Tablero acceptance rule is:
+
+```text
+TableroVerify(β, c, π) := Validate(β) and V_R(c, π) and Bind(β, c)
+```
+
+Intuitively:
+
+- `V_R(c, π)` keeps the compact cryptographic statement honest,
+- `Validate(β)` prevents malformed or semantically invalid boundary objects, and
+- `Bind(β, c)` prevents stale or mismatched boundary data from being attached to the
+  wrong compact claim.
+
+### 3.4 When the pattern applies
+
+Tablero is not a universal wrapper trick. It applies only when two conditions hold.
+
+1. **Replay worth removing.** The replay surface is expensive enough that replacing it
+   would materially change verifier cost.
+2. **Source emission completeness.** The source side emits the proof-native data needed
+   for the binding predicate to recreate the same public boundary the replay verifier
+   would have enforced.
+
+If either condition fails, the right outcome is not to force the pattern. It is to record
+an honest no-go.
+
+______________________________________________________________________
+
+## 4. Statement Preservation
+
+The formal question is now precise: under what assumptions does replacing replay with a
+typed boundary preserve the same accepted statement set?
+
+### 4.1 Assumptions
+
+We assume:
+
+1. **Compact-proof soundness.** If `V_R(c, π)` accepts, then `c` is a true statement in
+   relation `R` except with negligible probability `ε_R`.
+2. **Commitment binding.** The commitment functions used inside the boundary object and
+   its nested objects are collision resistant except with negligible probability `ε_H`.
+3. **Emission completeness.** The source side emits enough proof-native data for
+   `Bind(β, c)` to check all boundary facts that the replay verifier would otherwise
+   derive from `σ`.
+
+These are deliberately ordinary assumptions. The theorem below is not claiming a new
+cryptographic primitive. It is a theorem about preserving the same statement under a
+replay replacement discipline.
+
+### 4.2 Theorem
+
+**Theorem 1 (Tablero statement preservation).** Let `β` be a typed verifier boundary
+emitted from source surface `σ` and compact claim `c`. Suppose:
+
+1. `Validate(β)` accepts,
+2. `V_R(c, π)` accepts,
+3. `Bind(β, c)` accepts, and
+4. the three assumptions above hold.
+
+Then, except with probability at most `ε_R + ε_H`, accepting `(β, c, π)` through
+`TableroVerify` does not widen the accepted statement set relative to a verifier that
+checks `V_R(c, π)` and reconstructs the same public boundary facts directly from `σ`.
+
+### 4.3 Proof sketch
+
+The proof is straightforward.
+
+1. By compact-proof soundness, `V_R(c, π)` implies that `c` is a valid compact statement
+   except with probability `ε_R`.
+2. `Validate(β)` guarantees that the boundary object is structurally well formed, uses
+   the expected schema and semantic scope, and respects object-level invariants.
+3. `Bind(β, c)` guarantees that the public facts carried by `β` are commitment-bound to
+   the same compact claim `c` rather than to some stale or semantically different object.
+4. By commitment binding, the adversary cannot substitute a semantically different nested
+   object under the same commitments except with probability `ε_H`.
+5. Therefore the verifier that accepts `β` is accepting the same compact claim and the
+   same public boundary facts that the replay verifier would have enforced, but without
+   recomputing those facts from `σ` inside the verifier.
+
+So the accepted statement set is preserved up to `ε_R + ε_H`.
+
+### 4.4 What the theorem does not say
+
+The theorem does **not** imply:
+
+- that every replay surface can be replaced honestly,
+- that every typed boundary improves cost,
+- that a boundary result automatically generalizes across backends,
+- that recursive compression has already been achieved.
+
+It says only that when a boundary is emitted completely and bound correctly, replacing
+replay with that boundary does not widen the accepted statement set.
+
+______________________________________________________________________
+
+## 5. Implementation Boundary and Assurance
+
+The empirical laboratory behind this paper is a layered transformer-shaped STARK stack
+that already exposes:
+
+- a compact proof path,
+- a typed boundary path,
+- a public-input bridge,
+- a proof-adapter receipt,
+- higher wrapper surfaces, and
+- a structured source-side replay baseline.
+
+That stack is valuable because it lets us test the pattern under adversarial conditions
+rather than only in prose.
+
+The implementation assurance stack used for this paper is intentionally auditor-style.
+It includes:
+
+- deterministic tamper tests for malformed, stale, reordered, and semantically drifted
+  serialized artifacts,
+- deterministic tests for witness-discipline failures in the experimental arithmetic
+  layer,
+- bounded model checking on the narrow boundary and wrapper predicates that replace
+  replay,
+- differential fuzzing on serialized boundary and wrapper inputs,
+- runtime hardening that converts panic-prone shape assumptions into fail-closed errors
+  on trusted-core paths.
+
+This assurance stack does not replace the theorem. It complements it. The theorem says
+what claim is justified if the boundary path is implemented correctly; the assurance
+stack increases confidence that the implementation is not silently violating the
+conditions of the theorem.
+
+______________________________________________________________________
+
+## 6. Empirical Evaluation
+
+### 6.1 Setup and scope
+
+The empirical demonstrations in this paper come from one transformer-shaped STARK-zkML
+laboratory. They are not a matched benchmark against external systems. They are measured
+median-of-five results on one experimental backend, used to study the behavior of typed
+replay replacement under controlled variations in layout geometry.
+
+The main comparison is always the same:
+
+- **Typed-boundary path.** Verify the compact proof and accept one typed boundary object.
+- **Replay baseline.** Verify the same compact proof and then replay the ordered manifest
+  that the typed boundary is designed to replace.
+
+The important interpretation rule is simple:
+
+> These ratios measure replay avoidance on the current implementation, not faster FRI
+> verification and not a universal lower bound on all possible manifest designs.
+
+### 6.2 Cross-family transferability
+
+The main positive result is not a single large ratio. It is that the same mechanism
+reproduces across three layout families with the same growing-in-`N` shape.
+
+#### Table 1. Frontier summary across checked layout families
+
+| Family | Checked frontier | Replay-avoidance ratio at frontier | Typed-boundary verify | Replay baseline verify |
+| --- | ---: | ---: | ---: | ---: |
+| default | `1024` | `312.3x` | `427.209 ms` | `133,430.237 ms` |
+| `2x2` | `1024` | `925.1x` | `11.133 ms` | `10,299.110 ms` |
+| `3x3` | `256` | `250.6x` | `125.753 ms` | `31,511.802 ms` |
+
+This is the strongest empirical claim the current paper should make.
+
+- The mechanism survives all three checked families.
+- The constants differ sharply.
+- The ratio grows with `N` on every checked family.
+
+That means the typed boundary is removing a linearly growing replay surface rather than
+merely shaving a constant factor.
+
+### 6.3 What is constant and what is not
+
+One subtle but important point must be stated explicitly.
+
+Across the checked families, the boundary artifact itself is nearly constant in size:
+roughly `6.3-6.6 KB` at the checked frontiers. That is the clean cryptographic property.
+
+The **verify time** of the boundary is **not** family-constant. It varies substantially
+because the binding work still depends on the underlying compact path and layout geometry.
+So the right sentence is:
+
+> Tablero exposes a near-constant boundary artifact size across checked families, while
+> the boundary verify cost remains family dependent.
+
+This distinction matters. If we blur it, a reviewer can correctly object that the data do
+not show family-invariant verifier cost.
+
+### 6.4 Causal decomposition
+
+The large ratios are easy to misread if we only quote the frontier numbers. The causal
+breakdown shows where the baseline actually spends time.
+
+#### Table 2. Frontier causal decomposition
+
+| Family | Compact proof only | Boundary binding only | Replay only |
+| --- | ---: | ---: | ---: |
+| default (`1024`) | `77.942 ms` | `277.236 ms` | `137,423.421 ms` |
+| `2x2` (`1024`) | `2.350 ms` | `5.116 ms` | `8,996.324 ms` |
+| `3x3` (`256`) | `26.649 ms` | `79.561 ms` | `32,233.963 ms` |
+
+This is the main empirical lesson:
+
+- the compact proof stays relatively small,
+- the typed boundary binding stays much smaller than the replay baseline, and
+- the replay baseline dominates because it performs ordered canonical serialization,
+  hashing, and manifest reconstruction work that the typed boundary removes from the
+  verifier path.
+
+So a `925x` ratio is not a claim that STARK verification itself became `925x` faster.
+It is a claim that the current verifier-side replay surface became unnecessary once the
+same public facts were carried by a typed, commitment-bound boundary object.
+
+### 6.5 Bounded negative result
+
+The paper also includes one negative result because that is part of the pattern's honest
+boundary.
+
+We evaluated a second candidate boundary over a different source-binding surface. It did
+not clear as a meaningful replay-elimination boundary. Two problems blocked it:
+
+1. the source side did not yet emit enough proof-native material to let the verifier bind
+   the boundary completely, and
+2. the dependency it would have eliminated was already too cheap to produce a meaningful
+   replay-avoidance gain.
+
+That is not a failure of the theorem. It is exactly the situation in which the theorem's
+preconditions do not hold, and the right result is a recorded no-go rather than an
+inflated second positive example.
+
+______________________________________________________________________
+
+## 7. External Calibration
+
+The paper should not present the local results in isolation. The strongest honest
+external calibration we currently have is a source-backed public STARK-native deployment
+row from Obelyzk's Starknet Sepolia verifier object [2, 3].
+
+That row is useful because it gives:
+
+- a concrete recursive verifier contract,
+- a concrete verified transaction,
+- a concrete calldata width, and
+- public gas numbers for a live settlement path.
+
+What it does **not** give is a matched local verifier-time comparator to the typed
+boundary results in this paper. The objects live at different layers:
+
+- the public Obelyzk object is a recursive settlement proof rather than a pre-recursive boundary object,
+- the main local object in this paper is a pre-recursive typed verifier boundary,
+- the narrower local compact handoff object is a compactness surface rather than a replay
+  avoidance surface.
+
+That is why the external calibration should be read as deployment posture, not as an
+apples-to-apples verifier race.
+
+A second, narrower external calibration remains useful in the compact-object regime.
+Public NANOZK material reports a `5.5 KB`, `24 ms` verifier-facing layer proof on a
+small-width workload [1]. The closest local compact handoff object is smaller but slower
+on its current path. That is another example of the paper's central claim: different
+verifier-facing layers improve different costs.
+
+______________________________________________________________________
+
+## 8. Threats to Validity and Explicit Non-Claims
+
+This paper is only strong if its claim boundary stays narrow.
+
+### 8.1 Experimental-backend scope
+
+The large replay-avoidance curves reported here come from one experimental backend. That
+backend has been hardened aggressively, but the empirical demonstrations are still
+backend-scoped. Today we can defend transferability across layout families. We cannot yet
+defend backend independence.
+
+### 8.2 Implementation-dependent replay cost
+
+The replay baseline in this paper is real, but it is also implementation grounded.
+In the current codebase, the dominant replay cost comes from ordered canonical
+serialization, hashing, and manifest reconstruction. That is the cost Tablero removes in
+this system. It is not a theorem that every replay implementation in every system would
+pay the same constant factors.
+
+### 8.3 No recursive-compression claim
+
+The typed boundary path is not recursive proof compression. It is a settlement-layer
+replacement of verifier-side replay. The paper therefore does not claim:
+
+- recursive or proof-carrying data constructions,
+- incrementally verifiable computation,
+- backend-independent proof of the pattern,
+- full end-to-end transformer inference proving,
+- onchain deployment of the typed boundary path itself.
+
+### 8.4 No universal speedup claim
+
+The paper does not claim that Tablero is always a win. A typed boundary only helps when:
+
+- the replay surface is expensive, and
+- the source side emits enough proof-native binding material.
+
+The recorded negative result exists precisely to show that we are not smoothing over this
+constraint.
+
+______________________________________________________________________
+
+## 9. Conclusion
+
+The main point of this paper is simple.
+
+A layered STARK system often already knows the compact statement it wants to enforce, but
+still wastes verifier time replaying heavier source structure around that statement.
+Tablero is a disciplined way to remove that replay work: emit a typed, commitment-bound
+boundary object and prove that accepting it preserves the same accepted statement set.
+
+That gives a contribution at three levels.
+
+- At the design level, it names a settlement-layer pattern that appears whenever replay
+  dominates verification.
+- At the formal level, it states a clean statement-preservation theorem with explicit
+  preconditions.
+- At the empirical level, it shows a real replay-avoidance curve across three layout
+  families, together with a bounded negative result that marks where the pattern does not
+  yet apply.
+
+This is not the end of the story. The next steps are clear: broader backend transfer,
+stronger external calibration, and eventually a recursive layer that preserves the same
+boundary semantics. But those are follow-on results. The present paper is about the
+strongest honest claim the current system can already defend.
+
+______________________________________________________________________
+
+## References
+
+1. NANOZK authors. *Public transformer-proof abstract and verifier-object metrics*. Public materials cited in the package calibration note.
+2. BitSage. *Obelyzk public verifier object on Starknet Sepolia*. Public docs.rs materials for `obelyzk` 0.3.0.
+3. BitSage. *Obelyzk paper and Starknet Sepolia gas figures*. Public paper linked from the `obelyzk` 0.3.0 docs.rs package.

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -29,10 +29,9 @@ PUBLICATION_METADATA_FILES = [
 ]
 
 PAPER_FILES = [
-    "docs/paper/stark-transformer-alignment-2026.md",
+    "docs/paper/tablero-typed-verifier-boundaries-2026.md",
+    "docs/paper/appendix-tablero-claim-boundary.md",
     "docs/paper/appendix-system-comparison.md",
-    "docs/paper/appendix-scaling-companion.md",
-    "docs/paper/appendix-influence-realization.md",
     *PUBLICATION_METADATA_FILES,
 ]
 


### PR DESCRIPTION
## Summary
- add a presentation-facing Tablero paper in external language only
- add a clean claim-boundary appendix for the presentation draft
- repoint the paper package, comparison appendix, calibration note, and preflight to the new presentation paper

## Validation
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `python3 -m py_compile scripts/paper/paper_preflight.py`
- local release gate passed: `14 / 14`
- `git diff --check`

## Hardening
- [x] no internal phase-language in the presentation-facing paper package prose
- [x] explicit claim boundary and non-claims included
- [x] replay-avoidance framing tied to implementation-specific manifest replay cost
- [x] package preflight updated to cover the new presentation paper entrypoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced "Tablero: Typed Verifier Boundaries" as the new primary paper with formal theorem statements and empirical evaluation across STARK systems
  * Added appendix explicitly defining paper claims (typed verifier boundary substitution) and non-claims (new theorems, universal speedups, onchain deployment)
  * Updated system comparison appendix with new framework focused on typed verifier boundaries
  * Refined overall package documentation, README, and validation procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->