### PR TITLE
[codex] Add d64 RMSNorm-SwiGLU surface probe

### DIFF
--- a/docs/engineering/design/README.md
+++ b/docs/engineering/design/README.md
@@ -20,5 +20,6 @@ Tablero itself proves agents, reasoning, tool truth, or policy semantics.
 - [Stwo statement-bound primitive gate](../zkai-stwo-statement-bound-primitive-gate-2026-04-29.md)
 - [Stwo statement-bound transformer-block result gate](../zkai-stwo-statement-bound-transformer-block-result-gate-2026-05-01.md)
 - [Matched RMSNorm-SwiGLU block feasibility gate](../zkai-matched-rmsnorm-swiglu-block-feasibility-gate-2026-05-01.md)
+- [d64 RMSNorm-SwiGLU implementation-surface probe](../zkai-d64-rmsnorm-swiglu-surface-probe-2026-05-01.md)
 - [Agent-step zkAI Stwo composition gate](../agent-step-zkai-stwo-composition-gate-2026-04-29.md)
 - [Agent-step model subreceipt callback gate](../agent-step-model-subreceipt-callback-gate-2026-04-29.md)

--- a/docs/engineering/design/statement-bound-transformer-primitive-spec.md
+++ b/docs/engineering/design/statement-bound-transformer-primitive-spec.md
@@ -160,6 +160,19 @@ The next comparison result should move from this width-4 baseline to a matched
 d64 or d128 RMSNorm/SwiGLU/residual target before comparing against public zkML
 systems.
 
+The follow-up implementation-surface probe narrows the required work:
+
+- `docs/engineering/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05-01.md`
+- `docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json`
+
+That probe records a direct TVM-fixture-growth NO-GO. A minimal `d=64` target
+needs roughly `49,152` projection multiplications and `49,152` weight scalars,
+while the current TVM representation has a `u8` address/PC surface and the
+checked transformer-block fixture has `21` memory cells, `43` instructions, and
+`7` `MulMemory` operations. The next credible result therefore needs a
+parameterized vector-block AIR/export path with committed weights, not a larger
+hand-written toy fixture.
+
 ## NO-GO criteria
 
 Record an explicit NO-GO if:

--- a/docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json
+++ b/docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json
@@ -21,8 +21,11 @@
       },
       {
         "id": "missing_parameterized_stwo_backend",
+        "missing": [
+          "stwo-rmsnorm-swiglu-residual-d64-v1"
+        ],
         "required_backend_version": "stwo-rmsnorm-swiglu-residual-d64-v1",
-        "why_it_matters": "the current Stwo generator recognizes shipped fixtures/decoding families, not the d64 vector-block backend"
+        "why_it_matters": "the probe should only report GO when it confirms both the current gate surface and the explicit d64 vector-block backend"
       },
       {
         "id": "carry_aware_lane_is_decoding_family_only",
@@ -109,7 +112,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.tsv"
     ],
-    "git_commit": "5fe4e72ecda7463663ae23dec1d1386178911d85"
+    "git_commit": "da5991733fbe6e06b681eaaf535ea378df893d8d"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "schema": "zkai-d64-rmsnorm-swiglu-surface-probe-v1",

--- a/docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json
+++ b/docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json
@@ -112,7 +112,7 @@
       "--write-tsv",
       "docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.tsv"
     ],
-    "git_commit": "da5991733fbe6e06b681eaaf535ea378df893d8d"
+    "git_commit": "unspecified"
   },
   "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
   "schema": "zkai-d64-rmsnorm-swiglu-surface-probe-v1",

--- a/docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json
+++ b/docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json
@@ -1,0 +1,152 @@
+{
+  "classification": {
+    "blockers": [
+      {
+        "current_limit_cells": 255,
+        "id": "weight_surface_exceeds_u8_memory_addressing",
+        "required_weight_scalars": 49152,
+        "why_it_matters": "a naive memory-resident d64 block cannot bind all gate/value/down weights in the current TVM memory surface"
+      },
+      {
+        "current_pc_horizon": 256,
+        "id": "unrolled_mul_surface_exceeds_u8_pc_horizon",
+        "required_mul_events": 49152,
+        "why_it_matters": "a direct one-instruction-per-scalar lowering cannot fit in the current u8 program-counter horizon"
+      },
+      {
+        "fixture_mul_memory_ops": 7,
+        "id": "current_fixture_is_toy_width",
+        "required_mul_events": 49152,
+        "why_it_matters": "the checked statement-bound block is useful for binding, not for matched d64 compute coverage"
+      },
+      {
+        "id": "missing_parameterized_stwo_backend",
+        "required_backend_version": "stwo-rmsnorm-swiglu-residual-d64-v1",
+        "why_it_matters": "the current Stwo generator recognizes shipped fixtures/decoding families, not the d64 vector-block backend"
+      },
+      {
+        "id": "carry_aware_lane_is_decoding_family_only",
+        "why_it_matters": "the scalable carry-aware proving lane cannot currently be reused as a generic RMSNorm/SwiGLU block prover"
+      }
+    ],
+    "mul_ops_over_pc_horizon": 192.0,
+    "reason": "direct TVM fixture growth is not the right implementation path for a matched d64 RMSNorm-SwiGLU block",
+    "status": "NO_GO_DIRECT_TVM_LOWERING",
+    "target_id": "rmsnorm-swiglu-residual-d64-v1",
+    "target_width": 64,
+    "weight_cells_over_memory_limit": 192.75294117647059
+  },
+  "current_fixture_profile": {
+    "instruction_count": 43,
+    "memory_cells": 21,
+    "mul_memory_ops": 7,
+    "program_path": "programs/linear_block_v4_with_lookup.tvm",
+    "program_sha256": "fed75a4eafca96b9fcbb632de7de28757de9ae6a6c1be08428b857bb3d3b5dee"
+  },
+  "current_prover_gates": {
+    "fixture_gate_detected": true,
+    "known_stwo_backend_versions": [
+      "stwo-phase10-linear-block-v4-with-lookup",
+      "stwo-phase11-decoding-step-v1"
+    ],
+    "markers": {
+      "broader_arithmetic_subset_internal": true,
+      "decoding_step_v2_family_matcher": true,
+      "fixture_gate_function": true,
+      "linear_block_v4_exact_matcher": true,
+      "phase12_decoding_only": true
+    },
+    "required_backend_version_present": false,
+    "source_path": "src/stwo_backend/arithmetic_subset_prover.rs",
+    "source_sha256": "b5a3eb01a57774a74188f5952e8e136cbf565d374b8bb0c5bf85774296361858"
+  },
+  "current_tvm_limits": {
+    "address_u8_detected": true,
+    "immediate_i16_detected": true,
+    "instruction_source_path": "src/instruction.rs",
+    "instruction_source_sha256": "f27fe1cc7c67136a8180e3f0323661230d86dad9e4a3d5043a5ec455716cfef0",
+    "limits_are_current": true,
+    "max_addressable_memory_cells": 255,
+    "memory_limit_detected": true,
+    "pc_horizon": 256,
+    "pc_u8_detected": true,
+    "state_source_path": "src/state.rs",
+    "state_source_sha256": "844f14b73455a7b8deeab560dad4b6a2e9c8887d5948a425f7526d622a5d7507"
+  },
+  "decision": "NO_GO_DIRECT_TVM_LOWERING",
+  "generated_at": "1970-01-01T00:00:00Z",
+  "next_required_work": [
+    {
+      "description": "Bind gate, value, and down projection weights through a table/vector commitment instead of TVM memory cells.",
+      "id": "weight_commitment_surface"
+    },
+    {
+      "description": "Represent the d64 block over vector/matrix rows rather than one TVM program counter step per scalar multiplication.",
+      "id": "vector_row_domain"
+    },
+    {
+      "description": "Add an explicit stwo-rmsnorm-swiglu-residual-d64-v1 or equivalent backend version with verifier-facing statement commitments.",
+      "id": "parameterized_backend_version"
+    },
+    {
+      "description": "Use the same model/input/output/config/weight receipt fields for Stwo and external proof-stack comparisons.",
+      "id": "same_statement_comparison"
+    }
+  ],
+  "non_claims": [
+    "This is not a d64 proof.",
+    "This is not a performance benchmark.",
+    "This does not claim Stwo cannot prove the target.",
+    "This does not claim a full transformer-inference result.",
+    "This does not weaken the existing width-4 statement-binding result."
+  ],
+  "repro": {
+    "command": [
+      "python3",
+      "scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py",
+      "--write-json",
+      "docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json",
+      "--write-tsv",
+      "docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.tsv"
+    ],
+    "git_commit": "5fe4e72ecda7463663ae23dec1d1386178911d85"
+  },
+  "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
+  "schema": "zkai-d64-rmsnorm-swiglu-surface-probe-v1",
+  "summary": {
+    "best_next_path": "parameterized vector-block AIR/export surface with committed weights, not a larger hand-written TVM fixture",
+    "direct_fixture_growth": "NO_GO",
+    "first_target": "d64 before d128",
+    "positive_result": "the next implementation blocker is now localized to representation/backend surface rather than statement binding"
+  },
+  "target": {
+    "activation": "SwiGLU",
+    "estimated_activation_rows": 256,
+    "estimated_linear_muls": 49152,
+    "estimated_norm_rows": 1,
+    "estimated_weight_scalars": 49152,
+    "ff_dim": 256,
+    "minimum_public_statement_bindings": [
+      "model_artifact_commitment",
+      "model_config_commitment",
+      "weight_commitment",
+      "input_activation_commitment",
+      "output_activation_commitment",
+      "normalization_config_commitment",
+      "activation_lookup_commitment",
+      "public_instance_commitment",
+      "proof_commitment",
+      "verifying_key_commitment",
+      "setup_commitment",
+      "verifier_domain",
+      "proof_system_version"
+    ],
+    "model_id": "urn:zkai:ptvm:rmsnorm-swiglu-residual-d64-v1",
+    "normalization": "RMSNorm",
+    "required_proof_backend_version": "stwo-rmsnorm-swiglu-residual-d64-v1",
+    "residual": true,
+    "statement_kind": "transformer-block",
+    "target_id": "rmsnorm-swiglu-residual-d64-v1",
+    "width": 64
+  }
+}

--- a/docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.tsv
@@ -1,0 +1,2 @@
+target_width	decision	ff_dim	estimated_linear_muls	estimated_weight_scalars	current_max_addressable_memory_cells	current_pc_horizon	current_fixture_memory_cells	current_fixture_instruction_count	current_fixture_mul_memory_ops	weight_cells_over_memory_limit	mul_ops_over_pc_horizon	blocker_count
+64	NO_GO_DIRECT_TVM_LOWERING	256	49152	49152	255	256	21	43	7	192.753	192.000	5

--- a/docs/engineering/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05-01.md
+++ b/docs/engineering/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05-01.md
@@ -1,0 +1,118 @@
+# zkAI d64 RMSNorm-SwiGLU surface probe - 2026-05-01
+
+## Question
+
+Can the next matched `d=64` RMSNorm-SwiGLU-residual result be obtained by
+directly emitting a larger TVM fixture for the current Stwo proving surface?
+
+## Decision
+
+**NO-GO for direct TVM fixture growth.**
+
+This is a narrower result than "Stwo cannot prove the block." It says the
+current repository surface is the wrong representation for a matched `d=64`
+block if the plan is merely to make the existing hand-written fixture larger.
+The next credible implementation path is a parameterized vector-block
+AIR/export surface with committed weights, not a bigger toy-width TVM program.
+
+## Checked target
+
+The first public-comparison target remains:
+
+| Target | Width | `ff_dim` | Estimated linear multiplications | Estimated weight scalars |
+|---|---:|---:|---:|---:|
+| RMSNorm-SwiGLU-residual | `64` | `256` | `49,152` | `49,152` |
+
+The estimate counts the three projection matrices needed by a standard gated
+MLP shape: gate, value, and down projection with `ff_dim = 4d`. It deliberately
+does not count all support rows for normalization, activation lookup, range
+handling, packing, or statement binding.
+
+## Current implementation surface
+
+The probe scans the checked source and current fixture surface:
+
+| Surface | Current value |
+|---|---:|
+| TVM addressable memory cells | `255` |
+| TVM program-counter horizon | `256` |
+| Current transformer-block fixture memory cells | `21` |
+| Current transformer-block fixture instructions | `43` |
+| Current transformer-block fixture `MulMemory` ops | `7` |
+
+The direct-lowering mismatch is large:
+
+| Ratio | Value |
+|---|---:|
+| Required weight scalars / current memory-cell limit | `192.753x` |
+| Required scalar multiplications / current PC horizon | `192.000x` |
+
+## Blockers
+
+The probe records five direct blockers:
+
+1. `weight_surface_exceeds_u8_memory_addressing`: the current TVM memory surface
+   cannot hold the `49,152` gate/value/down weights of a naive `d=64` block.
+2. `unrolled_mul_surface_exceeds_u8_pc_horizon`: a one-instruction-per-scalar
+   lowering cannot fit under the current `u8` program-counter horizon.
+3. `current_fixture_is_toy_width`: the checked width-4 transformer-block result
+   exposes `7` `MulMemory` operations, so it is useful for statement binding but
+   not matched compute coverage.
+4. `missing_parameterized_stwo_backend`: no
+   `stwo-rmsnorm-swiglu-residual-d64-v1` backend/version is exposed today.
+5. `carry_aware_lane_is_decoding_family_only`: the scalable carry-aware proving
+   lane is currently scoped to the decoding family, not generic vector MLP
+   blocks.
+
+## Engineering implication
+
+Do **not** spend the next research sprint hand-authoring a larger TVM fixture.
+That path hits representation limits before it becomes a credible benchmark.
+
+The implementation path that could become a real GO is:
+
+1. Add a weight/table commitment surface for gate, value, and down projection
+   parameters.
+2. Represent the block over vector/matrix rows rather than one TVM program
+   counter step per scalar multiplication.
+3. Expose an explicit `stwo-rmsnorm-swiglu-residual-d64-v1` or equivalent
+   backend version.
+4. Bind model, input, output, config, weights, proof, setup, verifier domain,
+   and public-instance commitments through the same statement receipt used by
+   the external adapters.
+
+## Why this is positive
+
+This result moves the blocker from a vague "we need a bigger transformer block"
+to a precise implementation boundary. The statement-binding and agent-receipt
+work still stands. What is missing for a competitor-facing zkAI result is the
+prover representation: committed vector-block rows and weights.
+
+## Non-claims
+
+- This is not a `d=64` proof.
+- This is not a performance benchmark.
+- This does not claim Stwo cannot prove the target.
+- This does not claim full transformer inference.
+- This does not weaken the existing width-4 statement-binding result.
+
+## Evidence
+
+- JSON:
+  `docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json`
+- TSV:
+  `docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.tsv`
+- Probe:
+  `scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py`
+- Tests:
+  `scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py`
+
+## Reproduce
+
+```bash
+python3 scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py \
+  --write-json docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.tsv
+
+python3 -m unittest scripts.tests.test_zkai_d64_rmsnorm_swiglu_surface_probe
+```

--- a/docs/paper/tablero-typed-verifier-boundaries-2026.md
+++ b/docs/paper/tablero-typed-verifier-boundaries-2026.md
@@ -770,6 +770,13 @@ parameterized vector-block AIR. This is useful as claim hygiene: the statement
 receipt result is a binding/composition result, not a competitor-facing zkML
 throughput result. The feasibility gate is anchored to
 `docs/engineering/zkai-matched-rmsnorm-swiglu-block-feasibility-gate-2026-05-01.md`.
+A subsequent implementation-surface probe makes the follow-up path more precise:
+directly growing the current byte-addressed TVM fixture is also NO-GO for `d=64`
+because the target needs roughly `49,152` projection multiplications and weight
+scalars, while the current accepted fixture exposes a bounded `u8` address/PC
+surface. The next credible comparison target is therefore a parameterized
+vector-block proof surface with committed weights, not a larger hand-written
+fixture.
 
 A separate composition gate then consumes the checked Stwo statement receipt as
 the model subreceipt inside an agent-step receipt. The composed

--- a/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -124,6 +124,30 @@ class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
         )
         self.assertIn("confirmed fixture-gate scan", row["blockers"][0]["missing"])
 
+    def test_classifier_handles_zero_limits_without_crashing(self) -> None:
+        target = PROBE.d64_target()
+        limits = {
+            "limits_are_current": False,
+            "max_addressable_memory_cells": 0,
+            "pc_horizon": 0,
+        }
+        gates = {
+            "fixture_gate_detected": False,
+            "required_backend_version_present": False,
+            "markers": {"phase12_decoding_only": False},
+        }
+        fixture = {
+            "memory_cells": 0,
+            "instruction_count": 0,
+            "mul_memory_ops": 0,
+        }
+
+        row = PROBE.classify_surface(target, limits, gates, fixture)
+
+        self.assertEqual(row["status"], PROBE.DECISION_NO_GO)
+        self.assertEqual(row["weight_cells_over_memory_limit"], float("inf"))
+        self.assertEqual(row["mul_ops_over_pc_horizon"], float("inf"))
+
     def test_scan_tvm_limits_fails_closed_when_markers_are_missing(self) -> None:
         with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
             tmp = pathlib.Path(raw_tmp)
@@ -138,6 +162,30 @@ class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
         self.assertFalse(limits["pc_u8_detected"])
         self.assertFalse(limits["address_u8_detected"])
 
+    def test_scan_tvm_limits_ignores_comment_and_string_spoofed_markers(self) -> None:
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            instruction = tmp / "instruction.rs"
+            state = tmp / "state.rs"
+            instruction.write_text(
+                "\n".join(
+                    [
+                        "// memory_size > usize::from(u8::MAX)",
+                        "const SPOOF: &str = \"Load(u8) MulMemory(u8) LoadImmediate(i16)\";",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            state.write_text('const SPOOF: &str = "pub pc: u8 instruction_at(&self, pc: u8)";\n', encoding="utf-8")
+
+            limits = PROBE.scan_tvm_limits(instruction_path=instruction, state_path=state)
+
+        self.assertFalse(limits["limits_are_current"])
+        self.assertFalse(limits["memory_limit_detected"])
+        self.assertFalse(limits["pc_u8_detected"])
+        self.assertFalse(limits["address_u8_detected"])
+        self.assertFalse(limits["immediate_i16_detected"])
+
     def test_scan_prover_gates_fails_closed_when_markers_are_missing(self) -> None:
         with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
             tmp = pathlib.Path(raw_tmp)
@@ -149,6 +197,30 @@ class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
         self.assertFalse(gates["fixture_gate_detected"])
         self.assertTrue(gates["markers"]["fixture_gate_function"])
         self.assertFalse(gates["markers"]["linear_block_v4_exact_matcher"])
+
+    def test_scan_prover_gates_ignores_comment_and_string_spoofed_identifiers(self) -> None:
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            source = tmp / "arithmetic_subset_prover.rs"
+            source.write_text(
+                "\n".join(
+                    [
+                        "// validate_phase5_proven_fixture matches_linear_block_v4_with_lookup",
+                        "// matches_decoding_step_v2",
+                        'const SPOOF: &str = "validate_phase5_proven_fixture matches_linear_block_v4_with_lookup matches_decoding_step_v2";',
+                        'const MESSAGE: &str = "broader arithmetic-subset AIR coverage remains internal";',
+                        'const MESSAGE_2: &str = "experimental Phase12 carry-aware proving supports only the decoding_step_v2 family";',
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            gates = PROBE.scan_prover_gates(source)
+
+        self.assertFalse(gates["fixture_gate_detected"])
+        self.assertFalse(gates["markers"]["fixture_gate_function"])
+        self.assertFalse(gates["markers"]["linear_block_v4_exact_matcher"])
+        self.assertFalse(gates["markers"]["decoding_step_v2_family_matcher"])
 
     def test_fixture_profile_rejects_missing_memory_directive(self) -> None:
         with tempfile.TemporaryDirectory() as raw_tmp:

--- a/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -148,6 +148,31 @@ class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
         self.assertEqual(row["weight_cells_over_memory_limit"], float("inf"))
         self.assertEqual(row["mul_ops_over_pc_horizon"], float("inf"))
 
+    def test_classifier_marks_ratios_infinite_when_limit_scan_is_unconfirmed(self) -> None:
+        target = PROBE.d64_target()
+        limits = {
+            "limits_are_current": False,
+            "max_addressable_memory_cells": 65_536,
+            "pc_horizon": 65_536,
+        }
+        gates = {
+            "fixture_gate_detected": True,
+            "required_backend_version_present": True,
+            "markers": {"phase12_decoding_only": False},
+        }
+        fixture = {
+            "memory_cells": 65_536,
+            "instruction_count": 49_153,
+            "mul_memory_ops": 49_152,
+        }
+
+        row = PROBE.classify_surface(target, limits, gates, fixture)
+
+        self.assertEqual(row["status"], PROBE.DECISION_NO_GO)
+        self.assertEqual(row["weight_cells_over_memory_limit"], float("inf"))
+        self.assertEqual(row["mul_ops_over_pc_horizon"], float("inf"))
+        self.assertEqual([blocker["id"] for blocker in row["blockers"]], ["unsupported_limit_scan"])
+
     def test_scan_tvm_limits_fails_closed_when_markers_are_missing(self) -> None:
         with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
             tmp = pathlib.Path(raw_tmp)

--- a/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -152,8 +152,8 @@ class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
         target = PROBE.d64_target()
         limits = {
             "limits_are_current": False,
-            "max_addressable_memory_cells": 65_536,
-            "pc_horizon": 65_536,
+            "max_addressable_memory_cells": 255,
+            "pc_horizon": 256,
         }
         gates = {
             "fixture_gate_detected": True,

--- a/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -82,7 +82,7 @@ class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
             "pc_horizon": 65_536,
         }
         gates = {
-            "fixture_gate_detected": False,
+            "fixture_gate_detected": True,
             "required_backend_version_present": True,
             "markers": {"phase12_decoding_only": False},
         }
@@ -96,6 +96,33 @@ class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
 
         self.assertEqual(row["status"], PROBE.DECISION_GO)
         self.assertEqual(row["blockers"], [])
+
+    def test_classifier_fails_closed_when_gate_scan_is_incomplete(self) -> None:
+        target = PROBE.d64_target()
+        limits = {
+            "limits_are_current": True,
+            "max_addressable_memory_cells": 65_536,
+            "pc_horizon": 65_536,
+        }
+        gates = {
+            "fixture_gate_detected": False,
+            "required_backend_version_present": True,
+            "markers": {"phase12_decoding_only": False},
+        }
+        fixture = {
+            "memory_cells": 65_536,
+            "instruction_count": 49_153,
+            "mul_memory_ops": 49_152,
+        }
+
+        row = PROBE.classify_surface(target, limits, gates, fixture)
+
+        self.assertEqual(row["status"], PROBE.DECISION_NO_GO)
+        self.assertEqual(
+            [blocker["id"] for blocker in row["blockers"]],
+            ["missing_parameterized_stwo_backend"],
+        )
+        self.assertIn("confirmed fixture-gate scan", row["blockers"][0]["missing"])
 
     def test_scan_tvm_limits_fails_closed_when_markers_are_missing(self) -> None:
         with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:

--- a/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "zkai_d64_rmsnorm_swiglu_surface_probe.py"
+SPEC = importlib.util.spec_from_file_location("zkai_d64_rmsnorm_swiglu_surface_probe", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load d64 surface probe from {SCRIPT_PATH}")
+PROBE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PROBE)
+
+
+class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
+    def test_d64_target_estimates_are_pinned(self) -> None:
+        target = PROBE.d64_target()
+
+        self.assertEqual(target["width"], 64)
+        self.assertEqual(target["ff_dim"], 256)
+        self.assertEqual(target["estimated_linear_muls"], 49_152)
+        self.assertEqual(target["estimated_weight_scalars"], 49_152)
+        self.assertEqual(target["required_proof_backend_version"], "stwo-rmsnorm-swiglu-residual-d64-v1")
+        self.assertIn("weight_commitment", target["minimum_public_statement_bindings"])
+
+    def test_scans_current_tvm_limits_from_source(self) -> None:
+        limits = PROBE.scan_tvm_limits()
+
+        self.assertTrue(limits["limits_are_current"])
+        self.assertTrue(limits["pc_u8_detected"])
+        self.assertTrue(limits["address_u8_detected"])
+        self.assertTrue(limits["immediate_i16_detected"])
+        self.assertEqual(limits["max_addressable_memory_cells"], 255)
+        self.assertEqual(limits["pc_horizon"], 256)
+
+    def test_scans_current_prover_fixture_gates_from_source(self) -> None:
+        gates = PROBE.scan_prover_gates()
+
+        self.assertTrue(gates["fixture_gate_detected"])
+        self.assertFalse(gates["required_backend_version_present"])
+        self.assertTrue(gates["markers"]["phase12_decoding_only"])
+        self.assertTrue(gates["markers"]["broader_arithmetic_subset_internal"])
+
+    def test_fixture_profile_is_pinned(self) -> None:
+        profile = PROBE.fixture_profile()
+
+        self.assertEqual(profile["memory_cells"], 21)
+        self.assertEqual(profile["instruction_count"], 43)
+        self.assertEqual(profile["mul_memory_ops"], 7)
+
+    def test_payload_records_direct_tvm_lowering_no_go(self) -> None:
+        with mock.patch.dict(os.environ, {"ZKAI_GIT_COMMIT": "test-commit"}, clear=True):
+            payload = PROBE.build_payload()
+
+        self.assertEqual(payload["schema"], PROBE.SCHEMA)
+        self.assertEqual(payload["generated_at"], "1970-01-01T00:00:00Z")
+        self.assertEqual(payload["decision"], PROBE.DECISION_NO_GO)
+        self.assertEqual(payload["summary"]["direct_fixture_growth"], "NO_GO")
+        self.assertEqual(payload["target"]["estimated_linear_muls"], 49_152)
+        self.assertEqual(payload["current_tvm_limits"]["max_addressable_memory_cells"], 255)
+        self.assertEqual(payload["current_tvm_limits"]["pc_horizon"], 256)
+
+        blocker_ids = {blocker["id"] for blocker in payload["classification"]["blockers"]}
+        self.assertIn("weight_surface_exceeds_u8_memory_addressing", blocker_ids)
+        self.assertIn("unrolled_mul_surface_exceeds_u8_pc_horizon", blocker_ids)
+        self.assertIn("current_fixture_is_toy_width", blocker_ids)
+        self.assertIn("missing_parameterized_stwo_backend", blocker_ids)
+        self.assertIn("carry_aware_lane_is_decoding_family_only", blocker_ids)
+
+    def test_classifier_can_report_go_for_synthetic_parameterized_surface(self) -> None:
+        target = PROBE.d64_target()
+        limits = {
+            "limits_are_current": True,
+            "max_addressable_memory_cells": 65_536,
+            "pc_horizon": 65_536,
+        }
+        gates = {
+            "fixture_gate_detected": False,
+            "required_backend_version_present": True,
+            "markers": {"phase12_decoding_only": False},
+        }
+        fixture = {
+            "memory_cells": 65_536,
+            "instruction_count": 49_153,
+            "mul_memory_ops": 49_152,
+        }
+
+        row = PROBE.classify_surface(target, limits, gates, fixture)
+
+        self.assertEqual(row["status"], PROBE.DECISION_GO)
+        self.assertEqual(row["blockers"], [])
+
+    def test_scan_tvm_limits_fails_closed_when_markers_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            instruction = tmp / "instruction.rs"
+            state = tmp / "state.rs"
+            instruction.write_text("enum Instruction { Load(usize) }\n", encoding="utf-8")
+            state.write_text("pub struct MachineState { pub pc: usize }\n", encoding="utf-8")
+
+            limits = PROBE.scan_tvm_limits(instruction_path=instruction, state_path=state)
+
+        self.assertFalse(limits["limits_are_current"])
+        self.assertFalse(limits["pc_u8_detected"])
+        self.assertFalse(limits["address_u8_detected"])
+
+    def test_scan_prover_gates_fails_closed_when_markers_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            source = tmp / "arithmetic_subset_prover.rs"
+            source.write_text("fn validate_phase5_proven_fixture() {}\n", encoding="utf-8")
+
+            gates = PROBE.scan_prover_gates(source)
+
+        self.assertFalse(gates["fixture_gate_detected"])
+        self.assertTrue(gates["markers"]["fixture_gate_function"])
+        self.assertFalse(gates["markers"]["linear_block_v4_exact_matcher"])
+
+    def test_fixture_profile_rejects_missing_memory_directive(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            path = pathlib.Path(raw_tmp) / "bad.tvm"
+            path.write_text("LOAD 0\nHALT\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(PROBE.SurfaceProbeError, "memory"):
+                PROBE.fixture_profile(path)
+
+    def test_tsv_rows_are_stable(self) -> None:
+        payload = {
+            "decision": PROBE.DECISION_NO_GO,
+            "target": PROBE.d64_target(),
+            "current_tvm_limits": {
+                "max_addressable_memory_cells": 255,
+                "pc_horizon": 256,
+            },
+            "current_fixture_profile": {
+                "memory_cells": 21,
+                "instruction_count": 43,
+                "mul_memory_ops": 7,
+            },
+            "classification": {
+                "weight_cells_over_memory_limit": 49_152 / 255,
+                "mul_ops_over_pc_horizon": 49_152 / 256,
+                "blockers": [{"id": "a"}, {"id": "b"}],
+            },
+        }
+
+        rows = PROBE.rows_for_tsv(payload)
+
+        self.assertEqual(rows[0]["target_width"], 64)
+        self.assertEqual(rows[0]["weight_cells_over_memory_limit"], "192.753")
+        self.assertEqual(rows[0]["mul_ops_over_pc_horizon"], "192.000")
+        self.assertEqual(rows[0]["blocker_count"], 2)
+
+    def test_write_outputs_round_trips_json_and_tsv(self) -> None:
+        with mock.patch.dict(os.environ, {"ZKAI_GIT_COMMIT": "test-commit"}, clear=True):
+            payload = PROBE.build_payload()
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_path = tmp / "out.json"
+            tsv_path = tmp / "out.tsv"
+            PROBE.write_outputs(copy.deepcopy(payload), json_path, tsv_path)
+
+            self.assertEqual(json.loads(json_path.read_text(encoding="utf-8"))["schema"], PROBE.SCHEMA)
+            tsv = tsv_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(tsv[0].split("\t"), list(PROBE.TSV_COLUMNS))
+            self.assertEqual(tsv[1].split("\t")[0], "64")
+
+    def test_generated_at_is_deterministic_and_rejects_bad_env(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(PROBE._generated_at(), "1970-01-01T00:00:00Z")
+        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "bad"}, clear=True):
+            with self.assertRaisesRegex(PROBE.SurfaceProbeError, "SOURCE_DATE_EPOCH"):
+                PROBE._generated_at()
+        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": str(10**100)}, clear=True):
+            with self.assertRaisesRegex(PROBE.SurfaceProbeError, "timestamp range"):
+                PROBE._generated_at()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -246,6 +246,8 @@ class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
         self.assertFalse(gates["markers"]["fixture_gate_function"])
         self.assertFalse(gates["markers"]["linear_block_v4_exact_matcher"])
         self.assertFalse(gates["markers"]["decoding_step_v2_family_matcher"])
+        self.assertTrue(gates["markers"]["broader_arithmetic_subset_internal"])
+        self.assertTrue(gates["markers"]["phase12_decoding_only"])
 
     def test_fixture_profile_rejects_missing_memory_directive(self) -> None:
         with tempfile.TemporaryDirectory() as raw_tmp:

--- a/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -200,6 +200,20 @@ class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
             self.assertEqual(tsv[0].split("\t"), list(PROBE.TSV_COLUMNS))
             self.assertEqual(tsv[1].split("\t")[0], "64")
 
+    def test_write_outputs_wraps_os_errors(self) -> None:
+        payload = {
+            "schema": PROBE.SCHEMA,
+            "rows": [],
+        }
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            not_a_dir = tmp / "not-a-dir"
+            not_a_dir.write_text("file", encoding="utf-8")
+
+            with self.assertRaisesRegex(PROBE.SurfaceProbeError, "failed to write probe output"):
+                PROBE.write_outputs(payload, not_a_dir / "out.json", None)
+
     def test_generated_at_is_deterministic_and_rejects_bad_env(self) -> None:
         with mock.patch.dict(os.environ, {}, clear=True):
             self.assertEqual(PROBE._generated_at(), "1970-01-01T00:00:00Z")
@@ -209,6 +223,12 @@ class ZkAID64RMSNormSwiGLUSurfaceProbeTests(unittest.TestCase):
         with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": str(10**100)}, clear=True):
             with self.assertRaisesRegex(PROBE.SurfaceProbeError, "timestamp range"):
                 PROBE._generated_at()
+
+    def test_git_commit_is_deterministic_by_default_and_overrideable(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(PROBE._git_commit(), "unspecified")
+        with mock.patch.dict(os.environ, {"ZKAI_GIT_COMMIT": "test-commit"}, clear=True):
+            self.assertEqual(PROBE._git_commit(), "test-commit")
 
 
 if __name__ == "__main__":

--- a/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Implementation-surface probe for a d64 RMSNorm-SwiGLU-residual block.
+
+This is not a prover benchmark.  It asks whether the current checked TVM/Stwo
+surface can plausibly be extended by "just emitting a larger fixture" for a
+matched d=64 transformer block.  The answer matters because a matched public
+zkAI comparison needs a real vector-block proof surface, not another wrapper
+around the current bounded statement-binding fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import hashlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+ARITHMETIC_PROVER_SOURCE = ROOT / "src" / "stwo_backend" / "arithmetic_subset_prover.rs"
+INSTRUCTION_SOURCE = ROOT / "src" / "instruction.rs"
+STATE_SOURCE = ROOT / "src" / "state.rs"
+LINEAR_BLOCK_V4_PROGRAM = ROOT / "programs" / "linear_block_v4_with_lookup.tvm"
+
+SCHEMA = "zkai-d64-rmsnorm-swiglu-surface-probe-v1"
+DECISION_NO_GO = "NO_GO_DIRECT_TVM_LOWERING"
+DECISION_GO = "GO_PARAMETERIZED_VECTOR_SURFACE"
+TARGET_WIDTH = 64
+FF_DIM_MULTIPLIER = 4
+DEFAULT_SOURCE_DATE_EPOCH = 0
+REQUIRED_BACKEND_VERSION = "stwo-rmsnorm-swiglu-residual-d64-v1"
+
+TSV_COLUMNS = (
+    "target_width",
+    "decision",
+    "ff_dim",
+    "estimated_linear_muls",
+    "estimated_weight_scalars",
+    "current_max_addressable_memory_cells",
+    "current_pc_horizon",
+    "current_fixture_memory_cells",
+    "current_fixture_instruction_count",
+    "current_fixture_mul_memory_ops",
+    "weight_cells_over_memory_limit",
+    "mul_ops_over_pc_horizon",
+    "blocker_count",
+)
+
+
+class SurfaceProbeError(ValueError):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _display_path(path: pathlib.Path) -> str:
+    resolved_root = ROOT.resolve()
+    resolved_path = path.resolve()
+    try:
+        return resolved_path.relative_to(resolved_root).as_posix()
+    except ValueError:
+        return resolved_path.as_posix()
+
+
+def _generated_at() -> str:
+    raw = os.environ.get("SOURCE_DATE_EPOCH", str(DEFAULT_SOURCE_DATE_EPOCH))
+    try:
+        timestamp = int(raw)
+    except ValueError as err:
+        raise SurfaceProbeError("SOURCE_DATE_EPOCH must be an integer timestamp") from err
+    try:
+        generated_at = dt.datetime.fromtimestamp(timestamp, tz=dt.timezone.utc)
+    except (OverflowError, OSError, ValueError) as err:
+        raise SurfaceProbeError("SOURCE_DATE_EPOCH must be in the supported timestamp range") from err
+    return generated_at.isoformat().replace("+00:00", "Z")
+
+
+def _git_commit() -> str:
+    override = os.environ.get("ZKAI_GIT_COMMIT")
+    if override:
+        return override
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def _read_text(path: pathlib.Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as err:
+        raise SurfaceProbeError(f"failed to read {path}: {err}") from err
+
+
+def d64_target() -> dict[str, Any]:
+    ff_dim = TARGET_WIDTH * FF_DIM_MULTIPLIER
+    linear_muls = 3 * TARGET_WIDTH * ff_dim
+    return {
+        "target_id": "rmsnorm-swiglu-residual-d64-v1",
+        "statement_kind": "transformer-block",
+        "model_id": "urn:zkai:ptvm:rmsnorm-swiglu-residual-d64-v1",
+        "required_proof_backend_version": REQUIRED_BACKEND_VERSION,
+        "width": TARGET_WIDTH,
+        "ff_dim": ff_dim,
+        "activation": "SwiGLU",
+        "normalization": "RMSNorm",
+        "residual": True,
+        "estimated_linear_muls": linear_muls,
+        "estimated_weight_scalars": linear_muls,
+        "estimated_activation_rows": ff_dim,
+        "estimated_norm_rows": 1,
+        "minimum_public_statement_bindings": [
+            "model_artifact_commitment",
+            "model_config_commitment",
+            "weight_commitment",
+            "input_activation_commitment",
+            "output_activation_commitment",
+            "normalization_config_commitment",
+            "activation_lookup_commitment",
+            "public_instance_commitment",
+            "proof_commitment",
+            "verifying_key_commitment",
+            "setup_commitment",
+            "verifier_domain",
+            "proof_system_version",
+        ],
+    }
+
+
+def _extract_first_match_int(source: str, pattern: str, label: str) -> int:
+    match = re.search(pattern, source)
+    if not match:
+        raise SurfaceProbeError(f"could not extract {label}")
+    return int(match.group(1))
+
+
+def scan_tvm_limits(
+    instruction_path: pathlib.Path = INSTRUCTION_SOURCE,
+    state_path: pathlib.Path = STATE_SOURCE,
+) -> dict[str, Any]:
+    instruction_source = _read_text(instruction_path)
+    state_source = _read_text(state_path)
+    memory_limit_detected = "memory_size > usize::from(u8::MAX)" in instruction_source
+    pc_u8_detected = "pub pc: u8" in state_source and "instruction_at(&self, pc: u8)" in instruction_source
+    address_u8_detected = "Load(u8)" in instruction_source and "MulMemory(u8)" in instruction_source
+    immediate_i16_detected = "LoadImmediate(i16)" in instruction_source
+    return {
+        "instruction_source_path": _display_path(instruction_path),
+        "instruction_source_sha256": sha256_file(instruction_path),
+        "state_source_path": _display_path(state_path),
+        "state_source_sha256": sha256_file(state_path),
+        "memory_limit_detected": memory_limit_detected,
+        "pc_u8_detected": pc_u8_detected,
+        "address_u8_detected": address_u8_detected,
+        "immediate_i16_detected": immediate_i16_detected,
+        "max_addressable_memory_cells": 255,
+        "pc_horizon": 256,
+        "limits_are_current": all(
+            [
+                memory_limit_detected,
+                pc_u8_detected,
+                address_u8_detected,
+                immediate_i16_detected,
+            ]
+        ),
+    }
+
+
+def scan_prover_gates(source_path: pathlib.Path = ARITHMETIC_PROVER_SOURCE) -> dict[str, Any]:
+    source = _read_text(source_path)
+    markers = {
+        "fixture_gate_function": "validate_phase5_proven_fixture" in source,
+        "linear_block_v4_exact_matcher": "matches_linear_block_v4_with_lookup" in source,
+        "decoding_step_v2_family_matcher": "matches_decoding_step_v2" in source,
+        "broader_arithmetic_subset_internal": "broader arithmetic-subset AIR coverage remains internal"
+        in source,
+        "phase12_decoding_only": "experimental Phase12 carry-aware proving supports only the decoding_step_v2 family"
+        in source,
+    }
+    backend_versions = sorted(set(re.findall(r"stwo-[a-zA-Z0-9_.\\-]+", source)))
+    return {
+        "source_path": _display_path(source_path),
+        "source_sha256": sha256_file(source_path),
+        "markers": markers,
+        "fixture_gate_detected": all(markers.values()),
+        "required_backend_version_present": REQUIRED_BACKEND_VERSION in source,
+        "known_stwo_backend_versions": backend_versions,
+    }
+
+
+def fixture_profile(program_path: pathlib.Path = LINEAR_BLOCK_V4_PROGRAM) -> dict[str, Any]:
+    source = _read_text(program_path)
+    memory_cells = _extract_first_match_int(source, r"(?im)^\.memory\s+(\d+)\s*$", ".memory size")
+    instruction_lines = []
+    for raw_line in source.splitlines():
+        stripped = raw_line.split(";", 1)[0].split("#", 1)[0].strip()
+        if not stripped or stripped.startswith(".") or stripped.endswith(":"):
+            continue
+        instruction_lines.append(stripped)
+    mul_memory_ops = sum(1 for line in instruction_lines if line.upper().startswith("MULM "))
+    return {
+        "program_path": _display_path(program_path),
+        "program_sha256": sha256_file(program_path),
+        "memory_cells": memory_cells,
+        "instruction_count": len(instruction_lines),
+        "mul_memory_ops": mul_memory_ops,
+    }
+
+
+def classify_surface(
+    target: dict[str, Any],
+    tvm_limits: dict[str, Any],
+    prover_gates: dict[str, Any],
+    fixture: dict[str, Any],
+) -> dict[str, Any]:
+    blockers: list[dict[str, Any]] = []
+    estimated_weight_scalars = int(target["estimated_weight_scalars"])
+    estimated_linear_muls = int(target["estimated_linear_muls"])
+    memory_limit = int(tvm_limits["max_addressable_memory_cells"])
+    pc_horizon = int(tvm_limits["pc_horizon"])
+
+    if not tvm_limits.get("limits_are_current"):
+        blockers.append(
+            {
+                "id": "unsupported_limit_scan",
+                "why_it_matters": "the probe could not confirm the current TVM pc/address/immediate limits",
+            }
+        )
+    if estimated_weight_scalars > memory_limit:
+        blockers.append(
+            {
+                "id": "weight_surface_exceeds_u8_memory_addressing",
+                "current_limit_cells": memory_limit,
+                "required_weight_scalars": estimated_weight_scalars,
+                "why_it_matters": "a naive memory-resident d64 block cannot bind all gate/value/down weights in the current TVM memory surface",
+            }
+        )
+    if estimated_linear_muls > pc_horizon:
+        blockers.append(
+            {
+                "id": "unrolled_mul_surface_exceeds_u8_pc_horizon",
+                "current_pc_horizon": pc_horizon,
+                "required_mul_events": estimated_linear_muls,
+                "why_it_matters": "a direct one-instruction-per-scalar lowering cannot fit in the current u8 program-counter horizon",
+            }
+        )
+    if fixture["mul_memory_ops"] < estimated_linear_muls:
+        blockers.append(
+            {
+                "id": "current_fixture_is_toy_width",
+                "fixture_mul_memory_ops": fixture["mul_memory_ops"],
+                "required_mul_events": estimated_linear_muls,
+                "why_it_matters": "the checked statement-bound block is useful for binding, not for matched d64 compute coverage",
+            }
+        )
+    if prover_gates.get("fixture_gate_detected") and not prover_gates.get("required_backend_version_present"):
+        blockers.append(
+            {
+                "id": "missing_parameterized_stwo_backend",
+                "required_backend_version": target["required_proof_backend_version"],
+                "why_it_matters": "the current Stwo generator recognizes shipped fixtures/decoding families, not the d64 vector-block backend",
+            }
+        )
+    if prover_gates.get("markers", {}).get("phase12_decoding_only"):
+        blockers.append(
+            {
+                "id": "carry_aware_lane_is_decoding_family_only",
+                "why_it_matters": "the scalable carry-aware proving lane cannot currently be reused as a generic RMSNorm/SwiGLU block prover",
+            }
+        )
+
+    status = DECISION_GO if not blockers else DECISION_NO_GO
+    return {
+        "target_id": target["target_id"],
+        "target_width": target["width"],
+        "status": status,
+        "reason": (
+            "surface exposes a parameterized vector-block backend large enough for d64"
+            if status == DECISION_GO
+            else "direct TVM fixture growth is not the right implementation path for a matched d64 RMSNorm-SwiGLU block"
+        ),
+        "blockers": blockers,
+        "weight_cells_over_memory_limit": estimated_weight_scalars / float(memory_limit),
+        "mul_ops_over_pc_horizon": estimated_linear_muls / float(pc_horizon),
+    }
+
+
+def build_payload(
+    *,
+    instruction_path: pathlib.Path = INSTRUCTION_SOURCE,
+    state_path: pathlib.Path = STATE_SOURCE,
+    prover_source_path: pathlib.Path = ARITHMETIC_PROVER_SOURCE,
+    fixture_path: pathlib.Path = LINEAR_BLOCK_V4_PROGRAM,
+) -> dict[str, Any]:
+    target = d64_target()
+    tvm_limits = scan_tvm_limits(instruction_path=instruction_path, state_path=state_path)
+    prover_gates = scan_prover_gates(prover_source_path)
+    fixture = fixture_profile(fixture_path)
+    classification = classify_surface(target, tvm_limits, prover_gates, fixture)
+    return {
+        "schema": SCHEMA,
+        "generated_at": _generated_at(),
+        "decision": classification["status"],
+        "research_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/335",
+        "target": target,
+        "current_tvm_limits": tvm_limits,
+        "current_prover_gates": prover_gates,
+        "current_fixture_profile": fixture,
+        "classification": classification,
+        "summary": {
+            "direct_fixture_growth": "NO_GO" if classification["blockers"] else "GO",
+            "best_next_path": "parameterized vector-block AIR/export surface with committed weights, not a larger hand-written TVM fixture",
+            "positive_result": "the next implementation blocker is now localized to representation/backend surface rather than statement binding",
+            "first_target": "d64 before d128",
+        },
+        "next_required_work": [
+            {
+                "id": "weight_commitment_surface",
+                "description": "Bind gate, value, and down projection weights through a table/vector commitment instead of TVM memory cells.",
+            },
+            {
+                "id": "vector_row_domain",
+                "description": "Represent the d64 block over vector/matrix rows rather than one TVM program counter step per scalar multiplication.",
+            },
+            {
+                "id": "parameterized_backend_version",
+                "description": f"Add an explicit {REQUIRED_BACKEND_VERSION} or equivalent backend version with verifier-facing statement commitments.",
+            },
+            {
+                "id": "same_statement_comparison",
+                "description": "Use the same model/input/output/config/weight receipt fields for Stwo and external proof-stack comparisons.",
+            },
+        ],
+        "non_claims": [
+            "This is not a d64 proof.",
+            "This is not a performance benchmark.",
+            "This does not claim Stwo cannot prove the target.",
+            "This does not claim a full transformer-inference result.",
+            "This does not weaken the existing width-4 statement-binding result.",
+        ],
+        "repro": {
+            "git_commit": _git_commit(),
+            "command": [
+                "python3",
+                "scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py",
+                "--write-json",
+                "docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.json",
+                "--write-tsv",
+                "docs/engineering/evidence/zkai-d64-rmsnorm-swiglu-surface-probe-2026-05.tsv",
+            ],
+        },
+    }
+
+
+def rows_for_tsv(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    target = payload["target"]
+    limits = payload["current_tvm_limits"]
+    fixture = payload["current_fixture_profile"]
+    classification = payload["classification"]
+    return [
+        {
+            "target_width": target["width"],
+            "decision": payload["decision"],
+            "ff_dim": target["ff_dim"],
+            "estimated_linear_muls": target["estimated_linear_muls"],
+            "estimated_weight_scalars": target["estimated_weight_scalars"],
+            "current_max_addressable_memory_cells": limits["max_addressable_memory_cells"],
+            "current_pc_horizon": limits["pc_horizon"],
+            "current_fixture_memory_cells": fixture["memory_cells"],
+            "current_fixture_instruction_count": fixture["instruction_count"],
+            "current_fixture_mul_memory_ops": fixture["mul_memory_ops"],
+            "weight_cells_over_memory_limit": f"{classification['weight_cells_over_memory_limit']:.3f}",
+            "mul_ops_over_pc_horizon": f"{classification['mul_ops_over_pc_horizon']:.3f}",
+            "blocker_count": len(classification["blockers"]),
+        }
+    ]
+
+
+def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
+    if json_path is not None:
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if tsv_path is not None:
+        tsv_path.parent.mkdir(parents=True, exist_ok=True)
+        with tsv_path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+            writer.writeheader()
+            writer.writerows(rows_for_tsv(payload))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print the JSON payload to stdout")
+    parser.add_argument("--write-json", type=pathlib.Path, help="write the JSON payload")
+    parser.add_argument("--write-tsv", type=pathlib.Path, help="write the TSV summary")
+    args = parser.parse_args(argv)
+
+    try:
+        payload = build_payload()
+        write_outputs(payload, args.write_json, args.write_tsv)
+    except SurfaceProbeError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -18,7 +18,6 @@ import json
 import os
 import pathlib
 import re
-import subprocess
 import sys
 from typing import Any
 
@@ -96,15 +95,7 @@ def _git_commit() -> str:
     override = os.environ.get("ZKAI_GIT_COMMIT")
     if override:
         return override
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],
-            cwd=ROOT,
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).strip()
-    except (OSError, subprocess.CalledProcessError):
-        return "unknown"
+    return "unspecified"
 
 
 def _read_text(path: pathlib.Path) -> str:
@@ -407,15 +398,18 @@ def rows_for_tsv(payload: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
-    if json_path is not None:
-        json_path.parent.mkdir(parents=True, exist_ok=True)
-        json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    if tsv_path is not None:
-        tsv_path.parent.mkdir(parents=True, exist_ok=True)
-        with tsv_path.open("w", encoding="utf-8", newline="") as handle:
-            writer = csv.DictWriter(handle, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
-            writer.writeheader()
-            writer.writerows(rows_for_tsv(payload))
+    try:
+        if json_path is not None:
+            json_path.parent.mkdir(parents=True, exist_ok=True)
+            json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        if tsv_path is not None:
+            tsv_path.parent.mkdir(parents=True, exist_ok=True)
+            with tsv_path.open("w", encoding="utf-8", newline="") as handle:
+                writer = csv.DictWriter(handle, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+                writer.writeheader()
+                writer.writerows(rows_for_tsv(payload))
+    except OSError as err:
+        raise SurfaceProbeError(f"failed to write probe output: {err}") from err
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -275,12 +275,20 @@ def classify_surface(
                 "why_it_matters": "the checked statement-bound block is useful for binding, not for matched d64 compute coverage",
             }
         )
-    if prover_gates.get("fixture_gate_detected") and not prover_gates.get("required_backend_version_present"):
+    fixture_gate_detected = prover_gates.get("fixture_gate_detected") is True
+    required_backend_version_present = prover_gates.get("required_backend_version_present") is True
+    if not fixture_gate_detected or not required_backend_version_present:
+        missing = []
+        if not fixture_gate_detected:
+            missing.append("confirmed fixture-gate scan")
+        if not required_backend_version_present:
+            missing.append(target["required_proof_backend_version"])
         blockers.append(
             {
                 "id": "missing_parameterized_stwo_backend",
                 "required_backend_version": target["required_proof_backend_version"],
-                "why_it_matters": "the current Stwo generator recognizes shipped fixtures/decoding families, not the d64 vector-block backend",
+                "missing": missing,
+                "why_it_matters": "the probe should only report GO when it confirms both the current gate surface and the explicit d64 vector-block backend",
             }
         )
     if prover_gates.get("markers", {}).get("phase12_decoding_only"):

--- a/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -105,6 +105,76 @@ def _read_text(path: pathlib.Path) -> str:
         raise SurfaceProbeError(f"failed to read {path}: {err}") from err
 
 
+def _strip_rust_comments(source: str) -> str:
+    output: list[str] = []
+    i = 0
+    in_string = False
+    escaped = False
+    while i < len(source):
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < len(source) else ""
+        if in_string:
+            output.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            while i < len(source) and source[i] != "\n":
+                i += 1
+            if i < len(source):
+                output.append("\n")
+                i += 1
+            continue
+        if ch == "/" and nxt == "*":
+            i += 2
+            while i + 1 < len(source) and not (source[i] == "*" and source[i + 1] == "/"):
+                output.append("\n" if source[i] == "\n" else " ")
+                i += 1
+            i = min(i + 2, len(source))
+            continue
+        output.append(ch)
+        if ch == '"':
+            in_string = True
+        i += 1
+    return "".join(output)
+
+
+def _strip_rust_comments_and_strings(source: str) -> str:
+    source = _strip_rust_comments(source)
+    output: list[str] = []
+    i = 0
+    in_string = False
+    escaped = False
+    while i < len(source):
+        ch = source[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+                output.append('"')
+            else:
+                output.append(" ")
+            i += 1
+            continue
+        output.append(ch)
+        if ch == '"':
+            in_string = True
+        i += 1
+    return "".join(output)
+
+
+def _ratio_or_inf(numerator: int, denominator: int) -> float:
+    return numerator / float(denominator) if denominator > 0 else float("inf")
+
+
 def d64_target() -> dict[str, Any]:
     ff_dim = TARGET_WIDTH * FF_DIM_MULTIPLIER
     linear_muls = 3 * TARGET_WIDTH * ff_dim
@@ -151,8 +221,8 @@ def scan_tvm_limits(
     instruction_path: pathlib.Path = INSTRUCTION_SOURCE,
     state_path: pathlib.Path = STATE_SOURCE,
 ) -> dict[str, Any]:
-    instruction_source = _read_text(instruction_path)
-    state_source = _read_text(state_path)
+    instruction_source = _strip_rust_comments_and_strings(_read_text(instruction_path))
+    state_source = _strip_rust_comments_and_strings(_read_text(state_path))
     memory_limit_detected = "memory_size > usize::from(u8::MAX)" in instruction_source
     pc_u8_detected = "pub pc: u8" in state_source and "instruction_at(&self, pc: u8)" in instruction_source
     address_u8_detected = "Load(u8)" in instruction_source and "MulMemory(u8)" in instruction_source
@@ -180,23 +250,24 @@ def scan_tvm_limits(
 
 
 def scan_prover_gates(source_path: pathlib.Path = ARITHMETIC_PROVER_SOURCE) -> dict[str, Any]:
-    source = _read_text(source_path)
+    source_without_comments = _strip_rust_comments(_read_text(source_path))
+    code_source = _strip_rust_comments_and_strings(source_without_comments)
     markers = {
-        "fixture_gate_function": "validate_phase5_proven_fixture" in source,
-        "linear_block_v4_exact_matcher": "matches_linear_block_v4_with_lookup" in source,
-        "decoding_step_v2_family_matcher": "matches_decoding_step_v2" in source,
+        "fixture_gate_function": "validate_phase5_proven_fixture" in code_source,
+        "linear_block_v4_exact_matcher": "matches_linear_block_v4_with_lookup" in code_source,
+        "decoding_step_v2_family_matcher": "matches_decoding_step_v2" in code_source,
         "broader_arithmetic_subset_internal": "broader arithmetic-subset AIR coverage remains internal"
-        in source,
+        in source_without_comments,
         "phase12_decoding_only": "experimental Phase12 carry-aware proving supports only the decoding_step_v2 family"
-        in source,
+        in source_without_comments,
     }
-    backend_versions = sorted(set(re.findall(r"stwo-[a-zA-Z0-9_.\\-]+", source)))
+    backend_versions = sorted(set(re.findall(r"stwo-[a-zA-Z0-9_.\\-]+", source_without_comments)))
     return {
         "source_path": _display_path(source_path),
         "source_sha256": sha256_file(source_path),
         "markers": markers,
         "fixture_gate_detected": all(markers.values()),
-        "required_backend_version_present": REQUIRED_BACKEND_VERSION in source,
+        "required_backend_version_present": REQUIRED_BACKEND_VERSION in source_without_comments,
         "known_stwo_backend_versions": backend_versions,
     }
 
@@ -301,8 +372,8 @@ def classify_surface(
             else "direct TVM fixture growth is not the right implementation path for a matched d64 RMSNorm-SwiGLU block"
         ),
         "blockers": blockers,
-        "weight_cells_over_memory_limit": estimated_weight_scalars / float(memory_limit),
-        "mul_ops_over_pc_horizon": estimated_linear_muls / float(pc_horizon),
+        "weight_cells_over_memory_limit": _ratio_or_inf(estimated_weight_scalars, memory_limit),
+        "mul_ops_over_pc_horizon": _ratio_or_inf(estimated_linear_muls, pc_horizon),
     }
 
 

--- a/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -311,7 +311,7 @@ def classify_surface(
                 "why_it_matters": "the probe could not confirm the current TVM pc/address/immediate limits",
             }
         )
-    if estimated_weight_scalars > memory_limit:
+    if limits_are_current and estimated_weight_scalars > memory_limit:
         blockers.append(
             {
                 "id": "weight_surface_exceeds_u8_memory_addressing",
@@ -320,7 +320,7 @@ def classify_surface(
                 "why_it_matters": "a naive memory-resident d64 block cannot bind all gate/value/down weights in the current TVM memory surface",
             }
         )
-    if estimated_linear_muls > pc_horizon:
+    if limits_are_current and estimated_linear_muls > pc_horizon:
         blockers.append(
             {
                 "id": "unrolled_mul_surface_exceeds_u8_pc_horizon",

--- a/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
+++ b/scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py
@@ -302,8 +302,9 @@ def classify_surface(
     estimated_linear_muls = int(target["estimated_linear_muls"])
     memory_limit = int(tvm_limits["max_addressable_memory_cells"])
     pc_horizon = int(tvm_limits["pc_horizon"])
+    limits_are_current = tvm_limits.get("limits_are_current") is True
 
-    if not tvm_limits.get("limits_are_current"):
+    if not limits_are_current:
         blockers.append(
             {
                 "id": "unsupported_limit_scan",
@@ -372,8 +373,12 @@ def classify_surface(
             else "direct TVM fixture growth is not the right implementation path for a matched d64 RMSNorm-SwiGLU block"
         ),
         "blockers": blockers,
-        "weight_cells_over_memory_limit": _ratio_or_inf(estimated_weight_scalars, memory_limit),
-        "mul_ops_over_pc_horizon": _ratio_or_inf(estimated_linear_muls, pc_horizon),
+        "weight_cells_over_memory_limit": (
+            _ratio_or_inf(estimated_weight_scalars, memory_limit) if limits_are_current else float("inf")
+        ),
+        "mul_ops_over_pc_horizon": (
+            _ratio_or_inf(estimated_linear_muls, pc_horizon) if limits_are_current else float("inf")
+        ),
     }
 
 


### PR DESCRIPTION
## Summary

Adds a checked implementation-surface probe for the next matched `d=64` RMSNorm-SwiGLU-residual target.

This is deliberately scoped as a NO-GO for direct TVM fixture growth, not as a prover benchmark. The probe records that a minimal `d=64` target needs `49,152` projection multiplications/weight scalars, while the current TVM/Stwo surface is bounded by a `u8` address/PC representation and the checked transformer-block fixture has `21` memory cells, `43` instructions, and `7` `MulMemory` ops.

## Why

Issue #335 needs a path to a real matched zkAI comparison target. This PR narrows the next implementation step: do not spend the next sprint hand-authoring a larger toy fixture. The credible path is a parameterized vector-block AIR/export surface with committed weights and the same statement-binding receipt fields used by the external adapters.

Refs #335.

## What changed

- Adds `scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py`.
- Adds unit coverage, including a synthetic future GO surface so the probe is not hardcoded pessimism.
- Checks in JSON/TSV evidence for the current NO-GO.
- Adds an engineering gate note and links it from the design index/spec.
- Adds a short paper-facing caveat so the Tablero paper points to the precise follow-up path without overstating the current Stwo block result.

## Validation

- `python3 -m py_compile scripts/zkai_d64_rmsnorm_swiglu_surface_probe.py scripts/tests/test_zkai_d64_rmsnorm_swiglu_surface_probe.py`
- `python3 -m unittest scripts.tests.test_zkai_d64_rmsnorm_swiglu_surface_probe`
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `just gate-fast`
- `bash scripts/run_paper_preflight_suite.sh`
- `just gate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed d=64 RMSNorm‑SwiGLU surface‑probe report with feasibility analysis, explicit blockers, evidence artifacts, and a recommended parameterized vector‑block path; updated related design and paper docs to reference the probe.

* **Tests**
  * Added comprehensive test suite validating probe outputs, gate/limit scanning, error handling, deterministic artifacts, and JSON/TSV I/O.

* **New Features**
  * Added a reproducible surface‑probe CLI tool that evaluates execution‑surface constraints and emits deterministic JSON/TSV reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->