### PR TITLE
[codex] Strengthen presentation paper package

### DIFF
--- a/docs/paper/PUBLICATION_RELEASE.md
+++ b/docs/paper/PUBLICATION_RELEASE.md
@@ -8,8 +8,10 @@ Primary presentation title:
 
 Primary presentation files:
 
+- `docs/paper/abstract-tablero-2026.md`
 - `docs/paper/tablero-typed-verifier-boundaries-2026.md`
 - `docs/paper/appendix-tablero-claim-boundary.md`
+- `docs/paper/appendix-methodology-and-reproducibility.md`
 - `docs/paper/appendix-system-comparison.md`
 
 Supporting package directories:
@@ -29,6 +31,7 @@ It supports the following presentation posture:
 - the formal core is a statement-preservation theorem under explicit assumptions,
 - the empirical lab is one transformer-shaped STARK-zkML stack,
 - the main positive evidence is replay avoidance across three layout families,
+- the main presentation figure is the cross-family results overview generated from checked evidence,
 - the main negative evidence is one bounded no-go on a second candidate boundary,
 - the external calibration is source-backed but not presented as a matched verifier race.
 

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -7,7 +7,9 @@ This directory contains the presentation-facing paper package for:
 Primary presentation files:
 
 - `tablero-typed-verifier-boundaries-2026.md`
+- `abstract-tablero-2026.md`
 - `appendix-tablero-claim-boundary.md`
+- `appendix-methodology-and-reproducibility.md`
 - `appendix-system-comparison.md`
 - `PUBLICATION_RELEASE.md`
 
@@ -17,6 +19,14 @@ Supporting publication assets:
 - `evidence/`
 - `artifacts/`
 - `submission-v4-2026-04-11/`
+
+Recommended presentation order:
+
+1. `abstract-tablero-2026.md`
+2. `tablero-typed-verifier-boundaries-2026.md`
+3. `appendix-tablero-claim-boundary.md`
+4. `appendix-methodology-and-reproducibility.md`
+5. `appendix-system-comparison.md`
 
 Package posture:
 

--- a/docs/paper/abstract-tablero-2026.md
+++ b/docs/paper/abstract-tablero-2026.md
@@ -1,0 +1,26 @@
+# Short Abstract: Tablero
+
+Use this version when a submission form or talk proposal asks for a compact abstract.
+
+Tablero is a typed verifier-boundary pattern for layered STARK systems. The motivating
+problem is common: a verifier may already have a compact cryptographic statement, yet
+still spend most of its wall-clock budget replaying heavier source-side structure such
+as ordered manifests, public-input summaries, or wrapper objects. Tablero replaces that
+replay path with a compact boundary object whose fields are explicitly bound to the same
+accepted statement. The paper's formal claim is narrow: under compact-proof soundness,
+commitment binding, and complete source emission of the required public facts, accepting
+a well-formed typed boundary preserves the same accepted statement set as replaying the
+heavier source surface directly. This is not a new theorem about STARKs and not a
+recursive-compression result. It is a criterion for when replay replacement is honest.
+
+We study the pattern in one transformer-shaped STARK-zkML laboratory. Across three
+checked layout families, the same typed-boundary mechanism exhibits a growing replay-
+avoidance curve: the typed verifier path stays comparatively small while the replay
+baseline grows sharply with input length. At the checked frontiers, the replay-avoidance
+ratio ranges from `250.6x` to `925.1x`, with the dominant avoided cost coming from the
+verifier-side replay path itself rather than faster cryptographic verification. The
+paper also includes a bounded negative result showing that the pattern does not apply
+honestly when the source side emits too little proof-native material or when the
+candidate replay surface is already cheap. The contribution is therefore a reusable
+verifier-boundary pattern, a statement-preservation criterion for deploying it safely,
+and an empirical study of when replay elimination materially changes verifier latency.

--- a/docs/paper/appendix-methodology-and-reproducibility.md
+++ b/docs/paper/appendix-methodology-and-reproducibility.md
@@ -1,0 +1,95 @@
+# Appendix: Methodology and Reproducibility
+
+This appendix states exactly how the paper's claims should be read and how the checked
+numbers were produced.
+
+## 1. Evidence categories
+
+The paper combines four evidence categories.
+
+1. **Formal claim surface.** The theorem in the main paper is a statement-preservation
+   theorem for typed verifier boundaries under explicit assumptions.
+2. **Empirical typed-boundary evidence.** The main measurements compare a typed-boundary
+   verifier path against the heavier replay path it is designed to replace.
+3. **Negative evidence.** One candidate boundary is reported as a no-go because the
+   source side did not emit enough proof-native material and the eliminated dependency
+   was not expensive enough to justify the pattern.
+4. **External calibration.** Public external rows are used only to position the work by
+   verifier-facing regime, not to claim a matched race against another system.
+
+These categories should not be collapsed into one slogan. The paper is strongest when
+formal, empirical, negative, and calibration evidence remain visibly distinct.
+
+## 2. Timing policy
+
+The primary replay-avoidance curves in the paper use checked median-of-five timing
+capture from the local benchmark harness. The policy is intentionally stronger than a
+single-run anecdote and intentionally narrower than a cross-lab benchmarking campaign.
+
+The result should therefore be read as follows:
+
+- the trend is strong enough to support a paper claim about curve shape,
+- the constants are strong enough to support a paper claim about replay avoidance in the
+  current implementation, and
+- the numbers are not meant to stand in for every hardware target or every possible
+  verifier implementation.
+
+## 3. What the large ratios mean
+
+The paper's large ratios are implementation grounded. They compare a typed verifier path
+against the replay baseline that this codebase actually pays today.
+
+That baseline performs ordered canonical serialization, hashing, and replay
+reconstruction work. The typed boundary removes that work from the verifier path by
+carrying the same public facts in a compact boundary object that is bound to the same
+accepted statement.
+
+That is a real verifier-side improvement. It is **not** a claim that cryptographic STARK
+verification itself became hundreds of times faster, and it is **not** a universal lower
+bound on all possible replay implementations.
+
+## 4. What the cross-family result means
+
+The strongest empirical result in the paper is not one frontier number. It is that the
+same replay-avoidance mechanism reproduces across three checked layout families with the
+same qualitative shape.
+
+The families do **not** share the same constants. One family yields a much larger
+frontier ratio than the others. That does not weaken the paper's main point. It clarifies
+it:
+
+- the **mechanism** is stable across the checked families,
+- the **magnitude** of the gain depends on family structure, and
+- the typed boundary's artifact size stays in a narrow band while verifier cost remains
+  family dependent.
+
+## 5. Reproducibility handles
+
+The paper package is designed so that the exact public-facing numbers come from checked
+machine-readable evidence and not from prose drift.
+
+Use these directories as the canonical handles:
+
+- `docs/paper/evidence/` for checked TSV and JSON values used in the paper package,
+- `docs/paper/figures/` for generated paper figures,
+- `scripts/paper/` for generation and preflight scripts.
+
+The release gate for the paper package should always include:
+
+- `python3 scripts/paper/paper_preflight.py --repo-root .`
+- the unit tests for any paper-specific generation script that changed,
+- `git diff --check`
+
+## 6. Safe public wording
+
+The safest public wording is:
+
+> Tablero removes a verifier-side replay cost by replacing it with a typed,
+> commitment-bound boundary object, while preserving the same accepted statement under
+> explicit assumptions.
+
+The safest public warning is:
+
+> The large ratios in this paper are replay-avoidance results on the current
+> implementation, not a claim that all STARK verification or all replay implementations
+> would show the same constants.

--- a/docs/paper/evidence/tablero-results-overview-2026-04.json
+++ b/docs/paper/evidence/tablero-results-overview-2026-04.json
@@ -1,0 +1,203 @@
+{
+  "artifact_size_band_bytes": {
+    "max": 156614,
+    "min": 127787
+  },
+  "families": [
+    {
+      "binding_only_ms": 5.116,
+      "checked_frontier": 1024,
+      "compact_only_ms": 2.35,
+      "family": "2x2",
+      "family_label": "2x2 layout",
+      "first_checked_step": 2,
+      "first_ratio": 17.795,
+      "frontier_ratio": 925.097,
+      "ratio_growth": 51.986,
+      "replay_only_ms": 8996.324,
+      "replay_verify_ms": 10299.11,
+      "timing_mode": "measured_median",
+      "timing_policy": "median_of_5_runs_from_microsecond_capture",
+      "timing_runs": 5,
+      "typed_serialized_bytes": 156308,
+      "typed_verify_ms": 11.133
+    },
+    {
+      "binding_only_ms": 79.561,
+      "checked_frontier": 256,
+      "compact_only_ms": 26.649,
+      "family": "3x3",
+      "family_label": "3x3 layout",
+      "first_checked_step": 2,
+      "first_ratio": 19.164,
+      "frontier_ratio": 250.585,
+      "ratio_growth": 13.076,
+      "replay_only_ms": 32233.963,
+      "replay_verify_ms": 31511.802,
+      "timing_mode": "measured_median",
+      "timing_policy": "median_of_5_runs_from_microsecond_capture",
+      "timing_runs": 5,
+      "typed_serialized_bytes": 127787,
+      "typed_verify_ms": 125.753
+    },
+    {
+      "binding_only_ms": 277.236,
+      "checked_frontier": 1024,
+      "compact_only_ms": 77.942,
+      "family": "default",
+      "family_label": "Default layout",
+      "first_checked_step": 2,
+      "first_ratio": 21.312,
+      "frontier_ratio": 312.33,
+      "ratio_growth": 14.655,
+      "replay_only_ms": 137423.421,
+      "replay_verify_ms": 133430.237,
+      "timing_mode": "measured_median",
+      "timing_policy": "median_of_5_runs_from_microsecond_capture",
+      "timing_runs": 5,
+      "typed_serialized_bytes": 156614,
+      "typed_verify_ms": 427.209
+    }
+  ],
+  "interpretation": [
+    "The main claim is the growing-in-input-size replay-avoidance curve across checked families.",
+    "Typed-boundary artifact size stays in a narrow frontier band while verifier cost remains family dependent.",
+    "Large ratios are against the current implementation's replay baseline, not a universal lower bound and not faster FRI."
+  ],
+  "ratio_curves": [
+    {
+      "family": "2x2",
+      "family_label": "2x2 layout",
+      "points": [
+        {
+          "ratio": 17.795,
+          "steps": 2
+        },
+        {
+          "ratio": 27.399,
+          "steps": 4
+        },
+        {
+          "ratio": 58.714,
+          "steps": 8
+        },
+        {
+          "ratio": 108.569,
+          "steps": 16
+        },
+        {
+          "ratio": 175.994,
+          "steps": 32
+        },
+        {
+          "ratio": 307.645,
+          "steps": 64
+        },
+        {
+          "ratio": 481.213,
+          "steps": 128
+        },
+        {
+          "ratio": 546.511,
+          "steps": 256
+        },
+        {
+          "ratio": 711.002,
+          "steps": 512
+        },
+        {
+          "ratio": 925.097,
+          "steps": 1024
+        }
+      ]
+    },
+    {
+      "family": "3x3",
+      "family_label": "3x3 layout",
+      "points": [
+        {
+          "ratio": 19.164,
+          "steps": 2
+        },
+        {
+          "ratio": 31.227,
+          "steps": 4
+        },
+        {
+          "ratio": 48.514,
+          "steps": 8
+        },
+        {
+          "ratio": 92.817,
+          "steps": 16
+        },
+        {
+          "ratio": 139.005,
+          "steps": 32
+        },
+        {
+          "ratio": 183.875,
+          "steps": 64
+        },
+        {
+          "ratio": 225.716,
+          "steps": 128
+        },
+        {
+          "ratio": 250.585,
+          "steps": 256
+        }
+      ]
+    },
+    {
+      "family": "default",
+      "family_label": "Default layout",
+      "points": [
+        {
+          "ratio": 21.312,
+          "steps": 2
+        },
+        {
+          "ratio": 36.022,
+          "steps": 4
+        },
+        {
+          "ratio": 63.545,
+          "steps": 8
+        },
+        {
+          "ratio": 101.766,
+          "steps": 16
+        },
+        {
+          "ratio": 149.827,
+          "steps": 32
+        },
+        {
+          "ratio": 202.15,
+          "steps": 64
+        },
+        {
+          "ratio": 246.234,
+          "steps": 128
+        },
+        {
+          "ratio": 275.707,
+          "steps": 256
+        },
+        {
+          "ratio": 289.667,
+          "steps": 512
+        },
+        {
+          "ratio": 312.33,
+          "steps": 1024
+        }
+      ]
+    }
+  ],
+  "source_timing_mode": "measured_median",
+  "source_timing_policy": "median_of_5_runs_from_microsecond_capture",
+  "source_timing_runs": 5,
+  "summary_version": "tablero-results-overview-v1"
+}

--- a/docs/paper/evidence/tablero-results-overview-2026-04.tsv
+++ b/docs/paper/evidence/tablero-results-overview-2026-04.tsv
@@ -1,0 +1,4 @@
+family	family_label	first_checked_step	checked_frontier	first_ratio	frontier_ratio	ratio_growth	typed_verify_ms	replay_verify_ms	compact_only_ms	binding_only_ms	replay_only_ms	typed_serialized_bytes	timing_mode	timing_policy	timing_runs
+2x2	2x2 layout	2	1024	17.795	925.097	51.986	11.133	10299.11	2.35	5.116	8996.324	156308	measured_median	median_of_5_runs_from_microsecond_capture	5
+3x3	3x3 layout	2	256	19.164	250.585	13.076	125.753	31511.802	26.649	79.561	32233.963	127787	measured_median	median_of_5_runs_from_microsecond_capture	5
+default	Default layout	2	1024	21.312	312.33	14.655	427.209	133430.237	77.942	277.236	137423.421	156614	measured_median	median_of_5_runs_from_microsecond_capture	5

--- a/docs/paper/figures/tablero-results-overview-2026-04.svg
+++ b/docs/paper/figures/tablero-results-overview-2026-04.svg
@@ -1,0 +1,113 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1800" height="1120" viewBox="0 0 1800 1120">
+<rect width="100%" height="100%" fill="#F8FAFC" />
+<text x="900.0" y="60.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="32" font-weight="700" fill="#0F172A">Tablero Results Overview</text>
+<text x="900.0" y="95.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="16" font-weight="400" fill="#334155">Growing replay-avoidance curves across checked families, with a near-constant frontier artifact-size band.</text>
+<rect x="60" y="120" width="1680" height="470" rx="22" fill="#FFFFFF" stroke="#CBD5E1" />
+<text x="520.0" y="150.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="20" font-weight="700" fill="#0F172A">Replay-avoidance ratio vs checked input length</text>
+<line x1="90" y1="170" x2="90" y2="590" stroke="#94A3B8" stroke-width="1.5" />
+<line x1="90" y1="590" x2="1010" y2="590" stroke="#94A3B8" stroke-width="1.5" />
+<line x1="90" y1="590.0" x2="1010" y2="590.0" stroke="#E2E8F0" stroke-width="1" />
+<text x="78.0" y="595.0" text-anchor="end" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">18x</text>
+<line x1="90" y1="485.0" x2="1010" y2="485.0" stroke="#E2E8F0" stroke-width="1" />
+<text x="78.0" y="490.0" text-anchor="end" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">245x</text>
+<line x1="90" y1="380.0" x2="1010" y2="380.0" stroke="#E2E8F0" stroke-width="1" />
+<text x="78.0" y="385.0" text-anchor="end" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">471x</text>
+<line x1="90" y1="275.0" x2="1010" y2="275.0" stroke="#E2E8F0" stroke-width="1" />
+<text x="78.0" y="280.0" text-anchor="end" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">698x</text>
+<line x1="90" y1="170.0" x2="1010" y2="170.0" stroke="#E2E8F0" stroke-width="1" />
+<text x="78.0" y="175.0" text-anchor="end" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">925x</text>
+<line x1="90.0" y1="590" x2="90.0" y2="598" stroke="#64748B" stroke-width="1.5" />
+<text x="90.0" y="622.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">2</text>
+<line x1="192.2" y1="590" x2="192.2" y2="598" stroke="#64748B" stroke-width="1.5" />
+<text x="192.2" y="622.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">4</text>
+<line x1="294.4" y1="590" x2="294.4" y2="598" stroke="#64748B" stroke-width="1.5" />
+<text x="294.4" y="622.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">8</text>
+<line x1="396.7" y1="590" x2="396.7" y2="598" stroke="#64748B" stroke-width="1.5" />
+<text x="396.7" y="622.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">16</text>
+<line x1="498.9" y1="590" x2="498.9" y2="598" stroke="#64748B" stroke-width="1.5" />
+<text x="498.9" y="622.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">32</text>
+<line x1="601.1" y1="590" x2="601.1" y2="598" stroke="#64748B" stroke-width="1.5" />
+<text x="601.1" y="622.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">64</text>
+<line x1="703.3" y1="590" x2="703.3" y2="598" stroke="#64748B" stroke-width="1.5" />
+<text x="703.3" y="622.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">128</text>
+<line x1="805.6" y1="590" x2="805.6" y2="598" stroke="#64748B" stroke-width="1.5" />
+<text x="805.6" y="622.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">256</text>
+<line x1="907.8" y1="590" x2="907.8" y2="598" stroke="#64748B" stroke-width="1.5" />
+<text x="907.8" y="622.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">512</text>
+<line x1="1010.0" y1="590" x2="1010.0" y2="598" stroke="#64748B" stroke-width="1.5" />
+<text x="1010.0" y="622.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">1024</text>
+<text x="550.0" y="650.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="14" font-weight="400" fill="#334155">Checked input length</text>
+<text x="20.0" y="380.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="14" font-weight="400" fill="#334155">Replay ratio</text>
+<polyline fill="none" stroke="#059669" stroke-width="4" points="90.0,590.0 192.2,585.6 294.4,571.1 396.7,548.0 498.9,516.8 601.1,455.8 703.3,375.5 805.6,345.3 907.8,269.1 1010.0,170.0" />
+<circle cx="90.0" cy="590.0" r="5.5" fill="#059669" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="192.2" cy="585.6" r="5.5" fill="#059669" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="294.4" cy="571.1" r="5.5" fill="#059669" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="396.7" cy="548.0" r="5.5" fill="#059669" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="498.9" cy="516.8" r="5.5" fill="#059669" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="601.1" cy="455.8" r="5.5" fill="#059669" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="703.3" cy="375.5" r="5.5" fill="#059669" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="805.6" cy="345.3" r="5.5" fill="#059669" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="907.8" cy="269.1" r="5.5" fill="#059669" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="1010.0" cy="170.0" r="5.5" fill="#059669" stroke="#ffffff" stroke-width="1.5" />
+<line x1="120" y1="545" x2="148" y2="545" stroke="#059669" stroke-width="4" />
+<text x="160.0" y="550.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="14" font-weight="400" fill="#334155">2x2 layout</text>
+<polyline fill="none" stroke="#D97706" stroke-width="4" points="90.0,589.4 192.2,583.8 294.4,575.8 396.7,555.3 498.9,533.9 601.1,513.1 703.3,493.8 805.6,482.2" />
+<circle cx="90.0" cy="589.4" r="5.5" fill="#D97706" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="192.2" cy="583.8" r="5.5" fill="#D97706" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="294.4" cy="575.8" r="5.5" fill="#D97706" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="396.7" cy="555.3" r="5.5" fill="#D97706" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="498.9" cy="533.9" r="5.5" fill="#D97706" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="601.1" cy="513.1" r="5.5" fill="#D97706" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="703.3" cy="493.8" r="5.5" fill="#D97706" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="805.6" cy="482.2" r="5.5" fill="#D97706" stroke="#ffffff" stroke-width="1.5" />
+<line x1="340" y1="545" x2="368" y2="545" stroke="#D97706" stroke-width="4" />
+<text x="380.0" y="550.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="14" font-weight="400" fill="#334155">3x3 layout</text>
+<polyline fill="none" stroke="#1D4ED8" stroke-width="4" points="90.0,588.4 192.2,581.6 294.4,568.8 396.7,551.1 498.9,528.9 601.1,504.7 703.3,484.3 805.6,470.6 907.8,464.1 1010.0,453.7" />
+<circle cx="90.0" cy="588.4" r="5.5" fill="#1D4ED8" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="192.2" cy="581.6" r="5.5" fill="#1D4ED8" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="294.4" cy="568.8" r="5.5" fill="#1D4ED8" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="396.7" cy="551.1" r="5.5" fill="#1D4ED8" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="498.9" cy="528.9" r="5.5" fill="#1D4ED8" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="601.1" cy="504.7" r="5.5" fill="#1D4ED8" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="703.3" cy="484.3" r="5.5" fill="#1D4ED8" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="805.6" cy="470.6" r="5.5" fill="#1D4ED8" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="907.8" cy="464.1" r="5.5" fill="#1D4ED8" stroke="#ffffff" stroke-width="1.5" />
+<circle cx="1010.0" cy="453.7" r="5.5" fill="#1D4ED8" stroke="#ffffff" stroke-width="1.5" />
+<line x1="560" y1="545" x2="588" y2="545" stroke="#1D4ED8" stroke-width="4" />
+<text x="600.0" y="550.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="14" font-weight="400" fill="#334155">Default layout</text>
+<text x="1390.0" y="150.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="20" font-weight="700" fill="#0F172A">Frontier summary</text>
+<rect x="1060" y="180" width="640" height="360" rx="18" fill="#F8FAFC" stroke="#CBD5E1" />
+<text x="1110.0" y="220.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="14" font-weight="700" fill="#0F172A">Family</text>
+<text x="1340.0" y="220.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="14" font-weight="700" fill="#0F172A">Frontier</text>
+<text x="1510.0" y="220.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="14" font-weight="700" fill="#0F172A">Ratio</text>
+<text x="1650.0" y="220.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="14" font-weight="700" fill="#0F172A">Typed verify</text>
+<rect x="1085" y="240" width="10" height="10" rx="2" fill="#059669" />
+<text x="1110.0" y="250.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="400" fill="#0F172A">2x2 layout</text>
+<text x="1340.0" y="250.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="400" fill="#0F172A">1024</text>
+<text x="1510.0" y="250.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="700" fill="#0F172A">925.1x</text>
+<text x="1650.0" y="250.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="400" fill="#0F172A">11.133 ms</text>
+<text x="1110.0" y="274.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">Replay baseline 10299.110 ms</text>
+<text x="1410.0" y="274.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">Boundary bytes 156,308</text>
+<rect x="1085" y="332" width="10" height="10" rx="2" fill="#D97706" />
+<text x="1110.0" y="342.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="400" fill="#0F172A">3x3 layout</text>
+<text x="1340.0" y="342.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="400" fill="#0F172A">256</text>
+<text x="1510.0" y="342.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="700" fill="#0F172A">250.6x</text>
+<text x="1650.0" y="342.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="400" fill="#0F172A">125.753 ms</text>
+<text x="1110.0" y="366.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">Replay baseline 31511.802 ms</text>
+<text x="1410.0" y="366.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">Boundary bytes 127,787</text>
+<rect x="1085" y="424" width="10" height="10" rx="2" fill="#1D4ED8" />
+<text x="1110.0" y="434.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="400" fill="#0F172A">Default layout</text>
+<text x="1340.0" y="434.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="400" fill="#0F172A">1024</text>
+<text x="1510.0" y="434.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="700" fill="#0F172A">312.3x</text>
+<text x="1650.0" y="434.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="400" fill="#0F172A">427.209 ms</text>
+<text x="1110.0" y="458.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">Replay baseline 133430.237 ms</text>
+<text x="1410.0" y="458.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="13" font-weight="400" fill="#475569">Boundary bytes 156,614</text>
+<rect x="60" y="630" width="1680" height="390" rx="22" fill="#FFFFFF" stroke="#CBD5E1" />
+<text x="900.0" y="670.0" text-anchor="middle" font-family="STIX Two Text, Georgia, serif" font-size="22" font-weight="700" fill="#0F172A">How to read the result</text>
+<text x="120.0" y="730.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="16" font-weight="400" fill="#334155">1. The main result is the curve shape: every checked family shows a replay-avoidance ratio that grows with input length.</text>
+<text x="120.0" y="770.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="16" font-weight="400" fill="#334155">2. Frontier boundary artifact size stays in a narrow band: 127,787 to 156,614 bytes.</text>
+<text x="120.0" y="810.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="16" font-weight="400" fill="#334155">3. Boundary verify cost is not family-constant; the artifact size is the near-constant property.</text>
+<text x="120.0" y="850.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="16" font-weight="400" fill="#334155">4. Large ratios come from removing verifier-side replay work in the current implementation, not from faster FRI.</text>
+<text x="120.0" y="890.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="16" font-weight="400" fill="#334155">5. The strongest claim is replay replacement with preserved statement scope, not a universal speedup story.</text>
+<text x="120.0" y="955.0" text-anchor="start" font-family="STIX Two Text, Georgia, serif" font-size="15" font-weight="400" fill="#475569">Checked evidence source: machine-readable family-matrix benchmark with median-of-five timings.</text>
+</svg>

--- a/docs/paper/tablero-typed-verifier-boundaries-2026.md
+++ b/docs/paper/tablero-typed-verifier-boundaries-2026.md
@@ -8,6 +8,8 @@ Starknet Foundation</p>
 
 *April 2026 draft*
 
+Short submission abstract: [`abstract-tablero-2026.md`](abstract-tablero-2026.md).
+
 ## Abstract
 
 Layered proof systems often pay a verifier-side replay cost long after the core
@@ -299,7 +301,9 @@ ______________________________________________________________________
 The empirical demonstrations in this paper come from one transformer-shaped STARK-zkML
 laboratory. They are not a matched benchmark against external systems. They are measured
 median-of-five results on one experimental backend, used to study the behavior of typed
-replay replacement under controlled variations in layout geometry.
+replay replacement under controlled variations in layout geometry. The measurement policy,
+reproducibility handles, and public wording rules are summarized in
+[`appendix-methodology-and-reproducibility.md`](appendix-methodology-and-reproducibility.md).
 
 The main comparison is always the same:
 
@@ -333,6 +337,12 @@ This is the strongest empirical claim the current paper should make.
 
 That means the typed boundary is removing a linearly growing replay surface rather than
 merely shaving a constant factor.
+
+![Tablero results overview across checked families](figures/tablero-results-overview-2026-04.svg)
+
+**Figure 1.** The main empirical fact is the curve shape across the three checked
+families. The frontier artifact size stays in a narrow band, while verifier cost remains
+family dependent.
 
 ### 6.3 What is constant and what is not
 

--- a/scripts/paper/generate_tablero_results_overview.py
+++ b/scripts/paper/generate_tablero_results_overview.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Generate a paper-facing overview table and SVG for Tablero results."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+from xml.sax.saxutils import escape
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCE_TSV = (
+    ROOT / "docs" / "engineering" / "evidence" / "phase44d-carry-aware-experimental-family-matrix-2026-04.tsv"
+)
+DEFAULT_OUT_TSV = ROOT / "docs" / "paper" / "evidence" / "tablero-results-overview-2026-04.tsv"
+DEFAULT_OUT_JSON = ROOT / "docs" / "paper" / "evidence" / "tablero-results-overview-2026-04.json"
+DEFAULT_OUT_SVG = ROOT / "docs" / "paper" / "figures" / "tablero-results-overview-2026-04.svg"
+
+REQUIRED_COLUMNS = {
+    "benchmark_version",
+    "semantic_scope",
+    "timing_mode",
+    "timing_policy",
+    "timing_unit",
+    "timing_runs",
+    "family",
+    "family_label",
+    "steps",
+    "typed_verify_ms",
+    "baseline_verify_ms",
+    "replay_ratio",
+    "typed_serialized_bytes",
+    "compact_only_verify_ms",
+    "boundary_binding_only_verify_ms",
+    "manifest_replay_only_verify_ms",
+    "checked_frontier_step",
+}
+EXPECTED_VERSION = "phase44d-carry-aware-experimental-family-matrix-v1"
+EXPECTED_SCOPE = "phase44d_typed_source_emission_boundary_layout_family_transferability_map"
+
+COLORS = {
+    "default": "#1D4ED8",
+    "2x2": "#059669",
+    "3x3": "#D97706",
+}
+
+@dataclass(frozen=True)
+class SourceRow:
+    family: str
+    family_label: str
+    steps: int
+    typed_verify_ms: float
+    baseline_verify_ms: float
+    replay_ratio: float
+    typed_serialized_bytes: int
+    compact_only_verify_ms: float
+    boundary_binding_only_verify_ms: float
+    manifest_replay_only_verify_ms: float
+    checked_frontier_step: int
+    timing_mode: str
+    timing_policy: str
+    timing_runs: int
+
+
+def read_rows(path: Path) -> List[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        actual = set(reader.fieldnames or [])
+        missing = sorted(REQUIRED_COLUMNS - actual)
+        if missing:
+            raise SystemExit(f"{path} missing required TSV columns: {missing}")
+        return list(reader)
+
+
+def parse_float(value: str, *, label: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise SystemExit(f"malformed float for {label}: {value!r}") from exc
+    if not math.isfinite(parsed):
+        raise SystemExit(f"non-finite float for {label}: {value!r}")
+    return parsed
+
+
+def parse_int(value: str, *, label: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise SystemExit(f"malformed integer for {label}: {value!r}") from exc
+
+
+def validate_and_parse(rows: List[dict[str, str]], *, source: Path) -> List[SourceRow]:
+    parsed: List[SourceRow] = []
+    seen = set()
+    for row in rows:
+        if row["benchmark_version"] != EXPECTED_VERSION:
+            raise SystemExit(f"unexpected benchmark_version in {source}: {row['benchmark_version']}")
+        if row["semantic_scope"] != EXPECTED_SCOPE:
+            raise SystemExit(f"unexpected semantic_scope in {source}: {row['semantic_scope']}")
+        if row["timing_unit"] != "milliseconds":
+            raise SystemExit(f"unexpected timing_unit in {source}: {row['timing_unit']}")
+        item = SourceRow(
+            family=row["family"].strip(),
+            family_label=row["family_label"].strip(),
+            steps=parse_int(row["steps"], label="steps"),
+            typed_verify_ms=parse_float(row["typed_verify_ms"], label="typed_verify_ms"),
+            baseline_verify_ms=parse_float(row["baseline_verify_ms"], label="baseline_verify_ms"),
+            replay_ratio=parse_float(row["replay_ratio"], label="replay_ratio"),
+            typed_serialized_bytes=parse_int(row["typed_serialized_bytes"], label="typed_serialized_bytes"),
+            compact_only_verify_ms=parse_float(row["compact_only_verify_ms"], label="compact_only_verify_ms"),
+            boundary_binding_only_verify_ms=parse_float(row["boundary_binding_only_verify_ms"], label="boundary_binding_only_verify_ms"),
+            manifest_replay_only_verify_ms=parse_float(row["manifest_replay_only_verify_ms"], label="manifest_replay_only_verify_ms"),
+            checked_frontier_step=parse_int(row["checked_frontier_step"], label="checked_frontier_step"),
+            timing_mode=row["timing_mode"].strip(),
+            timing_policy=row["timing_policy"].strip(),
+            timing_runs=parse_int(row["timing_runs"], label="timing_runs"),
+        )
+        if item.steps < 2 or item.steps & (item.steps - 1):
+            raise SystemExit(f"non-power-of-two step count in {source}: {item.steps}")
+        key = (item.family, item.steps)
+        if key in seen:
+            raise SystemExit(f"duplicate family/step row in {source}: {key}")
+        seen.add(key)
+        parsed.append(item)
+
+    by_family: Dict[str, List[SourceRow]] = {}
+    for row in parsed:
+        by_family.setdefault(row.family, []).append(row)
+
+    for family, family_rows in by_family.items():
+        family_rows.sort(key=lambda item: item.steps)
+        frontier_steps = {item.checked_frontier_step for item in family_rows}
+        if len(frontier_steps) != 1:
+            raise SystemExit(f"inconsistent frontier declaration for family {family}: {sorted(frontier_steps)}")
+        frontier = next(iter(frontier_steps))
+        if family_rows[-1].steps != frontier:
+            raise SystemExit(
+                f"family {family} declares frontier {frontier} but highest checked row is {family_rows[-1].steps}"
+            )
+        expected_steps = []
+        step = family_rows[0].steps
+        while step <= frontier:
+            expected_steps.append(step)
+            step *= 2
+        actual_steps = [item.steps for item in family_rows]
+        if actual_steps != expected_steps:
+            raise SystemExit(f"family {family} has non-contiguous power-of-two grid: {actual_steps}")
+        metadata = {(item.timing_mode, item.timing_policy, item.timing_runs) for item in family_rows}
+        if len(metadata) != 1:
+            raise SystemExit(f"family {family} has inconsistent timing metadata")
+    return parsed
+
+
+def build_overview(rows: List[SourceRow]) -> dict[str, object]:
+    by_family: Dict[str, List[SourceRow]] = {}
+    for row in rows:
+        by_family.setdefault(row.family, []).append(row)
+    for family_rows in by_family.values():
+        family_rows.sort(key=lambda item: item.steps)
+
+    frontier_bytes = []
+    overview_rows = []
+    ratio_curves = []
+    for family, family_rows in sorted(by_family.items(), key=lambda item: item[0]):
+        first = family_rows[0]
+        frontier = family_rows[-1]
+        frontier_bytes.append(frontier.typed_serialized_bytes)
+        overview_rows.append(
+            {
+                "family": family,
+                "family_label": frontier.family_label,
+                "first_checked_step": first.steps,
+                "checked_frontier": frontier.steps,
+                "first_ratio": round(first.replay_ratio, 3),
+                "frontier_ratio": round(frontier.replay_ratio, 3),
+                "ratio_growth": round(frontier.replay_ratio / first.replay_ratio, 3),
+                "typed_verify_ms": round(frontier.typed_verify_ms, 3),
+                "replay_verify_ms": round(frontier.baseline_verify_ms, 3),
+                "compact_only_ms": round(frontier.compact_only_verify_ms, 3),
+                "binding_only_ms": round(frontier.boundary_binding_only_verify_ms, 3),
+                "replay_only_ms": round(frontier.manifest_replay_only_verify_ms, 3),
+                "typed_serialized_bytes": frontier.typed_serialized_bytes,
+                "timing_mode": frontier.timing_mode,
+                "timing_policy": frontier.timing_policy,
+                "timing_runs": frontier.timing_runs,
+            }
+        )
+        ratio_curves.append(
+            {
+                "family": family,
+                "family_label": frontier.family_label,
+                "points": [{"steps": row.steps, "ratio": round(row.replay_ratio, 3)} for row in family_rows],
+            }
+        )
+
+    return {
+        "summary_version": "tablero-results-overview-v1",
+        "source_timing_policy": overview_rows[0]["timing_policy"],
+        "source_timing_mode": overview_rows[0]["timing_mode"],
+        "source_timing_runs": overview_rows[0]["timing_runs"],
+        "artifact_size_band_bytes": {
+            "min": min(frontier_bytes),
+            "max": max(frontier_bytes),
+        },
+        "families": overview_rows,
+        "ratio_curves": ratio_curves,
+        "interpretation": [
+            "The main claim is the growing-in-input-size replay-avoidance curve across checked families.",
+            "Typed-boundary artifact size stays in a narrow frontier band while verifier cost remains family dependent.",
+            "Large ratios are against the current implementation's replay baseline, not a universal lower bound and not faster FRI.",
+        ],
+    }
+
+
+def write_tsv(path: Path, summary: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "family",
+        "family_label",
+        "first_checked_step",
+        "checked_frontier",
+        "first_ratio",
+        "frontier_ratio",
+        "ratio_growth",
+        "typed_verify_ms",
+        "replay_verify_ms",
+        "compact_only_ms",
+        "binding_only_ms",
+        "replay_only_ms",
+        "typed_serialized_bytes",
+        "timing_mode",
+        "timing_policy",
+        "timing_runs",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, delimiter="\t", fieldnames=fields)
+        writer.writeheader()
+        for row in summary["families"]:
+            writer.writerow(row)
+
+
+def write_json(path: Path, summary: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def render_text(x: float, y: float, text: str, *, size: int, anchor: str = "middle", weight: str = "400", fill: str = "#0F172A") -> str:
+    return (
+        '<text x="{:.1f}" y="{:.1f}" text-anchor="{}" font-family="STIX Two Text, Georgia, serif" font-size="{}" font-weight="{}" fill="{}">{}</text>'
+    ).format(x, y, anchor, size, weight, fill, escape(text))
+
+
+def polyline(points: List[tuple[float, float]], *, color: str) -> str:
+    joined = " ".join(f"{x:.1f},{y:.1f}" for x, y in points)
+    return f'<polyline fill="none" stroke="{color}" stroke-width="4" points="{joined}" />'
+
+
+def circle(x: float, y: float, *, color: str) -> str:
+    return f'<circle cx="{x:.1f}" cy="{y:.1f}" r="5.5" fill="{color}" stroke="#ffffff" stroke-width="1.5" />'
+
+
+def render_svg(path: Path, summary: dict[str, object]) -> None:
+    width = 1800
+    height = 1120
+    left = 90
+    top = 170
+    chart_w = 920
+    chart_h = 420
+    right_x = 1090
+    ratio_curves = summary["ratio_curves"]
+    all_steps = sorted({point["steps"] for curve in ratio_curves for point in curve["points"]})
+    all_ratios = [point["ratio"] for curve in ratio_curves for point in curve["points"]]
+    min_ratio = min(all_ratios)
+    max_ratio = max(all_ratios)
+
+    def x_pos(steps: int) -> float:
+        idx = all_steps.index(steps)
+        return left + idx * (chart_w / max(1, len(all_steps) - 1))
+
+    def y_pos(ratio: float) -> float:
+        return top + chart_h - ((ratio - min_ratio) / (max_ratio - min_ratio)) * chart_h
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="#F8FAFC" />',
+        render_text(width / 2, 60, 'Tablero Results Overview', size=32, weight='700'),
+        render_text(width / 2, 95, 'Growing replay-avoidance curves across checked families, with a near-constant frontier artifact-size band.', size=16, fill='#334155'),
+        '<rect x="60" y="120" width="1680" height="470" rx="22" fill="#FFFFFF" stroke="#CBD5E1" />',
+        render_text(520, 150, 'Replay-avoidance ratio vs checked input length', size=20, weight='700'),
+        '<line x1="90" y1="170" x2="90" y2="590" stroke="#94A3B8" stroke-width="1.5" />',
+        '<line x1="90" y1="590" x2="1010" y2="590" stroke="#94A3B8" stroke-width="1.5" />',
+    ]
+    for tick in [0.0, 0.25, 0.5, 0.75, 1.0]:
+        value = min_ratio + (max_ratio - min_ratio) * tick
+        y = top + chart_h - tick * chart_h
+        parts.append(f'<line x1="90" y1="{y:.1f}" x2="1010" y2="{y:.1f}" stroke="#E2E8F0" stroke-width="1" />')
+        parts.append(render_text(78, y + 5, f'{value:.0f}x', size=13, anchor='end', fill='#475569'))
+    for step in all_steps:
+        x = x_pos(step)
+        parts.append(f'<line x1="{x:.1f}" y1="590" x2="{x:.1f}" y2="598" stroke="#64748B" stroke-width="1.5" />')
+        parts.append(render_text(x, 622, str(step), size=13, fill='#475569'))
+    parts.append(render_text(550, 650, 'Checked input length', size=14, fill='#334155'))
+    parts.append(render_text(20, 380, 'Replay ratio', size=14, anchor='start', fill='#334155'))
+
+    legend_y = 545
+    legend_x = 120
+    for curve in ratio_curves:
+        color = COLORS[curve['family']]
+        points = [(x_pos(point['steps']), y_pos(point['ratio'])) for point in curve['points']]
+        parts.append(polyline(points, color=color))
+        for x, y in points:
+            parts.append(circle(x, y, color=color))
+        parts.append(f'<line x1="{legend_x}" y1="{legend_y}" x2="{legend_x + 28}" y2="{legend_y}" stroke="{color}" stroke-width="4" />')
+        parts.append(render_text(legend_x + 40, legend_y + 5, curve['family_label'], size=14, anchor='start', fill='#334155'))
+        legend_x += 220
+
+    parts.extend([
+        render_text(1390, 150, 'Frontier summary', size=20, weight='700'),
+        '<rect x="1060" y="180" width="640" height="360" rx="18" fill="#F8FAFC" stroke="#CBD5E1" />',
+    ])
+    header_y = 220
+    parts.append(render_text(1110, header_y, 'Family', size=14, anchor='start', weight='700'))
+    parts.append(render_text(1340, header_y, 'Frontier', size=14, anchor='middle', weight='700'))
+    parts.append(render_text(1510, header_y, 'Ratio', size=14, anchor='middle', weight='700'))
+    parts.append(render_text(1650, header_y, 'Typed verify', size=14, anchor='middle', weight='700'))
+    row_y = 260
+    for row in summary['families']:
+        color = COLORS[row['family']]
+        parts.append(f'<rect x="1085" y="{row_y - 20}" width="10" height="10" rx="2" fill="{color}" />')
+        parts.append(render_text(1110, row_y - 10, row['family_label'], size=15, anchor='start'))
+        parts.append(render_text(1340, row_y - 10, str(row['checked_frontier']), size=15))
+        parts.append(render_text(1510, row_y - 10, f"{row['frontier_ratio']:.1f}x", size=15, weight='700'))
+        parts.append(render_text(1650, row_y - 10, f"{row['typed_verify_ms']:.3f} ms", size=15))
+        parts.append(render_text(1110, row_y + 14, f"Replay baseline {row['replay_verify_ms']:.3f} ms", size=13, anchor='start', fill='#475569'))
+        parts.append(render_text(1410, row_y + 14, f"Boundary bytes {row['typed_serialized_bytes']:,}", size=13, anchor='start', fill='#475569'))
+        row_y += 92
+
+    band = summary['artifact_size_band_bytes']
+    parts.extend([
+        '<rect x="60" y="630" width="1680" height="390" rx="22" fill="#FFFFFF" stroke="#CBD5E1" />',
+        render_text(900, 670, 'How to read the result', size=22, weight='700'),
+        render_text(120, 730, '1. The main result is the curve shape: every checked family shows a replay-avoidance ratio that grows with input length.', size=16, anchor='start', fill='#334155'),
+        render_text(120, 770, f"2. Frontier boundary artifact size stays in a narrow band: {band['min']:,} to {band['max']:,} bytes.", size=16, anchor='start', fill='#334155'),
+        render_text(120, 810, '3. Boundary verify cost is not family-constant; the artifact size is the near-constant property.', size=16, anchor='start', fill='#334155'),
+        render_text(120, 850, '4. Large ratios come from removing verifier-side replay work in the current implementation, not from faster FRI.', size=16, anchor='start', fill='#334155'),
+        render_text(120, 890, '5. The strongest claim is replay replacement with preserved statement scope, not a universal speedup story.', size=16, anchor='start', fill='#334155'),
+        render_text(120, 955, 'Checked evidence source: machine-readable family-matrix benchmark with median-of-five timings.', size=15, anchor='start', fill='#475569'),
+    ])
+    parts.append('</svg>')
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(parts) + "\n", encoding="utf-8")
+
+
+def generate(source_tsv: Path, out_tsv: Path, out_json: Path, out_svg: Path) -> None:
+    rows = validate_and_parse(read_rows(source_tsv), source=source_tsv)
+    summary = build_overview(rows)
+    write_tsv(out_tsv, summary)
+    write_json(out_json, summary)
+    render_svg(out_svg, summary)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-tsv", type=Path, default=DEFAULT_SOURCE_TSV)
+    parser.add_argument("--out-tsv", type=Path, default=DEFAULT_OUT_TSV)
+    parser.add_argument("--out-json", type=Path, default=DEFAULT_OUT_JSON)
+    parser.add_argument("--out-svg", type=Path, default=DEFAULT_OUT_SVG)
+    args = parser.parse_args()
+    generate(args.source_tsv, args.out_tsv, args.out_json, args.out_svg)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/paper/paper_preflight.py
+++ b/scripts/paper/paper_preflight.py
@@ -29,10 +29,22 @@ PUBLICATION_METADATA_FILES = [
 ]
 
 PAPER_FILES = [
+    "docs/paper/abstract-tablero-2026.md",
     "docs/paper/tablero-typed-verifier-boundaries-2026.md",
     "docs/paper/appendix-tablero-claim-boundary.md",
+    "docs/paper/appendix-methodology-and-reproducibility.md",
     "docs/paper/appendix-system-comparison.md",
     *PUBLICATION_METADATA_FILES,
+]
+
+PRIMARY_PRESENTATION_FILES = [
+    "docs/paper/abstract-tablero-2026.md",
+    "docs/paper/tablero-typed-verifier-boundaries-2026.md",
+    "docs/paper/appendix-tablero-claim-boundary.md",
+    "docs/paper/appendix-methodology-and-reproducibility.md",
+    "docs/paper/appendix-system-comparison.md",
+    "docs/paper/PUBLICATION_RELEASE.md",
+    "docs/paper/README.md",
 ]
 
 SNAPSHOT_FIELD_PREFIXES = (
@@ -169,6 +181,15 @@ CLAIM_LANGUAGE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
         ),
     ),
 )
+
+INTERNAL_PHASE_PATTERN = re.compile(r"\b[Pp]hase\d+[A-Za-z]?\b")
+REQUIRED_PRIMARY_LINKS = {
+    "docs/paper/tablero-typed-verifier-boundaries-2026.md": [
+        "abstract-tablero-2026.md",
+        "appendix-methodology-and-reproducibility.md",
+        "figures/tablero-results-overview-2026-04.svg",
+    ],
+}
 
 
 @dataclass
@@ -339,6 +360,29 @@ def run_file_checks(file_path: pathlib.Path, repo_root: pathlib.Path, findings: 
     links = extract_markdown_links(text)
     check_local_relative_links(file_path, links, findings)
     check_immutable_local_repo_links(file_path, links, repo_root, findings)
+
+
+def check_primary_presentation_guardrails(repo_root: pathlib.Path, findings: Findings) -> None:
+    for rel_path in PRIMARY_PRESENTATION_FILES:
+        path = repo_root / rel_path
+        if not path.exists():
+            findings.error(f"{path}: missing primary presentation file.")
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            findings.error(f"{path}: failed to read primary presentation file: {exc}")
+            continue
+        match = INTERNAL_PHASE_PATTERN.search(text)
+        if match:
+            findings.error(
+                f"{path}: internal phase-style terminology leaked into primary presentation copy: {match.group(0)}"
+            )
+        for required_link in REQUIRED_PRIMARY_LINKS.get(rel_path, []):
+            if required_link not in text:
+                findings.error(
+                    f"{path}: missing required presentation link `{required_link}`."
+                )
 
 
 def check_appendix_source_note(repo_root: pathlib.Path, findings: Findings) -> None:
@@ -1514,6 +1558,7 @@ def main() -> int:
             continue
         run_file_checks(path, repo_root, findings)
 
+    check_primary_presentation_guardrails(repo_root, findings)
     check_appendix_source_note(repo_root, findings)
     check_backend_appendix_consistency(repo_root, findings)
     check_publication_snapshot_placeholders(repo_root, findings)

--- a/scripts/paper/tests/test_generate_tablero_results_overview.py
+++ b/scripts/paper/tests/test_generate_tablero_results_overview.py
@@ -1,0 +1,103 @@
+import csv
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+def load_module():
+    root = pathlib.Path(__file__).resolve().parents[3]
+    module_path = root / "scripts/paper/generate_tablero_results_overview.py"
+    spec = importlib.util.spec_from_file_location("generate_tablero_results_overview", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load overview generator")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MOD = load_module()
+
+HEADERS = [
+    "benchmark_version",
+    "semantic_scope",
+    "timing_mode",
+    "timing_policy",
+    "timing_unit",
+    "timing_runs",
+    "family",
+    "family_label",
+    "steps",
+    "typed_verify_ms",
+    "baseline_verify_ms",
+    "replay_ratio",
+    "typed_serialized_bytes",
+    "compact_only_verify_ms",
+    "boundary_binding_only_verify_ms",
+    "manifest_replay_only_verify_ms",
+    "checked_frontier_step",
+]
+
+
+def write_rows(path: pathlib.Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, delimiter="\t", fieldnames=HEADERS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def sample_rows() -> list[dict[str, object]]:
+    base = {
+        "benchmark_version": MOD.EXPECTED_VERSION,
+        "semantic_scope": MOD.EXPECTED_SCOPE,
+        "timing_mode": "measured_median",
+        "timing_policy": "median_of_5_runs_from_microsecond_capture",
+        "timing_unit": "milliseconds",
+        "timing_runs": 5,
+    }
+    return [
+        {**base, "family": "default", "family_label": "Default layout", "steps": 2, "typed_verify_ms": 10.0, "baseline_verify_ms": 200.0, "replay_ratio": 20.0, "typed_serialized_bytes": 6500, "compact_only_verify_ms": 4.0, "boundary_binding_only_verify_ms": 5.0, "manifest_replay_only_verify_ms": 190.0, "checked_frontier_step": 4},
+        {**base, "family": "default", "family_label": "Default layout", "steps": 4, "typed_verify_ms": 20.0, "baseline_verify_ms": 800.0, "replay_ratio": 40.0, "typed_serialized_bytes": 6600, "compact_only_verify_ms": 6.0, "boundary_binding_only_verify_ms": 10.0, "manifest_replay_only_verify_ms": 780.0, "checked_frontier_step": 4},
+        {**base, "family": "2x2", "family_label": "2x2 layout", "steps": 2, "typed_verify_ms": 1.0, "baseline_verify_ms": 25.0, "replay_ratio": 25.0, "typed_serialized_bytes": 6400, "compact_only_verify_ms": 0.4, "boundary_binding_only_verify_ms": 0.5, "manifest_replay_only_verify_ms": 24.0, "checked_frontier_step": 4},
+        {**base, "family": "2x2", "family_label": "2x2 layout", "steps": 4, "typed_verify_ms": 2.0, "baseline_verify_ms": 100.0, "replay_ratio": 50.0, "typed_serialized_bytes": 6450, "compact_only_verify_ms": 0.8, "boundary_binding_only_verify_ms": 1.0, "manifest_replay_only_verify_ms": 98.0, "checked_frontier_step": 4},
+    ]
+
+
+class GenerateTableroResultsOverviewTests(unittest.TestCase):
+    def test_generate_writes_expected_outputs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            source = root / "source.tsv"
+            out_tsv = root / "out.tsv"
+            out_json = root / "out.json"
+            out_svg = root / "out.svg"
+            write_rows(source, sample_rows())
+            MOD.generate(source, out_tsv, out_json, out_svg)
+            self.assertTrue(out_tsv.exists())
+            self.assertTrue(out_json.exists())
+            self.assertTrue(out_svg.exists())
+            summary = json.loads(out_json.read_text(encoding="utf-8"))
+            self.assertEqual(summary["artifact_size_band_bytes"]["min"], 6450)
+            self.assertEqual(summary["artifact_size_band_bytes"]["max"], 6600)
+            self.assertEqual(len(summary["families"]), 2)
+            self.assertIn("Replay-avoidance", out_svg.read_text(encoding="utf-8"))
+
+    def test_generate_rejects_missing_frontier_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            source = root / "source.tsv"
+            rows = sample_rows()
+            rows[1]["checked_frontier_step"] = 8
+            write_rows(source, rows)
+            with self.assertRaises(SystemExit) as ctx:
+                MOD.generate(source, root / "out.tsv", root / "out.json", root / "out.svg")
+            self.assertIn("frontier", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/paper/tests/test_paper_preflight.py
+++ b/scripts/paper/tests/test_paper_preflight.py
@@ -1085,7 +1085,40 @@ class PaperPreflightTests(unittest.TestCase):
                 any("missing docs/paper directory" in msg for msg in findings.errors),
                 findings.errors,
             )
+    def test_primary_presentation_guardrails_reject_internal_phase_language(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            for rel_path in MOD.PRIMARY_PRESENTATION_FILES:
+                write_text(repo / rel_path, "# Placeholder\n")
+            write_text(
+                repo / 'docs/paper/tablero-typed-verifier-boundaries-2026.md',
+                "See [abstract](abstract-tablero-2026.md) and [method]"
+                "(appendix-methodology-and-reproducibility.md) and "
+                "![overview](figures/tablero-results-overview-2026-04.svg).\n"
+                "Phase44D leaks here.\n",
+            )
+            findings = MOD.Findings()
+            MOD.check_primary_presentation_guardrails(repo, findings)
+            self.assertTrue(findings.errors)
+            self.assertIn("internal phase-style terminology leaked", findings.errors[0])
 
+    def test_primary_presentation_guardrails_require_core_links(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = pathlib.Path(tmp)
+            for rel_path in MOD.PRIMARY_PRESENTATION_FILES:
+                write_text(repo / rel_path, "# Placeholder\n")
+            write_text(
+                repo / "docs/paper/tablero-typed-verifier-boundaries-2026.md",
+                "No required links here.\n",
+            )
+            findings = MOD.Findings()
+            MOD.check_primary_presentation_guardrails(repo, findings)
+            self.assertTrue(
+                any(
+                    "missing required presentation link" in error
+                    for error in findings.errors
+                )
+            )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a short submission-ready abstract and a methodology appendix for the presentation paper
- generate a checked paper-facing results overview table, JSON summary, and SVG figure from the family-matrix evidence
- harden paper preflight so the primary presentation package rejects leaked internal phase terminology and missing core links

## Validation
- `python3 -m py_compile scripts/paper/paper_preflight.py scripts/paper/generate_tablero_results_overview.py`
- `python3 -m unittest scripts.paper.tests.test_paper_preflight scripts.paper.tests.test_generate_tablero_results_overview`
- `python3 scripts/paper/generate_tablero_results_overview.py`
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `git diff --check`

## Why this improves the paper
- the package now has a submission-length abstract, not just the full paper draft
- the paper now has a single canonical results overview figure backed by checked evidence
- the methodology and interpretation caveats are explicit and separate from the main narrative
- the paper preflight now fails if primary presentation copy leaks internal phase-style naming back into the package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added abstract document for compact submission use.
  * Added methodology and reproducibility appendix defining evidence categories and measurement policies.
  * Updated README with recommended presentation reading order.
  * Updated publication release documentation.
  * Added cross-family results overview figure to main paper document.

* **New Features**
  * Added results overview generation script for producing summary tables and visualizations.

* **Tests**
  * Added test coverage for results generation and documentation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->