### PR TITLE
[codex] Add Stwo zkAI transformer-block gate

### DIFF
--- a/docs/engineering/agent-step-zkai-stwo-composition-gate-2026-04-29.md
+++ b/docs/engineering/agent-step-zkai-stwo-composition-gate-2026-04-29.md
@@ -158,5 +158,7 @@ python3 -m unittest \
 
 The immediate nested-subreceipt verifier callback hardening is implemented in
 `docs/engineering/agent-step-model-subreceipt-callback-gate-2026-04-29.md` and
-now exercised by this gate. The next useful research step is a larger
-Stwo-native statement-bound transformer block, not another callback seam.
+now exercised by this gate. The next research step is pinned in
+`docs/engineering/zkai-stwo-statement-bound-transformer-block-gate-2026-04-30.md`:
+a larger Stwo-native statement-bound transformer block, not another callback
+seam.

--- a/docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-plan-2026-04.json
+++ b/docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-plan-2026-04.json
@@ -1,0 +1,144 @@
+{
+  "schema": "zkai-stwo-statement-bound-transformer-block-plan-v1",
+  "date": "2026-04-30",
+  "status": "design_gate",
+  "decision": "GO_TO_IMPLEMENTATION_ONLY_AFTER_CRITERIA_ARE_MET",
+  "current_baseline": {
+    "statement_receipt_schema": "zkai-statement-receipt-v1",
+    "proof_system": "stwo-transparent-stark",
+    "proof_system_version": "stwo-phase10-linear-block-v4-with-lookup",
+    "verifier_domain": "ptvm-stwo-verify-stark-reexecute-stwo-phase10-linear-block-v4-with-lookup",
+    "statement_kind": "transformer-primitive",
+    "model_id": "urn:zkai:ptvm:linear-block-v4-with-lookup",
+    "evidence": [
+      "docs/engineering/zkai-stwo-statement-bound-primitive-gate-2026-04-29.md",
+      "docs/engineering/evidence/zkai-stwo-statement-envelope-benchmark-2026-04.json",
+      "docs/engineering/agent-step-zkai-stwo-composition-gate-2026-04-29.md",
+      "docs/engineering/evidence/agent-step-zkai-stwo-composition-2026-04.json"
+    ],
+    "mutation_result": {
+      "proof_only": {
+        "decision": "NO_GO_FOR_METADATA_RELABELING_BY_ITSELF",
+        "mutations_rejected": 1,
+        "mutations_checked": 14
+      },
+      "statement_envelope": {
+        "decision": "GO_FOR_STATEMENT_BINDING",
+        "mutations_rejected": 14,
+        "mutations_checked": 14
+      }
+    },
+    "agent_composition_result": {
+      "decision": "GO_FOR_NESTED_STATEMENT_RECEIPT_CALLBACK",
+      "mutations_rejected": 36,
+      "mutations_checked": 36
+    }
+  },
+  "target": {
+    "name": "rmsnorm-affine-residual-block-v1",
+    "statement_kind": "transformer-block",
+    "purpose": "prove one small transformer-shaped block while binding the proof to model, input, output, config, public instance, verifier identity, and evidence manifest labels",
+    "width": 4,
+    "integer_domain": "signed fixed-width quantized M31-compatible integers",
+    "operations": [
+      {
+        "id": "rmsnorm_scale_lookup",
+        "description": "bind a fixed-width normalization denominator or scale lookup to the block config and input vector"
+      },
+      {
+        "id": "quantized_affine_projection",
+        "description": "apply a committed quantized weight matrix and bias vector to the normalized vector"
+      },
+      {
+        "id": "residual_add",
+        "description": "add the original input vector back into the projected vector with explicit range and overflow policy"
+      }
+    ],
+    "public_commitments": [
+      "model_artifact_commitment",
+      "model_config_commitment",
+      "input_commitment",
+      "output_commitment",
+      "public_instance_commitment",
+      "proof_commitment",
+      "verifying_key_commitment",
+      "setup_commitment",
+      "verifier_domain",
+      "proof_system_version",
+      "evidence_manifest_commitment"
+    ],
+    "minimum_artifacts": [
+      "program_or_air_identifier",
+      "model_weights_fixture",
+      "input_vector_fixture",
+      "output_vector_fixture",
+      "proof_object",
+      "statement_receipt",
+      "mutation_suite"
+    ]
+  },
+  "go_criteria": [
+    {
+      "id": "native_stwo_proof_accepts_honest_block",
+      "criterion": "A native Stwo verifier accepts one honest transformer-block instance with the declared width, operations, and public instance."
+    },
+    {
+      "id": "receipt_binds_all_public_commitments",
+      "criterion": "The zkAI statement receipt binds every target.public_commitments field into the statement commitment."
+    },
+    {
+      "id": "relabeling_suite_rejects_all_statement_mutations",
+      "criterion": "The mutation suite rejects model, input, output, config, proof, public-instance, verifier-domain, proof-system-version, setup, verifying-key, and evidence-manifest relabeling."
+    },
+    {
+      "id": "agent_step_composition_accepts_baseline",
+      "criterion": "The composed agent-step receipt accepts the honest transformer-block statement receipt as its model subreceipt."
+    },
+    {
+      "id": "agent_step_composition_rejects_nested_relabels",
+      "criterion": "At least one nested statement-receipt relabeling and one cross-layer agent-field relabeling are rejected through the Rust callback path."
+    }
+  ],
+  "no_go_criteria": [
+    {
+      "id": "proof_generator_cannot_emit_block_proof",
+      "criterion": "If the Stwo path cannot emit an honest proof for the declared block without removing normalization or residual semantics, stop and record a NO-GO."
+    },
+    {
+      "id": "verifier_accepts_statement_relabeling",
+      "criterion": "If any statement receipt mutation is accepted after recomputing unrelated digests, stop and record a NO-GO."
+    },
+    {
+      "id": "target_collapses_to_linear_toy",
+      "criterion": "If the target drops both normalization and residual structure, stop and do not present it as a transformer-block result."
+    },
+    {
+      "id": "public_instance_not_bound",
+      "criterion": "If the verifier accepts a proof whose public instance no longer matches the receipt commitment, stop and record a NO-GO."
+    }
+  ],
+  "non_claims": [
+    "This is not full transformer inference.",
+    "This is not an agent reasoning proof.",
+    "This is not a throughput or latency benchmark.",
+    "This is not backend independence.",
+    "This is not recursive or on-chain verification.",
+    "This does not claim that the existing linear-block primitive already proves transformer-block semantics.",
+    "This does not claim model truthfulness, policy compliance, or tool-output truth."
+  ],
+  "validation_commands": [
+    "python3 scripts/zkai_stwo_transformer_block_plan.py --json",
+    "python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan"
+  ],
+  "next_implementation_pr": {
+    "title": "Implement Stwo zkAI statement-bound transformer-block harness",
+    "minimum_scope": [
+      "honest fixture generation",
+      "native Stwo proof verification for the declared block",
+      "statement receipt construction",
+      "statement relabeling mutation suite",
+      "agent-step callback composition check"
+    ],
+    "merge_blocker": "Do not merge an implementation PR as GO unless all go_criteria pass and no_go_criteria remain false."
+  }
+}

--- a/docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-plan-2026-04.json
+++ b/docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-plan-2026-04.json
@@ -132,6 +132,13 @@
     "just gate-fast",
     "just gate"
   ],
+  "validation_command_alternatives": [
+    {
+      "instead_of": "just gate",
+      "command": "just gate-no-nightly",
+      "condition": "Use only when the pinned nightly toolchain is unavailable."
+    }
+  ],
   "next_implementation_pr": {
     "title": "Implement Stwo zkAI statement-bound transformer-block harness",
     "minimum_scope": [

--- a/docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-plan-2026-04.json
+++ b/docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-plan-2026-04.json
@@ -128,7 +128,9 @@
   ],
   "validation_commands": [
     "python3 scripts/zkai_stwo_transformer_block_plan.py --json",
-    "python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan scripts.tests.test_zkai_stwo_statement_envelope_benchmark scripts.tests.test_agent_step_zkai_stwo_composition"
+    "python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan scripts.tests.test_zkai_stwo_statement_envelope_benchmark scripts.tests.test_agent_step_zkai_stwo_composition",
+    "just gate-fast",
+    "just gate"
   ],
   "next_implementation_pr": {
     "title": "Implement Stwo zkAI statement-bound transformer-block harness",

--- a/docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-plan-2026-04.json
+++ b/docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-plan-2026-04.json
@@ -128,7 +128,7 @@
   ],
   "validation_commands": [
     "python3 scripts/zkai_stwo_transformer_block_plan.py --json",
-    "python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan"
+    "python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan scripts.tests.test_zkai_stwo_statement_envelope_benchmark scripts.tests.test_agent_step_zkai_stwo_composition"
   ],
   "next_implementation_pr": {
     "title": "Implement Stwo zkAI statement-bound transformer-block harness",

--- a/docs/engineering/zkai-stwo-statement-bound-primitive-gate-2026-04-29.md
+++ b/docs/engineering/zkai-stwo-statement-bound-primitive-gate-2026-04-29.md
@@ -118,8 +118,10 @@ The agent/action receipt follow-up has landed: the checked Stwo statement
 receipt is consumed as a proved model subreceipt, and the Rust callback verifier
 now validates that nested receipt against the outer agent receipt fields.
 
-The next useful step is to move from this bounded primitive to a Stwo-native
-statement-bound block with more transformer structure and the same receipt
+The next useful step is now pinned in
+`docs/engineering/zkai-stwo-statement-bound-transformer-block-gate-2026-04-30.md`:
+move from this bounded primitive to a width-4 Stwo-native statement-bound block
+with normalization, affine projection, residual structure, and the same receipt
 discipline.
 
 Do not use this gate to claim end-to-end verifiable intelligence. It is one

--- a/docs/engineering/zkai-stwo-statement-bound-transformer-block-gate-2026-04-30.md
+++ b/docs/engineering/zkai-stwo-statement-bound-transformer-block-gate-2026-04-30.md
@@ -120,6 +120,13 @@ Validate the gate plan:
 python3 scripts/zkai_stwo_transformer_block_plan.py --json
 ```
 
+Repository gates:
+
+```bash
+just gate-fast
+just gate
+```
+
 ## Non-claims
 
 - This is not full transformer inference.

--- a/docs/engineering/zkai-stwo-statement-bound-transformer-block-gate-2026-04-30.md
+++ b/docs/engineering/zkai-stwo-statement-bound-transformer-block-gate-2026-04-30.md
@@ -1,0 +1,142 @@
+# zkAI Stwo statement-bound transformer-block gate - 2026-04-30
+
+## Question
+
+Define the smallest honest next target after the checked Stwo
+linear-block-with-lookup statement receipt:
+
+> Can this repository produce a Stwo-native statement-bound proof for one
+> transformer-shaped block, while preserving the relabeling rejection discipline
+> already checked for external adapters, the native Stwo primitive, and the
+> composed agent-step receipt?
+
+This is a design and implementation gate. It is not yet a proof result.
+
+## Current baseline
+
+The current checked native Stwo result is intentionally smaller:
+
+- proof system: `stwo-transparent-stark`
+- proof-system version: `stwo-phase10-linear-block-v4-with-lookup`
+- statement kind: `transformer-primitive`
+- model ID: `urn:zkai:ptvm:linear-block-v4-with-lookup`
+- checked statement-envelope result: raw proof-only verification rejects
+  `1 / 14` checked relabels, while the statement envelope rejects `14 / 14`
+- checked agent composition result: the composed receipt rejects `36 / 36`
+  checked nested and cross-layer mutations
+
+The baseline establishes the binding lesson:
+
+> proof validity is not statement validity.
+
+It does not establish transformer-block semantics.
+
+## Target
+
+The next target is:
+
+- name: `rmsnorm-affine-residual-block-v1`
+- statement kind: `transformer-block`
+- width: `4`
+- integer domain: signed fixed-width quantized M31-compatible integers
+- required operations:
+  - `rmsnorm_scale_lookup`
+  - `quantized_affine_projection`
+  - `residual_add`
+
+The target is deliberately small. A width-4 block is large enough to include
+real transformer structure and small enough to keep proof-generation debugging
+bounded.
+
+## Binding surface
+
+The statement receipt must bind at least these public fields:
+
+- `model_artifact_commitment`
+- `model_config_commitment`
+- `input_commitment`
+- `output_commitment`
+- `public_instance_commitment`
+- `proof_commitment`
+- `verifying_key_commitment`
+- `setup_commitment`
+- `verifier_domain`
+- `proof_system_version`
+- `evidence_manifest_commitment`
+
+The implementation should reject a relabeling of any of these fields after
+recomputing unrelated wrapper digests.
+
+## GO criteria
+
+This track is a GO only if all of the following pass:
+
+1. A native Stwo verifier accepts one honest transformer-block instance with the
+   declared width, operations, and public instance.
+2. The zkAI statement receipt binds every public commitment listed above.
+3. The mutation suite rejects model, input, output, config, proof,
+   public-instance, verifier-domain, proof-system-version, setup,
+   verifying-key, and evidence-manifest relabeling.
+4. The composed agent-step receipt accepts the honest transformer-block
+   statement receipt as its model subreceipt.
+5. The Rust callback path rejects at least one nested statement-receipt
+   relabeling and one cross-layer agent-field relabeling.
+
+## NO-GO criteria
+
+Stop and record a NO-GO if any of these happen:
+
+1. The Stwo path cannot emit an honest proof for the declared block without
+   removing normalization or residual semantics.
+2. The verifier accepts any statement-receipt mutation after recomputing
+   unrelated digests.
+3. The target collapses into a plain linear toy by dropping both normalization
+   and residual structure.
+4. The verifier accepts a proof whose public instance no longer matches the
+   receipt commitment.
+
+## Artifacts
+
+The machine-readable gate is:
+
+- `docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-plan-2026-04.json`
+
+The validator is:
+
+- `scripts/zkai_stwo_transformer_block_plan.py`
+
+Focused tests:
+
+```bash
+python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan
+```
+
+Validate the gate plan:
+
+```bash
+python3 scripts/zkai_stwo_transformer_block_plan.py --json
+```
+
+## Non-claims
+
+- This is not full transformer inference.
+- This is not an agent reasoning proof.
+- This is not a throughput or latency benchmark.
+- This is not backend independence.
+- This is not recursive or on-chain verification.
+- This does not claim that the existing linear-block primitive already proves
+  transformer-block semantics.
+- This does not claim model truthfulness, policy compliance, or tool-output
+  truth.
+
+## Next implementation PR
+
+The next PR should implement the bounded harness, not expand the claim:
+
+1. Build one honest width-4 fixture.
+2. Generate or load one native Stwo proof for the declared block.
+3. Construct a `zkai-statement-receipt-v1` for that proof.
+4. Run a statement-relabeling mutation suite.
+5. Compose the checked statement receipt into the agent-step receipt callback
+   path.
+6. Record GO or NO-GO explicitly.

--- a/docs/engineering/zkai-stwo-statement-bound-transformer-block-gate-2026-04-30.md
+++ b/docs/engineering/zkai-stwo-statement-bound-transformer-block-gate-2026-04-30.md
@@ -127,6 +127,10 @@ just gate-fast
 just gate
 ```
 
+If the pinned nightly toolchain is unavailable, use `just gate-no-nightly` as
+the final command instead of `just gate`; do not run additional validation
+commands after the final repo gate.
+
 ## Non-claims
 
 - This is not full transformer inference.

--- a/docs/engineering/zkai-stwo-statement-bound-transformer-block-gate-2026-04-30.md
+++ b/docs/engineering/zkai-stwo-statement-bound-transformer-block-gate-2026-04-30.md
@@ -108,7 +108,10 @@ The validator is:
 Focused tests:
 
 ```bash
-python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan
+python3 -m unittest \
+  scripts.tests.test_zkai_stwo_transformer_block_plan \
+  scripts.tests.test_zkai_stwo_statement_envelope_benchmark \
+  scripts.tests.test_agent_step_zkai_stwo_composition
 ```
 
 Validate the gate plan:

--- a/scripts/tests/test_zkai_stwo_transformer_block_plan.py
+++ b/scripts/tests/test_zkai_stwo_transformer_block_plan.py
@@ -120,6 +120,66 @@ class ZkAIStwoTransformerBlockPlanTests(unittest.TestCase):
         with self.assertRaisesRegex(PLAN.PlanValidationError, "proof-only baseline"):
             PLAN.validate_plan(plan)
 
+    def test_plan_rejects_baseline_proof_system_version_drift(self) -> None:
+        plan = self._plan()
+        plan["current_baseline"]["proof_system_version"] = "stwo-phase999-invalid"
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "proof_system_version"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_rejects_statement_corpus_size_weakening(self) -> None:
+        plan = self._plan()
+        plan["current_baseline"]["mutation_result"]["statement_envelope"][
+            "mutations_checked"
+        ] = 1
+        plan["current_baseline"]["mutation_result"]["statement_envelope"][
+            "mutations_rejected"
+        ] = 1
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "statement-envelope baseline"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_rejects_proof_only_corpus_size_drift(self) -> None:
+        plan = self._plan()
+        plan["current_baseline"]["mutation_result"]["proof_only"][
+            "mutations_checked"
+        ] = 1
+        plan["current_baseline"]["mutation_result"]["proof_only"][
+            "mutations_rejected"
+        ] = 1
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "proof-only baseline"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_rejects_agent_composition_corpus_size_weakening(self) -> None:
+        plan = self._plan()
+        plan["current_baseline"]["agent_composition_result"][
+            "mutations_checked"
+        ] = 1
+        plan["current_baseline"]["agent_composition_result"][
+            "mutations_rejected"
+        ] = 1
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "agent composition baseline"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_rejects_validation_command_coverage_weakening(self) -> None:
+        plan = self._plan()
+        plan["validation_commands"] = [
+            "python3 scripts/zkai_stwo_transformer_block_plan.py --json",
+            "python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan",
+        ]
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "test_zkai_stwo_statement_envelope"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_rejects_non_string_validation_command_cleanly(self) -> None:
+        plan = self._plan()
+        plan["validation_commands"].append({"bad": "shape"})
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "validation_commands"):
+            PLAN.validate_plan(plan)
+
     def test_plan_rejects_non_string_non_claim_cleanly(self) -> None:
         plan = self._plan()
         plan["non_claims"].append({"not": "a string"})

--- a/scripts/tests/test_zkai_stwo_transformer_block_plan.py
+++ b/scripts/tests/test_zkai_stwo_transformer_block_plan.py
@@ -67,6 +67,13 @@ class ZkAIStwoTransformerBlockPlanTests(unittest.TestCase):
         with self.assertRaisesRegex(PLAN.PlanValidationError, "public_instance_commitment"):
             PLAN.validate_plan(plan)
 
+    def test_plan_rejects_unhashable_public_commitment_cleanly(self) -> None:
+        plan = self._plan()
+        plan["target"]["public_commitments"].append({"bad": "shape"})
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "public_commitments"):
+            PLAN.validate_plan(plan)
+
     def test_plan_requires_relabeling_go_criterion(self) -> None:
         plan = self._plan()
         plan["go_criteria"] = [
@@ -111,6 +118,13 @@ class ZkAIStwoTransformerBlockPlanTests(unittest.TestCase):
         ] = "GO_FOR_STATEMENT_BINDING"
 
         with self.assertRaisesRegex(PLAN.PlanValidationError, "proof-only baseline"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_rejects_non_string_non_claim_cleanly(self) -> None:
+        plan = self._plan()
+        plan["non_claims"].append({"not": "a string"})
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "non_claims"):
             PLAN.validate_plan(plan)
 
     def test_main_returns_failure_on_malformed_plan_file(self) -> None:

--- a/scripts/tests/test_zkai_stwo_transformer_block_plan.py
+++ b/scripts/tests/test_zkai_stwo_transformer_block_plan.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+PLAN_PATH = ROOT / "scripts" / "zkai_stwo_transformer_block_plan.py"
+SPEC = importlib.util.spec_from_file_location("zkai_stwo_transformer_block_plan", PLAN_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load transformer-block plan validator from {PLAN_PATH}")
+PLAN = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = PLAN
+SPEC.loader.exec_module(PLAN)
+
+
+class ZkAIStwoTransformerBlockPlanTests(unittest.TestCase):
+    def _plan(self) -> dict:
+        return PLAN.load_plan()
+
+    def test_checked_plan_validates_and_summarizes_gate(self) -> None:
+        summary = PLAN.validate_plan(self._plan())
+
+        self.assertEqual(summary["schema"], PLAN.PLAN_SCHEMA)
+        self.assertEqual(summary["status"], "design_gate")
+        self.assertEqual(summary["target"], "rmsnorm-affine-residual-block-v1")
+        self.assertEqual(summary["statement_kind"], "transformer-block")
+        self.assertEqual(summary["width"], 4)
+        self.assertEqual(summary["go_criteria_count"], 5)
+        self.assertEqual(summary["no_go_criteria_count"], 4)
+
+    def test_plan_requires_transformer_structure_not_linear_relabel(self) -> None:
+        plan = self._plan()
+        plan["target"]["operations"] = [
+            {"id": "quantized_affine_projection", "description": "linear only"}
+        ]
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "rmsnorm_scale_lookup"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_requires_residual_structure(self) -> None:
+        plan = self._plan()
+        plan["target"]["operations"] = [
+            item
+            for item in plan["target"]["operations"]
+            if item["id"] != "residual_add"
+        ]
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "residual_add"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_requires_statement_binding_fields(self) -> None:
+        plan = self._plan()
+        plan["target"]["public_commitments"].remove("evidence_manifest_commitment")
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "evidence_manifest_commitment"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_requires_public_instance_binding(self) -> None:
+        plan = self._plan()
+        plan["target"]["public_commitments"].remove("public_instance_commitment")
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "public_instance_commitment"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_requires_relabeling_go_criterion(self) -> None:
+        plan = self._plan()
+        plan["go_criteria"] = [
+            item
+            for item in plan["go_criteria"]
+            if item["id"] != "relabeling_suite_rejects_all_statement_mutations"
+        ]
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "relabeling_suite"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_requires_no_go_for_linear_toy_collapse(self) -> None:
+        plan = self._plan()
+        plan["no_go_criteria"] = [
+            item
+            for item in plan["no_go_criteria"]
+            if item["id"] != "target_collapses_to_linear_toy"
+        ]
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "target_collapses_to_linear_toy"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_keeps_existing_linear_block_as_baseline_not_result(self) -> None:
+        plan = self._plan()
+        self.assertEqual(
+            plan["current_baseline"]["model_id"],
+            "urn:zkai:ptvm:linear-block-v4-with-lookup",
+        )
+        self.assertEqual(
+            plan["target"]["statement_kind"],
+            "transformer-block",
+        )
+        self.assertIn(
+            "does not claim that the existing linear-block primitive already proves transformer-block semantics",
+            "\n".join(plan["non_claims"]).lower(),
+        )
+
+    def test_plan_rejects_overstated_baseline(self) -> None:
+        plan = self._plan()
+        plan["current_baseline"]["mutation_result"]["proof_only"][
+            "decision"
+        ] = "GO_FOR_STATEMENT_BINDING"
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "proof-only baseline"):
+            PLAN.validate_plan(plan)
+
+    def test_main_returns_failure_on_malformed_plan_file(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            path = pathlib.Path(raw_tmp) / "bad.json"
+            path.write_text("[]", encoding="utf-8")
+
+            self.assertEqual(PLAN.main(["--plan", str(path), "--json"]), 1)
+
+    def test_validation_rejects_mutated_plan_without_mutating_fixture(self) -> None:
+        plan = self._plan()
+        mutated = copy.deepcopy(plan)
+        mutated["status"] = "result_go"
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "status"):
+            PLAN.validate_plan(mutated)
+        self.assertEqual(plan["status"], "design_gate")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_stwo_transformer_block_plan.py
+++ b/scripts/tests/test_zkai_stwo_transformer_block_plan.py
@@ -214,6 +214,13 @@ class ZkAIStwoTransformerBlockPlanTests(unittest.TestCase):
         with self.assertRaisesRegex(PLAN.PlanValidationError, "validation_commands"):
             PLAN.validate_plan(plan)
 
+    def test_plan_rejects_empty_validation_commands_cleanly(self) -> None:
+        plan = self._plan()
+        plan["validation_commands"] = []
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "at least one command"):
+            PLAN.validate_plan(plan)
+
     def test_plan_rejects_missing_no_nightly_alternative(self) -> None:
         plan = self._plan()
         plan["validation_command_alternatives"] = []

--- a/scripts/tests/test_zkai_stwo_transformer_block_plan.py
+++ b/scripts/tests/test_zkai_stwo_transformer_block_plan.py
@@ -195,11 +195,37 @@ class ZkAIStwoTransformerBlockPlanTests(unittest.TestCase):
         with self.assertRaisesRegex(PLAN.PlanValidationError, "final repo gate"):
             PLAN.validate_plan(plan)
 
+    def test_plan_rejects_final_repo_gate_not_last(self) -> None:
+        plan = self._plan()
+        plan["validation_commands"] = [
+            "python3 scripts/zkai_stwo_transformer_block_plan.py --json",
+            "just gate-fast",
+            "just gate",
+            "python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan scripts.tests.test_zkai_stwo_statement_envelope_benchmark scripts.tests.test_agent_step_zkai_stwo_composition",
+        ]
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "end with final repo gate"):
+            PLAN.validate_plan(plan)
+
     def test_plan_rejects_non_string_validation_command_cleanly(self) -> None:
         plan = self._plan()
         plan["validation_commands"].append({"bad": "shape"})
 
         with self.assertRaisesRegex(PLAN.PlanValidationError, "validation_commands"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_rejects_missing_no_nightly_alternative(self) -> None:
+        plan = self._plan()
+        plan["validation_command_alternatives"] = []
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "validation_command_alternatives"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_rejects_wrong_no_nightly_alternative(self) -> None:
+        plan = self._plan()
+        plan["validation_command_alternatives"][0]["command"] = "just something-else"
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "just gate-no-nightly"):
             PLAN.validate_plan(plan)
 
     def test_plan_rejects_non_string_non_claim_cleanly(self) -> None:

--- a/scripts/tests/test_zkai_stwo_transformer_block_plan.py
+++ b/scripts/tests/test_zkai_stwo_transformer_block_plan.py
@@ -168,9 +168,31 @@ class ZkAIStwoTransformerBlockPlanTests(unittest.TestCase):
         plan["validation_commands"] = [
             "python3 scripts/zkai_stwo_transformer_block_plan.py --json",
             "python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan",
+            "just gate-fast",
+            "just gate",
         ]
 
         with self.assertRaisesRegex(PLAN.PlanValidationError, "test_zkai_stwo_statement_envelope"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_rejects_missing_fast_repo_gate(self) -> None:
+        plan = self._plan()
+        plan["validation_commands"] = [
+            command for command in plan["validation_commands"] if command != "just gate-fast"
+        ]
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "just gate-fast"):
+            PLAN.validate_plan(plan)
+
+    def test_plan_rejects_missing_final_repo_gate(self) -> None:
+        plan = self._plan()
+        plan["validation_commands"] = [
+            command
+            for command in plan["validation_commands"]
+            if command not in {"just gate", "just gate-no-nightly"}
+        ]
+
+        with self.assertRaisesRegex(PLAN.PlanValidationError, "final repo gate"):
             PLAN.validate_plan(plan)
 
     def test_plan_rejects_non_string_validation_command_cleanly(self) -> None:

--- a/scripts/zkai_stwo_transformer_block_plan.py
+++ b/scripts/zkai_stwo_transformer_block_plan.py
@@ -87,6 +87,7 @@ REQUIRED_VALIDATION_COMMAND_FRAGMENTS = (
     "scripts.tests.test_agent_step_zkai_stwo_composition",
     "just gate-fast",
 )
+FINAL_REPO_GATES = frozenset({"just gate", "just gate-no-nightly"})
 
 
 class PlanValidationError(ValueError):
@@ -185,6 +186,28 @@ def _validate_current_baseline(plan: dict[str, Any]) -> None:
         )
 
 
+def _validate_command_alternatives(plan: dict[str, Any]) -> None:
+    alternatives = _required_list(
+        plan.get("validation_command_alternatives"),
+        "validation_command_alternatives",
+    )
+    expected = {
+        "instead_of": "just gate",
+        "command": "just gate-no-nightly",
+        "condition": "Use only when the pinned nightly toolchain is unavailable.",
+    }
+    if len(alternatives) != 1:
+        raise PlanValidationError("validation_command_alternatives must contain exactly one final-gate alternative")
+    alternative = alternatives[0]
+    if not isinstance(alternative, dict):
+        raise PlanValidationError("validation_command_alternatives[0] must be an object")
+    for key, value in expected.items():
+        if alternative.get(key) != value:
+            raise PlanValidationError(
+                f"validation_command_alternatives[0].{key} must be {value!r}"
+            )
+
+
 def validate_plan(plan: dict[str, Any]) -> dict[str, Any]:
     if plan.get("schema") != PLAN_SCHEMA:
         raise PlanValidationError(f"unexpected schema: {plan.get('schema')!r}")
@@ -230,7 +253,8 @@ def validate_plan(plan: dict[str, Any]) -> dict[str, Any]:
     commands = _required_list(plan.get("validation_commands"), "validation_commands")
     if not all(isinstance(command, str) and command for command in commands):
         raise PlanValidationError("validation_commands must contain only non-empty strings")
-    command_text = "\n".join(commands)
+    normalized_commands = [command.strip() for command in commands]
+    command_text = "\n".join(normalized_commands)
     missing_command_fragments = [
         fragment for fragment in REQUIRED_VALIDATION_COMMAND_FRAGMENTS if fragment not in command_text
     ]
@@ -239,11 +263,13 @@ def validate_plan(plan: dict[str, Any]) -> dict[str, Any]:
             "validation_commands is missing required coverage: "
             + ", ".join(missing_command_fragments)
         )
-    normalized_commands = {command.strip() for command in commands}
-    if not ({"just gate", "just gate-no-nightly"} & normalized_commands):
+    if normalized_commands[-1] not in FINAL_REPO_GATES:
         raise PlanValidationError(
-            "validation_commands must include final repo gate: `just gate` or `just gate-no-nightly`"
+            "validation_commands must end with final repo gate: `just gate` or `just gate-no-nightly`"
         )
+    if "just gate-fast" not in normalized_commands[:-1]:
+        raise PlanValidationError("validation_commands must run `just gate-fast` before the final repo gate")
+    _validate_command_alternatives(plan)
 
     return {
         "schema": PLAN_SCHEMA,

--- a/scripts/zkai_stwo_transformer_block_plan.py
+++ b/scripts/zkai_stwo_transformer_block_plan.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Validate the next Stwo-native statement-bound transformer-block gate plan.
+
+The plan is intentionally a design gate, not a proof result. This validator
+keeps the next implementation target honest by rejecting plans that omit
+transformer-block structure, binding fields, GO/NO-GO criteria, or non-claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_PLAN_PATH = (
+    ROOT
+    / "docs"
+    / "engineering"
+    / "evidence"
+    / "zkai-stwo-statement-bound-transformer-block-plan-2026-04.json"
+)
+
+PLAN_SCHEMA = "zkai-stwo-statement-bound-transformer-block-plan-v1"
+PLAN_STATUS = "design_gate"
+TARGET_NAME = "rmsnorm-affine-residual-block-v1"
+TARGET_STATEMENT_KIND = "transformer-block"
+
+REQUIRED_OPERATION_IDS = frozenset(
+    {
+        "rmsnorm_scale_lookup",
+        "quantized_affine_projection",
+        "residual_add",
+    }
+)
+REQUIRED_PUBLIC_COMMITMENTS = frozenset(
+    {
+        "model_artifact_commitment",
+        "model_config_commitment",
+        "input_commitment",
+        "output_commitment",
+        "public_instance_commitment",
+        "proof_commitment",
+        "verifying_key_commitment",
+        "setup_commitment",
+        "verifier_domain",
+        "proof_system_version",
+        "evidence_manifest_commitment",
+    }
+)
+REQUIRED_GO_IDS = frozenset(
+    {
+        "native_stwo_proof_accepts_honest_block",
+        "receipt_binds_all_public_commitments",
+        "relabeling_suite_rejects_all_statement_mutations",
+        "agent_step_composition_accepts_baseline",
+        "agent_step_composition_rejects_nested_relabels",
+    }
+)
+REQUIRED_NO_GO_IDS = frozenset(
+    {
+        "proof_generator_cannot_emit_block_proof",
+        "verifier_accepts_statement_relabeling",
+        "target_collapses_to_linear_toy",
+        "public_instance_not_bound",
+    }
+)
+REQUIRED_NON_CLAIM_FRAGMENTS = (
+    "not full transformer inference",
+    "not an agent reasoning proof",
+    "not a throughput or latency benchmark",
+    "not backend independence",
+    "not recursive or on-chain verification",
+    "does not claim that the existing linear-block primitive already proves transformer-block semantics",
+)
+
+
+class PlanValidationError(ValueError):
+    pass
+
+
+def load_plan(path: pathlib.Path = DEFAULT_PLAN_PATH) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError) as err:
+        raise PlanValidationError(f"failed to load plan {path}: {err}") from err
+    if not isinstance(data, dict):
+        raise PlanValidationError("plan must be a JSON object")
+    return data
+
+
+def _required_dict(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise PlanValidationError(f"{label} must be an object")
+    return value
+
+
+def _required_list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise PlanValidationError(f"{label} must be a list")
+    return value
+
+
+def _ids(entries: Iterable[Any], label: str) -> set[str]:
+    result: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise PlanValidationError(f"{label}[{index}] must be an object")
+        item_id = entry.get("id")
+        if not isinstance(item_id, str) or not item_id:
+            raise PlanValidationError(f"{label}[{index}].id must be a non-empty string")
+        result.add(item_id)
+    return result
+
+
+def _require_superset(actual: set[str], required: set[str], label: str) -> None:
+    missing = sorted(required - actual)
+    if missing:
+        raise PlanValidationError(f"{label} is missing required entries: {', '.join(missing)}")
+
+
+def _validate_current_baseline(plan: dict[str, Any]) -> None:
+    baseline = _required_dict(plan.get("current_baseline"), "current_baseline")
+    if baseline.get("statement_receipt_schema") != "zkai-statement-receipt-v1":
+        raise PlanValidationError("current_baseline.statement_receipt_schema is not the checked receipt schema")
+    if baseline.get("proof_system") != "stwo-transparent-stark":
+        raise PlanValidationError("current_baseline.proof_system must stay Stwo-native")
+    if baseline.get("model_id") != "urn:zkai:ptvm:linear-block-v4-with-lookup":
+        raise PlanValidationError("current_baseline.model_id does not match the checked Stwo primitive")
+
+    mutation_result = _required_dict(baseline.get("mutation_result"), "current_baseline.mutation_result")
+    statement = _required_dict(mutation_result.get("statement_envelope"), "mutation_result.statement_envelope")
+    if statement.get("mutations_rejected") != statement.get("mutations_checked"):
+        raise PlanValidationError("current statement-envelope baseline must reject all checked mutations")
+
+    proof_only = _required_dict(mutation_result.get("proof_only"), "mutation_result.proof_only")
+    if proof_only.get("decision") != "NO_GO_FOR_METADATA_RELABELING_BY_ITSELF":
+        raise PlanValidationError("proof-only baseline must remain scoped as NO-GO for metadata relabeling")
+
+    composition = _required_dict(baseline.get("agent_composition_result"), "current_baseline.agent_composition_result")
+    if composition.get("mutations_rejected") != composition.get("mutations_checked"):
+        raise PlanValidationError("agent composition baseline must reject all checked mutations")
+
+
+def validate_plan(plan: dict[str, Any]) -> dict[str, Any]:
+    if plan.get("schema") != PLAN_SCHEMA:
+        raise PlanValidationError(f"unexpected schema: {plan.get('schema')!r}")
+    if plan.get("status") != PLAN_STATUS:
+        raise PlanValidationError(f"plan status must be {PLAN_STATUS!r}")
+    if plan.get("decision") != "GO_TO_IMPLEMENTATION_ONLY_AFTER_CRITERIA_ARE_MET":
+        raise PlanValidationError("decision must keep this artifact scoped as an implementation gate")
+
+    _validate_current_baseline(plan)
+
+    target = _required_dict(plan.get("target"), "target")
+    if target.get("name") != TARGET_NAME:
+        raise PlanValidationError(f"target.name must be {TARGET_NAME!r}")
+    if target.get("statement_kind") != TARGET_STATEMENT_KIND:
+        raise PlanValidationError(f"target.statement_kind must be {TARGET_STATEMENT_KIND!r}")
+    if target.get("width") != 4:
+        raise PlanValidationError("target.width must remain the bounded width-4 implementation target")
+
+    operations = _required_list(target.get("operations"), "target.operations")
+    operation_ids = _ids(operations, "target.operations")
+    _require_superset(operation_ids, REQUIRED_OPERATION_IDS, "target.operations")
+
+    public_commitments = set(_required_list(target.get("public_commitments"), "target.public_commitments"))
+    if not all(isinstance(item, str) and item for item in public_commitments):
+        raise PlanValidationError("target.public_commitments must contain only non-empty strings")
+    _require_superset(public_commitments, REQUIRED_PUBLIC_COMMITMENTS, "target.public_commitments")
+
+    go_ids = _ids(_required_list(plan.get("go_criteria"), "go_criteria"), "go_criteria")
+    _require_superset(go_ids, REQUIRED_GO_IDS, "go_criteria")
+
+    no_go_ids = _ids(_required_list(plan.get("no_go_criteria"), "no_go_criteria"), "no_go_criteria")
+    _require_superset(no_go_ids, REQUIRED_NO_GO_IDS, "no_go_criteria")
+
+    non_claims = _required_list(plan.get("non_claims"), "non_claims")
+    non_claim_text = "\n".join(str(item).lower() for item in non_claims)
+    for fragment in REQUIRED_NON_CLAIM_FRAGMENTS:
+        if fragment.lower() not in non_claim_text:
+            raise PlanValidationError(f"non_claims is missing: {fragment}")
+
+    commands = _required_list(plan.get("validation_commands"), "validation_commands")
+    if "python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan" not in commands:
+        raise PlanValidationError("validation_commands must include the focused unit test")
+
+    return {
+        "schema": PLAN_SCHEMA,
+        "status": PLAN_STATUS,
+        "target": target["name"],
+        "statement_kind": target["statement_kind"],
+        "width": target["width"],
+        "operation_count": len(operation_ids),
+        "public_commitment_count": len(public_commitments),
+        "go_criteria_count": len(go_ids),
+        "no_go_criteria_count": len(no_go_ids),
+        "decision": plan["decision"],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", type=pathlib.Path, default=DEFAULT_PLAN_PATH)
+    parser.add_argument("--json", action="store_true", help="emit a JSON validation summary")
+    args = parser.parse_args(argv)
+
+    try:
+        summary = validate_plan(load_plan(args.plan))
+    except PlanValidationError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(summary, sort_keys=True, indent=2))
+    else:
+        print(
+            f"{summary['target']}: {summary['statement_kind']} width={summary['width']} "
+            f"with {summary['go_criteria_count']} GO criteria and "
+            f"{summary['no_go_criteria_count']} NO-GO criteria"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zkai_stwo_transformer_block_plan.py
+++ b/scripts/zkai_stwo_transformer_block_plan.py
@@ -169,9 +169,10 @@ def validate_plan(plan: dict[str, Any]) -> dict[str, Any]:
     operation_ids = _ids(operations, "target.operations")
     _require_superset(operation_ids, REQUIRED_OPERATION_IDS, "target.operations")
 
-    public_commitments = set(_required_list(target.get("public_commitments"), "target.public_commitments"))
-    if not all(isinstance(item, str) and item for item in public_commitments):
+    public_commitment_items = _required_list(target.get("public_commitments"), "target.public_commitments")
+    if not all(isinstance(item, str) and item for item in public_commitment_items):
         raise PlanValidationError("target.public_commitments must contain only non-empty strings")
+    public_commitments = set(public_commitment_items)
     _require_superset(public_commitments, REQUIRED_PUBLIC_COMMITMENTS, "target.public_commitments")
 
     go_ids = _ids(_required_list(plan.get("go_criteria"), "go_criteria"), "go_criteria")
@@ -181,7 +182,9 @@ def validate_plan(plan: dict[str, Any]) -> dict[str, Any]:
     _require_superset(no_go_ids, REQUIRED_NO_GO_IDS, "no_go_criteria")
 
     non_claims = _required_list(plan.get("non_claims"), "non_claims")
-    non_claim_text = "\n".join(str(item).lower() for item in non_claims)
+    if not all(isinstance(item, str) and item for item in non_claims):
+        raise PlanValidationError("non_claims must contain only non-empty strings")
+    non_claim_text = "\n".join(item.lower() for item in non_claims)
     for fragment in REQUIRED_NON_CLAIM_FRAGMENTS:
         if fragment.lower() not in non_claim_text:
             raise PlanValidationError(f"non_claims is missing: {fragment}")

--- a/scripts/zkai_stwo_transformer_block_plan.py
+++ b/scripts/zkai_stwo_transformer_block_plan.py
@@ -27,8 +27,12 @@ DEFAULT_PLAN_PATH = (
 
 PLAN_SCHEMA = "zkai-stwo-statement-bound-transformer-block-plan-v1"
 PLAN_STATUS = "design_gate"
+BASELINE_PROOF_SYSTEM_VERSION = "stwo-phase10-linear-block-v4-with-lookup"
 TARGET_NAME = "rmsnorm-affine-residual-block-v1"
 TARGET_STATEMENT_KIND = "transformer-block"
+EXPECTED_STATEMENT_MUTATIONS = 14
+EXPECTED_PROOF_ONLY_REJECTIONS = 1
+EXPECTED_COMPOSITION_MUTATIONS = 36
 
 REQUIRED_OPERATION_IDS = frozenset(
     {
@@ -76,6 +80,11 @@ REQUIRED_NON_CLAIM_FRAGMENTS = (
     "not backend independence",
     "not recursive or on-chain verification",
     "does not claim that the existing linear-block primitive already proves transformer-block semantics",
+)
+REQUIRED_VALIDATION_COMMAND_FRAGMENTS = (
+    "scripts.tests.test_zkai_stwo_transformer_block_plan",
+    "scripts.tests.test_zkai_stwo_statement_envelope_benchmark",
+    "scripts.tests.test_agent_step_zkai_stwo_composition",
 )
 
 
@@ -130,6 +139,10 @@ def _validate_current_baseline(plan: dict[str, Any]) -> None:
         raise PlanValidationError("current_baseline.statement_receipt_schema is not the checked receipt schema")
     if baseline.get("proof_system") != "stwo-transparent-stark":
         raise PlanValidationError("current_baseline.proof_system must stay Stwo-native")
+    if baseline.get("proof_system_version") != BASELINE_PROOF_SYSTEM_VERSION:
+        raise PlanValidationError(
+            f"current_baseline.proof_system_version must be {BASELINE_PROOF_SYSTEM_VERSION!r}"
+        )
     if baseline.get("model_id") != "urn:zkai:ptvm:linear-block-v4-with-lookup":
         raise PlanValidationError("current_baseline.model_id does not match the checked Stwo primitive")
 
@@ -137,14 +150,38 @@ def _validate_current_baseline(plan: dict[str, Any]) -> None:
     statement = _required_dict(mutation_result.get("statement_envelope"), "mutation_result.statement_envelope")
     if statement.get("mutations_rejected") != statement.get("mutations_checked"):
         raise PlanValidationError("current statement-envelope baseline must reject all checked mutations")
+    if (
+        statement.get("mutations_checked") != EXPECTED_STATEMENT_MUTATIONS
+        or statement.get("mutations_rejected") != EXPECTED_STATEMENT_MUTATIONS
+    ):
+        raise PlanValidationError(
+            f"current statement-envelope baseline must stay pinned at "
+            f"{EXPECTED_STATEMENT_MUTATIONS}/{EXPECTED_STATEMENT_MUTATIONS}"
+        )
 
     proof_only = _required_dict(mutation_result.get("proof_only"), "mutation_result.proof_only")
     if proof_only.get("decision") != "NO_GO_FOR_METADATA_RELABELING_BY_ITSELF":
         raise PlanValidationError("proof-only baseline must remain scoped as NO-GO for metadata relabeling")
+    if (
+        proof_only.get("mutations_checked") != EXPECTED_STATEMENT_MUTATIONS
+        or proof_only.get("mutations_rejected") != EXPECTED_PROOF_ONLY_REJECTIONS
+    ):
+        raise PlanValidationError(
+            f"proof-only baseline must stay pinned at "
+            f"{EXPECTED_PROOF_ONLY_REJECTIONS}/{EXPECTED_STATEMENT_MUTATIONS}"
+        )
 
     composition = _required_dict(baseline.get("agent_composition_result"), "current_baseline.agent_composition_result")
     if composition.get("mutations_rejected") != composition.get("mutations_checked"):
         raise PlanValidationError("agent composition baseline must reject all checked mutations")
+    if (
+        composition.get("mutations_checked") != EXPECTED_COMPOSITION_MUTATIONS
+        or composition.get("mutations_rejected") != EXPECTED_COMPOSITION_MUTATIONS
+    ):
+        raise PlanValidationError(
+            f"agent composition baseline must stay pinned at "
+            f"{EXPECTED_COMPOSITION_MUTATIONS}/{EXPECTED_COMPOSITION_MUTATIONS}"
+        )
 
 
 def validate_plan(plan: dict[str, Any]) -> dict[str, Any]:
@@ -190,8 +227,17 @@ def validate_plan(plan: dict[str, Any]) -> dict[str, Any]:
             raise PlanValidationError(f"non_claims is missing: {fragment}")
 
     commands = _required_list(plan.get("validation_commands"), "validation_commands")
-    if "python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan" not in commands:
-        raise PlanValidationError("validation_commands must include the focused unit test")
+    if not all(isinstance(command, str) and command for command in commands):
+        raise PlanValidationError("validation_commands must contain only non-empty strings")
+    command_text = "\n".join(commands)
+    missing_command_fragments = [
+        fragment for fragment in REQUIRED_VALIDATION_COMMAND_FRAGMENTS if fragment not in command_text
+    ]
+    if missing_command_fragments:
+        raise PlanValidationError(
+            "validation_commands is missing required coverage: "
+            + ", ".join(missing_command_fragments)
+        )
 
     return {
         "schema": PLAN_SCHEMA,

--- a/scripts/zkai_stwo_transformer_block_plan.py
+++ b/scripts/zkai_stwo_transformer_block_plan.py
@@ -85,6 +85,7 @@ REQUIRED_VALIDATION_COMMAND_FRAGMENTS = (
     "scripts.tests.test_zkai_stwo_transformer_block_plan",
     "scripts.tests.test_zkai_stwo_statement_envelope_benchmark",
     "scripts.tests.test_agent_step_zkai_stwo_composition",
+    "just gate-fast",
 )
 
 
@@ -237,6 +238,11 @@ def validate_plan(plan: dict[str, Any]) -> dict[str, Any]:
         raise PlanValidationError(
             "validation_commands is missing required coverage: "
             + ", ".join(missing_command_fragments)
+        )
+    normalized_commands = {command.strip() for command in commands}
+    if not ({"just gate", "just gate-no-nightly"} & normalized_commands):
+        raise PlanValidationError(
+            "validation_commands must include final repo gate: `just gate` or `just gate-no-nightly`"
         )
 
     return {

--- a/scripts/zkai_stwo_transformer_block_plan.py
+++ b/scripts/zkai_stwo_transformer_block_plan.py
@@ -251,7 +251,9 @@ def validate_plan(plan: dict[str, Any]) -> dict[str, Any]:
             raise PlanValidationError(f"non_claims is missing: {fragment}")
 
     commands = _required_list(plan.get("validation_commands"), "validation_commands")
-    if not all(isinstance(command, str) and command for command in commands):
+    if not commands:
+        raise PlanValidationError("validation_commands must contain at least one command")
+    if not all(isinstance(command, str) and command.strip() for command in commands):
         raise PlanValidationError("validation_commands must contain only non-empty strings")
     normalized_commands = [command.strip() for command in commands]
     command_text = "\n".join(normalized_commands)


### PR DESCRIPTION
## Summary

Adds a bounded Stwo zkAI transformer-block design gate for the next implementation step after the checked linear-block-with-lookup statement receipt.

This PR does not claim a transformer-block proof result. It pins the smallest honest target and the GO/NO-GO criteria before implementation:

- target: `rmsnorm-affine-residual-block-v1`
- statement kind: `transformer-block`
- width: `4`
- required structure: normalization lookup, quantized affine projection, residual add
- required binding fields: model/config/input/output/public-instance/proof/verifier/setup/evidence commitments
- required composition check: nested statement receipt consumed by the agent-step callback path

It also adds a validator and focused tests so the gate fails closed if someone weakens the target into a relabeled linear toy, drops the statement-binding criteria, shrinks mutation corpora, drifts the baseline Stwo version, or omits the adjacent statement-envelope / agent-composition checks.

## Hardening

Trusted-core proof code is not changed. This PR touches `scripts/**` and engineering documentation only.

Hardening added in scope:

- malformed JSON plans return `PlanValidationError` / exit `1` instead of stack traces
- unhashable or non-string `public_commitments`, `non_claims`, and `validation_commands` fail closed
- baseline mutation totals are pinned at `14/14` for statement-envelope, `1/14` for proof-only metadata relabeling, and `36/36` for agent composition
- the baseline Stwo proof-system version is pinned to `stwo-phase10-linear-block-v4-with-lookup`
- validation commands must include the transformer-block plan test, the native Stwo statement-envelope benchmark test, and the agent-step composition test

## Why

The repo already has a checked Stwo-native statement receipt for a smaller linear-block-with-lookup primitive. The next research step should be a real transformer-shaped block, but the claim boundary needs to be fixed before implementation so a partial result cannot drift into an overclaim.

## Validation

- `python3 scripts/zkai_stwo_transformer_block_plan.py --json`
- `python3 -m unittest scripts.tests.test_zkai_stwo_transformer_block_plan scripts.tests.test_zkai_stwo_statement_envelope_benchmark scripts.tests.test_agent_step_zkai_stwo_composition`
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `python3 -m py_compile scripts/zkai_stwo_transformer_block_plan.py scripts/tests/test_zkai_stwo_transformer_block_plan.py`
- `git diff --check`
- `just gate-fast`
- `just gate` (`14 / 14` release-gate steps OK)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new transformer-block gate spec and updated related gates to point to explicit next-step documentation with a tightened width‑4 transformer target and required normalization/affine/residual expectations.

* **Tests**
  * Added comprehensive unit tests covering plan validation, required go/no-go checks, mutation rejection cases, and plan integrity.

* **Chores**
  * Added a CLI plan validator that verifies gate plans and emits concise summaries or errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->