### PR TITLE
Add matched RMSNorm-SwiGLU block feasibility gate

### DIFF
--- a/docs/engineering/design/README.md
+++ b/docs/engineering/design/README.md
@@ -19,5 +19,6 @@ Tablero itself proves agents, reasoning, tool truth, or policy semantics.
 - [statement-bound transformer primitive spec](statement-bound-transformer-primitive-spec.md)
 - [Stwo statement-bound primitive gate](../zkai-stwo-statement-bound-primitive-gate-2026-04-29.md)
 - [Stwo statement-bound transformer-block result gate](../zkai-stwo-statement-bound-transformer-block-result-gate-2026-05-01.md)
+- [Matched RMSNorm-SwiGLU block feasibility gate](../zkai-matched-rmsnorm-swiglu-block-feasibility-gate-2026-05-01.md)
 - [Agent-step zkAI Stwo composition gate](../agent-step-zkai-stwo-composition-gate-2026-04-29.md)
 - [Agent-step model subreceipt callback gate](../agent-step-model-subreceipt-callback-gate-2026-04-29.md)

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -39,7 +39,7 @@
     "proof_backend": "stwo",
     "proof_backend_version": "stwo-phase10-linear-block-v4-with-lookup",
     "proof_path": "docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-2026-05/linear_block_v4_with_lookup.proof.json.gz",
-    "proof_payload_bytes": 90458,
+    "proof_payload_bytes": 277942,
     "proof_sha256": "50849745b28d62d1045372678215ba1df45ac6bb033084249302c8dc88c84586",
     "statement_envelope_mutations_checked": 14,
     "statement_envelope_mutations_rejected": 14,
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "f4248edd0e775b19cfe09e0ece6d1a3d4e451a2a"
+    "git_commit": "a54145d665f36b429dc903e67c1a9ff01dacc2ba"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "d61f46150901a730aed5d4ad7b71b5ef92b2eaea"
+    "git_commit": "0550a89f2096fd3ce531fd3269afee5b5027d396"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -46,7 +46,7 @@
     "statement_model_id": "urn:zkai:ptvm:rmsnorm-gated-affine-residual-block-v1"
   },
   "decision": "NO_GO_CURRENT_STWO_PROOF_SURFACE",
-  "generated_at": "2026-04-30T23:09:46Z",
+  "generated_at": "2026-04-30T23:17:10Z",
   "next_required_work": [
     {
       "description": "Expose input/output activation, weight, normalization, activation-lookup, and config commitments as verifier-facing public statement material.",
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "67adfe54c8282f7d6b82abdb9c0644c7a7888a02"
+    "git_commit": "576bc113c8e8cc43ba15bca34bb47a286ec045d6"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "f34f321ad0373493ac15c9ce94e62804ad67a4b9"
+    "git_commit": "f4248edd0e775b19cfe09e0ece6d1a3d4e451a2a"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "dc6b41088ecc5c6a9b47945b6cfe76e16bc3fd55"
+    "git_commit": "d7ecbbb5bd252eab84e8294227b8dcee14cc10c5"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [
@@ -103,6 +103,8 @@
         },
         {
           "id": "proof_generator_fixture_allowlist",
+          "pinned_fixture_version": "stwo-phase10-linear-block-v4-with-lookup",
+          "proof_backend_version": "stwo-phase10-linear-block-v4-with-lookup",
           "why_it_matters": "the current Stwo generator is scoped to shipped fixtures/decoding families, not arbitrary matched MLP programs"
         }
       ],
@@ -141,6 +143,8 @@
         },
         {
           "id": "proof_generator_fixture_allowlist",
+          "pinned_fixture_version": "stwo-phase10-linear-block-v4-with-lookup",
+          "proof_backend_version": "stwo-phase10-linear-block-v4-with-lookup",
           "why_it_matters": "the current Stwo generator is scoped to shipped fixtures/decoding families, not arbitrary matched MLP programs"
         }
       ],

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "8e801d79cde42db196eb0c3b0412ca683edc8ff9"
+    "git_commit": "f34f321ad0373493ac15c9ce94e62804ad67a4b9"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [
@@ -180,6 +180,7 @@
       "ff_dim": 256,
       "model_id": "urn:zkai:ptvm:rmsnorm-swiglu-residual-d64-v1",
       "normalization": "RMSNorm",
+      "required_proof_backend_version": "stwo-rmsnorm-swiglu-residual-d64-v1",
       "required_statement_bindings": [
         "model_artifact_commitment",
         "model_config_commitment",
@@ -208,6 +209,7 @@
       "ff_dim": 512,
       "model_id": "urn:zkai:ptvm:rmsnorm-swiglu-residual-d128-v1",
       "normalization": "RMSNorm",
+      "required_proof_backend_version": "stwo-rmsnorm-swiglu-residual-d128-v1",
       "required_statement_bindings": [
         "model_artifact_commitment",
         "model_config_commitment",

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "0550a89f2096fd3ce531fd3269afee5b5027d396"
+    "git_commit": "6453faaeab9f5e60bbca95ee4cda7355974d504e"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "d7ecbbb5bd252eab84e8294227b8dcee14cc10c5"
+    "git_commit": "8e801d79cde42db196eb0c3b0412ca683edc8ff9"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -1,0 +1,227 @@
+{
+  "current_surface": {
+    "block_logical_width": 4,
+    "block_operation_ids": [
+      "rmsnorm_scale_lookup",
+      "quantized_affine_projection",
+      "gated_value_mix",
+      "residual_add",
+      "bounded_activation_lookup"
+    ],
+    "block_profile_version": "rmsnorm-gated-affine-residual-block-v1",
+    "claim_add_memory_ops": 4,
+    "claim_instruction_count": 43,
+    "claim_memory_cells": 21,
+    "claim_mul_memory_ops": 7,
+    "claim_semantic_scope": "native_isa_execution_with_transformer_native_equivalence_check",
+    "claim_steps": 43,
+    "claim_transformer_config": {
+      "attention_mode": "AverageHard",
+      "d_model": 36,
+      "ff_dim": 72,
+      "max_seq_len": 1000000,
+      "num_heads": 18,
+      "num_layers": 1,
+      "vocab_size": 256
+    },
+    "evidence_path": "docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-benchmark-2026-05.json",
+    "evidence_sha256": "d77bd207cf88137f9af775a076611d41ab1078081d4748d91341a845ce87ef47",
+    "fixture_gate": {
+      "fixture_gate_detected": true,
+      "markers": {
+        "broader_arithmetic_subset_internal": true,
+        "decoding_step_v2_family": true,
+        "linear_block_v4_with_lookup": true
+      },
+      "source_path": "src/stwo_backend/arithmetic_subset_prover.rs",
+      "source_sha256": "b5a3eb01a57774a74188f5952e8e136cbf565d374b8bb0c5bf85774296361858"
+    },
+    "proof_backend": "stwo",
+    "proof_backend_version": "stwo-phase10-linear-block-v4-with-lookup",
+    "proof_path": "docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-2026-05/linear_block_v4_with_lookup.proof.json.gz",
+    "proof_payload_bytes": 90458,
+    "proof_sha256": "50849745b28d62d1045372678215ba1df45ac6bb033084249302c8dc88c84586",
+    "statement_envelope_mutations_checked": 14,
+    "statement_envelope_mutations_rejected": 14,
+    "statement_model_id": "urn:zkai:ptvm:rmsnorm-gated-affine-residual-block-v1"
+  },
+  "decision": "NO_GO_CURRENT_STWO_PROOF_SURFACE",
+  "generated_at": "2026-04-30T23:09:46Z",
+  "next_required_work": [
+    {
+      "description": "Expose input/output activation, weight, normalization, activation-lookup, and config commitments as verifier-facing public statement material.",
+      "id": "parameterized_vector_public_claim"
+    },
+    {
+      "description": "Add or export a proof surface whose constraints actually cover RMSNorm, SwiGLU gate/value/down projections, and residual addition at d=64 before d=128.",
+      "id": "stwo_air_for_vector_mlp_block"
+    },
+    {
+      "description": "If using EZKL/ONNX or another proof stack for comparison, bind the same statement fields and run the same relabeling suite.",
+      "id": "same_statement_external_adapter"
+    }
+  ],
+  "non_claims": [
+    "This is not a d64 or d128 proof result.",
+    "This is not a performance benchmark.",
+    "This does not claim full transformer inference.",
+    "This does not claim that the width-4 statement-bound block already proves matched RMSNorm-SwiGLU semantics.",
+    "This does not claim Stwo is incapable of such a proof; it records that the current repo proof surface does not expose it."
+  ],
+  "repro": {
+    "command": [
+      "python3",
+      "scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py",
+      "--write-json",
+      "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json",
+      "--write-tsv",
+      "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
+    ],
+    "git_commit": "67adfe54c8282f7d6b82abdb9c0644c7a7888a02"
+  },
+  "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
+  "rows": [
+    {
+      "blockers": [
+        {
+          "current": 36,
+          "id": "proof_claim_d_model_mismatch",
+          "required": 64,
+          "why_it_matters": "the checked proof public claim is not a d64/d128 transformer block claim"
+        },
+        {
+          "current": 4,
+          "id": "statement_profile_width_mismatch",
+          "required": 64,
+          "why_it_matters": "the statement receipt binds a width-4 profile, not a matched public benchmark width"
+        },
+        {
+          "current_mul_memory_ops": 7,
+          "estimated_required_linear_muls": 49152,
+          "id": "instruction_surface_too_small_for_swiglu",
+          "why_it_matters": "a matched SwiGLU block needs gate, value, and down projections over d x ff_dim matrices"
+        },
+        {
+          "id": "proof_generator_fixture_allowlist",
+          "why_it_matters": "the current Stwo generator is scoped to shipped fixtures/decoding families, not arbitrary matched MLP programs"
+        }
+      ],
+      "current_d_model": 36,
+      "current_logical_width": 4,
+      "current_mul_memory_ops": 7,
+      "mul_gap_factor": 7021.714285714285,
+      "reason": "current checked Stwo proof surface is a bounded statement-binding fixture, not a matched d64/d128 RMSNorm-SwiGLU proof",
+      "status": "NO_GO_CURRENT_SURFACE",
+      "target_activation_rows": 256,
+      "target_estimated_linear_muls": 49152,
+      "target_ff_dim": 256,
+      "target_id": "rmsnorm-swiglu-residual-d64-v1",
+      "target_norm_rows": 1,
+      "target_width": 64
+    },
+    {
+      "blockers": [
+        {
+          "current": 36,
+          "id": "proof_claim_d_model_mismatch",
+          "required": 128,
+          "why_it_matters": "the checked proof public claim is not a d64/d128 transformer block claim"
+        },
+        {
+          "current": 4,
+          "id": "statement_profile_width_mismatch",
+          "required": 128,
+          "why_it_matters": "the statement receipt binds a width-4 profile, not a matched public benchmark width"
+        },
+        {
+          "current_mul_memory_ops": 7,
+          "estimated_required_linear_muls": 196608,
+          "id": "instruction_surface_too_small_for_swiglu",
+          "why_it_matters": "a matched SwiGLU block needs gate, value, and down projections over d x ff_dim matrices"
+        },
+        {
+          "id": "proof_generator_fixture_allowlist",
+          "why_it_matters": "the current Stwo generator is scoped to shipped fixtures/decoding families, not arbitrary matched MLP programs"
+        }
+      ],
+      "current_d_model": 36,
+      "current_logical_width": 4,
+      "current_mul_memory_ops": 7,
+      "mul_gap_factor": 28086.85714285714,
+      "reason": "current checked Stwo proof surface is a bounded statement-binding fixture, not a matched d64/d128 RMSNorm-SwiGLU proof",
+      "status": "NO_GO_CURRENT_SURFACE",
+      "target_activation_rows": 512,
+      "target_estimated_linear_muls": 196608,
+      "target_ff_dim": 512,
+      "target_id": "rmsnorm-swiglu-residual-d128-v1",
+      "target_norm_rows": 1,
+      "target_width": 128
+    }
+  ],
+  "schema": "zkai-matched-rmsnorm-swiglu-block-feasibility-v1",
+  "summary": {
+    "current_result_is_not": "a matched d64/d128 zkML benchmark",
+    "current_result_is_still_useful_for": "statement-binding and agent-step composition discipline",
+    "first_required_backend_work": "parameterized Stwo AIR or export path for RMSNorm/SwiGLU/residual vector blocks",
+    "no_go_count": 2,
+    "target_count": 2
+  },
+  "targets": [
+    {
+      "activation": "SwiGLU",
+      "estimated_activation_rows": 256,
+      "estimated_linear_muls": 49152,
+      "estimated_norm_rows": 1,
+      "ff_dim": 256,
+      "model_id": "urn:zkai:ptvm:rmsnorm-swiglu-residual-d64-v1",
+      "normalization": "RMSNorm",
+      "required_statement_bindings": [
+        "model_artifact_commitment",
+        "model_config_commitment",
+        "weight_commitment",
+        "input_activation_commitment",
+        "output_activation_commitment",
+        "normalization_config_commitment",
+        "activation_lookup_commitment",
+        "public_instance_commitment",
+        "proof_commitment",
+        "verifying_key_commitment",
+        "setup_commitment",
+        "verifier_domain",
+        "proof_system_version"
+      ],
+      "residual": true,
+      "statement_kind": "transformer-block",
+      "target_id": "rmsnorm-swiglu-residual-d64-v1",
+      "width": 64
+    },
+    {
+      "activation": "SwiGLU",
+      "estimated_activation_rows": 512,
+      "estimated_linear_muls": 196608,
+      "estimated_norm_rows": 1,
+      "ff_dim": 512,
+      "model_id": "urn:zkai:ptvm:rmsnorm-swiglu-residual-d128-v1",
+      "normalization": "RMSNorm",
+      "required_statement_bindings": [
+        "model_artifact_commitment",
+        "model_config_commitment",
+        "weight_commitment",
+        "input_activation_commitment",
+        "output_activation_commitment",
+        "normalization_config_commitment",
+        "activation_lookup_commitment",
+        "public_instance_commitment",
+        "proof_commitment",
+        "verifying_key_commitment",
+        "setup_commitment",
+        "verifier_domain",
+        "proof_system_version"
+      ],
+      "residual": true,
+      "statement_kind": "transformer-block",
+      "target_id": "rmsnorm-swiglu-residual-d128-v1",
+      "width": 128
+    }
+  ]
+}

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "a54145d665f36b429dc903e67c1a9ff01dacc2ba"
+    "git_commit": "d61f46150901a730aed5d4ad7b71b5ef92b2eaea"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -46,7 +46,7 @@
     "statement_model_id": "urn:zkai:ptvm:rmsnorm-gated-affine-residual-block-v1"
   },
   "decision": "NO_GO_CURRENT_STWO_PROOF_SURFACE",
-  "generated_at": "2026-04-30T23:17:10Z",
+  "generated_at": "1970-01-01T00:00:00Z",
   "next_required_work": [
     {
       "description": "Expose input/output activation, weight, normalization, activation-lookup, and config commitments as verifier-facing public statement material.",
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "576bc113c8e8cc43ba15bca34bb47a286ec045d6"
+    "git_commit": "8f61b1649bc36c6e09df91ca5379090424f765ae"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [
@@ -163,6 +163,7 @@
     "current_result_is_not": "a matched d64/d128 zkML benchmark",
     "current_result_is_still_useful_for": "statement-binding and agent-step composition discipline",
     "first_required_backend_work": "parameterized Stwo AIR or export path for RMSNorm/SwiGLU/residual vector blocks",
+    "go_count": 0,
     "no_go_count": 2,
     "target_count": 2
   },

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json
@@ -77,7 +77,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv"
     ],
-    "git_commit": "8f61b1649bc36c6e09df91ca5379090424f765ae"
+    "git_commit": "dc6b41088ecc5c6a9b47945b6cfe76e16bc3fd55"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "rows": [

--- a/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv
@@ -1,0 +1,3 @@
+target_width	status	reason	current_d_model	current_logical_width	target_ff_dim	target_estimated_linear_muls	current_mul_memory_ops	mul_gap_factor	target_activation_rows	target_norm_rows	blocker_count
+64	NO_GO_CURRENT_SURFACE	current checked Stwo proof surface is a bounded statement-binding fixture, not a matched d64/d128 RMSNorm-SwiGLU proof	36	4	256	49152	7	7021.714	256	1	4
+128	NO_GO_CURRENT_SURFACE	current checked Stwo proof surface is a bounded statement-binding fixture, not a matched d64/d128 RMSNorm-SwiGLU proof	36	4	512	196608	7	28086.857	512	1	4

--- a/docs/engineering/zkai-matched-rmsnorm-swiglu-block-feasibility-gate-2026-05-01.md
+++ b/docs/engineering/zkai-matched-rmsnorm-swiglu-block-feasibility-gate-2026-05-01.md
@@ -1,0 +1,105 @@
+# zkAI matched RMSNorm-SwiGLU block feasibility gate - 2026-05-01
+
+## Question
+
+Can the current checked Stwo statement-bound transformer-block surface honestly
+serve as a matched `d=64` or `d=128` RMSNorm-SwiGLU-residual zkML benchmark?
+
+## Decision
+
+**NO-GO on the current Stwo proof surface.**
+
+This is not a failure of the statement-receipt discipline. The width-4
+statement-bound block result remains useful for binding and composition. The
+NO-GO is narrower: the current checked proof artifact and proof generator do not
+yet expose the vector proof surface needed for a competitor-facing `d=64` or
+`d=128` RMSNorm-SwiGLU block.
+
+## Current checked surface
+
+The current Stwo statement-bound transformer-block result is anchored to:
+
+- proof backend version: `stwo-phase10-linear-block-v4-with-lookup`
+- statement model ID: `urn:zkai:ptvm:rmsnorm-gated-affine-residual-block-v1`
+- checked statement profile: width `4`
+- proof public claim `d_model`: `36`
+- proof public claim `ff_dim`: `72`
+- proof final memory cells: `21`
+- proof instruction count: `43`
+- proof `MulMemory` count: `7`
+- statement-envelope relabeling result: `14 / 14` rejected
+
+That is enough for a bounded statement-binding and agent-step composition gate.
+It is not enough for a matched public zkML benchmark.
+
+## Target shape
+
+The feasibility probe pins the next honest target as:
+
+| Target | `ff_dim` | Estimated linear multiplications | Activation rows | Norm rows |
+|---|---:|---:|---:|---:|
+| `d=64` RMSNorm-SwiGLU-residual | `256` | `49,152` | `256` | `1` |
+| `d=128` RMSNorm-SwiGLU-residual | `512` | `196,608` | `512` | `1` |
+
+The multiplication estimate is the minimal gate/value/down-projection surface:
+`3 * d * ff_dim`, with `ff_dim = 4d`. It deliberately excludes optimization
+claims and does not count all supporting range, normalization, lookup, or
+packing constraints.
+
+## Blockers
+
+For both `d=64` and `d=128`, the probe records the same four blockers:
+
+1. `proof_claim_d_model_mismatch`: the checked proof public claim reports
+   `d_model = 36`, not `64` or `128`.
+2. `statement_profile_width_mismatch`: the statement receipt binds a width-4
+   profile, not a matched public-benchmark width.
+3. `instruction_surface_too_small_for_swiglu`: the checked fixture has `7`
+   `MulMemory` operations; a matched block needs roughly `49,152` linear
+   multiplications at `d=64` and `196,608` at `d=128`.
+4. `proof_generator_fixture_allowlist`: the current Stwo generator is scoped to
+   shipped fixtures and decoding families, not arbitrary matched MLP programs.
+
+## Engineering implication
+
+The next implementation work is not another wrapper around the existing
+width-4 proof. The required work is one of:
+
+- a parameterized Stwo AIR/export path for RMSNorm/SwiGLU/residual vector
+  blocks;
+- a public-instance surface that binds input activation, output activation,
+  weight, normalization, activation-lookup, setup, verifier-domain, and proof
+  commitments;
+- or an external proof-stack adapter that proves the same target and binds the
+  same statement fields for comparison.
+
+## Non-claims
+
+- This is not a `d=64` or `d=128` proof result.
+- This is not a performance benchmark.
+- This does not claim full transformer inference.
+- This does not claim that Stwo cannot support such a proof.
+- This does not weaken the width-4 statement-binding result; it prevents that
+  result from being overstated.
+
+## Evidence
+
+- JSON:
+  `docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json`
+- TSV:
+  `docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv`
+- Probe:
+  `scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py`
+- Tests:
+  `scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py`
+
+## Reproduce
+
+```bash
+python3 scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py \
+  --write-json docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv
+
+python3 -m unittest scripts.tests.test_zkai_matched_rmsnorm_swiglu_block_feasibility
+```
+

--- a/docs/paper/tablero-typed-verifier-boundaries-2026.md
+++ b/docs/paper/tablero-typed-verifier-boundaries-2026.md
@@ -759,6 +759,18 @@ receipt. It is anchored to
 and
 `docs/engineering/evidence/zkai-stwo-statement-bound-transformer-block-benchmark-2026-05.json`.
 
+A follow-up matched-block feasibility probe prevents this result from being
+overstated. It asks whether the same checked Stwo surface can honestly serve as
+a `d=64` or `d=128` RMSNorm-SwiGLU-residual benchmark. The current answer is
+NO-GO: the checked proof public claim reports `d_model = 36`, the receipt binds
+a width-4 block profile, the fixture exposes `7` `MulMemory` operations while a
+minimal `d=64` SwiGLU block already requires roughly `49,152` linear
+multiplications, and the current proof generator is fixture-gated rather than a
+parameterized vector-block AIR. This is useful as claim hygiene: the statement
+receipt result is a binding/composition result, not a competitor-facing zkML
+throughput result. The feasibility gate is anchored to
+`docs/engineering/zkai-matched-rmsnorm-swiglu-block-feasibility-gate-2026-05-01.md`.
+
 A separate composition gate then consumes the checked Stwo statement receipt as
 the model subreceipt inside an agent-step receipt. The composed
 `AgentStepReceiptV1` binds its model identity, model artifact, model

--- a/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -50,6 +50,12 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
         self.assertEqual(payload["current_surface"]["claim_transformer_config"]["d_model"], 36)
         self.assertEqual(payload["current_surface"]["block_logical_width"], 4)
         self.assertEqual(payload["current_surface"]["claim_mul_memory_ops"], 7)
+        with gzip.open(PROBE.CURRENT_PROOF_PATH, "rt", encoding="utf-8") as handle:
+            proof = json.load(handle)
+        self.assertEqual(
+            payload["current_surface"]["proof_payload_bytes"],
+            len(PROBE.canonical_json_bytes(proof["proof"])),
+        )
         self.assertTrue(payload["current_surface"]["fixture_gate"]["fixture_gate_detected"])
 
         widths = [row["target_width"] for row in payload["rows"]]
@@ -140,6 +146,26 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
         self.assertTrue(result["markers"]["linear_block_v4_with_lookup"])
         self.assertFalse(result["markers"]["decoding_step_v2_family"])
 
+    def test_fixture_gate_scan_records_external_paths_without_crashing(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            source = pathlib.Path(raw_tmp) / "probe.rs"
+            source.write_text(
+                "\n".join(
+                    [
+                        "fn matches_linear_block_v4_with_lookup() {}",
+                        "fn matches_decoding_step_v2() {}",
+                        "// broader arithmetic-subset AIR coverage remains internal",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = PROBE._fixture_gate_scan(source)
+
+        self.assertTrue(result["fixture_gate_detected"])
+        self.assertTrue(result["source_path"])
+        self.assertNotEqual(result["source_path"], ".")
+
     def test_tsv_rows_are_stable_and_include_gap_factor(self) -> None:
         current = {
             "proof_backend_version": PROBE.CURRENT_FIXTURE_PROOF_SYSTEM_VERSION,
@@ -189,6 +215,20 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
         self.assertEqual(row["status"], "GO_FEASIBLE")
         self.assertEqual(row["blockers"], [])
         self.assertEqual(PROBE.decision_for_rows([row]), PROBE.DECISION_GO)
+
+    def test_classifier_allows_explicit_matched_backend_even_if_fixture_markers_remain(self) -> None:
+        current = {
+            "proof_backend_version": "stwo-rmsnorm-swiglu-residual-d64-v1",
+            "claim_transformer_config": {"d_model": 64},
+            "block_logical_width": 64,
+            "claim_mul_memory_ops": 49_152,
+            "fixture_gate": {"fixture_gate_detected": True},
+        }
+
+        row = PROBE.classify_target(current, PROBE.matched_target(64))
+
+        self.assertEqual(row["status"], "GO_FEASIBLE")
+        self.assertEqual(row["blockers"], [])
 
     def test_classifier_keeps_fixture_blocker_for_renamed_backend_version(self) -> None:
         current = {

--- a/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -84,6 +84,30 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
             with self.assertRaisesRegex(PROBE.FeasibilityError, "logical_width disagrees"):
                 PROBE.current_surface(evidence_path=evidence_path, proof_path=PROBE.CURRENT_PROOF_PATH)
 
+    def test_current_surface_rejects_baseline_statement_model_id_drift(self) -> None:
+        evidence = json.loads(PROBE.CURRENT_EVIDENCE_PATH.read_text(encoding="utf-8"))
+        evidence["cases"][0]["baseline_statement"]["model_id"] = "urn:zkai:ptvm:wrong-model"
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            evidence_path = tmp / "evidence.json"
+            evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
+
+            with self.assertRaisesRegex(PROBE.FeasibilityError, "baseline_statement.model_id"):
+                PROBE.current_surface(evidence_path=evidence_path, proof_path=PROBE.CURRENT_PROOF_PATH)
+
+    def test_current_surface_rejects_missing_baseline_statement_model_id(self) -> None:
+        evidence = json.loads(PROBE.CURRENT_EVIDENCE_PATH.read_text(encoding="utf-8"))
+        del evidence["cases"][0]["baseline_statement"]["model_id"]
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            evidence_path = tmp / "evidence.json"
+            evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
+
+            with self.assertRaisesRegex(PROBE.FeasibilityError, "baseline_statement.model_id"):
+                PROBE.current_surface(evidence_path=evidence_path, proof_path=PROBE.CURRENT_PROOF_PATH)
+
     def test_current_surface_rejects_malformed_proof_instruction_shape(self) -> None:
         with gzip.open(PROBE.CURRENT_PROOF_PATH, "rt", encoding="utf-8") as handle:
             proof = json.load(handle)

--- a/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -165,6 +165,7 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
         self.assertTrue(result["fixture_gate_detected"])
         self.assertTrue(result["source_path"])
         self.assertNotEqual(result["source_path"], ".")
+        self.assertNotIn("\\", result["source_path"])
 
     def test_tsv_rows_are_stable_and_include_gap_factor(self) -> None:
         current = {

--- a/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import copy
+import gzip
+import importlib.util
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "zkai_matched_rmsnorm_swiglu_block_feasibility.py"
+SPEC = importlib.util.spec_from_file_location(
+    "zkai_matched_rmsnorm_swiglu_block_feasibility",
+    SCRIPT_PATH,
+)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load matched-block feasibility probe from {SCRIPT_PATH}")
+PROBE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PROBE)
+
+
+class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
+    def test_target_estimates_are_pinned_for_d64_and_d128(self) -> None:
+        d64 = PROBE.matched_target(64)
+        d128 = PROBE.matched_target(128)
+
+        self.assertEqual(d64["ff_dim"], 256)
+        self.assertEqual(d64["estimated_linear_muls"], 49_152)
+        self.assertEqual(d64["estimated_activation_rows"], 256)
+        self.assertEqual(d128["ff_dim"], 512)
+        self.assertEqual(d128["estimated_linear_muls"], 196_608)
+        self.assertEqual(d128["estimated_activation_rows"], 512)
+
+    def test_payload_records_current_surface_no_go_for_both_targets(self) -> None:
+        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "0", "ZKAI_GIT_COMMIT": "test-commit"}):
+            payload = PROBE.build_payload()
+
+        self.assertEqual(payload["schema"], PROBE.SCHEMA)
+        self.assertEqual(payload["generated_at"], "1970-01-01T00:00:00Z")
+        self.assertEqual(payload["decision"], "NO_GO_CURRENT_STWO_PROOF_SURFACE")
+        self.assertEqual(payload["summary"]["target_count"], 2)
+        self.assertEqual(payload["summary"]["no_go_count"], 2)
+        self.assertEqual(payload["current_surface"]["claim_transformer_config"]["d_model"], 36)
+        self.assertEqual(payload["current_surface"]["block_logical_width"], 4)
+        self.assertEqual(payload["current_surface"]["claim_mul_memory_ops"], 7)
+        self.assertTrue(payload["current_surface"]["fixture_gate"]["fixture_gate_detected"])
+
+        widths = [row["target_width"] for row in payload["rows"]]
+        self.assertEqual(widths, [64, 128])
+        for row in payload["rows"]:
+            self.assertEqual(row["status"], "NO_GO_CURRENT_SURFACE")
+            blocker_ids = {blocker["id"] for blocker in row["blockers"]}
+            self.assertIn("proof_claim_d_model_mismatch", blocker_ids)
+            self.assertIn("statement_profile_width_mismatch", blocker_ids)
+            self.assertIn("instruction_surface_too_small_for_swiglu", blocker_ids)
+            self.assertIn("proof_generator_fixture_allowlist", blocker_ids)
+
+    def test_current_surface_rejects_stale_statement_evidence(self) -> None:
+        evidence = json.loads(PROBE.CURRENT_EVIDENCE_PATH.read_text(encoding="utf-8"))
+        proof_path = PROBE.CURRENT_PROOF_PATH
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            evidence["summary"]["stwo-statement-envelope"]["all_mutations_rejected"] = False
+            evidence_path = tmp / "evidence.json"
+            evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
+
+            with self.assertRaisesRegex(PROBE.FeasibilityError, "does not reject every checked mutation"):
+                PROBE.current_surface(evidence_path=evidence_path, proof_path=proof_path)
+
+    def test_current_surface_rejects_profile_metadata_drift(self) -> None:
+        evidence = json.loads(PROBE.CURRENT_EVIDENCE_PATH.read_text(encoding="utf-8"))
+        evidence["artifact_metadata"]["transformer_block_profile"]["logical_width"] = 64
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            evidence_path = tmp / "evidence.json"
+            evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
+
+            with self.assertRaisesRegex(PROBE.FeasibilityError, "logical_width disagrees"):
+                PROBE.current_surface(evidence_path=evidence_path, proof_path=PROBE.CURRENT_PROOF_PATH)
+
+    def test_current_surface_rejects_malformed_proof_instruction_shape(self) -> None:
+        with gzip.open(PROBE.CURRENT_PROOF_PATH, "rt", encoding="utf-8") as handle:
+            proof = json.load(handle)
+        proof["claim"]["program"]["instructions"][0] = {"Load": 0, "Extra": 1}
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            proof_path = tmp / "proof.json.gz"
+            with gzip.open(proof_path, "wt", encoding="utf-8") as handle:
+                json.dump(proof, handle)
+
+            with self.assertRaisesRegex(PROBE.FeasibilityError, "singleton object"):
+                PROBE.current_surface(
+                    evidence_path=PROBE.CURRENT_EVIDENCE_PATH,
+                    proof_path=proof_path,
+                )
+
+    def test_fixture_gate_scan_fails_closed_when_source_markers_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            source = tmp / "probe.rs"
+            source.write_text("fn matches_linear_block_v4_with_lookup() {}\n", encoding="utf-8")
+
+            result = PROBE._fixture_gate_scan(source)
+
+        self.assertFalse(result["fixture_gate_detected"])
+        self.assertTrue(result["markers"]["linear_block_v4_with_lookup"])
+        self.assertFalse(result["markers"]["decoding_step_v2_family"])
+
+    def test_tsv_rows_are_stable_and_include_gap_factor(self) -> None:
+        current = {
+            "claim_transformer_config": {"d_model": 36},
+            "block_logical_width": 4,
+            "claim_mul_memory_ops": 7,
+            "fixture_gate": {"fixture_gate_detected": True},
+        }
+        rows = [
+            PROBE.classify_target(current, PROBE.matched_target(64)),
+            PROBE.classify_target(current, PROBE.matched_target(128)),
+        ]
+        payload = {"rows": rows}
+
+        tsv_rows = PROBE.rows_for_tsv(payload)
+
+        self.assertEqual(tsv_rows[0]["target_width"], 64)
+        self.assertEqual(tsv_rows[0]["mul_gap_factor"], "7021.714")
+        self.assertEqual(tsv_rows[1]["mul_gap_factor"], "28086.857")
+        self.assertEqual(tsv_rows[0]["blocker_count"], 4)
+
+    def test_write_outputs_round_trips_json_and_tsv(self) -> None:
+        payload = {
+            "schema": PROBE.SCHEMA,
+            "rows": [
+                PROBE.classify_target(
+                    {
+                        "claim_transformer_config": {"d_model": 36},
+                        "block_logical_width": 4,
+                        "claim_mul_memory_ops": 7,
+                        "fixture_gate": {"fixture_gate_detected": True},
+                    },
+                    PROBE.matched_target(64),
+                )
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_path = tmp / "out.json"
+            tsv_path = tmp / "out.tsv"
+            PROBE.write_outputs(copy.deepcopy(payload), json_path, tsv_path)
+
+            self.assertEqual(json.loads(json_path.read_text(encoding="utf-8"))["schema"], PROBE.SCHEMA)
+            tsv = tsv_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(tsv[0].split("\t"), list(PROBE.TSV_COLUMNS))
+            self.assertEqual(tsv[1].split("\t")[0], "64")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -168,6 +168,11 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
             with self.assertRaisesRegex(PROBE.FeasibilityError, "SOURCE_DATE_EPOCH"):
                 PROBE._generated_at()
 
+    def test_generated_at_rejects_out_of_range_source_date_epoch(self) -> None:
+        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": str(10**100)}, clear=True):
+            with self.assertRaisesRegex(PROBE.FeasibilityError, "timestamp range"):
+                PROBE._generated_at()
+
     def test_classifier_can_report_go_for_synthetic_matched_surface(self) -> None:
         current = {
             "proof_backend_version": "stwo-rmsnorm-swiglu-residual-d64-v1",
@@ -182,6 +187,21 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
         self.assertEqual(row["status"], "GO_FEASIBLE")
         self.assertEqual(row["blockers"], [])
         self.assertEqual(PROBE.decision_for_rows([row]), PROBE.DECISION_GO)
+
+    def test_classifier_keeps_fixture_blocker_for_renamed_backend_version(self) -> None:
+        current = {
+            "proof_backend_version": "stwo-phase10-linear-block-v5-renamed",
+            "claim_transformer_config": {"d_model": 64},
+            "block_logical_width": 64,
+            "claim_mul_memory_ops": 49_152,
+            "fixture_gate": {"fixture_gate_detected": True},
+        }
+
+        row = PROBE.classify_target(current, PROBE.matched_target(64))
+
+        self.assertEqual(row["status"], "NO_GO_CURRENT_SURFACE")
+        self.assertEqual([blocker["id"] for blocker in row["blockers"]], ["proof_generator_fixture_allowlist"])
+        self.assertEqual(row["blockers"][0]["proof_backend_version"], "stwo-phase10-linear-block-v5-renamed")
 
     def test_write_outputs_round_trips_json_and_tsv(self) -> None:
         payload = {

--- a/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -29,9 +29,11 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
         d128 = PROBE.matched_target(128)
 
         self.assertEqual(d64["ff_dim"], 256)
+        self.assertEqual(d64["required_proof_backend_version"], "stwo-rmsnorm-swiglu-residual-d64-v1")
         self.assertEqual(d64["estimated_linear_muls"], 49_152)
         self.assertEqual(d64["estimated_activation_rows"], 256)
         self.assertEqual(d128["ff_dim"], 512)
+        self.assertEqual(d128["required_proof_backend_version"], "stwo-rmsnorm-swiglu-residual-d128-v1")
         self.assertEqual(d128["estimated_linear_muls"], 196_608)
         self.assertEqual(d128["estimated_activation_rows"], 512)
 
@@ -200,8 +202,26 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
         row = PROBE.classify_target(current, PROBE.matched_target(64))
 
         self.assertEqual(row["status"], "NO_GO_CURRENT_SURFACE")
-        self.assertEqual([blocker["id"] for blocker in row["blockers"]], ["proof_generator_fixture_allowlist"])
-        self.assertEqual(row["blockers"][0]["proof_backend_version"], "stwo-phase10-linear-block-v5-renamed")
+        self.assertEqual(
+            [blocker["id"] for blocker in row["blockers"]],
+            ["proof_backend_version_mismatch", "proof_generator_fixture_allowlist"],
+        )
+        self.assertEqual(row["blockers"][1]["proof_backend_version"], "stwo-phase10-linear-block-v5-renamed")
+
+    def test_classifier_rejects_backend_version_drift_on_matched_shape(self) -> None:
+        current = {
+            "proof_backend_version": "corrupt-version",
+            "claim_transformer_config": {"d_model": 64},
+            "block_logical_width": 64,
+            "claim_mul_memory_ops": 49_152,
+            "fixture_gate": {"fixture_gate_detected": False},
+        }
+
+        row = PROBE.classify_target(current, PROBE.matched_target(64))
+
+        self.assertEqual(row["status"], "NO_GO_CURRENT_SURFACE")
+        self.assertEqual([blocker["id"] for blocker in row["blockers"]], ["proof_backend_version_mismatch"])
+        self.assertEqual(PROBE.decision_for_rows([row]), PROBE.DECISION_NO_GO)
 
     def test_write_outputs_round_trips_json_and_tsv(self) -> None:
         payload = {

--- a/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -36,14 +36,15 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
         self.assertEqual(d128["estimated_activation_rows"], 512)
 
     def test_payload_records_current_surface_no_go_for_both_targets(self) -> None:
-        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "0", "ZKAI_GIT_COMMIT": "test-commit"}):
+        with mock.patch.dict(os.environ, {"ZKAI_GIT_COMMIT": "test-commit"}, clear=True):
             payload = PROBE.build_payload()
 
         self.assertEqual(payload["schema"], PROBE.SCHEMA)
         self.assertEqual(payload["generated_at"], "1970-01-01T00:00:00Z")
-        self.assertEqual(payload["decision"], "NO_GO_CURRENT_STWO_PROOF_SURFACE")
+        self.assertEqual(payload["decision"], PROBE.DECISION_NO_GO)
         self.assertEqual(payload["summary"]["target_count"], 2)
         self.assertEqual(payload["summary"]["no_go_count"], 2)
+        self.assertEqual(payload["summary"]["go_count"], 0)
         self.assertEqual(payload["current_surface"]["claim_transformer_config"]["d_model"], 36)
         self.assertEqual(payload["current_surface"]["block_logical_width"], 4)
         self.assertEqual(payload["current_surface"]["claim_mul_memory_ops"], 7)
@@ -139,6 +140,7 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
 
     def test_tsv_rows_are_stable_and_include_gap_factor(self) -> None:
         current = {
+            "proof_backend_version": PROBE.CURRENT_FIXTURE_PROOF_SYSTEM_VERSION,
             "claim_transformer_config": {"d_model": 36},
             "block_logical_width": 4,
             "claim_mul_memory_ops": 7,
@@ -157,12 +159,37 @@ class ZkAIMatchedRMSNormSwiGLUBlockFeasibilityTests(unittest.TestCase):
         self.assertEqual(tsv_rows[1]["mul_gap_factor"], "28086.857")
         self.assertEqual(tsv_rows[0]["blocker_count"], 4)
 
+    def test_generated_at_is_deterministic_by_default(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(PROBE._generated_at(), "1970-01-01T00:00:00Z")
+
+    def test_generated_at_rejects_malformed_source_date_epoch(self) -> None:
+        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "not-an-int"}, clear=True):
+            with self.assertRaisesRegex(PROBE.FeasibilityError, "SOURCE_DATE_EPOCH"):
+                PROBE._generated_at()
+
+    def test_classifier_can_report_go_for_synthetic_matched_surface(self) -> None:
+        current = {
+            "proof_backend_version": "stwo-rmsnorm-swiglu-residual-d64-v1",
+            "claim_transformer_config": {"d_model": 64},
+            "block_logical_width": 64,
+            "claim_mul_memory_ops": 49_152,
+            "fixture_gate": {"fixture_gate_detected": False},
+        }
+
+        row = PROBE.classify_target(current, PROBE.matched_target(64))
+
+        self.assertEqual(row["status"], "GO_FEASIBLE")
+        self.assertEqual(row["blockers"], [])
+        self.assertEqual(PROBE.decision_for_rows([row]), PROBE.DECISION_GO)
+
     def test_write_outputs_round_trips_json_and_tsv(self) -> None:
         payload = {
             "schema": PROBE.SCHEMA,
             "rows": [
                 PROBE.classify_target(
                     {
+                        "proof_backend_version": PROBE.CURRENT_FIXTURE_PROOF_SYSTEM_VERSION,
                         "claim_transformer_config": {"d_model": 36},
                         "block_logical_width": 4,
                         "claim_mul_memory_ops": 7,

--- a/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -42,10 +42,13 @@ CURRENT_PROOF_PATH = (
 CURRENT_STWO_SOURCE_PATH = ROOT / "src" / "stwo_backend" / "arithmetic_subset_prover.rs"
 
 SCHEMA = "zkai-matched-rmsnorm-swiglu-block-feasibility-v1"
-DECISION = "NO_GO_CURRENT_STWO_PROOF_SURFACE"
+DECISION_GO = "GO_MATCHED_STWO_PROOF_SURFACE"
+DECISION_NO_GO = "NO_GO_CURRENT_STWO_PROOF_SURFACE"
 TARGET_WIDTHS = (64, 128)
 FF_DIM_MULTIPLIER = 4
 CURRENT_EXPECTED_MODEL_ID = "urn:zkai:ptvm:rmsnorm-gated-affine-residual-block-v1"
+CURRENT_FIXTURE_PROOF_SYSTEM_VERSION = "stwo-phase10-linear-block-v4-with-lookup"
+DEFAULT_SOURCE_DATE_EPOCH = 0
 TSV_COLUMNS = (
     "target_width",
     "status",
@@ -120,14 +123,12 @@ def _instruction_op_ids(proof: dict[str, Any]) -> list[str]:
 
 
 def _generated_at() -> str:
-    source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH")
-    if source_date_epoch:
-        try:
-            timestamp = int(source_date_epoch)
-        except ValueError as err:
-            raise FeasibilityError("SOURCE_DATE_EPOCH must be an integer timestamp") from err
-        return dt.datetime.fromtimestamp(timestamp, tz=dt.UTC).isoformat().replace("+00:00", "Z")
-    return dt.datetime.now(tz=dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH", str(DEFAULT_SOURCE_DATE_EPOCH))
+    try:
+        timestamp = int(source_date_epoch)
+    except ValueError as err:
+        raise FeasibilityError("SOURCE_DATE_EPOCH must be an integer timestamp") from err
+    return dt.datetime.fromtimestamp(timestamp, tz=dt.timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _git_commit() -> str:
@@ -319,14 +320,16 @@ def classify_target(current: dict[str, Any], target: dict[str, Any]) -> dict[str
                 "why_it_matters": "a matched SwiGLU block needs gate, value, and down projections over d x ff_dim matrices",
             }
         )
-    if not _require_dict(current.get("fixture_gate"), "current.fixture_gate").get("fixture_gate_detected"):
+    fixture_gate = _require_dict(current.get("fixture_gate"), "current.fixture_gate")
+    proof_backend_version = current.get("proof_backend_version")
+    if not fixture_gate.get("fixture_gate_detected") and proof_backend_version == CURRENT_FIXTURE_PROOF_SYSTEM_VERSION:
         blockers.append(
             {
                 "id": "unsupported_source_probe",
                 "why_it_matters": "the probe could not confirm the current fixture-gated Stwo proof surface",
             }
         )
-    else:
+    if fixture_gate.get("fixture_gate_detected") and proof_backend_version == CURRENT_FIXTURE_PROOF_SYSTEM_VERSION:
         blockers.append(
             {
                 "id": "proof_generator_fixture_allowlist",
@@ -335,11 +338,17 @@ def classify_target(current: dict[str, Any], target: dict[str, Any]) -> dict[str
         )
 
     gap = float(target["estimated_linear_muls"]) / float(current_mul_ops or 1)
+    status = "GO_FEASIBLE" if not blockers else "NO_GO_CURRENT_SURFACE"
+    reason = (
+        "current checked proof surface satisfies the matched RMSNorm-SwiGLU target shape"
+        if status == "GO_FEASIBLE"
+        else "current checked Stwo proof surface is a bounded statement-binding fixture, not a matched d64/d128 RMSNorm-SwiGLU proof"
+    )
     return {
         "target_id": target["target_id"],
         "target_width": target["width"],
-        "status": "NO_GO_CURRENT_SURFACE",
-        "reason": "current checked Stwo proof surface is a bounded statement-binding fixture, not a matched d64/d128 RMSNorm-SwiGLU proof",
+        "status": status,
+        "reason": reason,
         "current_d_model": current_d_model,
         "current_logical_width": current_width,
         "current_mul_memory_ops": current_mul_ops,
@@ -350,6 +359,12 @@ def classify_target(current: dict[str, Any], target: dict[str, Any]) -> dict[str
         "target_norm_rows": target["estimated_norm_rows"],
         "blockers": blockers,
     }
+
+
+def decision_for_rows(rows: list[dict[str, Any]]) -> str:
+    if not rows:
+        raise FeasibilityError("rows must not be empty")
+    return DECISION_GO if all(row["status"] == "GO_FEASIBLE" for row in rows) else DECISION_NO_GO
 
 
 def build_payload(
@@ -364,7 +379,7 @@ def build_payload(
     return {
         "schema": SCHEMA,
         "generated_at": _generated_at(),
-        "decision": DECISION,
+        "decision": decision_for_rows(rows),
         "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
         "current_surface": current,
         "targets": targets,
@@ -372,6 +387,7 @@ def build_payload(
         "summary": {
             "target_count": len(rows),
             "no_go_count": sum(1 for row in rows if row["status"].startswith("NO_GO")),
+            "go_count": sum(1 for row in rows if row["status"] == "GO_FEASIBLE"),
             "first_required_backend_work": "parameterized Stwo AIR or export path for RMSNorm/SwiGLU/residual vector blocks",
             "current_result_is_still_useful_for": "statement-binding and agent-step composition discipline",
             "current_result_is_not": "a matched d64/d128 zkML benchmark",

--- a/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -128,7 +128,11 @@ def _generated_at() -> str:
         timestamp = int(source_date_epoch)
     except ValueError as err:
         raise FeasibilityError("SOURCE_DATE_EPOCH must be an integer timestamp") from err
-    return dt.datetime.fromtimestamp(timestamp, tz=dt.timezone.utc).isoformat().replace("+00:00", "Z")
+    try:
+        generated_at = dt.datetime.fromtimestamp(timestamp, tz=dt.timezone.utc)
+    except (OverflowError, OSError, ValueError) as err:
+        raise FeasibilityError("SOURCE_DATE_EPOCH must be in the supported timestamp range") from err
+    return generated_at.isoformat().replace("+00:00", "Z")
 
 
 def _git_commit() -> str:
@@ -329,10 +333,12 @@ def classify_target(current: dict[str, Any], target: dict[str, Any]) -> dict[str
                 "why_it_matters": "the probe could not confirm the current fixture-gated Stwo proof surface",
             }
         )
-    if fixture_gate.get("fixture_gate_detected") and proof_backend_version == CURRENT_FIXTURE_PROOF_SYSTEM_VERSION:
+    if fixture_gate.get("fixture_gate_detected"):
         blockers.append(
             {
                 "id": "proof_generator_fixture_allowlist",
+                "proof_backend_version": proof_backend_version,
+                "pinned_fixture_version": CURRENT_FIXTURE_PROOF_SYSTEM_VERSION,
                 "why_it_matters": "the current Stwo generator is scoped to shipped fixtures/decoding families, not arbitrary matched MLP programs",
             }
         )

--- a/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -264,6 +264,7 @@ def matched_target(width: int) -> dict[str, Any]:
         "target_id": f"rmsnorm-swiglu-residual-d{width}-v1",
         "statement_kind": "transformer-block",
         "model_id": f"urn:zkai:ptvm:rmsnorm-swiglu-residual-d{width}-v1",
+        "required_proof_backend_version": f"stwo-rmsnorm-swiglu-residual-d{width}-v1",
         "width": width,
         "ff_dim": ff_dim,
         "activation": "SwiGLU",
@@ -326,6 +327,19 @@ def classify_target(current: dict[str, Any], target: dict[str, Any]) -> dict[str
         )
     fixture_gate = _require_dict(current.get("fixture_gate"), "current.fixture_gate")
     proof_backend_version = current.get("proof_backend_version")
+    allowed_backend_versions = {
+        CURRENT_FIXTURE_PROOF_SYSTEM_VERSION,
+        target["required_proof_backend_version"],
+    }
+    if proof_backend_version not in allowed_backend_versions:
+        blockers.append(
+            {
+                "id": "proof_backend_version_mismatch",
+                "current": proof_backend_version,
+                "allowed": sorted(allowed_backend_versions),
+                "why_it_matters": "the gate only classifies the checked fixture surface or the explicit matched target backend",
+            }
+        )
     if not fixture_gate.get("fixture_gate_detected") and proof_backend_version == CURRENT_FIXTURE_PROOF_SYSTEM_VERSION:
         blockers.append(
             {

--- a/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -85,9 +85,9 @@ def _display_path(path: pathlib.Path) -> str:
     resolved_root = ROOT.resolve()
     resolved_path = path.resolve()
     try:
-        return str(resolved_path.relative_to(resolved_root))
+        return resolved_path.relative_to(resolved_root).as_posix()
     except ValueError:
-        return os.path.relpath(resolved_path, resolved_root)
+        return resolved_path.as_posix()
 
 
 def _load_json(path: pathlib.Path) -> dict[str, Any]:

--- a/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -171,6 +171,26 @@ def _current_block_profile(evidence: dict[str, Any]) -> dict[str, Any]:
     return profile
 
 
+def _baseline_statement_model_id(evidence: dict[str, Any]) -> str:
+    cases = _require_list(evidence.get("cases"), "cases")
+    if not cases:
+        raise FeasibilityError("cases must not be empty")
+    model_ids: set[str] = set()
+    for index, case in enumerate(cases):
+        case_dict = _require_dict(case, f"cases[{index}]")
+        statement = _require_dict(case_dict.get("baseline_statement"), f"cases[{index}].baseline_statement")
+        model_id = statement.get("model_id")
+        if model_id != CURRENT_EXPECTED_MODEL_ID:
+            raise FeasibilityError(
+                f"cases[{index}].baseline_statement.model_id must be "
+                f"{CURRENT_EXPECTED_MODEL_ID!r}, got {model_id!r}"
+            )
+        model_ids.add(model_id)
+    if model_ids != {CURRENT_EXPECTED_MODEL_ID}:
+        raise FeasibilityError("baseline statement model IDs are inconsistent")
+    return CURRENT_EXPECTED_MODEL_ID
+
+
 def _fixture_gate_scan(source_path: pathlib.Path = CURRENT_STWO_SOURCE_PATH) -> dict[str, Any]:
     try:
         source = source_path.read_text(encoding="utf-8")
@@ -198,6 +218,7 @@ def current_surface(
     proof = _load_json(proof_path)
     statement_summary = _statement_envelope_summary(evidence)
     block_profile = _current_block_profile(evidence)
+    statement_model_id = _baseline_statement_model_id(evidence)
     claim = _require_dict(proof.get("claim"), "claim")
     transformer_config = _require_dict(claim.get("transformer_config"), "claim.transformer_config")
     final_state = _require_dict(claim.get("final_state"), "claim.final_state")
@@ -211,9 +232,7 @@ def current_surface(
         "proof_sha256": sha256_file(proof_path),
         "proof_backend": proof.get("proof_backend"),
         "proof_backend_version": proof.get("proof_backend_version"),
-        "statement_model_id": _require_dict(evidence.get("EXPECTED_STATEMENT"), "EXPECTED_STATEMENT").get("model_id")
-        if "EXPECTED_STATEMENT" in evidence
-        else CURRENT_EXPECTED_MODEL_ID,
+        "statement_model_id": statement_model_id,
         "claim_semantic_scope": claim.get("semantic_scope"),
         "claim_steps": claim.get("steps"),
         "claim_transformer_config": transformer_config,

--- a/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -81,6 +81,15 @@ def sha256_file(path: pathlib.Path) -> str:
     return digest.hexdigest()
 
 
+def _display_path(path: pathlib.Path) -> str:
+    resolved_root = ROOT.resolve()
+    resolved_path = path.resolve()
+    try:
+        return str(resolved_path.relative_to(resolved_root))
+    except ValueError:
+        return os.path.relpath(resolved_path, resolved_root)
+
+
 def _load_json(path: pathlib.Path) -> dict[str, Any]:
     try:
         if path.suffix == ".gz":
@@ -207,7 +216,7 @@ def _fixture_gate_scan(source_path: pathlib.Path = CURRENT_STWO_SOURCE_PATH) -> 
         "broader_arithmetic_subset_internal": "broader arithmetic-subset AIR coverage remains internal" in source,
     }
     return {
-        "source_path": str(source_path.relative_to(ROOT)),
+        "source_path": _display_path(source_path),
         "source_sha256": sha256_file(source_path),
         "fixture_gate_detected": all(markers.values()),
         "markers": markers,
@@ -230,10 +239,11 @@ def current_surface(
     memory = _require_list(final_state.get("memory"), "claim.final_state.memory")
     op_ids = _instruction_op_ids(proof)
     proof_payload = _require_list(proof.get("proof"), "proof")
+    proof_payload_bytes = len(canonical_json_bytes(proof_payload))
     return {
-        "evidence_path": str(evidence_path.relative_to(ROOT)),
+        "evidence_path": _display_path(evidence_path),
         "evidence_sha256": sha256_file(evidence_path),
-        "proof_path": str(proof_path.relative_to(ROOT)),
+        "proof_path": _display_path(proof_path),
         "proof_sha256": sha256_file(proof_path),
         "proof_backend": proof.get("proof_backend"),
         "proof_backend_version": proof.get("proof_backend_version"),
@@ -245,7 +255,7 @@ def current_surface(
         "claim_instruction_count": len(op_ids),
         "claim_mul_memory_ops": op_ids.count("MulMemory"),
         "claim_add_memory_ops": op_ids.count("AddMemory"),
-        "proof_payload_bytes": len(proof_payload),
+        "proof_payload_bytes": proof_payload_bytes,
         "block_profile_version": block_profile.get("profile_version"),
         "block_logical_width": block_profile.get("logical_width"),
         "block_operation_ids": block_profile.get("operation_ids"),
@@ -347,7 +357,7 @@ def classify_target(current: dict[str, Any], target: dict[str, Any]) -> dict[str
                 "why_it_matters": "the probe could not confirm the current fixture-gated Stwo proof surface",
             }
         )
-    if fixture_gate.get("fixture_gate_detected"):
+    if fixture_gate.get("fixture_gate_detected") and proof_backend_version != target["required_proof_backend_version"]:
         blockers.append(
             {
                 "id": "proof_generator_fixture_allowlist",

--- a/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
+++ b/scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Feasibility probe for matched d64/d128 RMSNorm-SwiGLU block targets.
+
+This is intentionally a gate, not a benchmark.  It compares the checked
+statement-bound Stwo transformer-block surface against the minimum shape needed
+for a public d=64 or d=128 RMSNorm-SwiGLU-residual block.  If the current proof
+surface cannot honestly support that target, the output records an explicit
+NO-GO with the exact blockers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import gzip
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CURRENT_EVIDENCE_PATH = (
+    ROOT
+    / "docs"
+    / "engineering"
+    / "evidence"
+    / "zkai-stwo-statement-bound-transformer-block-benchmark-2026-05.json"
+)
+CURRENT_PROOF_PATH = (
+    ROOT
+    / "docs"
+    / "engineering"
+    / "evidence"
+    / "zkai-stwo-statement-bound-transformer-block-2026-05"
+    / "linear_block_v4_with_lookup.proof.json.gz"
+)
+CURRENT_STWO_SOURCE_PATH = ROOT / "src" / "stwo_backend" / "arithmetic_subset_prover.rs"
+
+SCHEMA = "zkai-matched-rmsnorm-swiglu-block-feasibility-v1"
+DECISION = "NO_GO_CURRENT_STWO_PROOF_SURFACE"
+TARGET_WIDTHS = (64, 128)
+FF_DIM_MULTIPLIER = 4
+CURRENT_EXPECTED_MODEL_ID = "urn:zkai:ptvm:rmsnorm-gated-affine-residual-block-v1"
+TSV_COLUMNS = (
+    "target_width",
+    "status",
+    "reason",
+    "current_d_model",
+    "current_logical_width",
+    "target_ff_dim",
+    "target_estimated_linear_muls",
+    "current_mul_memory_ops",
+    "mul_gap_factor",
+    "target_activation_rows",
+    "target_norm_rows",
+    "blocker_count",
+)
+
+
+class FeasibilityError(ValueError):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_json(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        if path.suffix == ".gz":
+            with gzip.open(path, "rt", encoding="utf-8") as handle:
+                value = json.load(handle)
+        else:
+            with path.open("r", encoding="utf-8") as handle:
+                value = json.load(handle)
+    except (OSError, json.JSONDecodeError, gzip.BadGzipFile) as err:
+        raise FeasibilityError(f"failed to load JSON artifact {path}: {err}") from err
+    if not isinstance(value, dict):
+        raise FeasibilityError(f"JSON artifact {path} must be an object")
+    return value
+
+
+def _require_dict(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FeasibilityError(f"{label} must be an object")
+    return value
+
+
+def _require_list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise FeasibilityError(f"{label} must be a list")
+    return value
+
+
+def _instruction_op_ids(proof: dict[str, Any]) -> list[str]:
+    program = _require_dict(_require_dict(proof.get("claim"), "claim").get("program"), "claim.program")
+    instructions = _require_list(program.get("instructions"), "claim.program.instructions")
+    op_ids: list[str] = []
+    for index, instruction in enumerate(instructions):
+        if isinstance(instruction, str):
+            op_ids.append(instruction)
+            continue
+        if not isinstance(instruction, dict) or len(instruction) != 1:
+            raise FeasibilityError(f"claim.program.instructions[{index}] must be a string or singleton object")
+        op_ids.append(next(iter(instruction)))
+    return op_ids
+
+
+def _generated_at() -> str:
+    source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if source_date_epoch:
+        try:
+            timestamp = int(source_date_epoch)
+        except ValueError as err:
+            raise FeasibilityError("SOURCE_DATE_EPOCH must be an integer timestamp") from err
+        return dt.datetime.fromtimestamp(timestamp, tz=dt.UTC).isoformat().replace("+00:00", "Z")
+    return dt.datetime.now(tz=dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _git_commit() -> str:
+    override = os.environ.get("ZKAI_GIT_COMMIT")
+    if override:
+        return override
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def _statement_envelope_summary(evidence: dict[str, Any]) -> dict[str, Any]:
+    summary = _require_dict(evidence.get("summary"), "summary")
+    statement_summary = _require_dict(summary.get("stwo-statement-envelope"), "summary.stwo-statement-envelope")
+    if statement_summary.get("baseline_accepted") is not True:
+        raise FeasibilityError("current statement-envelope baseline is not accepted")
+    if statement_summary.get("all_mutations_rejected") is not True:
+        raise FeasibilityError("current statement-envelope evidence does not reject every checked mutation")
+    if statement_summary.get("mutations_checked") not in (None, statement_summary.get("mutation_count")):
+        raise FeasibilityError("current statement-envelope mutation count aliases disagree")
+    return statement_summary
+
+
+def _current_block_profile(evidence: dict[str, Any]) -> dict[str, Any]:
+    profile = _require_dict(evidence.get("block_profile"), "block_profile")
+    artifact_metadata = _require_dict(evidence.get("artifact_metadata"), "artifact_metadata")
+    metadata_profile = _require_dict(
+        artifact_metadata.get("transformer_block_profile"),
+        "artifact_metadata.transformer_block_profile",
+    )
+    if profile.get("logical_width") != metadata_profile.get("logical_width"):
+        raise FeasibilityError("current block profile logical_width disagrees with artifact metadata")
+    if profile.get("profile_version") != metadata_profile.get("profile_version"):
+        raise FeasibilityError("current block profile version disagrees with artifact metadata")
+    return profile
+
+
+def _fixture_gate_scan(source_path: pathlib.Path = CURRENT_STWO_SOURCE_PATH) -> dict[str, Any]:
+    try:
+        source = source_path.read_text(encoding="utf-8")
+    except OSError as err:
+        raise FeasibilityError(f"failed to read Stwo source {source_path}: {err}") from err
+    markers = {
+        "linear_block_v4_with_lookup": "matches_linear_block_v4_with_lookup" in source,
+        "decoding_step_v2_family": "matches_decoding_step_v2" in source,
+        "broader_arithmetic_subset_internal": "broader arithmetic-subset AIR coverage remains internal" in source,
+    }
+    return {
+        "source_path": str(source_path.relative_to(ROOT)),
+        "source_sha256": sha256_file(source_path),
+        "fixture_gate_detected": all(markers.values()),
+        "markers": markers,
+    }
+
+
+def current_surface(
+    evidence_path: pathlib.Path = CURRENT_EVIDENCE_PATH,
+    proof_path: pathlib.Path = CURRENT_PROOF_PATH,
+    source_path: pathlib.Path = CURRENT_STWO_SOURCE_PATH,
+) -> dict[str, Any]:
+    evidence = _load_json(evidence_path)
+    proof = _load_json(proof_path)
+    statement_summary = _statement_envelope_summary(evidence)
+    block_profile = _current_block_profile(evidence)
+    claim = _require_dict(proof.get("claim"), "claim")
+    transformer_config = _require_dict(claim.get("transformer_config"), "claim.transformer_config")
+    final_state = _require_dict(claim.get("final_state"), "claim.final_state")
+    memory = _require_list(final_state.get("memory"), "claim.final_state.memory")
+    op_ids = _instruction_op_ids(proof)
+    proof_payload = _require_list(proof.get("proof"), "proof")
+    return {
+        "evidence_path": str(evidence_path.relative_to(ROOT)),
+        "evidence_sha256": sha256_file(evidence_path),
+        "proof_path": str(proof_path.relative_to(ROOT)),
+        "proof_sha256": sha256_file(proof_path),
+        "proof_backend": proof.get("proof_backend"),
+        "proof_backend_version": proof.get("proof_backend_version"),
+        "statement_model_id": _require_dict(evidence.get("EXPECTED_STATEMENT"), "EXPECTED_STATEMENT").get("model_id")
+        if "EXPECTED_STATEMENT" in evidence
+        else CURRENT_EXPECTED_MODEL_ID,
+        "claim_semantic_scope": claim.get("semantic_scope"),
+        "claim_steps": claim.get("steps"),
+        "claim_transformer_config": transformer_config,
+        "claim_memory_cells": len(memory),
+        "claim_instruction_count": len(op_ids),
+        "claim_mul_memory_ops": op_ids.count("MulMemory"),
+        "claim_add_memory_ops": op_ids.count("AddMemory"),
+        "proof_payload_bytes": len(proof_payload),
+        "block_profile_version": block_profile.get("profile_version"),
+        "block_logical_width": block_profile.get("logical_width"),
+        "block_operation_ids": block_profile.get("operation_ids"),
+        "statement_envelope_mutations_checked": statement_summary.get("mutation_count"),
+        "statement_envelope_mutations_rejected": statement_summary.get("mutations_rejected"),
+        "fixture_gate": _fixture_gate_scan(source_path),
+    }
+
+
+def matched_target(width: int) -> dict[str, Any]:
+    if width <= 0:
+        raise FeasibilityError("target width must be positive")
+    ff_dim = width * FF_DIM_MULTIPLIER
+    linear_muls = 3 * width * ff_dim
+    return {
+        "target_id": f"rmsnorm-swiglu-residual-d{width}-v1",
+        "statement_kind": "transformer-block",
+        "model_id": f"urn:zkai:ptvm:rmsnorm-swiglu-residual-d{width}-v1",
+        "width": width,
+        "ff_dim": ff_dim,
+        "activation": "SwiGLU",
+        "normalization": "RMSNorm",
+        "residual": True,
+        "estimated_linear_muls": linear_muls,
+        "estimated_activation_rows": ff_dim,
+        "estimated_norm_rows": 1,
+        "required_statement_bindings": [
+            "model_artifact_commitment",
+            "model_config_commitment",
+            "weight_commitment",
+            "input_activation_commitment",
+            "output_activation_commitment",
+            "normalization_config_commitment",
+            "activation_lookup_commitment",
+            "public_instance_commitment",
+            "proof_commitment",
+            "verifying_key_commitment",
+            "setup_commitment",
+            "verifier_domain",
+            "proof_system_version",
+        ],
+    }
+
+
+def classify_target(current: dict[str, Any], target: dict[str, Any]) -> dict[str, Any]:
+    current_config = _require_dict(current.get("claim_transformer_config"), "current.claim_transformer_config")
+    current_d_model = current_config.get("d_model")
+    current_width = current.get("block_logical_width")
+    current_mul_ops = current.get("claim_mul_memory_ops")
+    blockers: list[dict[str, Any]] = []
+
+    if current_d_model != target["width"]:
+        blockers.append(
+            {
+                "id": "proof_claim_d_model_mismatch",
+                "current": current_d_model,
+                "required": target["width"],
+                "why_it_matters": "the checked proof public claim is not a d64/d128 transformer block claim",
+            }
+        )
+    if current_width != target["width"]:
+        blockers.append(
+            {
+                "id": "statement_profile_width_mismatch",
+                "current": current_width,
+                "required": target["width"],
+                "why_it_matters": "the statement receipt binds a width-4 profile, not a matched public benchmark width",
+            }
+        )
+    if current_mul_ops < target["estimated_linear_muls"]:
+        blockers.append(
+            {
+                "id": "instruction_surface_too_small_for_swiglu",
+                "current_mul_memory_ops": current_mul_ops,
+                "estimated_required_linear_muls": target["estimated_linear_muls"],
+                "why_it_matters": "a matched SwiGLU block needs gate, value, and down projections over d x ff_dim matrices",
+            }
+        )
+    if not _require_dict(current.get("fixture_gate"), "current.fixture_gate").get("fixture_gate_detected"):
+        blockers.append(
+            {
+                "id": "unsupported_source_probe",
+                "why_it_matters": "the probe could not confirm the current fixture-gated Stwo proof surface",
+            }
+        )
+    else:
+        blockers.append(
+            {
+                "id": "proof_generator_fixture_allowlist",
+                "why_it_matters": "the current Stwo generator is scoped to shipped fixtures/decoding families, not arbitrary matched MLP programs",
+            }
+        )
+
+    gap = float(target["estimated_linear_muls"]) / float(current_mul_ops or 1)
+    return {
+        "target_id": target["target_id"],
+        "target_width": target["width"],
+        "status": "NO_GO_CURRENT_SURFACE",
+        "reason": "current checked Stwo proof surface is a bounded statement-binding fixture, not a matched d64/d128 RMSNorm-SwiGLU proof",
+        "current_d_model": current_d_model,
+        "current_logical_width": current_width,
+        "current_mul_memory_ops": current_mul_ops,
+        "target_ff_dim": target["ff_dim"],
+        "target_estimated_linear_muls": target["estimated_linear_muls"],
+        "mul_gap_factor": gap,
+        "target_activation_rows": target["estimated_activation_rows"],
+        "target_norm_rows": target["estimated_norm_rows"],
+        "blockers": blockers,
+    }
+
+
+def build_payload(
+    *,
+    evidence_path: pathlib.Path = CURRENT_EVIDENCE_PATH,
+    proof_path: pathlib.Path = CURRENT_PROOF_PATH,
+    source_path: pathlib.Path = CURRENT_STWO_SOURCE_PATH,
+) -> dict[str, Any]:
+    current = current_surface(evidence_path=evidence_path, proof_path=proof_path, source_path=source_path)
+    targets = [matched_target(width) for width in TARGET_WIDTHS]
+    rows = [classify_target(current, target) for target in targets]
+    return {
+        "schema": SCHEMA,
+        "generated_at": _generated_at(),
+        "decision": DECISION,
+        "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
+        "current_surface": current,
+        "targets": targets,
+        "rows": rows,
+        "summary": {
+            "target_count": len(rows),
+            "no_go_count": sum(1 for row in rows if row["status"].startswith("NO_GO")),
+            "first_required_backend_work": "parameterized Stwo AIR or export path for RMSNorm/SwiGLU/residual vector blocks",
+            "current_result_is_still_useful_for": "statement-binding and agent-step composition discipline",
+            "current_result_is_not": "a matched d64/d128 zkML benchmark",
+        },
+        "next_required_work": [
+            {
+                "id": "parameterized_vector_public_claim",
+                "description": "Expose input/output activation, weight, normalization, activation-lookup, and config commitments as verifier-facing public statement material.",
+            },
+            {
+                "id": "stwo_air_for_vector_mlp_block",
+                "description": "Add or export a proof surface whose constraints actually cover RMSNorm, SwiGLU gate/value/down projections, and residual addition at d=64 before d=128.",
+            },
+            {
+                "id": "same_statement_external_adapter",
+                "description": "If using EZKL/ONNX or another proof stack for comparison, bind the same statement fields and run the same relabeling suite.",
+            },
+        ],
+        "non_claims": [
+            "This is not a d64 or d128 proof result.",
+            "This is not a performance benchmark.",
+            "This does not claim full transformer inference.",
+            "This does not claim that the width-4 statement-bound block already proves matched RMSNorm-SwiGLU semantics.",
+            "This does not claim Stwo is incapable of such a proof; it records that the current repo proof surface does not expose it.",
+        ],
+        "repro": {
+            "git_commit": _git_commit(),
+            "command": [
+                "python3",
+                "scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py",
+                "--write-json",
+                "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json",
+                "--write-tsv",
+                "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv",
+            ],
+        },
+    }
+
+
+def rows_for_tsv(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for row in _require_list(payload.get("rows"), "rows"):
+        rows.append(
+            {
+                "target_width": row["target_width"],
+                "status": row["status"],
+                "reason": row["reason"],
+                "current_d_model": row["current_d_model"],
+                "current_logical_width": row["current_logical_width"],
+                "target_ff_dim": row["target_ff_dim"],
+                "target_estimated_linear_muls": row["target_estimated_linear_muls"],
+                "current_mul_memory_ops": row["current_mul_memory_ops"],
+                "mul_gap_factor": f"{row['mul_gap_factor']:.3f}",
+                "target_activation_rows": row["target_activation_rows"],
+                "target_norm_rows": row["target_norm_rows"],
+                "blocker_count": len(row["blockers"]),
+            }
+        )
+    return rows
+
+
+def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
+    if json_path is not None:
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if tsv_path is not None:
+        tsv_path.parent.mkdir(parents=True, exist_ok=True)
+        with tsv_path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+            writer.writeheader()
+            writer.writerows(rows_for_tsv(payload))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print the JSON payload to stdout")
+    parser.add_argument("--write-json", type=pathlib.Path, help="write the JSON payload")
+    parser.add_argument("--write-tsv", type=pathlib.Path, help="write the TSV summary")
+    args = parser.parse_args(argv)
+
+    try:
+        payload = build_payload()
+        write_outputs(payload, args.write_json, args.write_tsv)
+    except FeasibilityError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a checked feasibility probe for the matched `d=64` / `d=128` RMSNorm-SwiGLU-residual target from #335
- record an explicit current-surface NO-GO: the checked Stwo statement-block proof is width-4 / `d_model=36`, has 21 memory cells and 7 `MulMemory` ops, and the generator is fixture-gated
- write deterministic JSON/TSV evidence with exact blockers and update the Tablero paper wording so the width-4 result is not overstated as a competitor-facing benchmark

## Result

This PR does **not** claim a d64/d128 proof or benchmark. It records the current-surface NO-GO under #335's falsification criteria and keeps #335 open as the real implementation target:

- d64 target: estimated 49,152 linear multiplications, current surface NO-GO
- d128 target: estimated 196,608 linear multiplications, current surface NO-GO
- required next work: parameterized Stwo AIR/export path or same-statement external adapter

## Review hardening

- deterministic `generated_at` by default; no wall-clock evidence drift
- Python 3.10-compatible UTC handling via `datetime.timezone.utc`
- strict statement-model identity checks across baseline evidence cases
- classifier can report `GO_FEASIBLE` for a synthetic future matched surface, so the gate is falsifiable rather than hard-coded to NO-GO

## Evidence

- Gate note: `docs/engineering/zkai-matched-rmsnorm-swiglu-block-feasibility-gate-2026-05-01.md`
- JSON: `docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json`
- TSV: `docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.tsv`

## Validation

- `python3 -m py_compile scripts/zkai_matched_rmsnorm_swiglu_block_feasibility.py scripts/tests/test_zkai_matched_rmsnorm_swiglu_block_feasibility.py`
- `python3 -m unittest scripts.tests.test_zkai_matched_rmsnorm_swiglu_block_feasibility` (13 tests OK)
- `just gate-fast`

Refs #335. This PR intentionally does not close #335 because the matched d64/d128 implementation target remains open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a feasibility‑gate document for matched RMSNorm‑SwiGLU transformer blocks and updated the design index to reference it.
  * Clarified in the paper why an existing checked statement cannot be reused as the targeted benchmark.

* **Tests**
  * Added a comprehensive test suite validating feasibility decisions, error paths, reproducible timestamps, and output stability.

* **New Features**
  * Added a reproducible feasibility assessment tool that emits GO/NO‑GO decision payloads and TSV/JSON reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->