### PR TITLE
chore: ignore local .venv for Python evidence tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 __pycache__/
 *.pyc
+.venv/
 scripts/node_modules/
 .agents/
 .claude/


### PR DESCRIPTION
Adds `.venv/` to `.gitignore` so local matplotlib/numpy virtualenvs used for Phase44D evidence scripts are not offered as accidental commits.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude virtual environment directory from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->