### PR TITLE
[codex] Add JSTprove shape probe evidence

### DIFF
--- a/docs/engineering/design/statement-bound-transformer-primitive-spec.md
+++ b/docs/engineering/design/statement-bound-transformer-primitive-spec.md
@@ -218,10 +218,14 @@ The JSTprove/Remainder shape probe adds a smaller external proof-stack axis:
 That probe is not a d64 benchmark and not a transformer proof, but it is useful
 operator-pressure context. Tiny `Gemm -> residual Add` and
 `Gemm -> LayerNormalization` fixtures prove and verify under JSTprove/Remainder,
-while `Gemm -> Softmax` is refused at proof construction as an unconstrained op
-and `Gemm -> Relu` fails witness generation on range-check capacity. This keeps
-the research split explicit: statement binding, exact statement semantics, and
-backend operator support are separate gates.
+the checked `Gemm` dimension sweep clears widths `1`, `2`, and `4`, and scaled
+`Gemm -> Relu` variants clear even though the baseline magnitude fails witness
+generation on range-check capacity. `Gemm -> Softmax` is still refused at proof
+construction as an unconstrained op, with the refusal tied to the pinned
+Remainder source, and literal `MatMul -> Add` still fails witness generation.
+This keeps the research split explicit: statement binding, exact statement
+semantics, numeric range discipline, and backend operator support are separate
+gates.
 
 The native Stwo vector-row surface probe is also checked in:
 

--- a/docs/engineering/design/statement-bound-transformer-primitive-spec.md
+++ b/docs/engineering/design/statement-bound-transformer-primitive-spec.md
@@ -209,6 +209,20 @@ approximate export is a different statement unless it gets a separate target and
 commitment. The receipt target remains reusable once an exact native or custom
 external proof exists.
 
+The JSTprove/Remainder shape probe adds a smaller external proof-stack axis:
+
+- `docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md`
+- `docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json`
+- `docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv`
+
+That probe is not a d64 benchmark and not a transformer proof, but it is useful
+operator-pressure context. Tiny `Gemm -> residual Add` and
+`Gemm -> LayerNormalization` fixtures prove and verify under JSTprove/Remainder,
+while `Gemm -> Softmax` is refused at proof construction as an unconstrained op
+and `Gemm -> Relu` fails witness generation on range-check capacity. This keeps
+the research split explicit: statement binding, exact statement semantics, and
+backend operator support are separate gates.
+
 The native Stwo vector-row surface probe is also checked in:
 
 - `docs/engineering/zkai-d64-stwo-vector-row-surface-probe-2026-05-01.md`

--- a/docs/engineering/design/zkai-statement-receipt-spec.md
+++ b/docs/engineering/design/zkai-statement-receipt-spec.md
@@ -184,6 +184,14 @@ mutation. The statement envelope accepts the same baseline and rejects `13 / 13`
 checked mutations. This is not a JSTprove security finding and not a transformer
 proof; it is a third proof-stack check of the statement-envelope boundary.
 
+A follow-up JSTprove shape probe keeps that adapter result scoped while making
+the operator-support boundary more concrete. A real `jstprove-remainder` binary
+proves tiny `Gemm -> residual Add`, `Gemm -> LayerNormalization`, and
+`Gemm -> BatchNormalization` fixtures, but the checked `Gemm -> Relu`,
+`Gemm -> Softmax`, and literal `MatMul -> Add` fixtures expose separate backend
+blockers. This is engineering context for proof-stack comparison, not a
+statement-envelope mutation result and not a transformer proof.
+
 The fourth checked adapter is native to this repository's Stwo lane
 (`stwo-phase10-linear-block-v4-with-lookup`): a linear-block-with-lookup proof
 over `programs/linear_block_v4_with_lookup.tvm`. The raw Stwo
@@ -216,6 +224,9 @@ Evidence handles:
 - `docs/engineering/zkai-jstprove-external-adapter-gate-2026-05-01.md`
 - `docs/engineering/evidence/zkai-jstprove-statement-envelope-benchmark-2026-05.json`
 - `docs/engineering/evidence/zkai-jstprove-statement-envelope-benchmark-2026-05.tsv`
+- `docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md`
+- `docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json`
+- `docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv`
 - `docs/engineering/zkai-stwo-statement-bound-primitive-gate-2026-04-29.md`
 - `docs/engineering/evidence/zkai-stwo-statement-envelope-benchmark-2026-04.json`
 - `docs/engineering/evidence/zkai-stwo-statement-envelope-benchmark-2026-04.tsv`

--- a/docs/engineering/design/zkai-statement-receipt-spec.md
+++ b/docs/engineering/design/zkai-statement-receipt-spec.md
@@ -187,10 +187,15 @@ proof; it is a third proof-stack check of the statement-envelope boundary.
 A follow-up JSTprove shape probe keeps that adapter result scoped while making
 the operator-support boundary more concrete. A real `jstprove-remainder` binary
 proves tiny `Gemm -> residual Add`, `Gemm -> LayerNormalization`, and
-`Gemm -> BatchNormalization` fixtures, but the checked `Gemm -> Relu`,
-`Gemm -> Softmax`, and literal `MatMul -> Add` fixtures expose separate backend
-blockers. This is engineering context for proof-stack comparison, not a
-statement-envelope mutation result and not a transformer proof.
+`Gemm -> BatchNormalization` fixtures, and a tiny `Gemm` dimension sweep clears
+dimensions `1`, `2`, and `4`. The checked baseline `Gemm -> Relu` fixture fails
+on range-check capacity, but scaled ReLU variants clear; this makes the ReLU
+blocker magnitude-sensitive rather than a blanket unsupported-op result. The
+checked `Gemm -> Softmax` fixture reaches witness generation but is refused by
+Remainder proof construction as an unconstrained backend op, and literal
+`MatMul -> Add` still fails at witness generation. This is engineering context
+for proof-stack comparison, not a statement-envelope mutation result and not a
+transformer proof.
 
 The fourth checked adapter is native to this repository's Stwo lane
 (`stwo-phase10-linear-block-v4-with-lookup`): a linear-block-with-lookup proof

--- a/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json
+++ b/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json
@@ -7,10 +7,11 @@
       "tiny_gemm_layernorm",
       "tiny_gemm_batchnorm"
     ],
-    "interpretation": "JSTprove/Remainder can prove tiny projection, residual-add, and normalization-shaped fixtures, but the checked Softmax, ReLU, and literal MatMul variants expose separate backend/operator blockers. The ReLU blocker is input-dependent in this probe: scaled variants clear.",
+    "interpretation": "JSTprove/Remainder can prove tiny projection, residual-add, and normalization-shaped fixtures, but the checked Softmax, ReLU, and literal MatMul variants expose separate backend/operator blockers. The ReLU blocker is magnitude-sensitive in this probe: scaled variants clear.",
     "no_go_count": 3,
     "paper_usage": "engineering_context_only_not_transformer_proof_or_performance_benchmark",
-    "relu_scaling": "INPUT_DEPENDENT_BASELINE_FAILS_SCALED_VARIANTS_CLEAR",
+    "relu_scaling": "MAGNITUDE_SENSITIVE_BASELINE_FAILS_SCALED_VARIANTS_CLEAR",
+    "softmax_alternative_ref_check": "CHECKED_NO_CONSTRAINED_REMAINDER_SOFTMAX_PATH",
     "softmax_source_check": "SOURCE_HIT"
   },
   "decision": "GO_OPERATOR_SUPPORT_SPLIT_NOT_TRANSFORMER_PROOF",
@@ -22,20 +23,20 @@
       "model_bytes": 292,
       "onnx_bytes": 130,
       "proof_bytes": 11726,
-      "prove_seconds": "0.799333",
+      "prove_seconds": "0.912901",
       "status": "GO",
-      "verify_seconds": "1.971647"
+      "verify_seconds": "2.673158"
     },
     {
       "dimension": 2,
       "failed_step": "",
       "failure_kind": "",
-      "model_bytes": 319,
+      "model_bytes": 318,
       "onnx_bytes": 147,
       "proof_bytes": 71040,
-      "prove_seconds": "0.789629",
+      "prove_seconds": "1.019196",
       "status": "GO",
-      "verify_seconds": "1.948071"
+      "verify_seconds": "2.279538"
     },
     {
       "dimension": 4,
@@ -44,12 +45,12 @@
       "model_bytes": 349,
       "onnx_bytes": 203,
       "proof_bytes": 70138,
-      "prove_seconds": "0.781246",
+      "prove_seconds": "0.902361",
       "status": "GO",
-      "verify_seconds": "1.939688"
+      "verify_seconds": "2.237408"
     }
   ],
-  "exploration_commitment": "blake2b-256:2c55f3604c4d174922f3400ab2402e3292f1001d039a83a067914fe1314eb312",
+  "exploration_commitment": "blake2b-256:8973c901b88cb9720279997aa276973750786563c9f47addbde8dec9eda81d54",
   "fixture_catalog": [
     {
       "fixture": "tiny_gemm",
@@ -101,7 +102,14 @@
     }
   ],
   "generated_at": "1970-01-01T00:00:00Z",
-  "git_commit": "f8963ade432fa7f999c0eaf4c356ba06d526d57f",
+  "generator_dependencies": {
+    "msgpack": "(1, 1, 2)",
+    "numpy": "2.4.4",
+    "onnx": "1.21.0",
+    "onnx_opset": 17,
+    "python": "3.13.11"
+  },
+  "git_commit": "376eaa8a80544d5b4121e33314aa6bd28250caa1",
   "jstprove": {
     "binary": "/private/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder",
     "remainder_dependency_commit": "06a5f406",
@@ -120,7 +128,7 @@
     {
       "failed_step": "witness",
       "failure_kind": "range_check_capacity",
-      "model_bytes": 341,
+      "model_bytes": 339,
       "onnx_bytes": 151,
       "proof_bytes": null,
       "prove_seconds": "NA",
@@ -134,10 +142,10 @@
       "model_bytes": 336,
       "onnx_bytes": 154,
       "proof_bytes": 87377,
-      "prove_seconds": "3.995539",
+      "prove_seconds": "5.389730",
       "scale": "0.25",
       "status": "GO",
-      "verify_seconds": "9.395193"
+      "verify_seconds": "9.962077"
     },
     {
       "failed_step": "",
@@ -145,10 +153,10 @@
       "model_bytes": 338,
       "onnx_bytes": 153,
       "proof_bytes": 211088,
-      "prove_seconds": "3.981442",
+      "prove_seconds": "4.116503",
       "scale": "0.1",
       "status": "GO",
-      "verify_seconds": "9.412703"
+      "verify_seconds": "9.468539"
     },
     {
       "failed_step": "",
@@ -156,10 +164,10 @@
       "model_bytes": 343,
       "onnx_bytes": 154,
       "proof_bytes": 227462,
-      "prove_seconds": "3.987476",
+      "prove_seconds": "4.053108",
       "scale": "0.01",
       "status": "GO",
-      "verify_seconds": "9.523842"
+      "verify_seconds": "9.640854"
     },
     {
       "failed_step": "",
@@ -167,10 +175,10 @@
       "model_bytes": 341,
       "onnx_bytes": 155,
       "proof_bytes": 108172,
-      "prove_seconds": "1.592207",
+      "prove_seconds": "1.602478",
       "scale": "0.001",
       "status": "GO",
-      "verify_seconds": "4.051986"
+      "verify_seconds": "4.211324"
     }
   ],
   "results": [
@@ -185,7 +193,7 @@
       "op_sequence": "Gemm",
       "primary_observation": "baseline tiny linear projection proves and verifies",
       "proof_bytes": 11645,
-      "prove_seconds": "0.781818",
+      "prove_seconds": "0.834183",
       "status": "GO",
       "steps": [
         {
@@ -193,13 +201,13 @@
             "jstprove-remainder",
             "compile",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/tiny_gemm.onnx",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/tiny_gemm.onnx",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/model.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.024744,
-          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      1 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      1 layers, scale=2^18\n[4/4] Serializing\n      307 B\n\n  done Compiled in 0.00s",
+          "seconds": 0.049907,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      1 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      1 layers, scale=2^18\n[4/4] Serializing\n      307 B\n\n  done Compiled in 0.01s",
           "stdout_excerpt": "",
           "step": "compile"
         },
@@ -208,15 +216,15 @@
             "jstprove-remainder",
             "witness",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/model.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/input.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/input.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/witness.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.014631,
-          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      1 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      11 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
+          "seconds": 0.019382,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      1 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      11 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.01s",
           "stdout_excerpt": "",
           "step": "witness"
         },
@@ -225,15 +233,15 @@
             "jstprove-remainder",
             "prove",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/model.msgpack",
             "--witness",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/witness.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/witness.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/proof.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.781818,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      1 layers\n[2/4] Loading witness\n      11 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      11.4 KiB\n\n  done Proof generated in 0.77s",
+          "seconds": 0.834183,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      1 layers\n[2/4] Loading witness\n      11 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      11.4 KiB\n\n  done Proof generated in 0.82s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(6)\nLayer that calculates r - table has layer id: Layer(7)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(8)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(16)\nLayer that checks that fractions are eq",
           "step": "prove"
         },
@@ -243,21 +251,21 @@
             "--quiet",
             "verify",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/model.msgpack",
             "--proof",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/proof.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/proof.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/input.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 1.980332,
+          "seconds": 1.989027,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(6)\nLayer that calculates r - table has layer id: Layer(7)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(8)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(16)\nLayer that checks that fractions are eq",
           "step": "verify"
         }
       ],
       "transformer_relevance": "linear_projection_baseline",
-      "verify_seconds": "1.980332"
+      "verify_seconds": "1.989027"
     },
     {
       "failed_step": "",
@@ -270,7 +278,7 @@
       "op_sequence": "Gemm -> Add",
       "primary_observation": "extra Add layer proves and verifies",
       "proof_bytes": 36449,
-      "prove_seconds": "0.912362",
+      "prove_seconds": "1.044284",
       "status": "GO",
       "steps": [
         {
@@ -278,12 +286,12 @@
             "jstprove-remainder",
             "compile",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/tiny_gemm_add.onnx",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/tiny_gemm_add.onnx",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/model.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.008935,
+          "seconds": 0.015745,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      361 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -293,14 +301,14 @@
             "jstprove-remainder",
             "witness",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/model.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/input.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/input.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/witness.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.009036,
+          "seconds": 0.016493,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      13 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
@@ -310,15 +318,15 @@
             "jstprove-remainder",
             "prove",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/model.msgpack",
             "--witness",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/witness.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/witness.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/proof.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.912362,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      13 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      35.6 KiB\n\n  done Proof generated in 0.90s",
+          "seconds": 1.044284,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      13 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      35.6 KiB\n\n  done Proof generated in 1.03s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(17)\nLayer that checks that fractions are e",
           "step": "prove"
         },
@@ -328,21 +336,21 @@
             "--quiet",
             "verify",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/model.msgpack",
             "--proof",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/proof.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/proof.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/input.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.308319,
+          "seconds": 2.411266,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(17)\nLayer that checks that fractions are e",
           "step": "verify"
         }
       ],
       "transformer_relevance": "linear_projection_plus_bias_like_add",
-      "verify_seconds": "2.308319"
+      "verify_seconds": "2.411266"
     },
     {
       "failed_step": "",
@@ -355,7 +363,7 @@
       "op_sequence": "Gemm(width-preserving) -> Add(input)",
       "primary_observation": "residual-style Add proves and verifies",
       "proof_bytes": 56054,
-      "prove_seconds": "0.921516",
+      "prove_seconds": "1.010520",
       "status": "GO",
       "steps": [
         {
@@ -363,12 +371,12 @@
             "jstprove-remainder",
             "compile",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/tiny_gemm_residual_add.onnx",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/tiny_gemm_residual_add.onnx",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/model.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.015321,
+          "seconds": 0.015333,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      367 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -378,15 +386,15 @@
             "jstprove-remainder",
             "witness",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/model.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/input.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/input.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/witness.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.012706,
-          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
+          "seconds": 0.014828,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
         },
@@ -395,15 +403,15 @@
             "jstprove-remainder",
             "prove",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/model.msgpack",
             "--witness",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/witness.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/witness.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/proof.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.921516,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      54.7 KiB\n\n  done Proof generated in 0.91s",
+          "seconds": 1.01052,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      54.7 KiB\n\n  done Proof generated in 0.99s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(7)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(8)\nLayer that calculates r - table has layer id: Layer(9)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 8 of build_fractional_sumche",
           "step": "prove"
         },
@@ -413,21 +421,21 @@
             "--quiet",
             "verify",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/model.msgpack",
             "--proof",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/proof.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/proof.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/input.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.328602,
+          "seconds": 2.469885,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(7)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(8)\nLayer that calculates r - table has layer id: Layer(9)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 8 of build_fractional_sumche",
           "step": "verify"
         }
       ],
       "transformer_relevance": "linear_projection_plus_residual_add",
-      "verify_seconds": "2.328602"
+      "verify_seconds": "2.469885"
     },
     {
       "failed_step": "",
@@ -435,12 +443,12 @@
       "fixture": "tiny_gemm_layernorm",
       "gate": "GO_CHECKED_SMALL_SHAPE",
       "input_bytes": 26,
-      "model_bytes": 441,
+      "model_bytes": 442,
       "onnx_bytes": 287,
       "op_sequence": "Gemm(width-preserving) -> LayerNormalization",
       "primary_observation": "LayerNormalization-style tiny shape proves and verifies",
       "proof_bytes": 52080,
-      "prove_seconds": "0.778382",
+      "prove_seconds": "0.819784",
       "status": "GO",
       "steps": [
         {
@@ -448,13 +456,13 @@
             "jstprove-remainder",
             "compile",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/tiny_gemm_layernorm.onnx",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/tiny_gemm_layernorm.onnx",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/model.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.015773,
-          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      441 B\n\n  done Compiled in 0.00s",
+          "seconds": 0.013941,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      442 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
         },
@@ -463,15 +471,15 @@
             "jstprove-remainder",
             "witness",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/model.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/input.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/input.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/witness.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.012081,
-          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
+          "seconds": 0.011716,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
         },
@@ -480,15 +488,15 @@
             "jstprove-remainder",
             "prove",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/model.msgpack",
             "--witness",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/witness.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/witness.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/proof.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.778382,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      50.9 KiB\n\n  done Proof generated in 0.77s",
+          "seconds": 0.819784,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      50.9 KiB\n\n  done Proof generated in 0.81s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumchec",
           "step": "prove"
         },
@@ -498,21 +506,21 @@
             "--quiet",
             "verify",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/model.msgpack",
             "--proof",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/proof.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/proof.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/input.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 1.945761,
+          "seconds": 2.016979,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumchec",
           "step": "verify"
         }
       ],
       "transformer_relevance": "normalization_after_projection",
-      "verify_seconds": "1.945761"
+      "verify_seconds": "2.016979"
     },
     {
       "failed_step": "",
@@ -525,7 +533,7 @@
       "op_sequence": "Gemm -> BatchNormalization",
       "primary_observation": "normalization-like tiny shape proves and verifies",
       "proof_bytes": 95105,
-      "prove_seconds": "2.591887",
+      "prove_seconds": "2.777716",
       "status": "GO",
       "steps": [
         {
@@ -533,12 +541,12 @@
             "jstprove-remainder",
             "compile",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/tiny_gemm_batchnorm.onnx",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/tiny_gemm_batchnorm.onnx",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/model.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.016629,
+          "seconds": 0.017722,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      421 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -548,14 +556,14 @@
             "jstprove-remainder",
             "witness",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/model.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/input.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/input.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/witness.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.011738,
+          "seconds": 0.015905,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      19 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
@@ -565,15 +573,15 @@
             "jstprove-remainder",
             "prove",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/model.msgpack",
             "--witness",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/witness.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/witness.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/proof.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.591887,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      19 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      92.9 KiB\n\n  done Proof generated in 2.58s",
+          "seconds": 2.777716,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      19 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      92.9 KiB\n\n  done Proof generated in 2.76s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(6)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(7)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(8)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(9)\nLayer that calculates r - table has layer id: Layer(10)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(18)\nIteration 8 of build_fractional_sumch",
           "step": "prove"
         },
@@ -583,21 +591,21 @@
             "--quiet",
             "verify",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/model.msgpack",
             "--proof",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/proof.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/proof.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/input.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 6.078993,
+          "seconds": 6.530913,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(6)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(7)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(8)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(9)\nLayer that calculates r - table has layer id: Layer(10)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(18)\nIteration 8 of build_fractional_sumch",
           "step": "verify"
         }
       ],
       "transformer_relevance": "normalization_like_operator_after_projection",
-      "verify_seconds": "6.078993"
+      "verify_seconds": "6.530913"
     },
     {
       "failed_step": "witness",
@@ -618,12 +626,12 @@
             "jstprove-remainder",
             "compile",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/tiny_gemm_relu.onnx",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_relu/tiny_gemm_relu.onnx",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/model.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_relu/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.0094,
+          "seconds": 0.015574,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      341 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -633,14 +641,14 @@
             "jstprove-remainder",
             "witness",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_relu/model.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/input.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_relu/input.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/witness.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_relu/witness.msgpack"
           ],
           "returncode": 1,
-          "seconds": 0.009417,
+          "seconds": 0.015934,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n\nerror: Relu layer node_1 delta nv 20 exceeds two-chunk range-check capacity (max 18 bits)\nError: Relu layer node_1 delta nv 20 exceeds two-chunk range-check capacity (max 18 bits)",
           "stdout_excerpt": "",
           "step": "witness"
@@ -655,12 +663,12 @@
       "fixture": "tiny_gemm_softmax",
       "gate": "NO_GO_UNCONSTRAINED_BACKEND_OP",
       "input_bytes": 26,
-      "model_bytes": 382,
+      "model_bytes": 387,
       "onnx_bytes": 197,
       "op_sequence": "Gemm(width-preserving) -> Softmax",
       "primary_observation": "Softmax witness is generated but proof construction refuses an unconstrained op",
       "proof_bytes": null,
-      "prove_seconds": "0.009271",
+      "prove_seconds": "0.016604",
       "status": "NO_GO",
       "steps": [
         {
@@ -668,13 +676,13 @@
             "jstprove-remainder",
             "compile",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/tiny_gemm_softmax.onnx",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/tiny_gemm_softmax.onnx",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/model.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.009427,
-          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      382 B\n\n  done Compiled in 0.00s",
+          "seconds": 0.013569,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      387 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
         },
@@ -683,15 +691,15 @@
             "jstprove-remainder",
             "witness",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/model.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/input.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/input.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/witness.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.007735,
-          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
+          "seconds": 0.014962,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
         },
@@ -700,14 +708,14 @@
             "jstprove-remainder",
             "prove",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/model.msgpack",
             "--witness",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/witness.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/witness.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/proof.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/proof.msgpack"
           ],
           "returncode": 1,
-          "seconds": 0.009271,
+          "seconds": 0.016604,
           "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n\nerror: circuit builder: Softmax op in layer 'node_1' is not yet constrained in the Remainder backend; refusing to add unconstrained committed shred\nError: circuit builder: Softmax op in layer 'node_1' is not yet constrained in the Remainder backend; refusing to add unconstrained committed shred",
           "stdout_excerpt": "",
           "step": "prove"
@@ -735,12 +743,12 @@
             "jstprove-remainder",
             "compile",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/tiny_matmul_residual_add.onnx",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_matmul_residual_add/tiny_matmul_residual_add.onnx",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/model.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_matmul_residual_add/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.00892,
+          "seconds": 0.013128,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      339 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -750,14 +758,14 @@
             "jstprove-remainder",
             "witness",
             "--model",
-            "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/model.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_matmul_residual_add/model.msgpack",
             "--input",
-            "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/input.msgpack",
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_matmul_residual_add/input.msgpack",
             "--output",
-            "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/witness.msgpack"
+            "/tmp/zkai-jstprove-shape-probe-checked/tiny_matmul_residual_add/witness.msgpack"
           ],
           "returncode": 1,
-          "seconds": 0.009746,
+          "seconds": 0.012468,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n\nerror: witness: unsupported op type MatMul in layer node_0\nError: witness: unsupported op type MatMul in layer node_0",
           "stdout_excerpt": "",
           "step": "witness"
@@ -767,8 +775,31 @@
       "verify_seconds": "NA"
     }
   ],
-  "results_commitment": "blake2b-256:a525a858b3a48f0ec111f22fcd1f5c043436a585b14c0f09f74f9e152f620d63",
+  "results_commitment": "blake2b-256:d1cb79c02a1e30caaa18397b07ea3869f42d149cdf854eccee03cb7edd3aae3e",
   "schema": "zkai-jstprove-shape-probe-v1",
+  "softmax_alternative_ref_probe": [
+    {
+      "commit": "d71e49514f90877c1a6551514d1debec9930358e",
+      "observation": "Alternative ref did not expose a constrained Remainder Softmax path in this source probe.",
+      "ref": "origin/main-b",
+      "remainder_softmax_hits": [],
+      "status": "NO_REMAINDER_SOFTMAX_PATH_FOUND"
+    },
+    {
+      "commit": "eae2d6c214a46e8a43480dbab0239ff548786ee5",
+      "observation": "Alternative ref did not expose a constrained Remainder Softmax path in this source probe.",
+      "ref": "refs/tags/v2.12.1",
+      "remainder_softmax_hits": [],
+      "status": "NO_REMAINDER_SOFTMAX_PATH_FOUND"
+    },
+    {
+      "commit": "6d2f0e59343f3840634d028cd0f02309c1c0aa42",
+      "observation": "Alternative ref did not expose a constrained Remainder Softmax path in this source probe.",
+      "ref": "origin/eliminate/relu-zero-delta-range-check",
+      "remainder_softmax_hits": [],
+      "status": "NO_REMAINDER_SOFTMAX_PATH_FOUND"
+    }
+  ],
   "softmax_source_probe": {
     "hits": [
       {
@@ -868,5 +899,5 @@
     "source_root": "/private/tmp/jstprove-adapter-check/JSTprove",
     "status": "SOURCE_HIT"
   },
-  "work_dir": "/tmp/zkai-jstprove-shape-probe"
+  "work_dir": "/tmp/zkai-jstprove-shape-probe-checked"
 }

--- a/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json
+++ b/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json
@@ -1,0 +1,677 @@
+{
+  "conclusion": {
+    "go_count": 5,
+    "go_transformer_adjacent_fixtures": [
+      "tiny_gemm_residual_add",
+      "tiny_gemm_layernorm",
+      "tiny_gemm_batchnorm"
+    ],
+    "interpretation": "JSTprove/Remainder can prove tiny projection, residual-add, and normalization-shaped fixtures, but the checked Softmax, ReLU, and literal MatMul variants expose separate backend/operator blockers.",
+    "no_go_count": 3,
+    "paper_usage": "engineering_context_only_not_transformer_proof_or_performance_benchmark"
+  },
+  "decision": "GO_OPERATOR_SUPPORT_SPLIT_NOT_TRANSFORMER_PROOF",
+  "fixture_catalog": [
+    {
+      "fixture": "tiny_gemm",
+      "op_sequence": "Gemm",
+      "primary_observation": "baseline tiny linear projection proves and verifies",
+      "transformer_relevance": "linear_projection_baseline"
+    },
+    {
+      "fixture": "tiny_gemm_add",
+      "op_sequence": "Gemm -> Add",
+      "primary_observation": "extra Add layer proves and verifies",
+      "transformer_relevance": "linear_projection_plus_bias_like_add"
+    },
+    {
+      "fixture": "tiny_gemm_residual_add",
+      "op_sequence": "Gemm(width-preserving) -> Add(input)",
+      "primary_observation": "residual-style Add proves and verifies",
+      "transformer_relevance": "linear_projection_plus_residual_add"
+    },
+    {
+      "fixture": "tiny_gemm_layernorm",
+      "op_sequence": "Gemm(width-preserving) -> LayerNormalization",
+      "primary_observation": "LayerNormalization-style tiny shape proves and verifies",
+      "transformer_relevance": "normalization_after_projection"
+    },
+    {
+      "fixture": "tiny_gemm_batchnorm",
+      "op_sequence": "Gemm -> BatchNormalization",
+      "primary_observation": "normalization-like tiny shape proves and verifies",
+      "transformer_relevance": "normalization_like_operator_after_projection"
+    },
+    {
+      "fixture": "tiny_gemm_relu",
+      "op_sequence": "Gemm -> Relu",
+      "primary_observation": "Relu witness hits Remainder range-check capacity",
+      "transformer_relevance": "activation_or_range_check_pressure"
+    },
+    {
+      "fixture": "tiny_gemm_softmax",
+      "op_sequence": "Gemm(width-preserving) -> Softmax",
+      "primary_observation": "Softmax witness is generated but proof construction refuses an unconstrained op",
+      "transformer_relevance": "attention_normalization_pressure"
+    },
+    {
+      "fixture": "tiny_matmul_residual_add",
+      "op_sequence": "MatMul -> Add(input)",
+      "primary_observation": "MatMul compiles but witness generation reports unsupported MatMul",
+      "transformer_relevance": "literal_matmul_projection_plus_residual_add"
+    }
+  ],
+  "generated_at": "1970-01-01T00:00:00Z",
+  "git_commit": "4657787db01955b1d13248ede96ec49c3daa613b",
+  "jstprove": {
+    "binary": "/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder",
+    "remainder_dependency_commit": "06a5f406",
+    "upstream_commit": "7c3cbbee83aaa01adde700673f00e317a4e902f9"
+  },
+  "non_claims": [
+    "not a JSTprove security finding",
+    "not a full transformer proof",
+    "not a performance benchmark",
+    "not evidence that larger shapes remain small",
+    "not evidence that unsupported shapes are impossible in future JSTprove versions",
+    "not a Tablero result"
+  ],
+  "question": "Which tiny transformer-adjacent ONNX shapes does JSTprove/Remainder prove today?",
+  "results": [
+    {
+      "failed_step": "",
+      "failure_kind": "",
+      "fixture": "tiny_gemm",
+      "gate": "GO_CHECKED_SMALL_SHAPE",
+      "input_bytes": 26,
+      "model_bytes": 307,
+      "onnx_bytes": 133,
+      "op_sequence": "Gemm",
+      "primary_observation": "baseline tiny linear projection proves and verifies",
+      "proof_bytes": 11645,
+      "prove_seconds": "0.820710",
+      "status": "GO",
+      "steps": [
+        {
+          "argv": [
+            "jstprove-remainder",
+            "compile",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/tiny_gemm.onnx",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/model.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.020807,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      1 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      1 layers, scale=2^18\n[4/4] Serializing\n      307 B\n\n  done Compiled in 0.00s",
+          "stdout_excerpt": "",
+          "step": "compile"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "witness",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/model.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/input.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/witness.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.014109,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      1 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      11 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
+          "stdout_excerpt": "",
+          "step": "witness"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "prove",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/model.msgpack",
+            "--witness",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/witness.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/proof.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.82071,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      1 layers\n[2/4] Loading witness\n      11 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      11.4 KiB\n\n  done Proof generated in 0.81s",
+          "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(6)\nLayer that calculates r - table has layer id: Layer(7)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(8)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(16)\nLayer that checks that fractions are eq",
+          "step": "prove"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "--quiet",
+            "verify",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/model.msgpack",
+            "--proof",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/proof.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm/input.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 2.547536,
+          "stderr_excerpt": "",
+          "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(6)\nLayer that calculates r - table has layer id: Layer(7)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(8)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(16)\nLayer that checks that fractions are eq",
+          "step": "verify"
+        }
+      ],
+      "transformer_relevance": "linear_projection_baseline",
+      "verify_seconds": "2.547536"
+    },
+    {
+      "failed_step": "",
+      "failure_kind": "",
+      "fixture": "tiny_gemm_add",
+      "gate": "GO_CHECKED_SMALL_SHAPE",
+      "input_bytes": 26,
+      "model_bytes": 358,
+      "onnx_bytes": 169,
+      "op_sequence": "Gemm -> Add",
+      "primary_observation": "extra Add layer proves and verifies",
+      "proof_bytes": 36449,
+      "prove_seconds": "1.190031",
+      "status": "GO",
+      "steps": [
+        {
+          "argv": [
+            "jstprove-remainder",
+            "compile",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/tiny_gemm_add.onnx",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/model.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.015752,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      358 B\n\n  done Compiled in 0.00s",
+          "stdout_excerpt": "",
+          "step": "compile"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "witness",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/model.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/input.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/witness.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.020349,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      13 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
+          "stdout_excerpt": "",
+          "step": "witness"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "prove",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/model.msgpack",
+            "--witness",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/witness.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/proof.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 1.190031,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      13 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      35.6 KiB\n\n  done Proof generated in 1.18s",
+          "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(17)\nLayer that checks that fractions are e",
+          "step": "prove"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "--quiet",
+            "verify",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/model.msgpack",
+            "--proof",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/proof.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/input.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 2.693476,
+          "stderr_excerpt": "",
+          "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(17)\nLayer that checks that fractions are e",
+          "step": "verify"
+        }
+      ],
+      "transformer_relevance": "linear_projection_plus_bias_like_add",
+      "verify_seconds": "2.693476"
+    },
+    {
+      "failed_step": "",
+      "failure_kind": "",
+      "fixture": "tiny_gemm_residual_add",
+      "gate": "GO_CHECKED_SMALL_SHAPE",
+      "input_bytes": 26,
+      "model_bytes": 367,
+      "onnx_bytes": 183,
+      "op_sequence": "Gemm(width-preserving) -> Add(input)",
+      "primary_observation": "residual-style Add proves and verifies",
+      "proof_bytes": 56054,
+      "prove_seconds": "0.920887",
+      "status": "GO",
+      "steps": [
+        {
+          "argv": [
+            "jstprove-remainder",
+            "compile",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/tiny_gemm_residual_add.onnx",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/model.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.014029,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      367 B\n\n  done Compiled in 0.00s",
+          "stdout_excerpt": "",
+          "step": "compile"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "witness",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/model.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/input.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/witness.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.01166,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
+          "stdout_excerpt": "",
+          "step": "witness"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "prove",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/model.msgpack",
+            "--witness",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/witness.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/proof.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.920887,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      54.7 KiB\n\n  done Proof generated in 0.91s",
+          "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(7)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(8)\nLayer that calculates r - table has layer id: Layer(9)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 8 of build_fractional_sumche",
+          "step": "prove"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "--quiet",
+            "verify",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/model.msgpack",
+            "--proof",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/proof.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/input.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 2.303404,
+          "stderr_excerpt": "",
+          "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(7)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(8)\nLayer that calculates r - table has layer id: Layer(9)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 8 of build_fractional_sumche",
+          "step": "verify"
+        }
+      ],
+      "transformer_relevance": "linear_projection_plus_residual_add",
+      "verify_seconds": "2.303404"
+    },
+    {
+      "failed_step": "",
+      "failure_kind": "",
+      "fixture": "tiny_gemm_layernorm",
+      "gate": "GO_CHECKED_SMALL_SHAPE",
+      "input_bytes": 26,
+      "model_bytes": 441,
+      "onnx_bytes": 287,
+      "op_sequence": "Gemm(width-preserving) -> LayerNormalization",
+      "primary_observation": "LayerNormalization-style tiny shape proves and verifies",
+      "proof_bytes": 52080,
+      "prove_seconds": "0.799987",
+      "status": "GO",
+      "steps": [
+        {
+          "argv": [
+            "jstprove-remainder",
+            "compile",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/tiny_gemm_layernorm.onnx",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/model.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.01266,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      441 B\n\n  done Compiled in 0.00s",
+          "stdout_excerpt": "",
+          "step": "compile"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "witness",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/model.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/input.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/witness.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.01103,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
+          "stdout_excerpt": "",
+          "step": "witness"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "prove",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/model.msgpack",
+            "--witness",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/witness.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/proof.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.799987,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      50.9 KiB\n\n  done Proof generated in 0.79s",
+          "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumchec",
+          "step": "prove"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "--quiet",
+            "verify",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/model.msgpack",
+            "--proof",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/proof.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/input.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 1.97731,
+          "stderr_excerpt": "",
+          "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumchec",
+          "step": "verify"
+        }
+      ],
+      "transformer_relevance": "normalization_after_projection",
+      "verify_seconds": "1.977310"
+    },
+    {
+      "failed_step": "",
+      "failure_kind": "",
+      "fixture": "tiny_gemm_batchnorm",
+      "gate": "GO_CHECKED_SMALL_SHAPE",
+      "input_bytes": 26,
+      "model_bytes": 419,
+      "onnx_bytes": 287,
+      "op_sequence": "Gemm -> BatchNormalization",
+      "primary_observation": "normalization-like tiny shape proves and verifies",
+      "proof_bytes": 95105,
+      "prove_seconds": "2.639012",
+      "status": "GO",
+      "steps": [
+        {
+          "argv": [
+            "jstprove-remainder",
+            "compile",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/tiny_gemm_batchnorm.onnx",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/model.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.01264,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      419 B\n\n  done Compiled in 0.00s",
+          "stdout_excerpt": "",
+          "step": "compile"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "witness",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/model.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/input.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/witness.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.012679,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      19 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
+          "stdout_excerpt": "",
+          "step": "witness"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "prove",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/model.msgpack",
+            "--witness",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/witness.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/proof.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 2.639012,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      19 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      92.9 KiB\n\n  done Proof generated in 2.63s",
+          "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(6)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(7)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(8)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(9)\nLayer that calculates r - table has layer id: Layer(10)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(18)\nIteration 8 of build_fractional_sumch",
+          "step": "prove"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "--quiet",
+            "verify",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/model.msgpack",
+            "--proof",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/proof.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/input.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 7.234345,
+          "stderr_excerpt": "",
+          "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(6)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(7)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(8)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(9)\nLayer that calculates r - table has layer id: Layer(10)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(18)\nIteration 8 of build_fractional_sumch",
+          "step": "verify"
+        }
+      ],
+      "transformer_relevance": "normalization_like_operator_after_projection",
+      "verify_seconds": "7.234345"
+    },
+    {
+      "failed_step": "witness",
+      "failure_kind": "range_check_capacity",
+      "fixture": "tiny_gemm_relu",
+      "gate": "NO_GO_RANGE_CHECK_CAPACITY",
+      "input_bytes": 26,
+      "model_bytes": 339,
+      "onnx_bytes": 153,
+      "op_sequence": "Gemm -> Relu",
+      "primary_observation": "Relu witness hits Remainder range-check capacity",
+      "proof_bytes": null,
+      "prove_seconds": "NA",
+      "status": "NO_GO",
+      "steps": [
+        {
+          "argv": [
+            "jstprove-remainder",
+            "compile",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/tiny_gemm_relu.onnx",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/model.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.017344,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      339 B\n\n  done Compiled in 0.00s",
+          "stdout_excerpt": "",
+          "step": "compile"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "witness",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/model.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/input.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/witness.msgpack"
+          ],
+          "returncode": 1,
+          "seconds": 0.012777,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n\nerror: Relu layer node_1 delta nv 20 exceeds two-chunk range-check capacity (max 18 bits)\nError: Relu layer node_1 delta nv 20 exceeds two-chunk range-check capacity (max 18 bits)",
+          "stdout_excerpt": "",
+          "step": "witness"
+        }
+      ],
+      "transformer_relevance": "activation_or_range_check_pressure",
+      "verify_seconds": "NA"
+    },
+    {
+      "failed_step": "prove",
+      "failure_kind": "unconstrained_backend_op",
+      "fixture": "tiny_gemm_softmax",
+      "gate": "NO_GO_UNCONSTRAINED_BACKEND_OP",
+      "input_bytes": 26,
+      "model_bytes": 382,
+      "onnx_bytes": 197,
+      "op_sequence": "Gemm(width-preserving) -> Softmax",
+      "primary_observation": "Softmax witness is generated but proof construction refuses an unconstrained op",
+      "proof_bytes": null,
+      "prove_seconds": "0.013802",
+      "status": "NO_GO",
+      "steps": [
+        {
+          "argv": [
+            "jstprove-remainder",
+            "compile",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/tiny_gemm_softmax.onnx",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/model.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.011894,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      382 B\n\n  done Compiled in 0.00s",
+          "stdout_excerpt": "",
+          "step": "compile"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "witness",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/model.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/input.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/witness.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.016542,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
+          "stdout_excerpt": "",
+          "step": "witness"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "prove",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/model.msgpack",
+            "--witness",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/witness.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/proof.msgpack"
+          ],
+          "returncode": 1,
+          "seconds": 0.013802,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n\nerror: circuit builder: Softmax op in layer 'node_1' is not yet constrained in the Remainder backend; refusing to add unconstrained committed shred\nError: circuit builder: Softmax op in layer 'node_1' is not yet constrained in the Remainder backend; refusing to add unconstrained committed shred",
+          "stdout_excerpt": "",
+          "step": "prove"
+        }
+      ],
+      "transformer_relevance": "attention_normalization_pressure",
+      "verify_seconds": "NA"
+    },
+    {
+      "failed_step": "witness",
+      "failure_kind": "unsupported_witness_op",
+      "fixture": "tiny_matmul_residual_add",
+      "gate": "NO_GO_UNSUPPORTED_WITNESS_OP",
+      "input_bytes": 26,
+      "model_bytes": 339,
+      "onnx_bytes": 163,
+      "op_sequence": "MatMul -> Add(input)",
+      "primary_observation": "MatMul compiles but witness generation reports unsupported MatMul",
+      "proof_bytes": null,
+      "prove_seconds": "NA",
+      "status": "NO_GO",
+      "steps": [
+        {
+          "argv": [
+            "jstprove-remainder",
+            "compile",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/tiny_matmul_residual_add.onnx",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/model.msgpack"
+          ],
+          "returncode": 0,
+          "seconds": 0.013687,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      339 B\n\n  done Compiled in 0.00s",
+          "stdout_excerpt": "",
+          "step": "compile"
+        },
+        {
+          "argv": [
+            "jstprove-remainder",
+            "witness",
+            "--model",
+            "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/model.msgpack",
+            "--input",
+            "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/input.msgpack",
+            "--output",
+            "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/witness.msgpack"
+          ],
+          "returncode": 1,
+          "seconds": 0.011933,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n\nerror: witness: unsupported op type MatMul in layer node_0\nError: witness: unsupported op type MatMul in layer node_0",
+          "stdout_excerpt": "",
+          "step": "witness"
+        }
+      ],
+      "transformer_relevance": "literal_matmul_projection_plus_residual_add",
+      "verify_seconds": "NA"
+    }
+  ],
+  "results_commitment": "blake2b-256:076d187d37dc4c6ae281a0de070409a0c04242fa27f76e79906336a975eaa67a",
+  "schema": "zkai-jstprove-shape-probe-v1",
+  "work_dir": "/tmp/zkai-jstprove-shape-probe"
+}

--- a/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json
+++ b/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json
@@ -23,9 +23,9 @@
       "model_bytes": 292,
       "onnx_bytes": 130,
       "proof_bytes": 11726,
-      "prove_seconds": "0.912901",
+      "prove_seconds": "0.789040",
       "status": "GO",
-      "verify_seconds": "2.673158"
+      "verify_seconds": "2.014997"
     },
     {
       "dimension": 2,
@@ -34,9 +34,9 @@
       "model_bytes": 318,
       "onnx_bytes": 147,
       "proof_bytes": 71040,
-      "prove_seconds": "1.019196",
+      "prove_seconds": "0.789481",
       "status": "GO",
-      "verify_seconds": "2.279538"
+      "verify_seconds": "2.014832"
     },
     {
       "dimension": 4,
@@ -45,12 +45,12 @@
       "model_bytes": 349,
       "onnx_bytes": 203,
       "proof_bytes": 70138,
-      "prove_seconds": "0.902361",
+      "prove_seconds": "0.794956",
       "status": "GO",
-      "verify_seconds": "2.237408"
+      "verify_seconds": "2.011973"
     }
   ],
-  "exploration_commitment": "blake2b-256:8973c901b88cb9720279997aa276973750786563c9f47addbde8dec9eda81d54",
+  "exploration_commitment": "blake2b-256:e7e01a4bd3186d44b7fe47c464ec1449c423dcfcb178aba4dbf6de9689b10b98",
   "fixture_catalog": [
     {
       "fixture": "tiny_gemm",
@@ -109,7 +109,7 @@
     "onnx_opset": 17,
     "python": "3.13.11"
   },
-  "git_commit": "376eaa8a80544d5b4121e33314aa6bd28250caa1",
+  "git_commit": "e2f717b549e1a0e27f7aa108aecb5f4483ed56b5",
   "jstprove": {
     "binary": "/private/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder",
     "remainder_dependency_commit": "06a5f406",
@@ -139,24 +139,24 @@
     {
       "failed_step": "",
       "failure_kind": "",
-      "model_bytes": 336,
+      "model_bytes": 341,
       "onnx_bytes": 154,
       "proof_bytes": 87377,
-      "prove_seconds": "5.389730",
+      "prove_seconds": "4.258750",
       "scale": "0.25",
       "status": "GO",
-      "verify_seconds": "9.962077"
+      "verify_seconds": "10.371152"
     },
     {
       "failed_step": "",
       "failure_kind": "",
-      "model_bytes": 338,
+      "model_bytes": 340,
       "onnx_bytes": 153,
       "proof_bytes": 211088,
-      "prove_seconds": "4.116503",
+      "prove_seconds": "4.454804",
       "scale": "0.1",
       "status": "GO",
-      "verify_seconds": "9.468539"
+      "verify_seconds": "10.036734"
     },
     {
       "failed_step": "",
@@ -164,21 +164,21 @@
       "model_bytes": 343,
       "onnx_bytes": 154,
       "proof_bytes": 227462,
-      "prove_seconds": "4.053108",
+      "prove_seconds": "4.079425",
       "scale": "0.01",
       "status": "GO",
-      "verify_seconds": "9.640854"
+      "verify_seconds": "9.626077"
     },
     {
       "failed_step": "",
       "failure_kind": "",
-      "model_bytes": 341,
+      "model_bytes": 339,
       "onnx_bytes": 155,
       "proof_bytes": 108172,
-      "prove_seconds": "1.602478",
+      "prove_seconds": "1.646319",
       "scale": "0.001",
       "status": "GO",
-      "verify_seconds": "4.211324"
+      "verify_seconds": "4.252590"
     }
   ],
   "results": [
@@ -193,7 +193,7 @@
       "op_sequence": "Gemm",
       "primary_observation": "baseline tiny linear projection proves and verifies",
       "proof_bytes": 11645,
-      "prove_seconds": "0.834183",
+      "prove_seconds": "0.811731",
       "status": "GO",
       "steps": [
         {
@@ -206,8 +206,8 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.049907,
-          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      1 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      1 layers, scale=2^18\n[4/4] Serializing\n      307 B\n\n  done Compiled in 0.01s",
+          "seconds": 0.020358,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      1 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      1 layers, scale=2^18\n[4/4] Serializing\n      307 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
         },
@@ -223,8 +223,8 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.019382,
-          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      1 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      11 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.01s",
+          "seconds": 0.011196,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      1 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      11 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
         },
@@ -240,8 +240,8 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.834183,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      1 layers\n[2/4] Loading witness\n      11 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      11.4 KiB\n\n  done Proof generated in 0.82s",
+          "seconds": 0.811731,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      1 layers\n[2/4] Loading witness\n      11 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      11.4 KiB\n\n  done Proof generated in 0.80s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(6)\nLayer that calculates r - table has layer id: Layer(7)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(8)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(16)\nLayer that checks that fractions are eq",
           "step": "prove"
         },
@@ -258,14 +258,14 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 1.989027,
+          "seconds": 1.966926,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(6)\nLayer that calculates r - table has layer id: Layer(7)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(8)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(16)\nLayer that checks that fractions are eq",
           "step": "verify"
         }
       ],
       "transformer_relevance": "linear_projection_baseline",
-      "verify_seconds": "1.989027"
+      "verify_seconds": "1.966926"
     },
     {
       "failed_step": "",
@@ -278,7 +278,7 @@
       "op_sequence": "Gemm -> Add",
       "primary_observation": "extra Add layer proves and verifies",
       "proof_bytes": 36449,
-      "prove_seconds": "1.044284",
+      "prove_seconds": "0.940403",
       "status": "GO",
       "steps": [
         {
@@ -291,7 +291,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.015745,
+          "seconds": 0.01749,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      361 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -308,7 +308,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.016493,
+          "seconds": 0.013787,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      13 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
@@ -325,8 +325,8 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 1.044284,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      13 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      35.6 KiB\n\n  done Proof generated in 1.03s",
+          "seconds": 0.940403,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      13 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      35.6 KiB\n\n  done Proof generated in 0.93s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(17)\nLayer that checks that fractions are e",
           "step": "prove"
         },
@@ -343,14 +343,14 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_add/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.411266,
+          "seconds": 2.343996,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(17)\nLayer that checks that fractions are e",
           "step": "verify"
         }
       ],
       "transformer_relevance": "linear_projection_plus_bias_like_add",
-      "verify_seconds": "2.411266"
+      "verify_seconds": "2.343996"
     },
     {
       "failed_step": "",
@@ -363,7 +363,7 @@
       "op_sequence": "Gemm(width-preserving) -> Add(input)",
       "primary_observation": "residual-style Add proves and verifies",
       "proof_bytes": 56054,
-      "prove_seconds": "1.010520",
+      "prove_seconds": "0.936787",
       "status": "GO",
       "steps": [
         {
@@ -376,7 +376,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.015333,
+          "seconds": 0.019679,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      367 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -393,8 +393,8 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.014828,
-          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
+          "seconds": 0.014246,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
         },
@@ -410,8 +410,8 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 1.01052,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      54.7 KiB\n\n  done Proof generated in 0.99s",
+          "seconds": 0.936787,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      54.7 KiB\n\n  done Proof generated in 0.92s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(7)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(8)\nLayer that calculates r - table has layer id: Layer(9)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 8 of build_fractional_sumche",
           "step": "prove"
         },
@@ -428,14 +428,14 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_residual_add/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.469885,
+          "seconds": 2.394773,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(7)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(8)\nLayer that calculates r - table has layer id: Layer(9)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 8 of build_fractional_sumche",
           "step": "verify"
         }
       ],
       "transformer_relevance": "linear_projection_plus_residual_add",
-      "verify_seconds": "2.469885"
+      "verify_seconds": "2.394773"
     },
     {
       "failed_step": "",
@@ -448,7 +448,7 @@
       "op_sequence": "Gemm(width-preserving) -> LayerNormalization",
       "primary_observation": "LayerNormalization-style tiny shape proves and verifies",
       "proof_bytes": 52080,
-      "prove_seconds": "0.819784",
+      "prove_seconds": "0.849479",
       "status": "GO",
       "steps": [
         {
@@ -461,7 +461,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.013941,
+          "seconds": 0.016807,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      442 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -478,7 +478,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.011716,
+          "seconds": 0.014287,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
@@ -495,8 +495,8 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.819784,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      50.9 KiB\n\n  done Proof generated in 0.81s",
+          "seconds": 0.849479,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      50.9 KiB\n\n  done Proof generated in 0.84s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumchec",
           "step": "prove"
         },
@@ -513,14 +513,14 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_layernorm/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.016979,
+          "seconds": 1.967507,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumchec",
           "step": "verify"
         }
       ],
       "transformer_relevance": "normalization_after_projection",
-      "verify_seconds": "2.016979"
+      "verify_seconds": "1.967507"
     },
     {
       "failed_step": "",
@@ -528,12 +528,12 @@
       "fixture": "tiny_gemm_batchnorm",
       "gate": "GO_CHECKED_SMALL_SHAPE",
       "input_bytes": 26,
-      "model_bytes": 421,
+      "model_bytes": 419,
       "onnx_bytes": 287,
       "op_sequence": "Gemm -> BatchNormalization",
       "primary_observation": "normalization-like tiny shape proves and verifies",
       "proof_bytes": 95105,
-      "prove_seconds": "2.777716",
+      "prove_seconds": "2.659671",
       "status": "GO",
       "steps": [
         {
@@ -546,8 +546,8 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.017722,
-          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      421 B\n\n  done Compiled in 0.00s",
+          "seconds": 0.018786,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      419 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
         },
@@ -563,7 +563,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.015905,
+          "seconds": 0.012969,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      19 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
@@ -580,8 +580,8 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.777716,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      19 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      92.9 KiB\n\n  done Proof generated in 2.76s",
+          "seconds": 2.659671,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      19 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      92.9 KiB\n\n  done Proof generated in 2.64s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(6)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(7)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(8)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(9)\nLayer that calculates r - table has layer id: Layer(10)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(18)\nIteration 8 of build_fractional_sumch",
           "step": "prove"
         },
@@ -598,14 +598,14 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_batchnorm/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 6.530913,
+          "seconds": 6.161834,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(6)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(7)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(8)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(9)\nLayer that calculates r - table has layer id: Layer(10)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(18)\nIteration 8 of build_fractional_sumch",
           "step": "verify"
         }
       ],
       "transformer_relevance": "normalization_like_operator_after_projection",
-      "verify_seconds": "6.530913"
+      "verify_seconds": "6.161834"
     },
     {
       "failed_step": "witness",
@@ -631,7 +631,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_relu/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.015574,
+          "seconds": 0.020218,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      341 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -648,7 +648,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_relu/witness.msgpack"
           ],
           "returncode": 1,
-          "seconds": 0.015934,
+          "seconds": 0.012864,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n\nerror: Relu layer node_1 delta nv 20 exceeds two-chunk range-check capacity (max 18 bits)\nError: Relu layer node_1 delta nv 20 exceeds two-chunk range-check capacity (max 18 bits)",
           "stdout_excerpt": "",
           "step": "witness"
@@ -663,12 +663,12 @@
       "fixture": "tiny_gemm_softmax",
       "gate": "NO_GO_UNCONSTRAINED_BACKEND_OP",
       "input_bytes": 26,
-      "model_bytes": 387,
+      "model_bytes": 386,
       "onnx_bytes": 197,
       "op_sequence": "Gemm(width-preserving) -> Softmax",
       "primary_observation": "Softmax witness is generated but proof construction refuses an unconstrained op",
       "proof_bytes": null,
-      "prove_seconds": "0.016604",
+      "prove_seconds": "0.011955",
       "status": "NO_GO",
       "steps": [
         {
@@ -681,8 +681,8 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.013569,
-          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      387 B\n\n  done Compiled in 0.00s",
+          "seconds": 0.014979,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      386 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
         },
@@ -698,7 +698,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.014962,
+          "seconds": 0.013809,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
@@ -715,7 +715,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_gemm_softmax/proof.msgpack"
           ],
           "returncode": 1,
-          "seconds": 0.016604,
+          "seconds": 0.011955,
           "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n\nerror: circuit builder: Softmax op in layer 'node_1' is not yet constrained in the Remainder backend; refusing to add unconstrained committed shred\nError: circuit builder: Softmax op in layer 'node_1' is not yet constrained in the Remainder backend; refusing to add unconstrained committed shred",
           "stdout_excerpt": "",
           "step": "prove"
@@ -748,7 +748,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_matmul_residual_add/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.013128,
+          "seconds": 0.010782,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      339 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -765,7 +765,7 @@
             "/tmp/zkai-jstprove-shape-probe-checked/tiny_matmul_residual_add/witness.msgpack"
           ],
           "returncode": 1,
-          "seconds": 0.012468,
+          "seconds": 0.012496,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n\nerror: witness: unsupported op type MatMul in layer node_0\nError: witness: unsupported op type MatMul in layer node_0",
           "stdout_excerpt": "",
           "step": "witness"
@@ -775,7 +775,7 @@
       "verify_seconds": "NA"
     }
   ],
-  "results_commitment": "blake2b-256:d1cb79c02a1e30caaa18397b07ea3869f42d149cdf854eccee03cb7edd3aae3e",
+  "results_commitment": "blake2b-256:ead487a7eb184f8d2ec69291eccb7b3cf9d532d4e0b1d75f8453b88e5e471175",
   "schema": "zkai-jstprove-shape-probe-v1",
   "softmax_alternative_ref_probe": [
     {

--- a/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json
+++ b/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json
@@ -1,16 +1,55 @@
 {
   "conclusion": {
+    "gemm_dimension_sweep": "GO_DIMS_1_2_4",
     "go_count": 5,
     "go_transformer_adjacent_fixtures": [
       "tiny_gemm_residual_add",
       "tiny_gemm_layernorm",
       "tiny_gemm_batchnorm"
     ],
-    "interpretation": "JSTprove/Remainder can prove tiny projection, residual-add, and normalization-shaped fixtures, but the checked Softmax, ReLU, and literal MatMul variants expose separate backend/operator blockers.",
+    "interpretation": "JSTprove/Remainder can prove tiny projection, residual-add, and normalization-shaped fixtures, but the checked Softmax, ReLU, and literal MatMul variants expose separate backend/operator blockers. The ReLU blocker is input-dependent in this probe: scaled variants clear.",
     "no_go_count": 3,
-    "paper_usage": "engineering_context_only_not_transformer_proof_or_performance_benchmark"
+    "paper_usage": "engineering_context_only_not_transformer_proof_or_performance_benchmark",
+    "relu_scaling": "INPUT_DEPENDENT_BASELINE_FAILS_SCALED_VARIANTS_CLEAR",
+    "softmax_source_check": "SOURCE_HIT"
   },
   "decision": "GO_OPERATOR_SUPPORT_SPLIT_NOT_TRANSFORMER_PROOF",
+  "dimension_sweep": [
+    {
+      "dimension": 1,
+      "failed_step": "",
+      "failure_kind": "",
+      "model_bytes": 292,
+      "onnx_bytes": 130,
+      "proof_bytes": 11726,
+      "prove_seconds": "0.799333",
+      "status": "GO",
+      "verify_seconds": "1.971647"
+    },
+    {
+      "dimension": 2,
+      "failed_step": "",
+      "failure_kind": "",
+      "model_bytes": 319,
+      "onnx_bytes": 147,
+      "proof_bytes": 71040,
+      "prove_seconds": "0.789629",
+      "status": "GO",
+      "verify_seconds": "1.948071"
+    },
+    {
+      "dimension": 4,
+      "failed_step": "",
+      "failure_kind": "",
+      "model_bytes": 349,
+      "onnx_bytes": 203,
+      "proof_bytes": 70138,
+      "prove_seconds": "0.781246",
+      "status": "GO",
+      "verify_seconds": "1.939688"
+    }
+  ],
+  "exploration_commitment": "blake2b-256:2c55f3604c4d174922f3400ab2402e3292f1001d039a83a067914fe1314eb312",
   "fixture_catalog": [
     {
       "fixture": "tiny_gemm",
@@ -62,9 +101,9 @@
     }
   ],
   "generated_at": "1970-01-01T00:00:00Z",
-  "git_commit": "4657787db01955b1d13248ede96ec49c3daa613b",
+  "git_commit": "f8963ade432fa7f999c0eaf4c356ba06d526d57f",
   "jstprove": {
-    "binary": "/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder",
+    "binary": "/private/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder",
     "remainder_dependency_commit": "06a5f406",
     "upstream_commit": "7c3cbbee83aaa01adde700673f00e317a4e902f9"
   },
@@ -77,6 +116,63 @@
     "not a Tablero result"
   ],
   "question": "Which tiny transformer-adjacent ONNX shapes does JSTprove/Remainder prove today?",
+  "relu_scaling_probe": [
+    {
+      "failed_step": "witness",
+      "failure_kind": "range_check_capacity",
+      "model_bytes": 341,
+      "onnx_bytes": 151,
+      "proof_bytes": null,
+      "prove_seconds": "NA",
+      "scale": "1",
+      "status": "NO_GO",
+      "verify_seconds": "NA"
+    },
+    {
+      "failed_step": "",
+      "failure_kind": "",
+      "model_bytes": 336,
+      "onnx_bytes": 154,
+      "proof_bytes": 87377,
+      "prove_seconds": "3.995539",
+      "scale": "0.25",
+      "status": "GO",
+      "verify_seconds": "9.395193"
+    },
+    {
+      "failed_step": "",
+      "failure_kind": "",
+      "model_bytes": 338,
+      "onnx_bytes": 153,
+      "proof_bytes": 211088,
+      "prove_seconds": "3.981442",
+      "scale": "0.1",
+      "status": "GO",
+      "verify_seconds": "9.412703"
+    },
+    {
+      "failed_step": "",
+      "failure_kind": "",
+      "model_bytes": 343,
+      "onnx_bytes": 154,
+      "proof_bytes": 227462,
+      "prove_seconds": "3.987476",
+      "scale": "0.01",
+      "status": "GO",
+      "verify_seconds": "9.523842"
+    },
+    {
+      "failed_step": "",
+      "failure_kind": "",
+      "model_bytes": 341,
+      "onnx_bytes": 155,
+      "proof_bytes": 108172,
+      "prove_seconds": "1.592207",
+      "scale": "0.001",
+      "status": "GO",
+      "verify_seconds": "4.051986"
+    }
+  ],
   "results": [
     {
       "failed_step": "",
@@ -89,7 +185,7 @@
       "op_sequence": "Gemm",
       "primary_observation": "baseline tiny linear projection proves and verifies",
       "proof_bytes": 11645,
-      "prove_seconds": "0.820710",
+      "prove_seconds": "0.781818",
       "status": "GO",
       "steps": [
         {
@@ -102,7 +198,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.020807,
+          "seconds": 0.024744,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      1 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      1 layers, scale=2^18\n[4/4] Serializing\n      307 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -119,7 +215,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.014109,
+          "seconds": 0.014631,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      1 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      11 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
@@ -136,8 +232,8 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.82071,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      1 layers\n[2/4] Loading witness\n      11 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      11.4 KiB\n\n  done Proof generated in 0.81s",
+          "seconds": 0.781818,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      1 layers\n[2/4] Loading witness\n      11 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      11.4 KiB\n\n  done Proof generated in 0.77s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(6)\nLayer that calculates r - table has layer id: Layer(7)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(8)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(16)\nLayer that checks that fractions are eq",
           "step": "prove"
         },
@@ -154,14 +250,14 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.547536,
+          "seconds": 1.980332,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(6)\nLayer that calculates r - table has layer id: Layer(7)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(8)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(16)\nLayer that checks that fractions are eq",
           "step": "verify"
         }
       ],
       "transformer_relevance": "linear_projection_baseline",
-      "verify_seconds": "2.547536"
+      "verify_seconds": "1.980332"
     },
     {
       "failed_step": "",
@@ -169,12 +265,12 @@
       "fixture": "tiny_gemm_add",
       "gate": "GO_CHECKED_SMALL_SHAPE",
       "input_bytes": 26,
-      "model_bytes": 358,
+      "model_bytes": 361,
       "onnx_bytes": 169,
       "op_sequence": "Gemm -> Add",
       "primary_observation": "extra Add layer proves and verifies",
       "proof_bytes": 36449,
-      "prove_seconds": "1.190031",
+      "prove_seconds": "0.912362",
       "status": "GO",
       "steps": [
         {
@@ -187,8 +283,8 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.015752,
-          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      358 B\n\n  done Compiled in 0.00s",
+          "seconds": 0.008935,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      361 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
         },
@@ -204,7 +300,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.020349,
+          "seconds": 0.009036,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      13 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
@@ -221,8 +317,8 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 1.190031,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      13 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      35.6 KiB\n\n  done Proof generated in 1.18s",
+          "seconds": 0.912362,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      13 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      35.6 KiB\n\n  done Proof generated in 0.90s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(17)\nLayer that checks that fractions are e",
           "step": "prove"
         },
@@ -239,14 +335,14 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_add/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.693476,
+          "seconds": 2.308319,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumcheck has layer id: Layer(17)\nLayer that checks that fractions are e",
           "step": "verify"
         }
       ],
       "transformer_relevance": "linear_projection_plus_bias_like_add",
-      "verify_seconds": "2.693476"
+      "verify_seconds": "2.308319"
     },
     {
       "failed_step": "",
@@ -259,7 +355,7 @@
       "op_sequence": "Gemm(width-preserving) -> Add(input)",
       "primary_observation": "residual-style Add proves and verifies",
       "proof_bytes": 56054,
-      "prove_seconds": "0.920887",
+      "prove_seconds": "0.921516",
       "status": "GO",
       "steps": [
         {
@@ -272,7 +368,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.014029,
+          "seconds": 0.015321,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      367 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -289,7 +385,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.01166,
+          "seconds": 0.012706,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
@@ -306,7 +402,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.920887,
+          "seconds": 0.921516,
           "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      54.7 KiB\n\n  done Proof generated in 0.91s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(7)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(8)\nLayer that calculates r - table has layer id: Layer(9)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 8 of build_fractional_sumche",
           "step": "prove"
@@ -324,14 +420,14 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_residual_add/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.303404,
+          "seconds": 2.328602,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(5)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(6)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(7)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(8)\nLayer that calculates r - table has layer id: Layer(9)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 8 of build_fractional_sumche",
           "step": "verify"
         }
       ],
       "transformer_relevance": "linear_projection_plus_residual_add",
-      "verify_seconds": "2.303404"
+      "verify_seconds": "2.328602"
     },
     {
       "failed_step": "",
@@ -344,7 +440,7 @@
       "op_sequence": "Gemm(width-preserving) -> LayerNormalization",
       "primary_observation": "LayerNormalization-style tiny shape proves and verifies",
       "proof_bytes": 52080,
-      "prove_seconds": "0.799987",
+      "prove_seconds": "0.778382",
       "status": "GO",
       "steps": [
         {
@@ -357,7 +453,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.01266,
+          "seconds": 0.015773,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      441 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -374,8 +470,8 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.01103,
-          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
+          "seconds": 0.012081,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
         },
@@ -391,8 +487,8 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.799987,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      50.9 KiB\n\n  done Proof generated in 0.79s",
+          "seconds": 0.778382,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      50.9 KiB\n\n  done Proof generated in 0.77s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumchec",
           "step": "prove"
         },
@@ -409,14 +505,14 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_layernorm/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 1.97731,
+          "seconds": 1.945761,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(4)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(5)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(6)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(7)\nLayer that calculates r - table has layer id: Layer(8)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(9)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(10)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 8 of build_fractional_sumchec",
           "step": "verify"
         }
       ],
       "transformer_relevance": "normalization_after_projection",
-      "verify_seconds": "1.977310"
+      "verify_seconds": "1.945761"
     },
     {
       "failed_step": "",
@@ -424,12 +520,12 @@
       "fixture": "tiny_gemm_batchnorm",
       "gate": "GO_CHECKED_SMALL_SHAPE",
       "input_bytes": 26,
-      "model_bytes": 419,
+      "model_bytes": 421,
       "onnx_bytes": 287,
       "op_sequence": "Gemm -> BatchNormalization",
       "primary_observation": "normalization-like tiny shape proves and verifies",
       "proof_bytes": 95105,
-      "prove_seconds": "2.639012",
+      "prove_seconds": "2.591887",
       "status": "GO",
       "steps": [
         {
@@ -442,8 +538,8 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.01264,
-          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      419 B\n\n  done Compiled in 0.00s",
+          "seconds": 0.016629,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      421 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
         },
@@ -459,7 +555,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.012679,
+          "seconds": 0.011738,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      19 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
@@ -476,8 +572,8 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/proof.msgpack"
           ],
           "returncode": 0,
-          "seconds": 2.639012,
-          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      19 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      92.9 KiB\n\n  done Proof generated in 2.63s",
+          "seconds": 2.591887,
+          "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      19 shreds\n[3/4] Generating proof\n[4/4] Serializing\n      92.9 KiB\n\n  done Proof generated in 2.58s",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(6)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(7)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(8)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(9)\nLayer that calculates r - table has layer id: Layer(10)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(18)\nIteration 8 of build_fractional_sumch",
           "step": "prove"
         },
@@ -494,14 +590,14 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_batchnorm/input.msgpack"
           ],
           "returncode": 0,
-          "seconds": 7.234345,
+          "seconds": 6.078993,
           "stderr_excerpt": "",
           "stdout_excerpt": "Build the LHS of the equation (defined by the constrained values)\nLayer that calcs r - constrained has layer id: Layer(6)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(7)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(8)\nBuild the RHS of the equation (defined by the table values and multiplicities)\nLayer that aggs the multiplicities has layer id: Layer(9)\nLayer that calculates r - table has layer id: Layer(10)\nIteration 0 of build_fractional_sumcheck has layer id: Layer(11)\nIteration 1 of build_fractional_sumcheck has layer id: Layer(12)\nIteration 2 of build_fractional_sumcheck has layer id: Layer(13)\nIteration 3 of build_fractional_sumcheck has layer id: Layer(14)\nIteration 4 of build_fractional_sumcheck has layer id: Layer(15)\nIteration 5 of build_fractional_sumcheck has layer id: Layer(16)\nIteration 6 of build_fractional_sumcheck has layer id: Layer(17)\nIteration 7 of build_fractional_sumcheck has layer id: Layer(18)\nIteration 8 of build_fractional_sumch",
           "step": "verify"
         }
       ],
       "transformer_relevance": "normalization_like_operator_after_projection",
-      "verify_seconds": "7.234345"
+      "verify_seconds": "6.078993"
     },
     {
       "failed_step": "witness",
@@ -509,7 +605,7 @@
       "fixture": "tiny_gemm_relu",
       "gate": "NO_GO_RANGE_CHECK_CAPACITY",
       "input_bytes": 26,
-      "model_bytes": 339,
+      "model_bytes": 341,
       "onnx_bytes": 153,
       "op_sequence": "Gemm -> Relu",
       "primary_observation": "Relu witness hits Remainder range-check capacity",
@@ -527,8 +623,8 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.017344,
-          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      339 B\n\n  done Compiled in 0.00s",
+          "seconds": 0.0094,
+          "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      341 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
         },
@@ -544,7 +640,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_relu/witness.msgpack"
           ],
           "returncode": 1,
-          "seconds": 0.012777,
+          "seconds": 0.009417,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n\nerror: Relu layer node_1 delta nv 20 exceeds two-chunk range-check capacity (max 18 bits)\nError: Relu layer node_1 delta nv 20 exceeds two-chunk range-check capacity (max 18 bits)",
           "stdout_excerpt": "",
           "step": "witness"
@@ -564,7 +660,7 @@
       "op_sequence": "Gemm(width-preserving) -> Softmax",
       "primary_observation": "Softmax witness is generated but proof construction refuses an unconstrained op",
       "proof_bytes": null,
-      "prove_seconds": "0.013802",
+      "prove_seconds": "0.009271",
       "status": "NO_GO",
       "steps": [
         {
@@ -577,7 +673,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.011894,
+          "seconds": 0.009427,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      382 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -594,8 +690,8 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/witness.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.016542,
-          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.0 KiB\n\n  done Witness generated in 0.00s",
+          "seconds": 0.007735,
+          "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n      12 shreds\n[4/4] Serializing\n      1.1 KiB\n\n  done Witness generated in 0.00s",
           "stdout_excerpt": "",
           "step": "witness"
         },
@@ -611,7 +707,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_gemm_softmax/proof.msgpack"
           ],
           "returncode": 1,
-          "seconds": 0.013802,
+          "seconds": 0.009271,
           "stderr_excerpt": "jstprove prove\n\n[1/4] Loading model\n      2 layers\n[2/4] Loading witness\n      12 shreds\n[3/4] Generating proof\n\nerror: circuit builder: Softmax op in layer 'node_1' is not yet constrained in the Remainder backend; refusing to add unconstrained committed shred\nError: circuit builder: Softmax op in layer 'node_1' is not yet constrained in the Remainder backend; refusing to add unconstrained committed shred",
           "stdout_excerpt": "",
           "step": "prove"
@@ -644,7 +740,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/model.msgpack"
           ],
           "returncode": 0,
-          "seconds": 0.013687,
+          "seconds": 0.00892,
           "stderr_excerpt": "jstprove compile\n\n[1/4] Parsing ONNX model\n      2 nodes\n[2/4] Building layer graph\n[3/4] Quantizing model\n      2 layers, scale=2^18\n[4/4] Serializing\n      339 B\n\n  done Compiled in 0.00s",
           "stdout_excerpt": "",
           "step": "compile"
@@ -661,7 +757,7 @@
             "/tmp/zkai-jstprove-shape-probe/tiny_matmul_residual_add/witness.msgpack"
           ],
           "returncode": 1,
-          "seconds": 0.011933,
+          "seconds": 0.009746,
           "stderr_excerpt": "jstprove witness\n\n[1/4] Loading model\n      2 layers\n[2/4] Quantizing input\n      2 elements\n[3/4] Computing witness\n\nerror: witness: unsupported op type MatMul in layer node_0\nError: witness: unsupported op type MatMul in layer node_0",
           "stdout_excerpt": "",
           "step": "witness"
@@ -671,7 +767,106 @@
       "verify_seconds": "NA"
     }
   ],
-  "results_commitment": "blake2b-256:076d187d37dc4c6ae281a0de070409a0c04242fa27f76e79906336a975eaa67a",
+  "results_commitment": "blake2b-256:a525a858b3a48f0ec111f22fcd1f5c043436a585b14c0f09f74f9e152f620d63",
   "schema": "zkai-jstprove-shape-probe-v1",
+  "softmax_source_probe": {
+    "hits": [
+      {
+        "category": "circuit_hint",
+        "line": 18,
+        "path": "rust/jstprove_circuits/src/circuit_functions/hints/layer_norm.rs",
+        "text": "// The hint alone adds no constraint.  Unlike Exp/Sigmoid/Softmax, no LogUp"
+      },
+      {
+        "category": "circuit_hint",
+        "line": 15,
+        "path": "rust/jstprove_circuits/src/circuit_functions/hints/softmax.rs",
+        "text": "// The hint alone adds no constraint. The `SoftmaxLayer` circuit pairs this"
+      },
+      {
+        "category": "circuit_layer",
+        "line": 50,
+        "path": "rust/jstprove_circuits/src/circuit_functions/layers/layer_kinds.rs",
+        "text": "use crate::circuit_functions::layers::softmax::SoftmaxLayer;"
+      },
+      {
+        "category": "circuit_layer",
+        "line": 206,
+        "path": "rust/jstprove_circuits/src/circuit_functions/layers/layer_kinds.rs",
+        "text": "Softmax            => { name: \"Softmax\", builder: SoftmaxLayer::build },"
+      },
+      {
+        "category": "circuit_layer",
+        "line": 20,
+        "path": "rust/jstprove_circuits/src/circuit_functions/layers/softmax.rs",
+        "text": "pub struct SoftmaxLayer {"
+      },
+      {
+        "category": "circuit_layer",
+        "line": 28,
+        "path": "rust/jstprove_circuits/src/circuit_functions/layers/softmax.rs",
+        "text": "impl<C: Config, Builder: RootAPI<C>> LayerOp<C, Builder> for SoftmaxLayer {"
+      },
+      {
+        "category": "remainder_witness",
+        "line": 435,
+        "path": "rust/jstprove_circuits/src/expander_metadata.rs",
+        "text": "OpType::Softmax => \"Softmax\","
+      },
+      {
+        "category": "remainder_witness",
+        "line": 900,
+        "path": "rust/jstprove_circuits/src/expander_metadata.rs",
+        "text": "(OpType::Softmax, \"Softmax\"),"
+      },
+      {
+        "category": "remainder_witness",
+        "line": 1779,
+        "path": "rust/jstprove_onnx/src/quantizer.rs",
+        "text": "OpType::Softmax | OpType::Sigmoid => Ok(1.0),"
+      },
+      {
+        "category": "remainder_witness",
+        "line": 1889,
+        "path": "rust/jstprove_onnx/src/quantizer.rs",
+        "text": "| OpType::Softmax"
+      },
+      {
+        "category": "remainder_witness",
+        "line": 696,
+        "path": "rust/jstprove_onnx/src/shape_inference.rs",
+        "text": "OpType::Cast | OpType::Exp | OpType::Softmax | OpType::Sigmoid | OpType::Gelu => {"
+      },
+      {
+        "category": "remainder_witness",
+        "line": 455,
+        "path": "rust/jstprove_remainder/src/runner/circuit_builder.rs",
+        "text": "OpType::Exp | OpType::Softmax | OpType::Sigmoid | OpType::Gelu | OpType::Tile => {"
+      },
+      {
+        "category": "remainder_refusal",
+        "line": 458,
+        "path": "rust/jstprove_remainder/src/runner/circuit_builder.rs",
+        "text": "Remainder backend; refusing to add unconstrained committed shred\","
+      },
+      {
+        "category": "remainder_refusal",
+        "line": 474,
+        "path": "rust/jstprove_remainder/src/runner/circuit_builder.rs",
+        "text": "Remainder backend; refusing to add unconstrained committed shred\","
+      },
+      {
+        "category": "remainder_refusal",
+        "line": 481,
+        "path": "rust/jstprove_remainder/src/runner/circuit_builder.rs",
+        "text": "Remainder backend; refusing to add unconstrained committed shred\","
+      }
+    ],
+    "observation": "Pinned source inspection found the Remainder Softmax unconstrained-op refusal.",
+    "softmax_refusal_found": true,
+    "source_commit": "7c3cbbee83aaa01adde700673f00e317a4e902f9",
+    "source_root": "/private/tmp/jstprove-adapter-check/JSTprove",
+    "status": "SOURCE_HIT"
+  },
   "work_dir": "/tmp/zkai-jstprove-shape-probe"
 }

--- a/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv
@@ -1,9 +1,9 @@
 fixture	gate	op_sequence	transformer_relevance	status	failed_step	failure_kind	proof_bytes	model_bytes	onnx_bytes	prove_seconds	verify_seconds	primary_observation
-tiny_gemm	GO_CHECKED_SMALL_SHAPE	Gemm	linear_projection_baseline	GO			11645	307	133	0.820710	2.547536	baseline tiny linear projection proves and verifies
-tiny_gemm_add	GO_CHECKED_SMALL_SHAPE	Gemm -> Add	linear_projection_plus_bias_like_add	GO			36449	358	169	1.190031	2.693476	extra Add layer proves and verifies
-tiny_gemm_residual_add	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> Add(input)	linear_projection_plus_residual_add	GO			56054	367	183	0.920887	2.303404	residual-style Add proves and verifies
-tiny_gemm_layernorm	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> LayerNormalization	normalization_after_projection	GO			52080	441	287	0.799987	1.977310	LayerNormalization-style tiny shape proves and verifies
-tiny_gemm_batchnorm	GO_CHECKED_SMALL_SHAPE	Gemm -> BatchNormalization	normalization_like_operator_after_projection	GO			95105	419	287	2.639012	7.234345	normalization-like tiny shape proves and verifies
-tiny_gemm_relu	NO_GO_RANGE_CHECK_CAPACITY	Gemm -> Relu	activation_or_range_check_pressure	NO_GO	witness	range_check_capacity		339	153	NA	NA	Relu witness hits Remainder range-check capacity
-tiny_gemm_softmax	NO_GO_UNCONSTRAINED_BACKEND_OP	Gemm(width-preserving) -> Softmax	attention_normalization_pressure	NO_GO	prove	unconstrained_backend_op		382	197	0.013802	NA	Softmax witness is generated but proof construction refuses an unconstrained op
+tiny_gemm	GO_CHECKED_SMALL_SHAPE	Gemm	linear_projection_baseline	GO			11645	307	133	0.781818	1.980332	baseline tiny linear projection proves and verifies
+tiny_gemm_add	GO_CHECKED_SMALL_SHAPE	Gemm -> Add	linear_projection_plus_bias_like_add	GO			36449	361	169	0.912362	2.308319	extra Add layer proves and verifies
+tiny_gemm_residual_add	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> Add(input)	linear_projection_plus_residual_add	GO			56054	367	183	0.921516	2.328602	residual-style Add proves and verifies
+tiny_gemm_layernorm	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> LayerNormalization	normalization_after_projection	GO			52080	441	287	0.778382	1.945761	LayerNormalization-style tiny shape proves and verifies
+tiny_gemm_batchnorm	GO_CHECKED_SMALL_SHAPE	Gemm -> BatchNormalization	normalization_like_operator_after_projection	GO			95105	421	287	2.591887	6.078993	normalization-like tiny shape proves and verifies
+tiny_gemm_relu	NO_GO_RANGE_CHECK_CAPACITY	Gemm -> Relu	activation_or_range_check_pressure	NO_GO	witness	range_check_capacity		341	153	NA	NA	Relu witness hits Remainder range-check capacity
+tiny_gemm_softmax	NO_GO_UNCONSTRAINED_BACKEND_OP	Gemm(width-preserving) -> Softmax	attention_normalization_pressure	NO_GO	prove	unconstrained_backend_op		382	197	0.009271	NA	Softmax witness is generated but proof construction refuses an unconstrained op
 tiny_matmul_residual_add	NO_GO_UNSUPPORTED_WITNESS_OP	MatMul -> Add(input)	literal_matmul_projection_plus_residual_add	NO_GO	witness	unsupported_witness_op		339	163	NA	NA	MatMul compiles but witness generation reports unsupported MatMul

--- a/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv
@@ -1,0 +1,9 @@
+fixture	gate	op_sequence	transformer_relevance	status	failed_step	failure_kind	proof_bytes	model_bytes	onnx_bytes	prove_seconds	verify_seconds	primary_observation
+tiny_gemm	GO_CHECKED_SMALL_SHAPE	Gemm	linear_projection_baseline	GO			11645	307	133	0.820710	2.547536	baseline tiny linear projection proves and verifies
+tiny_gemm_add	GO_CHECKED_SMALL_SHAPE	Gemm -> Add	linear_projection_plus_bias_like_add	GO			36449	358	169	1.190031	2.693476	extra Add layer proves and verifies
+tiny_gemm_residual_add	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> Add(input)	linear_projection_plus_residual_add	GO			56054	367	183	0.920887	2.303404	residual-style Add proves and verifies
+tiny_gemm_layernorm	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> LayerNormalization	normalization_after_projection	GO			52080	441	287	0.799987	1.977310	LayerNormalization-style tiny shape proves and verifies
+tiny_gemm_batchnorm	GO_CHECKED_SMALL_SHAPE	Gemm -> BatchNormalization	normalization_like_operator_after_projection	GO			95105	419	287	2.639012	7.234345	normalization-like tiny shape proves and verifies
+tiny_gemm_relu	NO_GO_RANGE_CHECK_CAPACITY	Gemm -> Relu	activation_or_range_check_pressure	NO_GO	witness	range_check_capacity		339	153	NA	NA	Relu witness hits Remainder range-check capacity
+tiny_gemm_softmax	NO_GO_UNCONSTRAINED_BACKEND_OP	Gemm(width-preserving) -> Softmax	attention_normalization_pressure	NO_GO	prove	unconstrained_backend_op		382	197	0.013802	NA	Softmax witness is generated but proof construction refuses an unconstrained op
+tiny_matmul_residual_add	NO_GO_UNSUPPORTED_WITNESS_OP	MatMul -> Add(input)	literal_matmul_projection_plus_residual_add	NO_GO	witness	unsupported_witness_op		339	163	NA	NA	MatMul compiles but witness generation reports unsupported MatMul

--- a/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv
@@ -1,9 +1,9 @@
 fixture	gate	op_sequence	transformer_relevance	status	failed_step	failure_kind	proof_bytes	model_bytes	onnx_bytes	prove_seconds	verify_seconds	primary_observation
-tiny_gemm	GO_CHECKED_SMALL_SHAPE	Gemm	linear_projection_baseline	GO			11645	307	133	0.781818	1.980332	baseline tiny linear projection proves and verifies
-tiny_gemm_add	GO_CHECKED_SMALL_SHAPE	Gemm -> Add	linear_projection_plus_bias_like_add	GO			36449	361	169	0.912362	2.308319	extra Add layer proves and verifies
-tiny_gemm_residual_add	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> Add(input)	linear_projection_plus_residual_add	GO			56054	367	183	0.921516	2.328602	residual-style Add proves and verifies
-tiny_gemm_layernorm	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> LayerNormalization	normalization_after_projection	GO			52080	441	287	0.778382	1.945761	LayerNormalization-style tiny shape proves and verifies
-tiny_gemm_batchnorm	GO_CHECKED_SMALL_SHAPE	Gemm -> BatchNormalization	normalization_like_operator_after_projection	GO			95105	421	287	2.591887	6.078993	normalization-like tiny shape proves and verifies
+tiny_gemm	GO_CHECKED_SMALL_SHAPE	Gemm	linear_projection_baseline	GO			11645	307	133	0.834183	1.989027	baseline tiny linear projection proves and verifies
+tiny_gemm_add	GO_CHECKED_SMALL_SHAPE	Gemm -> Add	linear_projection_plus_bias_like_add	GO			36449	361	169	1.044284	2.411266	extra Add layer proves and verifies
+tiny_gemm_residual_add	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> Add(input)	linear_projection_plus_residual_add	GO			56054	367	183	1.010520	2.469885	residual-style Add proves and verifies
+tiny_gemm_layernorm	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> LayerNormalization	normalization_after_projection	GO			52080	442	287	0.819784	2.016979	LayerNormalization-style tiny shape proves and verifies
+tiny_gemm_batchnorm	GO_CHECKED_SMALL_SHAPE	Gemm -> BatchNormalization	normalization_like_operator_after_projection	GO			95105	421	287	2.777716	6.530913	normalization-like tiny shape proves and verifies
 tiny_gemm_relu	NO_GO_RANGE_CHECK_CAPACITY	Gemm -> Relu	activation_or_range_check_pressure	NO_GO	witness	range_check_capacity		341	153	NA	NA	Relu witness hits Remainder range-check capacity
-tiny_gemm_softmax	NO_GO_UNCONSTRAINED_BACKEND_OP	Gemm(width-preserving) -> Softmax	attention_normalization_pressure	NO_GO	prove	unconstrained_backend_op		382	197	0.009271	NA	Softmax witness is generated but proof construction refuses an unconstrained op
+tiny_gemm_softmax	NO_GO_UNCONSTRAINED_BACKEND_OP	Gemm(width-preserving) -> Softmax	attention_normalization_pressure	NO_GO	prove	unconstrained_backend_op		387	197	0.016604	NA	Softmax witness is generated but proof construction refuses an unconstrained op
 tiny_matmul_residual_add	NO_GO_UNSUPPORTED_WITNESS_OP	MatMul -> Add(input)	literal_matmul_projection_plus_residual_add	NO_GO	witness	unsupported_witness_op		339	163	NA	NA	MatMul compiles but witness generation reports unsupported MatMul

--- a/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv
@@ -1,9 +1,9 @@
 fixture	gate	op_sequence	transformer_relevance	status	failed_step	failure_kind	proof_bytes	model_bytes	onnx_bytes	prove_seconds	verify_seconds	primary_observation
-tiny_gemm	GO_CHECKED_SMALL_SHAPE	Gemm	linear_projection_baseline	GO			11645	307	133	0.834183	1.989027	baseline tiny linear projection proves and verifies
-tiny_gemm_add	GO_CHECKED_SMALL_SHAPE	Gemm -> Add	linear_projection_plus_bias_like_add	GO			36449	361	169	1.044284	2.411266	extra Add layer proves and verifies
-tiny_gemm_residual_add	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> Add(input)	linear_projection_plus_residual_add	GO			56054	367	183	1.010520	2.469885	residual-style Add proves and verifies
-tiny_gemm_layernorm	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> LayerNormalization	normalization_after_projection	GO			52080	442	287	0.819784	2.016979	LayerNormalization-style tiny shape proves and verifies
-tiny_gemm_batchnorm	GO_CHECKED_SMALL_SHAPE	Gemm -> BatchNormalization	normalization_like_operator_after_projection	GO			95105	421	287	2.777716	6.530913	normalization-like tiny shape proves and verifies
+tiny_gemm	GO_CHECKED_SMALL_SHAPE	Gemm	linear_projection_baseline	GO			11645	307	133	0.811731	1.966926	baseline tiny linear projection proves and verifies
+tiny_gemm_add	GO_CHECKED_SMALL_SHAPE	Gemm -> Add	linear_projection_plus_bias_like_add	GO			36449	361	169	0.940403	2.343996	extra Add layer proves and verifies
+tiny_gemm_residual_add	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> Add(input)	linear_projection_plus_residual_add	GO			56054	367	183	0.936787	2.394773	residual-style Add proves and verifies
+tiny_gemm_layernorm	GO_CHECKED_SMALL_SHAPE	Gemm(width-preserving) -> LayerNormalization	normalization_after_projection	GO			52080	442	287	0.849479	1.967507	LayerNormalization-style tiny shape proves and verifies
+tiny_gemm_batchnorm	GO_CHECKED_SMALL_SHAPE	Gemm -> BatchNormalization	normalization_like_operator_after_projection	GO			95105	419	287	2.659671	6.161834	normalization-like tiny shape proves and verifies
 tiny_gemm_relu	NO_GO_RANGE_CHECK_CAPACITY	Gemm -> Relu	activation_or_range_check_pressure	NO_GO	witness	range_check_capacity		341	153	NA	NA	Relu witness hits Remainder range-check capacity
-tiny_gemm_softmax	NO_GO_UNCONSTRAINED_BACKEND_OP	Gemm(width-preserving) -> Softmax	attention_normalization_pressure	NO_GO	prove	unconstrained_backend_op		387	197	0.016604	NA	Softmax witness is generated but proof construction refuses an unconstrained op
+tiny_gemm_softmax	NO_GO_UNCONSTRAINED_BACKEND_OP	Gemm(width-preserving) -> Softmax	attention_normalization_pressure	NO_GO	prove	unconstrained_backend_op		386	197	0.011955	NA	Softmax witness is generated but proof construction refuses an unconstrained op
 tiny_matmul_residual_add	NO_GO_UNSUPPORTED_WITNESS_OP	MatMul -> Add(input)	literal_matmul_projection_plus_residual_add	NO_GO	witness	unsupported_witness_op		339	163	NA	NA	MatMul compiles but witness generation reports unsupported MatMul

--- a/docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md
+++ b/docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md
@@ -21,7 +21,7 @@ Tablero result, and not a full transformer proof.
 - Generator dependencies: Python `3.13.11`, ONNX `1.21.0`,
   NumPy `2.4.4`, msgpack `(1, 1, 2)`, ONNX opset `17`
 - Generator commit recorded in evidence:
-  `376eaa8a80544d5b4121e33314aa6bd28250caa1`
+  `e2f717b549e1a0e27f7aa108aecb5f4483ed56b5`
 
 Checked evidence:
 
@@ -159,7 +159,7 @@ Regenerate the evidence:
 git -C /tmp/jstprove-adapter-check/JSTprove fetch origin \
   '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
 
-ZKAI_JSTPROVE_SHAPE_PROBE_GIT_COMMIT=376eaa8a80544d5b4121e33314aa6bd28250caa1 \
+ZKAI_JSTPROVE_SHAPE_PROBE_GIT_COMMIT=e2f717b549e1a0e27f7aa108aecb5f4483ed56b5 \
 ZKAI_JSTPROVE_REMAINDER_BIN=/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder \
   /tmp/jstprove-adapter-check/onnx-venv/bin/python \
   scripts/zkai_jstprove_shape_probe.py \

--- a/docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md
+++ b/docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md
@@ -18,8 +18,10 @@ Tablero result, and not a full transformer proof.
 - Remainder dependency commit: `06a5f406`
 - Binary: `/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder`
 - ONNX generation Python: `/tmp/jstprove-adapter-check/onnx-venv/bin/python`
+- Generator dependencies: Python `3.13.11`, ONNX `1.21.0`,
+  NumPy `2.4.4`, msgpack `(1, 1, 2)`, ONNX opset `17`
 - Generator commit recorded in evidence:
-  `f8963ade432fa7f999c0eaf4c356ba06d526d57f`
+  `376eaa8a80544d5b4121e33314aa6bd28250caa1`
 
 Checked evidence:
 
@@ -93,6 +95,20 @@ split is precise: Softmax exists in the broader codebase, but the checked
 Remainder path refuses this ONNX Softmax fixture at proof construction rather
 than accepting an unconstrained committed shred.
 
+The source probe also checked three additional local refs after fetching the
+JSTprove remote:
+
+| Ref | Commit | Result |
+| --- | --- | --- |
+| `origin/main-b` | `d71e49514f90877c1a6551514d1debec9930358e` | No Remainder Softmax path found. |
+| `refs/tags/v2.12.1` | `eae2d6c214a46e8a43480dbab0239ff548786ee5` | No Remainder Softmax path found. |
+| `origin/eliminate/relu-zero-delta-range-check` | `6d2f0e59343f3840634d028cd0f02309c1c0aa42` | No Remainder Softmax path found. |
+
+This does not prove no future JSTprove branch can constrain Softmax. It does
+close the narrower review question for this gate: the pinned branch refuses
+Remainder Softmax at proof construction, and the checked alternative refs did
+not expose a constrained Remainder Softmax path.
+
 ## Interpretation
 
 This is a useful external proof-stack split:
@@ -139,17 +155,23 @@ The run that generated this gate used:
 Regenerate the evidence:
 
 ```bash
-ZKAI_JSTPROVE_SHAPE_PROBE_GIT_COMMIT=f8963ade432fa7f999c0eaf4c356ba06d526d57f \
+git -C /tmp/jstprove-adapter-check/JSTprove fetch origin \
+  '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+
+ZKAI_JSTPROVE_SHAPE_PROBE_GIT_COMMIT=376eaa8a80544d5b4121e33314aa6bd28250caa1 \
 ZKAI_JSTPROVE_REMAINDER_BIN=/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder \
   /tmp/jstprove-adapter-check/onnx-venv/bin/python \
   scripts/zkai_jstprove_shape_probe.py \
+  --work-dir /tmp/zkai-jstprove-shape-probe-checked \
   --write-json docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json \
   --write-tsv docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv
 ```
 
 The script generates all ONNX fixtures and intermediate JSTprove artifacts under
-`/tmp/zkai-jstprove-shape-probe` by default. The intermediate proof artifacts
-are intentionally not checked in; the JSON/TSV record the gate result.
+a unique temp directory by default. The checked evidence command uses an
+explicit `--work-dir` so the recorded evidence path is stable. The intermediate
+proof artifacts are intentionally not checked in; the JSON/TSV record the gate
+result.
 
 ## Validation
 

--- a/docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md
+++ b/docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md
@@ -19,7 +19,7 @@ Tablero result, and not a full transformer proof.
 - Binary: `/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder`
 - ONNX generation Python: `/tmp/jstprove-adapter-check/onnx-venv/bin/python`
 - Generator commit recorded in evidence:
-  `4657787db01955b1d13248ede96ec49c3daa613b`
+  `f8963ade432fa7f999c0eaf4c356ba06d526d57f`
 
 Checked evidence:
 
@@ -30,7 +30,7 @@ Generator:
 
 - `scripts/zkai_jstprove_shape_probe.py`
 
-## Result
+## Main fixture result
 
 | Fixture | Shape | Gate | Proof bytes | Observation |
 | --- | --- | ---: | ---: | --- |
@@ -39,9 +39,59 @@ Generator:
 | `tiny_gemm_residual_add` | `Gemm(width-preserving) -> Add(input)` | GO | `56,054` | Residual-style Add proves and verifies. |
 | `tiny_gemm_layernorm` | `Gemm(width-preserving) -> LayerNormalization` | GO | `52,080` | LayerNormalization-style tiny shape proves and verifies. |
 | `tiny_gemm_batchnorm` | `Gemm -> BatchNormalization` | GO | `95,105` | Normalization-like tiny shape proves and verifies. |
-| `tiny_gemm_relu` | `Gemm -> Relu` | NO-GO | n/a | Witness fails with `range_check_capacity`. |
+| `tiny_gemm_relu` | `Gemm -> Relu` | NO-GO | n/a | Baseline witness fails with `range_check_capacity`. |
 | `tiny_gemm_softmax` | `Gemm(width-preserving) -> Softmax` | NO-GO | n/a | Witness succeeds, but proof construction refuses an unconstrained backend op. |
 | `tiny_matmul_residual_add` | `MatMul -> Add(input)` | NO-GO | n/a | Compile succeeds, but witness generation reports unsupported `MatMul`. |
+
+## Review-driven exploratory probes
+
+The PR review asked for three extra checks before treating the result as useful:
+Gemm dimension variation, ReLU input scaling, and a pinned Softmax source check.
+Those checks are now part of the machine-readable evidence and committed under
+`exploration_commitment`.
+
+### Gemm dimension sweep
+
+| Dimension | Gate | Proof bytes | Prove seconds | Verify seconds |
+| ---: | ---: | ---: | ---: | ---: |
+| `1` | GO | `11,726` | `0.799333` | `1.971647` |
+| `2` | GO | `71,040` | `0.789629` | `1.948071` |
+| `4` | GO | `70,138` | `0.781246` | `1.939688` |
+
+Interpretation: this remains a tiny-shape probe, but the positive result is no
+longer only a single scalar projection. JSTprove/Remainder clears `Gemm` at
+widths `1`, `2`, and `4` in this checked setup.
+
+### ReLU scaling probe
+
+| Scale | Gate | Failure kind | Proof bytes | Prove seconds | Verify seconds |
+| ---: | ---: | --- | ---: | ---: | ---: |
+| `1` | NO-GO | `range_check_capacity` | n/a | n/a | n/a |
+| `0.25` | GO | n/a | `87,377` | `3.995539` | `9.395193` |
+| `0.1` | GO | n/a | `211,088` | `3.981442` | `9.412703` |
+| `0.01` | GO | n/a | `227,462` | `3.987476` | `9.523842` |
+| `0.001` | GO | n/a | `108,172` | `1.592207` | `4.051986` |
+
+Interpretation: the baseline `Gemm -> Relu` NO-GO is not a blanket statement
+that ReLU can never clear under this backend. It is a concrete range-capacity
+failure at the checked magnitude. Scaled variants clear. That makes the next
+research question sharper: decide whether a transformer-adjacent activation path
+can keep all intermediate values within the current two-chunk range-check
+capacity, or whether the backend needs a wider range-check surface.
+
+### Softmax source check
+
+The checked `Gemm -> Softmax` fixture reaches witness generation but fails at
+proof construction with `unconstrained_backend_op`. The source probe ties this to
+the pinned JSTprove source at commit `7c3cbbee83aaa01adde700673f00e317a4e902f9`.
+The evidence records `SOURCE_HIT` with a Remainder proof-construction refusal in:
+
+- `rust/jstprove_remainder/src/runner/circuit_builder.rs:458`
+
+The source also contains Softmax witness and circuit-layer code, so the useful
+split is precise: Softmax exists in the broader codebase, but the checked
+Remainder path refuses this ONNX Softmax fixture at proof construction rather
+than accepting an unconstrained committed shred.
 
 ## Interpretation
 
@@ -49,10 +99,11 @@ This is a useful external proof-stack split:
 
 - JSTprove/Remainder can prove tiny projection, residual-add, and
   normalization-shaped fixtures.
-- The checked `Relu` path exposes a concrete Remainder range-check capacity
-  blocker.
+- `Gemm` clears at dimensions `1`, `2`, and `4` in this checked setup.
+- Baseline `Gemm -> Relu` fails with a range-check-capacity error, but smaller
+  scaled variants clear. The blocker is magnitude-sensitive in this probe.
 - The checked `Softmax` path reaches witness generation but is refused by proof
-  construction because the op is not constrained in the Remainder backend.
+  construction because the op is not constrained in the Remainder backend path.
 - Literal ONNX `MatMul` compiles, but witness generation rejects it; `Gemm` is
   the working projection surface in this probe.
 
@@ -60,9 +111,9 @@ The positive part is paper-useful only as engineering context: it makes the
 JSTprove adapter less toy-like than a one-node `Gemm` fixture because
 `Gemm -> residual Add` and `Gemm -> LayerNormalization` are recognizably
 transformer-adjacent. The negative part is also useful: it shows that statement
-binding, proof validity, and operator support are three separate gates. A zkAI
-system can bind a statement correctly while still being blocked by backend
-operator coverage.
+binding, proof validity, exact arithmetic semantics, and backend operator support
+are separate gates. A zkAI system can bind a statement correctly while still
+being blocked by backend operator coverage.
 
 Follow-up issue #362 tracks the operator-blocker exploration separately so this
 gate can stay closed once the checked shape evidence lands.
@@ -88,7 +139,7 @@ The run that generated this gate used:
 Regenerate the evidence:
 
 ```bash
-ZKAI_JSTPROVE_SHAPE_PROBE_GIT_COMMIT=4657787db01955b1d13248ede96ec49c3daa613b \
+ZKAI_JSTPROVE_SHAPE_PROBE_GIT_COMMIT=f8963ade432fa7f999c0eaf4c356ba06d526d57f \
 ZKAI_JSTPROVE_REMAINDER_BIN=/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder \
   /tmp/jstprove-adapter-check/onnx-venv/bin/python \
   scripts/zkai_jstprove_shape_probe.py \
@@ -103,7 +154,9 @@ are intentionally not checked in; the JSON/TSV record the gate result.
 ## Validation
 
 ```bash
-python3 -m unittest scripts.tests.test_zkai_jstprove_shape_probe
+python3 -m unittest \
+  scripts.tests.test_zkai_jstprove_shape_probe \
+  scripts.tests.test_zkai_jstprove_statement_envelope_benchmark
 python3 -m py_compile \
   scripts/zkai_jstprove_shape_probe.py \
   scripts/tests/test_zkai_jstprove_shape_probe.py

--- a/docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md
+++ b/docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md
@@ -149,7 +149,8 @@ Create or reuse a Python environment with `onnx`, `numpy`, and `msgpack`.
 The run that generated this gate used:
 
 ```bash
-/tmp/jstprove-adapter-check/onnx-venv/bin/python -m pip install onnx numpy msgpack
+/tmp/jstprove-adapter-check/onnx-venv/bin/python -m pip install \
+  onnx==1.21.0 numpy==2.4.4 msgpack==1.1.2
 ```
 
 Regenerate the evidence:

--- a/docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md
+++ b/docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md
@@ -1,0 +1,125 @@
+# zkAI JSTprove shape probe - 2026-05-01
+
+## Purpose
+
+Issue #360 asked whether the JSTprove/Remainder adapter can move beyond the
+checked one-node `Gemm` fixture without turning the result into an overclaim.
+This gate answers a narrower engineering question:
+
+> Which tiny transformer-adjacent ONNX shapes can a real
+> `jstprove-remainder` verifier stack compile, witness, prove, and verify today?
+
+This is not a JSTprove security audit, not a performance benchmark, not a
+Tablero result, and not a full transformer proof.
+
+## Environment
+
+- JSTprove upstream commit: `7c3cbbee83aaa01adde700673f00e317a4e902f9`
+- Remainder dependency commit: `06a5f406`
+- Binary: `/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder`
+- ONNX generation Python: `/tmp/jstprove-adapter-check/onnx-venv/bin/python`
+- Generator commit recorded in evidence:
+  `4657787db01955b1d13248ede96ec49c3daa613b`
+
+Checked evidence:
+
+- `docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json`
+- `docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv`
+
+Generator:
+
+- `scripts/zkai_jstprove_shape_probe.py`
+
+## Result
+
+| Fixture | Shape | Gate | Proof bytes | Observation |
+| --- | --- | ---: | ---: | --- |
+| `tiny_gemm` | `Gemm` | GO | `11,645` | Baseline tiny linear projection proves and verifies. |
+| `tiny_gemm_add` | `Gemm -> Add` | GO | `36,449` | Extra Add layer proves and verifies. |
+| `tiny_gemm_residual_add` | `Gemm(width-preserving) -> Add(input)` | GO | `56,054` | Residual-style Add proves and verifies. |
+| `tiny_gemm_layernorm` | `Gemm(width-preserving) -> LayerNormalization` | GO | `52,080` | LayerNormalization-style tiny shape proves and verifies. |
+| `tiny_gemm_batchnorm` | `Gemm -> BatchNormalization` | GO | `95,105` | Normalization-like tiny shape proves and verifies. |
+| `tiny_gemm_relu` | `Gemm -> Relu` | NO-GO | n/a | Witness fails with `range_check_capacity`. |
+| `tiny_gemm_softmax` | `Gemm(width-preserving) -> Softmax` | NO-GO | n/a | Witness succeeds, but proof construction refuses an unconstrained backend op. |
+| `tiny_matmul_residual_add` | `MatMul -> Add(input)` | NO-GO | n/a | Compile succeeds, but witness generation reports unsupported `MatMul`. |
+
+## Interpretation
+
+This is a useful external proof-stack split:
+
+- JSTprove/Remainder can prove tiny projection, residual-add, and
+  normalization-shaped fixtures.
+- The checked `Relu` path exposes a concrete Remainder range-check capacity
+  blocker.
+- The checked `Softmax` path reaches witness generation but is refused by proof
+  construction because the op is not constrained in the Remainder backend.
+- Literal ONNX `MatMul` compiles, but witness generation rejects it; `Gemm` is
+  the working projection surface in this probe.
+
+The positive part is paper-useful only as engineering context: it makes the
+JSTprove adapter less toy-like than a one-node `Gemm` fixture because
+`Gemm -> residual Add` and `Gemm -> LayerNormalization` are recognizably
+transformer-adjacent. The negative part is also useful: it shows that statement
+binding, proof validity, and operator support are three separate gates. A zkAI
+system can bind a statement correctly while still being blocked by backend
+operator coverage.
+
+Follow-up issue #362 tracks the operator-blocker exploration separately so this
+gate can stay closed once the checked shape evidence lands.
+
+## Reproduction
+
+Build JSTprove/Remainder:
+
+```bash
+git clone https://github.com/inference-labs-inc/JSTprove.git /tmp/jstprove-adapter-check/JSTprove
+cd /tmp/jstprove-adapter-check/JSTprove
+git checkout 7c3cbbee83aaa01adde700673f00e317a4e902f9
+cargo build --release --bin jstprove-remainder
+```
+
+Create or reuse a Python environment with `onnx`, `numpy`, and `msgpack`.
+The run that generated this gate used:
+
+```bash
+/tmp/jstprove-adapter-check/onnx-venv/bin/python -m pip install onnx numpy msgpack
+```
+
+Regenerate the evidence:
+
+```bash
+ZKAI_JSTPROVE_SHAPE_PROBE_GIT_COMMIT=4657787db01955b1d13248ede96ec49c3daa613b \
+ZKAI_JSTPROVE_REMAINDER_BIN=/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder \
+  /tmp/jstprove-adapter-check/onnx-venv/bin/python \
+  scripts/zkai_jstprove_shape_probe.py \
+  --write-json docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv
+```
+
+The script generates all ONNX fixtures and intermediate JSTprove artifacts under
+`/tmp/zkai-jstprove-shape-probe` by default. The intermediate proof artifacts
+are intentionally not checked in; the JSON/TSV record the gate result.
+
+## Validation
+
+```bash
+python3 -m unittest scripts.tests.test_zkai_jstprove_shape_probe
+python3 -m py_compile \
+  scripts/zkai_jstprove_shape_probe.py \
+  scripts/tests/test_zkai_jstprove_shape_probe.py
+ZKAI_JSTPROVE_REMAINDER_BIN=/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder \
+  /tmp/jstprove-adapter-check/onnx-venv/bin/python \
+  scripts/zkai_jstprove_shape_probe.py --json
+python3 scripts/paper/paper_preflight.py --repo-root .
+git diff --check
+```
+
+## Non-claims
+
+- This is not a JSTprove security finding.
+- This is not a full transformer proof.
+- This is not a performance benchmark.
+- This is not evidence that larger JSTprove shapes remain small.
+- This is not evidence that unsupported shapes are impossible in future
+  JSTprove versions.
+- This is not a Tablero result.

--- a/scripts/tests/test_zkai_jstprove_shape_probe.py
+++ b/scripts/tests/test_zkai_jstprove_shape_probe.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import os
 import pathlib
+import shutil
 import tempfile
 import unittest
 from unittest import mock
@@ -123,14 +124,39 @@ def synthetic_softmax_source_probe() -> dict[str, object]:
     }
 
 
+def synthetic_softmax_alternative_refs() -> list[dict[str, object]]:
+    return [
+        {
+            "ref": ref,
+            "commit": f"{index:040x}",
+            "status": "NO_REMAINDER_SOFTMAX_PATH_FOUND",
+            "remainder_softmax_hits": [],
+            "observation": "Alternative ref did not expose a constrained Remainder Softmax path in this source probe.",
+        }
+        for index, ref in enumerate(PROBE.SOFTMAX_ALTERNATIVE_REFS, start=1)
+    ]
+
+
+def synthetic_generator_dependencies() -> dict[str, object]:
+    return {
+        "python": "3.13.0",
+        "onnx": "1.18.0",
+        "numpy": "2.2.0",
+        "msgpack": "1.1.0",
+        "onnx_opset": PROBE.OPSET,
+    }
+
+
 def synthetic_payload() -> dict[str, object]:
     return PROBE.build_payload(
         synthetic_results(),
         jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
         work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
+        generator_dependencies=synthetic_generator_dependencies(),
         dimension_sweep=synthetic_dimension_sweep(),
         relu_scaling_probe=synthetic_relu_scaling_probe(),
         softmax_source=synthetic_softmax_source_probe(),
+        softmax_alternative_refs=synthetic_softmax_alternative_refs(),
     )
 
 
@@ -143,7 +169,11 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
         self.assertEqual(payload["conclusion"]["go_count"], 5)
         self.assertEqual(payload["conclusion"]["no_go_count"], 3)
         self.assertEqual(payload["conclusion"]["gemm_dimension_sweep"], "GO_DIMS_1_2_4")
-        self.assertEqual(payload["conclusion"]["relu_scaling"], "INPUT_DEPENDENT_BASELINE_FAILS_SCALED_VARIANTS_CLEAR")
+        self.assertEqual(payload["conclusion"]["relu_scaling"], "MAGNITUDE_SENSITIVE_BASELINE_FAILS_SCALED_VARIANTS_CLEAR")
+        self.assertEqual(
+            payload["conclusion"]["softmax_alternative_ref_check"],
+            "CHECKED_NO_CONSTRAINED_REMAINDER_SOFTMAX_PATH",
+        )
         self.assertEqual(
             set(payload["conclusion"]["go_transformer_adjacent_fixtures"]),
             {"tiny_gemm_residual_add", "tiny_gemm_layernorm", "tiny_gemm_batchnorm"},
@@ -205,6 +235,35 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
         with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "conclusion field set mismatch"):
             PROBE.validate_payload(payload)
 
+    def test_validation_rejects_toolchain_metadata_drift(self) -> None:
+        payload = synthetic_payload()
+        payload["jstprove"]["upstream_commit"] = "0" * 40
+
+        with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "JSTprove commit drift"):
+            PROBE.validate_payload(payload)
+
+        payload = synthetic_payload()
+        payload["generator_dependencies"]["onnx_opset"] = 18
+
+        with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "ONNX opset drift"):
+            PROBE.validate_payload(payload)
+
+    def test_validation_rejects_softmax_alternative_overclaim(self) -> None:
+        payload = synthetic_payload()
+        payload["softmax_alternative_ref_probe"][0]["status"] = "POSSIBLE_REMAINDER_SOFTMAX_PATH_FOUND"
+        payload["exploration_commitment"] = PROBE.blake2b_commitment(
+            {
+                "dimension_sweep": payload["dimension_sweep"],
+                "relu_scaling_probe": payload["relu_scaling_probe"],
+                "softmax_source_probe": payload["softmax_source_probe"],
+                "softmax_alternative_ref_probe": payload["softmax_alternative_ref_probe"],
+            },
+            "ptvm:zkai:jstprove-shape-exploration:v1",
+        )
+
+        with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "manual gate"):
+            PROBE.validate_payload(payload)
+
     def test_classify_failure_keeps_interesting_blockers_distinct(self) -> None:
         self.assertEqual(
             PROBE.classify_failure("witness", "Relu delta nv 20 exceeds two-chunk range-check capacity"),
@@ -247,6 +306,19 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
 
         self.assertEqual(resolved, binary.resolve())
 
+    def test_default_work_dir_is_unique_without_override(self) -> None:
+        with mock.patch.dict(os.environ, {PROBE.WORK_DIR_ENV: ""}):
+            first = PROBE._default_work_dir()
+            second = PROBE._default_work_dir()
+
+        try:
+            self.assertNotEqual(first, second)
+            self.assertTrue(first.is_dir())
+            self.assertTrue(second.is_dir())
+        finally:
+            shutil.rmtree(first, ignore_errors=True)
+            shutil.rmtree(second, ignore_errors=True)
+
     def test_write_outputs_round_trips_json_and_tsv(self) -> None:
         payload = synthetic_payload()
         with tempfile.TemporaryDirectory() as raw_tmp:
@@ -259,8 +331,7 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
             self.assertEqual(tsv_path.read_text(encoding="utf-8").splitlines()[1].split("\t")[0], "tiny_gemm")
 
     def test_checked_json_evidence_validates_when_present(self) -> None:
-        if not PROBE.JSON_OUT.exists():
-            self.skipTest("checked shape-probe evidence has not been generated")
+        self.assertTrue(PROBE.JSON_OUT.exists(), f"expected checked shape-probe evidence at {PROBE.JSON_OUT}")
         payload = json.loads(PROBE.JSON_OUT.read_text(encoding="utf-8"))
 
         PROBE.validate_payload(payload)

--- a/scripts/tests/test_zkai_jstprove_shape_probe.py
+++ b/scripts/tests/test_zkai_jstprove_shape_probe.py
@@ -264,6 +264,27 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
         with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "manual gate"):
             PROBE.validate_payload(payload)
 
+    def test_validation_reports_missing_softmax_alternative_ref_actionably(self) -> None:
+        payload = synthetic_payload()
+        payload["softmax_alternative_ref_probe"][0]["status"] = "REF_NOT_AVAILABLE"
+        payload["exploration_commitment"] = PROBE.blake2b_commitment(
+            {
+                "dimension_sweep": payload["dimension_sweep"],
+                "relu_scaling_probe": payload["relu_scaling_probe"],
+                "softmax_source_probe": payload["softmax_source_probe"],
+                "softmax_alternative_ref_probe": payload["softmax_alternative_ref_probe"],
+            },
+            "ptvm:zkai:jstprove-shape-exploration:v1",
+        )
+
+        with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "fetch origin heads/tags"):
+            PROBE.validate_payload(payload)
+
+    def test_softmax_alternative_probe_requires_git_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "local JSTprove git checkout"):
+                PROBE.softmax_alternative_ref_probe(raw_tmp)
+
     def test_classify_failure_keeps_interesting_blockers_distinct(self) -> None:
         self.assertEqual(
             PROBE.classify_failure("witness", "Relu delta nv 20 exceeds two-chunk range-check capacity"),

--- a/scripts/tests/test_zkai_jstprove_shape_probe.py
+++ b/scripts/tests/test_zkai_jstprove_shape_probe.py
@@ -54,18 +54,96 @@ def synthetic_results() -> list[dict[str, object]]:
     return results
 
 
+def synthetic_dimension_sweep() -> list[dict[str, object]]:
+    return [
+        {
+            "dimension": dimension,
+            "status": "GO",
+            "failed_step": "",
+            "failure_kind": "",
+            "proof_bytes": 20_000 + dimension,
+            "model_bytes": 1_000 + dimension,
+            "onnx_bytes": 400 + dimension,
+            "prove_seconds": "0.100000",
+            "verify_seconds": "0.200000",
+        }
+        for dimension in PROBE.GEMM_SWEEP_DIMENSIONS
+    ]
+
+
+def synthetic_relu_scaling_probe() -> list[dict[str, object]]:
+    rows = []
+    for scale in PROBE.RELU_SCALE_FACTORS:
+        if scale == "1":
+            rows.append(
+                {
+                    "scale": scale,
+                    "status": "NO_GO",
+                    "failed_step": "witness",
+                    "failure_kind": "range_check_capacity",
+                    "proof_bytes": None,
+                    "model_bytes": 1_100,
+                    "onnx_bytes": 410,
+                    "prove_seconds": "NA",
+                    "verify_seconds": "NA",
+                }
+            )
+        else:
+            rows.append(
+                {
+                    "scale": scale,
+                    "status": "GO",
+                    "failed_step": "",
+                    "failure_kind": "",
+                    "proof_bytes": 30_000 + len(rows),
+                    "model_bytes": 1_100,
+                    "onnx_bytes": 410,
+                    "prove_seconds": "0.300000",
+                    "verify_seconds": "0.400000",
+                }
+            )
+    return rows
+
+
+def synthetic_softmax_source_probe() -> dict[str, object]:
+    return {
+        "status": "SOURCE_HIT",
+        "source_root": "/tmp/JSTprove",
+        "source_commit": "7c3cbbee83aaa01adde700673f00e317a4e902f9",
+        "hits": [
+            {
+                "category": "remainder_refusal",
+                "path": "src/remainder.rs",
+                "line": 123,
+                "text": "Softmax op is not yet constrained",
+            }
+        ],
+        "softmax_refusal_found": True,
+        "observation": "Pinned source inspection found Softmax-related backend code.",
+    }
+
+
+def synthetic_payload() -> dict[str, object]:
+    return PROBE.build_payload(
+        synthetic_results(),
+        jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
+        work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
+        dimension_sweep=synthetic_dimension_sweep(),
+        relu_scaling_probe=synthetic_relu_scaling_probe(),
+        softmax_source=synthetic_softmax_source_probe(),
+    )
+
+
 class ZkAIJstproveShapeProbeTests(unittest.TestCase):
     def test_payload_records_operator_support_split_without_transformer_claim(self) -> None:
-        payload = PROBE.build_payload(
-            synthetic_results(),
-            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
-            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
-        )
+        payload = synthetic_payload()
         PROBE.validate_payload(payload)
 
         self.assertEqual(payload["decision"], PROBE.DECISION)
         self.assertEqual(payload["conclusion"]["go_count"], 5)
         self.assertEqual(payload["conclusion"]["no_go_count"], 3)
+        self.assertEqual(payload["conclusion"]["gemm_dimension_sweep"], "GO_DIMS_1_2_4")
+        self.assertEqual(payload["conclusion"]["relu_scaling"], "INPUT_DEPENDENT_BASELINE_FAILS_SCALED_VARIANTS_CLEAR")
         self.assertEqual(
             set(payload["conclusion"]["go_transformer_adjacent_fixtures"]),
             {"tiny_gemm_residual_add", "tiny_gemm_layernorm", "tiny_gemm_batchnorm"},
@@ -74,11 +152,7 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
         self.assertIn("not a Tablero result", payload["non_claims"])
 
     def test_rows_for_tsv_are_stable(self) -> None:
-        payload = PROBE.build_payload(
-            synthetic_results(),
-            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
-            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
-        )
+        payload = synthetic_payload()
         rows = PROBE.rows_for_tsv(payload)
 
         self.assertEqual(len(rows), 8)
@@ -89,11 +163,7 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
         self.assertEqual(PROBE.to_tsv(payload).splitlines()[0].split("\t"), list(PROBE.TSV_COLUMNS))
 
     def test_validation_rejects_status_overclaim(self) -> None:
-        payload = PROBE.build_payload(
-            synthetic_results(),
-            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
-            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
-        )
+        payload = synthetic_payload()
         for result in payload["results"]:
             if result["fixture"] == "tiny_gemm_relu":
                 result["status"] = "GO"
@@ -109,11 +179,7 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
             PROBE.validate_payload(payload)
 
     def test_validation_rejects_failure_kind_drift(self) -> None:
-        payload = PROBE.build_payload(
-            synthetic_results(),
-            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
-            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
-        )
+        payload = synthetic_payload()
         for result in payload["results"]:
             if result["fixture"] == "tiny_gemm_softmax":
                 result["failure_kind"] = "external_tool_error"
@@ -126,22 +192,14 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
             PROBE.validate_payload(payload)
 
     def test_validation_rejects_paper_usage_overclaim(self) -> None:
-        payload = PROBE.build_payload(
-            synthetic_results(),
-            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
-            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
-        )
+        payload = synthetic_payload()
         payload["conclusion"]["paper_usage"] = "transformer_proof_row"
 
         with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "paper usage overclaim"):
             PROBE.validate_payload(payload)
 
     def test_validation_rejects_unknown_conclusion_fields(self) -> None:
-        payload = PROBE.build_payload(
-            synthetic_results(),
-            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
-            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
-        )
+        payload = synthetic_payload()
         payload["conclusion"]["publish_as_performance_result"] = True
 
         with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "conclusion field set mismatch"):
@@ -173,12 +231,24 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
             with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "verifier is not executable"):
                 PROBE._resolve_jstprove_binary(str(binary))
 
+    def test_resolve_jstprove_binary_resolves_relative_path_before_fixture_cwd(self) -> None:
+        original_cwd = pathlib.Path.cwd()
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            binary = tmp / "bin" / "jstprove-remainder"
+            binary.parent.mkdir()
+            binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            binary.chmod(0o700)
+            os.chdir(tmp)
+            try:
+                resolved = PROBE._resolve_jstprove_binary("bin/jstprove-remainder")
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(resolved, binary.resolve())
+
     def test_write_outputs_round_trips_json_and_tsv(self) -> None:
-        payload = PROBE.build_payload(
-            synthetic_results(),
-            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
-            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
-        )
+        payload = synthetic_payload()
         with tempfile.TemporaryDirectory() as raw_tmp:
             tmp = pathlib.Path(raw_tmp)
             json_path = tmp / "shape.json"

--- a/scripts/tests/test_zkai_jstprove_shape_probe.py
+++ b/scripts/tests/test_zkai_jstprove_shape_probe.py
@@ -188,6 +188,13 @@ class ZkAIJstproveShapeProbeTests(unittest.TestCase):
             self.assertEqual(json.loads(json_path.read_text(encoding="utf-8"))["schema"], PROBE.SCHEMA)
             self.assertEqual(tsv_path.read_text(encoding="utf-8").splitlines()[1].split("\t")[0], "tiny_gemm")
 
+    def test_checked_json_evidence_validates_when_present(self) -> None:
+        if not PROBE.JSON_OUT.exists():
+            self.skipTest("checked shape-probe evidence has not been generated")
+        payload = json.loads(PROBE.JSON_OUT.read_text(encoding="utf-8"))
+
+        PROBE.validate_payload(payload)
+
     def test_git_commit_override_is_validated(self) -> None:
         with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "must be a 7-40 character hex SHA"):
             with mock.patch.dict(os.environ, {PROBE.GIT_COMMIT_ENV: "not-a-sha"}):

--- a/scripts/tests/test_zkai_jstprove_shape_probe.py
+++ b/scripts/tests/test_zkai_jstprove_shape_probe.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "zkai_jstprove_shape_probe.py"
+SPEC = importlib.util.spec_from_file_location("zkai_jstprove_shape_probe", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load JSTprove shape probe from {SCRIPT_PATH}")
+PROBE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PROBE)
+
+
+def synthetic_results() -> list[dict[str, object]]:
+    results = []
+    for index, fixture in enumerate(PROBE.EXPECTED_FIXTURE_ORDER, start=1):
+        status = PROBE.EXPECTED_STATUS[fixture]
+        failed_step = ""
+        failure_kind = ""
+        proof_bytes: int | None = 10_000 + index
+        gate = "GO_CHECKED_SMALL_SHAPE"
+        if status == "NO_GO":
+            failed_step = "witness" if fixture != "tiny_gemm_softmax" else "prove"
+            failure_kind = PROBE.EXPECTED_FAILURE_KIND[fixture]
+            proof_bytes = None
+            gate = f"NO_GO_{failure_kind.upper()}"
+        catalog = {item["fixture"]: item for item in PROBE.fixture_catalog()}[fixture]
+        results.append(
+            {
+                "fixture": fixture,
+                "gate": gate,
+                "op_sequence": catalog["op_sequence"],
+                "transformer_relevance": catalog["transformer_relevance"],
+                "status": status,
+                "failed_step": failed_step,
+                "failure_kind": failure_kind,
+                "proof_bytes": proof_bytes,
+                "model_bytes": 300 + index,
+                "onnx_bytes": 120 + index,
+                "input_bytes": 17,
+                "prove_seconds": "0.100000" if status == "GO" else "NA",
+                "verify_seconds": "0.200000" if status == "GO" else "NA",
+                "primary_observation": catalog["primary_observation"],
+                "steps": [],
+            }
+        )
+    return results
+
+
+class ZkAIJstproveShapeProbeTests(unittest.TestCase):
+    def test_payload_records_operator_support_split_without_transformer_claim(self) -> None:
+        payload = PROBE.build_payload(
+            synthetic_results(),
+            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
+            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
+        )
+        PROBE.validate_payload(payload)
+
+        self.assertEqual(payload["decision"], PROBE.DECISION)
+        self.assertEqual(payload["conclusion"]["go_count"], 5)
+        self.assertEqual(payload["conclusion"]["no_go_count"], 3)
+        self.assertEqual(
+            set(payload["conclusion"]["go_transformer_adjacent_fixtures"]),
+            {"tiny_gemm_residual_add", "tiny_gemm_layernorm", "tiny_gemm_batchnorm"},
+        )
+        self.assertIn("not a full transformer proof", payload["non_claims"])
+        self.assertIn("not a Tablero result", payload["non_claims"])
+
+    def test_rows_for_tsv_are_stable(self) -> None:
+        payload = PROBE.build_payload(
+            synthetic_results(),
+            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
+            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
+        )
+        rows = PROBE.rows_for_tsv(payload)
+
+        self.assertEqual(len(rows), 8)
+        self.assertEqual(rows[0]["fixture"], "tiny_gemm")
+        self.assertEqual(rows[0]["status"], "GO")
+        self.assertEqual(rows[5]["fixture"], "tiny_gemm_relu")
+        self.assertEqual(rows[5]["failure_kind"], "range_check_capacity")
+        self.assertEqual(PROBE.to_tsv(payload).splitlines()[0].split("\t"), list(PROBE.TSV_COLUMNS))
+
+    def test_validation_rejects_status_overclaim(self) -> None:
+        payload = PROBE.build_payload(
+            synthetic_results(),
+            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
+            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
+        )
+        for result in payload["results"]:
+            if result["fixture"] == "tiny_gemm_relu":
+                result["status"] = "GO"
+                result["proof_bytes"] = 1
+                result["failed_step"] = ""
+                result["failure_kind"] = ""
+                result["gate"] = "GO_CHECKED_SMALL_SHAPE"
+        payload["results_commitment"] = PROBE.blake2b_commitment(
+            payload["results"], "ptvm:zkai:jstprove-shape-results:v1"
+        )
+
+        with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "tiny_gemm_relu status drift"):
+            PROBE.validate_payload(payload)
+
+    def test_validation_rejects_failure_kind_drift(self) -> None:
+        payload = PROBE.build_payload(
+            synthetic_results(),
+            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
+            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
+        )
+        for result in payload["results"]:
+            if result["fixture"] == "tiny_gemm_softmax":
+                result["failure_kind"] = "external_tool_error"
+                result["gate"] = "NO_GO_EXTERNAL_TOOL_ERROR"
+        payload["results_commitment"] = PROBE.blake2b_commitment(
+            payload["results"], "ptvm:zkai:jstprove-shape-results:v1"
+        )
+
+        with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "tiny_gemm_softmax failure kind drift"):
+            PROBE.validate_payload(payload)
+
+    def test_validation_rejects_paper_usage_overclaim(self) -> None:
+        payload = PROBE.build_payload(
+            synthetic_results(),
+            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
+            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
+        )
+        payload["conclusion"]["paper_usage"] = "transformer_proof_row"
+
+        with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "paper usage overclaim"):
+            PROBE.validate_payload(payload)
+
+    def test_validation_rejects_unknown_conclusion_fields(self) -> None:
+        payload = PROBE.build_payload(
+            synthetic_results(),
+            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
+            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
+        )
+        payload["conclusion"]["publish_as_performance_result"] = True
+
+        with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "conclusion field set mismatch"):
+            PROBE.validate_payload(payload)
+
+    def test_classify_failure_keeps_interesting_blockers_distinct(self) -> None:
+        self.assertEqual(
+            PROBE.classify_failure("witness", "Relu delta nv 20 exceeds two-chunk range-check capacity"),
+            "range_check_capacity",
+        )
+        self.assertEqual(
+            PROBE.classify_failure("prove", "Softmax op is not yet constrained in the Remainder backend"),
+            "unconstrained_backend_op",
+        )
+        self.assertEqual(
+            PROBE.classify_failure("witness", "unsupported op type MatMul in layer node_0"),
+            "unsupported_witness_op",
+        )
+
+    def test_resolve_jstprove_binary_rejects_absolute_missing_or_non_executable(self) -> None:
+        missing = ROOT / "target" / "definitely-missing-jstprove-remainder"
+        with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "verifier is missing"):
+            PROBE._resolve_jstprove_binary(str(missing))
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            binary = pathlib.Path(raw_tmp) / "jstprove-remainder"
+            binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            binary.chmod(0o600)
+            with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "verifier is not executable"):
+                PROBE._resolve_jstprove_binary(str(binary))
+
+    def test_write_outputs_round_trips_json_and_tsv(self) -> None:
+        payload = PROBE.build_payload(
+            synthetic_results(),
+            jstprove_bin=pathlib.Path("/tmp/jstprove-remainder"),
+            work_dir=pathlib.Path("/tmp/jstprove-shape-test"),
+        )
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_path = tmp / "shape.json"
+            tsv_path = tmp / "shape.tsv"
+            PROBE.write_outputs(payload, json_path, tsv_path)
+
+            self.assertEqual(json.loads(json_path.read_text(encoding="utf-8"))["schema"], PROBE.SCHEMA)
+            self.assertEqual(tsv_path.read_text(encoding="utf-8").splitlines()[1].split("\t")[0], "tiny_gemm")
+
+    def test_git_commit_override_is_validated(self) -> None:
+        with self.assertRaisesRegex(PROBE.JstproveShapeProbeError, "must be a 7-40 character hex SHA"):
+            with mock.patch.dict(os.environ, {PROBE.GIT_COMMIT_ENV: "not-a-sha"}):
+                PROBE._git_commit()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/zkai_jstprove_shape_probe.py
+++ b/scripts/zkai_jstprove_shape_probe.py
@@ -16,6 +16,7 @@ import io
 import json
 import os
 import pathlib
+import platform
 import re
 import shutil
 import subprocess
@@ -31,12 +32,18 @@ TSV_OUT = ROOT / "docs" / "engineering" / "evidence" / "zkai-jstprove-shape-prob
 SCHEMA = "zkai-jstprove-shape-probe-v1"
 DECISION = "GO_OPERATOR_SUPPORT_SPLIT_NOT_TRANSFORMER_PROOF"
 SOURCE_DATE_EPOCH_DEFAULT = 0
-DEFAULT_WORK_DIR = pathlib.Path(os.environ.get("ZKAI_JSTPROVE_SHAPE_WORK_DIR", "/tmp/zkai-jstprove-shape-probe"))
+WORK_DIR_ENV = "ZKAI_JSTPROVE_SHAPE_WORK_DIR"
+DEFAULT_WORK_DIR_PREFIX = "zkai-jstprove-shape-probe-"
 JSTPROVE_BIN_ENV = "ZKAI_JSTPROVE_REMAINDER_BIN"
 GIT_COMMIT_ENV = "ZKAI_JSTPROVE_SHAPE_PROBE_GIT_COMMIT"
 JSTPROVE_COMMIT = "7c3cbbee83aaa01adde700673f00e317a4e902f9"
 REMAINDER_COMMIT = "06a5f406"
 OPSET = 17
+SOFTMAX_ALTERNATIVE_REFS = (
+    "origin/main-b",
+    "refs/tags/v2.12.1",
+    "origin/eliminate/relu-zero-delta-range-check",
+)
 
 EXPECTED_FIXTURE_ORDER = (
     "tiny_gemm",
@@ -136,6 +143,13 @@ def _git_commit() -> str:
     return completed.stdout.strip() or "unavailable"
 
 
+def _default_work_dir() -> pathlib.Path:
+    override = os.environ.get(WORK_DIR_ENV)
+    if override and override.strip():
+        return pathlib.Path(override.strip())
+    return pathlib.Path(tempfile.mkdtemp(prefix=DEFAULT_WORK_DIR_PREFIX))
+
+
 def fixture_catalog() -> list[dict[str, str]]:
     return [
         {
@@ -200,6 +214,17 @@ def _import_generation_deps():
             "shape generation requires onnx, numpy, and msgpack; run with the JSTprove ONNX Python environment"
         ) from err
     return msgpack, np, onnx, TensorProto, helper, numpy_helper
+
+
+def generator_dependency_versions() -> dict[str, str | int]:
+    msgpack, np, onnx, _tensor_proto, _helper, _numpy_helper = _import_generation_deps()
+    return {
+        "python": platform.python_version(),
+        "onnx": str(getattr(onnx, "__version__", "unknown")),
+        "numpy": str(getattr(np, "__version__", "unknown")),
+        "msgpack": str(getattr(msgpack, "version", getattr(msgpack, "__version__", "unknown"))),
+        "onnx_opset": OPSET,
+    }
 
 
 def write_fixture(fixture: str, out_dir: pathlib.Path) -> dict[str, int]:
@@ -551,6 +576,20 @@ def _source_git_commit(source_root: pathlib.Path) -> str:
     return completed.stdout.strip() or "unavailable"
 
 
+def _git_output(source_root: pathlib.Path, args: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(source_root), *args],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return completed.stdout
+
+
 def softmax_source_probe(jstprove_bin: pathlib.Path) -> dict[str, Any]:
     candidate_root = _infer_jstprove_source_root(jstprove_bin)
     if candidate_root is None:
@@ -607,9 +646,70 @@ def softmax_source_probe(jstprove_bin: pathlib.Path) -> dict[str, Any]:
     }
 
 
+def softmax_alternative_ref_probe(source_root: str) -> list[dict[str, Any]]:
+    root = pathlib.Path(source_root) if source_root else None
+    if root is None or not (root / ".git").exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for ref in SOFTMAX_ALTERNATIVE_REFS:
+        commit = _git_output(root, ["rev-parse", "--verify", f"{ref}^{{commit}}"])
+        if commit is None:
+            rows.append(
+                {
+                    "ref": ref,
+                    "commit": "unavailable",
+                    "status": "REF_NOT_AVAILABLE",
+                    "remainder_softmax_hits": [],
+                    "observation": "The alternative ref was not available in the local JSTprove checkout.",
+                }
+            )
+            continue
+        grep = _git_output(root, ["grep", "-n", "Softmax\\|not yet constrained", ref, "--", ":(glob)*.rs"])
+        lines = [] if grep is None else grep.splitlines()
+        remainder_hits = []
+        for line in lines:
+            if "jstprove_remainder" not in line:
+                continue
+            parts = line.split(":", 3)
+            if len(parts) < 4:
+                continue
+            _raw_ref, path, line_number, text = parts
+            remainder_hits.append(
+                {
+                    "path": path,
+                    "line": int(line_number) if line_number.isdigit() else line_number,
+                    "text": text.strip()[:240],
+                }
+            )
+            if len(remainder_hits) >= 8:
+                break
+        has_refusal = any("not yet constrained" in hit["text"] for hit in remainder_hits)
+        has_remainder_softmax = any("Softmax" in hit["text"] for hit in remainder_hits)
+        if has_refusal:
+            status = "REMAINDER_SOFTMAX_STILL_REFUSED"
+        elif has_remainder_softmax:
+            status = "POSSIBLE_REMAINDER_SOFTMAX_PATH_FOUND"
+        else:
+            status = "NO_REMAINDER_SOFTMAX_PATH_FOUND"
+        rows.append(
+            {
+                "ref": ref,
+                "commit": commit.strip(),
+                "status": status,
+                "remainder_softmax_hits": remainder_hits,
+                "observation": (
+                    "Alternative ref keeps Softmax in a Remainder unconstrained-op refusal."
+                    if status == "REMAINDER_SOFTMAX_STILL_REFUSED"
+                    else "Alternative ref did not expose a constrained Remainder Softmax path in this source probe."
+                ),
+            }
+        )
+    return rows
+
+
 def run_shape_probe(*, jstprove_bin: pathlib.Path | None = None, work_dir: pathlib.Path | None = None) -> dict[str, Any]:
     resolved_bin = jstprove_bin or _resolve_jstprove_binary()
-    raw_work_dir = work_dir or DEFAULT_WORK_DIR
+    raw_work_dir = work_dir or _default_work_dir()
     raw_work_dir.mkdir(parents=True, exist_ok=True)
     results = [
         run_fixture(fixture, jstprove_bin=resolved_bin, work_dir=raw_work_dir) for fixture in EXPECTED_FIXTURE_ORDER
@@ -617,13 +717,16 @@ def run_shape_probe(*, jstprove_bin: pathlib.Path | None = None, work_dir: pathl
     dimension_sweep = run_gemm_dimension_sweep(jstprove_bin=resolved_bin, work_dir=raw_work_dir / "_gemm_dimension_sweep")
     relu_scaling = run_relu_scaling_probe(jstprove_bin=resolved_bin, work_dir=raw_work_dir / "_relu_scaling_probe")
     softmax_probe = softmax_source_probe(resolved_bin)
+    softmax_alternatives = softmax_alternative_ref_probe(str(softmax_probe.get("source_root", "")))
     return build_payload(
         results,
         jstprove_bin=resolved_bin,
         work_dir=raw_work_dir,
+        generator_dependencies=generator_dependency_versions(),
         dimension_sweep=dimension_sweep,
         relu_scaling_probe=relu_scaling,
         softmax_source=softmax_probe,
+        softmax_alternative_refs=softmax_alternatives,
     )
 
 
@@ -632,14 +735,17 @@ def build_payload(
     *,
     jstprove_bin: pathlib.Path,
     work_dir: pathlib.Path,
+    generator_dependencies: dict[str, str | int] | None = None,
     dimension_sweep: list[dict[str, Any]] | None = None,
     relu_scaling_probe: list[dict[str, Any]] | None = None,
     softmax_source: dict[str, Any] | None = None,
+    softmax_alternative_refs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     go_results = [item for item in results if item["status"] == "GO"]
     no_go_results = [item for item in results if item["status"] == "NO_GO"]
     dimension_sweep = dimension_sweep or []
     relu_scaling_probe = relu_scaling_probe or []
+    generator_dependencies = generator_dependencies or {}
     softmax_source = softmax_source or {
         "status": "SOURCE_NOT_RECORDED",
         "source_root": "",
@@ -648,10 +754,12 @@ def build_payload(
         "softmax_refusal_found": False,
         "observation": "Softmax source inspection was not recorded for this synthetic payload.",
     }
+    softmax_alternative_refs = softmax_alternative_refs or []
     exploration = {
         "dimension_sweep": dimension_sweep,
         "relu_scaling_probe": relu_scaling_probe,
         "softmax_source_probe": softmax_source,
+        "softmax_alternative_ref_probe": softmax_alternative_refs,
     }
     payload = {
         "schema": SCHEMA,
@@ -664,6 +772,7 @@ def build_payload(
             "remainder_dependency_commit": REMAINDER_COMMIT,
             "binary": str(jstprove_bin),
         },
+        "generator_dependencies": generator_dependencies,
         "work_dir": str(work_dir),
         "fixture_catalog": fixture_catalog(),
         "results": results,
@@ -671,6 +780,7 @@ def build_payload(
         "dimension_sweep": dimension_sweep,
         "relu_scaling_probe": relu_scaling_probe,
         "softmax_source_probe": softmax_source,
+        "softmax_alternative_ref_probe": softmax_alternative_refs,
         "exploration_commitment": blake2b_commitment(exploration, "ptvm:zkai:jstprove-shape-exploration:v1"),
         "conclusion": {
             "go_count": len(go_results),
@@ -679,13 +789,14 @@ def build_payload(
                 item["fixture"] for item in go_results if item["fixture"] in EXPECTED_GO_TRANSFORMER_ADJACENT
             ],
             "gemm_dimension_sweep": "GO_DIMS_1_2_4",
-            "relu_scaling": "INPUT_DEPENDENT_BASELINE_FAILS_SCALED_VARIANTS_CLEAR",
+            "relu_scaling": "MAGNITUDE_SENSITIVE_BASELINE_FAILS_SCALED_VARIANTS_CLEAR",
             "softmax_source_check": softmax_source["status"],
+            "softmax_alternative_ref_check": "CHECKED_NO_CONSTRAINED_REMAINDER_SOFTMAX_PATH",
             "paper_usage": "engineering_context_only_not_transformer_proof_or_performance_benchmark",
             "interpretation": (
                 "JSTprove/Remainder can prove tiny projection, residual-add, and normalization-shaped fixtures, "
                 "but the checked Softmax, ReLU, and literal MatMul variants expose separate backend/operator blockers. "
-                "The ReLU blocker is input-dependent in this probe: scaled variants clear."
+                "The ReLU blocker is magnitude-sensitive in this probe: scaled variants clear."
             ),
         },
         "non_claims": [
@@ -709,6 +820,7 @@ def validate_payload(payload: dict[str, Any]) -> None:
         "decision",
         "question",
         "jstprove",
+        "generator_dependencies",
         "work_dir",
         "fixture_catalog",
         "results",
@@ -716,6 +828,7 @@ def validate_payload(payload: dict[str, Any]) -> None:
         "dimension_sweep",
         "relu_scaling_probe",
         "softmax_source_probe",
+        "softmax_alternative_ref_probe",
         "exploration_commitment",
         "conclusion",
         "non_claims",
@@ -727,6 +840,7 @@ def validate_payload(payload: dict[str, Any]) -> None:
         "gemm_dimension_sweep",
         "relu_scaling",
         "softmax_source_check",
+        "softmax_alternative_ref_check",
         "paper_usage",
         "interpretation",
     }
@@ -736,12 +850,27 @@ def validate_payload(payload: dict[str, Any]) -> None:
         raise JstproveShapeProbeError("schema drift")
     if payload["decision"] != DECISION:
         raise JstproveShapeProbeError("decision drift")
+    jstprove = payload["jstprove"]
+    if jstprove.get("upstream_commit") != JSTPROVE_COMMIT:
+        raise JstproveShapeProbeError("JSTprove commit drift")
+    if jstprove.get("remainder_dependency_commit") != REMAINDER_COMMIT:
+        raise JstproveShapeProbeError("Remainder commit drift")
+    deps = payload["generator_dependencies"]
+    expected_deps = {"python", "onnx", "numpy", "msgpack", "onnx_opset"}
+    if set(deps) != expected_deps:
+        raise JstproveShapeProbeError("generator dependency field drift")
+    if deps["onnx_opset"] != OPSET:
+        raise JstproveShapeProbeError("ONNX opset drift")
+    for dep_name in expected_deps - {"onnx_opset"}:
+        if not isinstance(deps.get(dep_name), str) or not deps[dep_name]:
+            raise JstproveShapeProbeError("generator dependency version missing")
     if payload["results_commitment"] != blake2b_commitment(payload["results"], "ptvm:zkai:jstprove-shape-results:v1"):
         raise JstproveShapeProbeError("results commitment mismatch")
     exploration = {
         "dimension_sweep": payload["dimension_sweep"],
         "relu_scaling_probe": payload["relu_scaling_probe"],
         "softmax_source_probe": payload["softmax_source_probe"],
+        "softmax_alternative_ref_probe": payload["softmax_alternative_ref_probe"],
     }
     if payload["exploration_commitment"] != blake2b_commitment(
         exploration, "ptvm:zkai:jstprove-shape-exploration:v1"
@@ -804,6 +933,17 @@ def validate_payload(payload: dict[str, Any]) -> None:
             raise JstproveShapeProbeError("Softmax source refusal drift")
         if not payload["softmax_source_probe"].get("hits"):
             raise JstproveShapeProbeError("Softmax source hits missing")
+    if [item.get("ref") for item in payload["softmax_alternative_ref_probe"]] != list(SOFTMAX_ALTERNATIVE_REFS):
+        raise JstproveShapeProbeError("Softmax alternative ref probe drift")
+    for item in payload["softmax_alternative_ref_probe"]:
+        if item.get("status") not in {
+            "REMAINDER_SOFTMAX_STILL_REFUSED",
+            "POSSIBLE_REMAINDER_SOFTMAX_PATH_FOUND",
+            "NO_REMAINDER_SOFTMAX_PATH_FOUND",
+        }:
+            raise JstproveShapeProbeError("Softmax alternative status drift")
+    if any(item.get("status") == "POSSIBLE_REMAINDER_SOFTMAX_PATH_FOUND" for item in payload["softmax_alternative_ref_probe"]):
+        raise JstproveShapeProbeError("Softmax alternative constrained-path claim needs manual gate")
 
     conclusion = payload["conclusion"]
     if set(conclusion) != expected_conclusion_fields:
@@ -816,8 +956,10 @@ def validate_payload(payload: dict[str, Any]) -> None:
         raise JstproveShapeProbeError("transformer-adjacent GO drift")
     if conclusion["gemm_dimension_sweep"] != "GO_DIMS_1_2_4":
         raise JstproveShapeProbeError("Gemm dimension conclusion drift")
-    if conclusion["relu_scaling"] != "INPUT_DEPENDENT_BASELINE_FAILS_SCALED_VARIANTS_CLEAR":
+    if conclusion["relu_scaling"] != "MAGNITUDE_SENSITIVE_BASELINE_FAILS_SCALED_VARIANTS_CLEAR":
         raise JstproveShapeProbeError("ReLU scaling conclusion drift")
+    if conclusion["softmax_alternative_ref_check"] != "CHECKED_NO_CONSTRAINED_REMAINDER_SOFTMAX_PATH":
+        raise JstproveShapeProbeError("Softmax alternative conclusion drift")
     required_non_claims = {
         "not a JSTprove security finding",
         "not a full transformer proof",
@@ -865,7 +1007,11 @@ def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_p
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--jstprove-bin", type=pathlib.Path, help=f"path to jstprove-remainder; defaults to ${JSTPROVE_BIN_ENV} or PATH")
-    parser.add_argument("--work-dir", type=pathlib.Path, default=DEFAULT_WORK_DIR, help="temporary fixture/proof work directory")
+    parser.add_argument(
+        "--work-dir",
+        type=pathlib.Path,
+        help=f"temporary fixture/proof work directory; defaults to ${WORK_DIR_ENV} or a unique temp directory",
+    )
     parser.add_argument("--write-json", type=pathlib.Path, help="write checked JSON evidence")
     parser.add_argument("--write-tsv", type=pathlib.Path, help="write checked TSV evidence")
     parser.add_argument("--json", action="store_true", help="print JSON to stdout")

--- a/scripts/zkai_jstprove_shape_probe.py
+++ b/scripts/zkai_jstprove_shape_probe.py
@@ -68,6 +68,8 @@ EXPECTED_GO_TRANSFORMER_ADJACENT = {
     "tiny_gemm_layernorm",
     "tiny_gemm_batchnorm",
 }
+GEMM_SWEEP_DIMENSIONS = (1, 2, 4)
+RELU_SCALE_FACTORS = ("1", "0.25", "0.1", "0.01", "0.001")
 TSV_COLUMNS = (
     "fixture",
     "gate",
@@ -283,19 +285,81 @@ def write_fixture(fixture: str, out_dir: pathlib.Path) -> dict[str, int]:
     return {"onnx_bytes": onnx_path.stat().st_size, "input_bytes": input_path.stat().st_size}
 
 
+def write_gemm_dimension_fixture(dimension: int, out_dir: pathlib.Path) -> dict[str, int]:
+    msgpack, np, onnx, TensorProto, helper, numpy_helper = _import_generation_deps()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fixture = f"gemm_dim_{dimension}"
+    input_value = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, dimension])
+    output_value = helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1, dimension])
+    weights = np.zeros((dimension, dimension), dtype=np.float32)
+    for row in range(dimension):
+        for col in range(dimension):
+            weights[row, col] = (row + col + 1) / (dimension + 2)
+    bias = np.array([(index + 1) / (dimension + 3) for index in range(dimension)], dtype=np.float32)
+    w = numpy_helper.from_array(weights, name="W")
+    b = numpy_helper.from_array(bias, name="B")
+    graph = helper.make_graph(
+        [helper.make_node("Gemm", ["input", "W", "B"], ["Z"])],
+        f"{fixture}_graph",
+        [input_value],
+        [output_value],
+        initializer=[w, b],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", OPSET)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx_path = out_dir / f"{fixture}.onnx"
+    input_path = out_dir / "input.msgpack"
+    onnx.save(model, onnx_path)
+    input_path.write_bytes(msgpack.packb({"input": [float(index + 1) for index in range(dimension)]}))
+    return {"onnx_bytes": onnx_path.stat().st_size, "input_bytes": input_path.stat().st_size}
+
+
+def write_relu_scaled_fixture(scale_label: str, out_dir: pathlib.Path) -> dict[str, int]:
+    msgpack, np, onnx, TensorProto, helper, numpy_helper = _import_generation_deps()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    scale = float(scale_label)
+    fixture = f"relu_scale_{scale_label.replace('.', 'p')}"
+    input_value = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 2])
+    output_value = helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1, 1])
+    w = numpy_helper.from_array(np.array([[0.5], [1.5]], dtype=np.float32) * scale, name="W")
+    b = numpy_helper.from_array(np.array([0.25], dtype=np.float32) * scale, name="B")
+    graph = helper.make_graph(
+        [helper.make_node("Gemm", ["input", "W", "B"], ["Y"]), helper.make_node("Relu", ["Y"], ["Z"])],
+        f"{fixture}_graph",
+        [input_value],
+        [output_value],
+        initializer=[w, b],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", OPSET)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx_path = out_dir / f"{fixture}.onnx"
+    input_path = out_dir / "input.msgpack"
+    onnx.save(model, onnx_path)
+    input_path.write_bytes(msgpack.packb({"input": [1.0 * scale, 2.0 * scale]}))
+    return {"onnx_bytes": onnx_path.stat().st_size, "input_bytes": input_path.stat().st_size}
+
+
+def _validate_executable_path(path: pathlib.Path, raw: str) -> pathlib.Path:
+    if not path.is_file():
+        raise JstproveShapeProbeError(f"JSTprove Remainder verifier is missing: {raw}")
+    if not os.access(path, os.X_OK):
+        raise JstproveShapeProbeError(f"JSTprove Remainder verifier is not executable: {raw}")
+    return path.resolve()
+
+
 def _resolve_jstprove_binary(raw: str | None = None) -> pathlib.Path:
     value = raw or os.environ.get(JSTPROVE_BIN_ENV, "jstprove-remainder")
     path = pathlib.Path(value)
     if path.is_absolute():
-        if not path.is_file():
-            raise JstproveShapeProbeError(f"JSTprove Remainder verifier is missing: {value}")
-        if not os.access(path, os.X_OK):
-            raise JstproveShapeProbeError(f"JSTprove Remainder verifier is not executable: {value}")
-        return path
+        return _validate_executable_path(path, value)
+    if path.parent != pathlib.Path("."):
+        return _validate_executable_path((pathlib.Path.cwd() / path).resolve(), value)
     resolved = shutil.which(value)
     if resolved is None:
         raise JstproveShapeProbeError(f"JSTprove Remainder verifier is not on PATH: {value}")
-    return pathlib.Path(resolved)
+    return pathlib.Path(resolved).resolve()
 
 
 def _run_command(command: list[str], *, cwd: pathlib.Path, timeout: int = 240) -> dict[str, Any]:
@@ -349,12 +413,7 @@ def _step_seconds(steps: list[dict[str, Any]], step: str) -> str:
     return "NA"
 
 
-def run_fixture(fixture: str, *, jstprove_bin: pathlib.Path, work_dir: pathlib.Path) -> dict[str, Any]:
-    fixture_dir = work_dir / fixture
-    if fixture_dir.exists():
-        shutil.rmtree(fixture_dir)
-    fixture_dir.mkdir(parents=True)
-    sizes = write_fixture(fixture, fixture_dir)
+def _run_pipeline(fixture: str, *, jstprove_bin: pathlib.Path, fixture_dir: pathlib.Path, sizes: dict[str, int]) -> dict[str, Any]:
     model = fixture_dir / "model.msgpack"
     witness = fixture_dir / "witness.msgpack"
     proof = fixture_dir / "proof.msgpack"
@@ -384,13 +443,10 @@ def run_fixture(fixture: str, *, jstprove_bin: pathlib.Path, work_dir: pathlib.P
 
     status = "GO" if failed_step is None else "NO_GO"
     failure_kind = "" if status == "GO" else classify_failure(failed_step, failure_message)
-    catalog = {item["fixture"]: item for item in fixture_catalog()}[fixture]
     gate = "GO_CHECKED_SMALL_SHAPE" if status == "GO" else f"NO_GO_{failure_kind.upper()}"
     return {
         "fixture": fixture,
         "gate": gate,
-        "op_sequence": catalog["op_sequence"],
-        "transformer_relevance": catalog["transformer_relevance"],
         "status": status,
         "failed_step": failed_step or "",
         "failure_kind": failure_kind,
@@ -400,8 +456,154 @@ def run_fixture(fixture: str, *, jstprove_bin: pathlib.Path, work_dir: pathlib.P
         "input_bytes": sizes["input_bytes"],
         "prove_seconds": _step_seconds(steps, "prove"),
         "verify_seconds": _step_seconds(steps, "verify"),
-        "primary_observation": catalog["primary_observation"],
         "steps": steps,
+    }
+
+
+def run_fixture(fixture: str, *, jstprove_bin: pathlib.Path, work_dir: pathlib.Path) -> dict[str, Any]:
+    fixture_dir = work_dir / fixture
+    if fixture_dir.exists():
+        shutil.rmtree(fixture_dir)
+    fixture_dir.mkdir(parents=True)
+    sizes = write_fixture(fixture, fixture_dir)
+    catalog = {item["fixture"]: item for item in fixture_catalog()}[fixture]
+    result = _run_pipeline(fixture, jstprove_bin=jstprove_bin, fixture_dir=fixture_dir, sizes=sizes)
+    result.update(
+        {
+            "op_sequence": catalog["op_sequence"],
+            "transformer_relevance": catalog["transformer_relevance"],
+            "primary_observation": catalog["primary_observation"],
+        }
+    )
+    return result
+
+
+def run_gemm_dimension_sweep(*, jstprove_bin: pathlib.Path, work_dir: pathlib.Path) -> list[dict[str, Any]]:
+    rows = []
+    for dimension in GEMM_SWEEP_DIMENSIONS:
+        fixture = f"gemm_dim_{dimension}"
+        fixture_dir = work_dir / fixture
+        if fixture_dir.exists():
+            shutil.rmtree(fixture_dir)
+        fixture_dir.mkdir(parents=True, exist_ok=True)
+        sizes = write_gemm_dimension_fixture(dimension, fixture_dir)
+        result = _run_pipeline(fixture, jstprove_bin=jstprove_bin, fixture_dir=fixture_dir, sizes=sizes)
+        rows.append(
+            {
+                "dimension": dimension,
+                "status": result["status"],
+                "failed_step": result["failed_step"],
+                "failure_kind": result["failure_kind"],
+                "proof_bytes": result["proof_bytes"],
+                "model_bytes": result["model_bytes"],
+                "onnx_bytes": result["onnx_bytes"],
+                "prove_seconds": result["prove_seconds"],
+                "verify_seconds": result["verify_seconds"],
+            }
+        )
+    return rows
+
+
+def run_relu_scaling_probe(*, jstprove_bin: pathlib.Path, work_dir: pathlib.Path) -> list[dict[str, Any]]:
+    rows = []
+    for scale_label in RELU_SCALE_FACTORS:
+        fixture = f"relu_scale_{scale_label.replace('.', 'p')}"
+        fixture_dir = work_dir / fixture
+        if fixture_dir.exists():
+            shutil.rmtree(fixture_dir)
+        fixture_dir.mkdir(parents=True, exist_ok=True)
+        sizes = write_relu_scaled_fixture(scale_label, fixture_dir)
+        result = _run_pipeline(fixture, jstprove_bin=jstprove_bin, fixture_dir=fixture_dir, sizes=sizes)
+        rows.append(
+            {
+                "scale": scale_label,
+                "status": result["status"],
+                "failed_step": result["failed_step"],
+                "failure_kind": result["failure_kind"],
+                "proof_bytes": result["proof_bytes"],
+                "model_bytes": result["model_bytes"],
+                "onnx_bytes": result["onnx_bytes"],
+                "prove_seconds": result["prove_seconds"],
+                "verify_seconds": result["verify_seconds"],
+            }
+        )
+    return rows
+
+
+def _infer_jstprove_source_root(jstprove_bin: pathlib.Path) -> pathlib.Path | None:
+    for candidate in jstprove_bin.resolve().parents:
+        if (candidate / "Cargo.toml").exists() and (candidate / "rust" / "jstprove_remainder").exists():
+            return candidate
+    return None
+
+
+def _source_git_commit(source_root: pathlib.Path) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(source_root), "rev-parse", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unavailable"
+    return completed.stdout.strip() or "unavailable"
+
+
+def softmax_source_probe(jstprove_bin: pathlib.Path) -> dict[str, Any]:
+    candidate_root = _infer_jstprove_source_root(jstprove_bin)
+    if candidate_root is None:
+        return {
+            "status": "SOURCE_NOT_AVAILABLE",
+            "source_root": "",
+            "source_commit": "unavailable",
+            "hits": [],
+            "softmax_refusal_found": False,
+            "observation": "JSTprove source root was not inferable from the binary path.",
+        }
+    hits = []
+    priority_needles = (
+        ("remainder_refusal", ("Softmax", "not yet constrained")),
+        ("remainder_refusal", ("refusing to add unconstrained committed shred",)),
+        ("remainder_witness", ("OpType::Softmax",)),
+        ("circuit_hint", ("Softmax", "hint alone adds no constraint")),
+        ("circuit_layer", ("SoftmaxLayer",)),
+    )
+    for path in sorted(candidate_root.rglob("*.rs")):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        for line_number, line in enumerate(lines, start=1):
+            for category, needles in priority_needles:
+                if all(needle in line for needle in needles):
+                    hits.append(
+                        {
+                            "category": category,
+                            "path": str(path.relative_to(candidate_root)),
+                            "line": line_number,
+                            "text": line.strip()[:240],
+                        }
+                    )
+                    break
+            if len(hits) >= 16:
+                break
+        if len(hits) >= 12:
+            break
+    softmax_refusal_found = any(hit["category"] == "remainder_refusal" for hit in hits)
+    status = "SOURCE_HIT" if softmax_refusal_found else "SOURCE_NO_HIT"
+    return {
+        "status": status,
+        "source_root": str(candidate_root),
+        "source_commit": _source_git_commit(candidate_root),
+        "hits": hits,
+        "softmax_refusal_found": softmax_refusal_found,
+        "observation": (
+            "Pinned source inspection found the Remainder Softmax unconstrained-op refusal."
+            if softmax_refusal_found
+            else "Pinned source inspection did not find the Remainder Softmax refusal."
+        ),
     }
 
 
@@ -412,12 +614,45 @@ def run_shape_probe(*, jstprove_bin: pathlib.Path | None = None, work_dir: pathl
     results = [
         run_fixture(fixture, jstprove_bin=resolved_bin, work_dir=raw_work_dir) for fixture in EXPECTED_FIXTURE_ORDER
     ]
-    return build_payload(results, jstprove_bin=resolved_bin, work_dir=raw_work_dir)
+    dimension_sweep = run_gemm_dimension_sweep(jstprove_bin=resolved_bin, work_dir=raw_work_dir / "_gemm_dimension_sweep")
+    relu_scaling = run_relu_scaling_probe(jstprove_bin=resolved_bin, work_dir=raw_work_dir / "_relu_scaling_probe")
+    softmax_probe = softmax_source_probe(resolved_bin)
+    return build_payload(
+        results,
+        jstprove_bin=resolved_bin,
+        work_dir=raw_work_dir,
+        dimension_sweep=dimension_sweep,
+        relu_scaling_probe=relu_scaling,
+        softmax_source=softmax_probe,
+    )
 
 
-def build_payload(results: list[dict[str, Any]], *, jstprove_bin: pathlib.Path, work_dir: pathlib.Path) -> dict[str, Any]:
+def build_payload(
+    results: list[dict[str, Any]],
+    *,
+    jstprove_bin: pathlib.Path,
+    work_dir: pathlib.Path,
+    dimension_sweep: list[dict[str, Any]] | None = None,
+    relu_scaling_probe: list[dict[str, Any]] | None = None,
+    softmax_source: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     go_results = [item for item in results if item["status"] == "GO"]
     no_go_results = [item for item in results if item["status"] == "NO_GO"]
+    dimension_sweep = dimension_sweep or []
+    relu_scaling_probe = relu_scaling_probe or []
+    softmax_source = softmax_source or {
+        "status": "SOURCE_NOT_RECORDED",
+        "source_root": "",
+        "source_commit": "unavailable",
+        "hits": [],
+        "softmax_refusal_found": False,
+        "observation": "Softmax source inspection was not recorded for this synthetic payload.",
+    }
+    exploration = {
+        "dimension_sweep": dimension_sweep,
+        "relu_scaling_probe": relu_scaling_probe,
+        "softmax_source_probe": softmax_source,
+    }
     payload = {
         "schema": SCHEMA,
         "generated_at": _generated_at(),
@@ -433,16 +668,24 @@ def build_payload(results: list[dict[str, Any]], *, jstprove_bin: pathlib.Path, 
         "fixture_catalog": fixture_catalog(),
         "results": results,
         "results_commitment": blake2b_commitment(results, "ptvm:zkai:jstprove-shape-results:v1"),
+        "dimension_sweep": dimension_sweep,
+        "relu_scaling_probe": relu_scaling_probe,
+        "softmax_source_probe": softmax_source,
+        "exploration_commitment": blake2b_commitment(exploration, "ptvm:zkai:jstprove-shape-exploration:v1"),
         "conclusion": {
             "go_count": len(go_results),
             "no_go_count": len(no_go_results),
             "go_transformer_adjacent_fixtures": [
                 item["fixture"] for item in go_results if item["fixture"] in EXPECTED_GO_TRANSFORMER_ADJACENT
             ],
+            "gemm_dimension_sweep": "GO_DIMS_1_2_4",
+            "relu_scaling": "INPUT_DEPENDENT_BASELINE_FAILS_SCALED_VARIANTS_CLEAR",
+            "softmax_source_check": softmax_source["status"],
             "paper_usage": "engineering_context_only_not_transformer_proof_or_performance_benchmark",
             "interpretation": (
                 "JSTprove/Remainder can prove tiny projection, residual-add, and normalization-shaped fixtures, "
-                "but the checked Softmax, ReLU, and literal MatMul variants expose separate backend/operator blockers."
+                "but the checked Softmax, ReLU, and literal MatMul variants expose separate backend/operator blockers. "
+                "The ReLU blocker is input-dependent in this probe: scaled variants clear."
             ),
         },
         "non_claims": [
@@ -470,6 +713,10 @@ def validate_payload(payload: dict[str, Any]) -> None:
         "fixture_catalog",
         "results",
         "results_commitment",
+        "dimension_sweep",
+        "relu_scaling_probe",
+        "softmax_source_probe",
+        "exploration_commitment",
         "conclusion",
         "non_claims",
     }
@@ -477,6 +724,9 @@ def validate_payload(payload: dict[str, Any]) -> None:
         "go_count",
         "no_go_count",
         "go_transformer_adjacent_fixtures",
+        "gemm_dimension_sweep",
+        "relu_scaling",
+        "softmax_source_check",
         "paper_usage",
         "interpretation",
     }
@@ -488,6 +738,15 @@ def validate_payload(payload: dict[str, Any]) -> None:
         raise JstproveShapeProbeError("decision drift")
     if payload["results_commitment"] != blake2b_commitment(payload["results"], "ptvm:zkai:jstprove-shape-results:v1"):
         raise JstproveShapeProbeError("results commitment mismatch")
+    exploration = {
+        "dimension_sweep": payload["dimension_sweep"],
+        "relu_scaling_probe": payload["relu_scaling_probe"],
+        "softmax_source_probe": payload["softmax_source_probe"],
+    }
+    if payload["exploration_commitment"] != blake2b_commitment(
+        exploration, "ptvm:zkai:jstprove-shape-exploration:v1"
+    ):
+        raise JstproveShapeProbeError("exploration commitment mismatch")
     catalog_names = [item.get("fixture") for item in payload["fixture_catalog"]]
     if catalog_names != list(EXPECTED_FIXTURE_ORDER):
         raise JstproveShapeProbeError("fixture catalog drift")
@@ -514,6 +773,38 @@ def validate_payload(payload: dict[str, Any]) -> None:
             if not result.get("failed_step"):
                 raise JstproveShapeProbeError(f"{fixture} missing failed step")
 
+    sweep_dimensions = [item.get("dimension") for item in payload["dimension_sweep"]]
+    if sweep_dimensions != list(GEMM_SWEEP_DIMENSIONS):
+        raise JstproveShapeProbeError("Gemm dimension sweep drift")
+    for item in payload["dimension_sweep"]:
+        if item.get("status") != "GO":
+            raise JstproveShapeProbeError("Gemm dimension sweep no-go drift")
+        if not isinstance(item.get("proof_bytes"), int) or item["proof_bytes"] <= 0:
+            raise JstproveShapeProbeError("Gemm dimension sweep proof size missing")
+
+    relu_scales = [item.get("scale") for item in payload["relu_scaling_probe"]]
+    if relu_scales != list(RELU_SCALE_FACTORS):
+        raise JstproveShapeProbeError("ReLU scaling probe drift")
+    for item in payload["relu_scaling_probe"]:
+        if item["scale"] == "1":
+            if item.get("status") != "NO_GO" or item.get("failure_kind") != "range_check_capacity":
+                raise JstproveShapeProbeError("ReLU baseline scaling drift")
+        elif item.get("status") != "GO":
+            raise JstproveShapeProbeError("ReLU scaled variant drift")
+
+    if payload["softmax_source_probe"].get("status") not in {
+        "SOURCE_HIT",
+        "SOURCE_NO_HIT",
+        "SOURCE_NOT_AVAILABLE",
+        "SOURCE_NOT_RECORDED",
+    }:
+        raise JstproveShapeProbeError("Softmax source probe drift")
+    if payload["softmax_source_probe"].get("status") == "SOURCE_HIT":
+        if not payload["softmax_source_probe"].get("softmax_refusal_found"):
+            raise JstproveShapeProbeError("Softmax source refusal drift")
+        if not payload["softmax_source_probe"].get("hits"):
+            raise JstproveShapeProbeError("Softmax source hits missing")
+
     conclusion = payload["conclusion"]
     if set(conclusion) != expected_conclusion_fields:
         raise JstproveShapeProbeError("conclusion field set mismatch")
@@ -523,6 +814,10 @@ def validate_payload(payload: dict[str, Any]) -> None:
         raise JstproveShapeProbeError("summary count drift")
     if set(conclusion["go_transformer_adjacent_fixtures"]) != EXPECTED_GO_TRANSFORMER_ADJACENT:
         raise JstproveShapeProbeError("transformer-adjacent GO drift")
+    if conclusion["gemm_dimension_sweep"] != "GO_DIMS_1_2_4":
+        raise JstproveShapeProbeError("Gemm dimension conclusion drift")
+    if conclusion["relu_scaling"] != "INPUT_DEPENDENT_BASELINE_FAILS_SCALED_VARIANTS_CLEAR":
+        raise JstproveShapeProbeError("ReLU scaling conclusion drift")
     required_non_claims = {
         "not a JSTprove security finding",
         "not a full transformer proof",

--- a/scripts/zkai_jstprove_shape_probe.py
+++ b/scripts/zkai_jstprove_shape_probe.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""JSTprove/Remainder shape probe for small transformer-adjacent ONNX fixtures.
+
+This is an engineering probe, not a performance benchmark and not a JSTprove
+security audit. It asks which tiny operator shapes can be compiled, witnessed,
+proved, and verified by a real JSTprove/Remainder binary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import hashlib
+import io
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+JSON_OUT = ROOT / "docs" / "engineering" / "evidence" / "zkai-jstprove-shape-probe-2026-05.json"
+TSV_OUT = ROOT / "docs" / "engineering" / "evidence" / "zkai-jstprove-shape-probe-2026-05.tsv"
+
+SCHEMA = "zkai-jstprove-shape-probe-v1"
+DECISION = "GO_OPERATOR_SUPPORT_SPLIT_NOT_TRANSFORMER_PROOF"
+SOURCE_DATE_EPOCH_DEFAULT = 0
+DEFAULT_WORK_DIR = pathlib.Path(os.environ.get("ZKAI_JSTPROVE_SHAPE_WORK_DIR", "/tmp/zkai-jstprove-shape-probe"))
+JSTPROVE_BIN_ENV = "ZKAI_JSTPROVE_REMAINDER_BIN"
+GIT_COMMIT_ENV = "ZKAI_JSTPROVE_SHAPE_PROBE_GIT_COMMIT"
+JSTPROVE_COMMIT = "7c3cbbee83aaa01adde700673f00e317a4e902f9"
+REMAINDER_COMMIT = "06a5f406"
+OPSET = 17
+
+EXPECTED_FIXTURE_ORDER = (
+    "tiny_gemm",
+    "tiny_gemm_add",
+    "tiny_gemm_residual_add",
+    "tiny_gemm_layernorm",
+    "tiny_gemm_batchnorm",
+    "tiny_gemm_relu",
+    "tiny_gemm_softmax",
+    "tiny_matmul_residual_add",
+)
+EXPECTED_STATUS = {
+    "tiny_gemm": "GO",
+    "tiny_gemm_add": "GO",
+    "tiny_gemm_residual_add": "GO",
+    "tiny_gemm_layernorm": "GO",
+    "tiny_gemm_batchnorm": "GO",
+    "tiny_gemm_relu": "NO_GO",
+    "tiny_gemm_softmax": "NO_GO",
+    "tiny_matmul_residual_add": "NO_GO",
+}
+EXPECTED_FAILURE_KIND = {
+    "tiny_gemm_relu": "range_check_capacity",
+    "tiny_gemm_softmax": "unconstrained_backend_op",
+    "tiny_matmul_residual_add": "unsupported_witness_op",
+}
+EXPECTED_GO_TRANSFORMER_ADJACENT = {
+    "tiny_gemm_residual_add",
+    "tiny_gemm_layernorm",
+    "tiny_gemm_batchnorm",
+}
+TSV_COLUMNS = (
+    "fixture",
+    "gate",
+    "op_sequence",
+    "transformer_relevance",
+    "status",
+    "failed_step",
+    "failure_kind",
+    "proof_bytes",
+    "model_bytes",
+    "onnx_bytes",
+    "prove_seconds",
+    "verify_seconds",
+    "primary_observation",
+)
+
+
+class JstproveShapeProbeError(ValueError):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def blake2b_commitment(value: Any, domain: str) -> str:
+    digest = hashlib.blake2b(digest_size=32)
+    digest.update(domain.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(canonical_json_bytes(value))
+    return f"blake2b-256:{digest.hexdigest()}"
+
+
+def _generated_at() -> str:
+    raw = os.environ.get("SOURCE_DATE_EPOCH", str(SOURCE_DATE_EPOCH_DEFAULT))
+    try:
+        timestamp = int(raw)
+    except ValueError as err:
+        raise JstproveShapeProbeError("SOURCE_DATE_EPOCH must be an integer timestamp") from err
+    try:
+        generated_at = dt.datetime.fromtimestamp(timestamp, tz=dt.timezone.utc)
+    except (OverflowError, OSError, ValueError) as err:
+        raise JstproveShapeProbeError("SOURCE_DATE_EPOCH must be in the supported timestamp range") from err
+    return generated_at.isoformat().replace("+00:00", "Z")
+
+
+def _git_commit() -> str:
+    override = os.environ.get(GIT_COMMIT_ENV)
+    if override and override.strip():
+        normalized = override.strip().lower()
+        if not re.fullmatch(r"[0-9a-f]{7,40}", normalized):
+            raise JstproveShapeProbeError(f"{GIT_COMMIT_ENV} must be a 7-40 character hex SHA")
+        return normalized
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(ROOT), "rev-parse", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unavailable"
+    return completed.stdout.strip() or "unavailable"
+
+
+def fixture_catalog() -> list[dict[str, str]]:
+    return [
+        {
+            "fixture": "tiny_gemm",
+            "op_sequence": "Gemm",
+            "transformer_relevance": "linear_projection_baseline",
+            "primary_observation": "baseline tiny linear projection proves and verifies",
+        },
+        {
+            "fixture": "tiny_gemm_add",
+            "op_sequence": "Gemm -> Add",
+            "transformer_relevance": "linear_projection_plus_bias_like_add",
+            "primary_observation": "extra Add layer proves and verifies",
+        },
+        {
+            "fixture": "tiny_gemm_residual_add",
+            "op_sequence": "Gemm(width-preserving) -> Add(input)",
+            "transformer_relevance": "linear_projection_plus_residual_add",
+            "primary_observation": "residual-style Add proves and verifies",
+        },
+        {
+            "fixture": "tiny_gemm_layernorm",
+            "op_sequence": "Gemm(width-preserving) -> LayerNormalization",
+            "transformer_relevance": "normalization_after_projection",
+            "primary_observation": "LayerNormalization-style tiny shape proves and verifies",
+        },
+        {
+            "fixture": "tiny_gemm_batchnorm",
+            "op_sequence": "Gemm -> BatchNormalization",
+            "transformer_relevance": "normalization_like_operator_after_projection",
+            "primary_observation": "normalization-like tiny shape proves and verifies",
+        },
+        {
+            "fixture": "tiny_gemm_relu",
+            "op_sequence": "Gemm -> Relu",
+            "transformer_relevance": "activation_or_range_check_pressure",
+            "primary_observation": "Relu witness hits Remainder range-check capacity",
+        },
+        {
+            "fixture": "tiny_gemm_softmax",
+            "op_sequence": "Gemm(width-preserving) -> Softmax",
+            "transformer_relevance": "attention_normalization_pressure",
+            "primary_observation": "Softmax witness is generated but proof construction refuses an unconstrained op",
+        },
+        {
+            "fixture": "tiny_matmul_residual_add",
+            "op_sequence": "MatMul -> Add(input)",
+            "transformer_relevance": "literal_matmul_projection_plus_residual_add",
+            "primary_observation": "MatMul compiles but witness generation reports unsupported MatMul",
+        },
+    ]
+
+
+def _import_generation_deps():
+    try:
+        import msgpack  # type: ignore[import-not-found]
+        import numpy as np  # type: ignore[import-not-found]
+        import onnx  # type: ignore[import-not-found]
+        from onnx import TensorProto, helper, numpy_helper  # type: ignore[import-not-found]
+    except ImportError as err:
+        raise JstproveShapeProbeError(
+            "shape generation requires onnx, numpy, and msgpack; run with the JSTprove ONNX Python environment"
+        ) from err
+    return msgpack, np, onnx, TensorProto, helper, numpy_helper
+
+
+def write_fixture(fixture: str, out_dir: pathlib.Path) -> dict[str, int]:
+    msgpack, np, onnx, TensorProto, helper, numpy_helper = _import_generation_deps()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    input_value = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 2])
+    input_data = [1.0, 2.0]
+
+    w1 = numpy_helper.from_array(np.array([[0.5], [1.5]], dtype=np.float32), name="W")
+    b1 = numpy_helper.from_array(np.array([0.25], dtype=np.float32), name="B")
+    y1 = helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1, 1])
+
+    w2 = numpy_helper.from_array(np.array([[0.5, -0.25], [1.5, 0.75]], dtype=np.float32), name="W2")
+    b2 = numpy_helper.from_array(np.array([0.25, -0.5], dtype=np.float32), name="B2")
+    y2 = helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1, 2])
+
+    if fixture == "tiny_gemm":
+        nodes = [helper.make_node("Gemm", ["input", "W", "B"], ["Z"])]
+        outputs = [y1]
+        initializers = [w1, b1]
+    elif fixture == "tiny_gemm_add":
+        c = numpy_helper.from_array(np.array([0.125], dtype=np.float32), name="C")
+        nodes = [helper.make_node("Gemm", ["input", "W", "B"], ["Y"]), helper.make_node("Add", ["Y", "C"], ["Z"])]
+        outputs = [y1]
+        initializers = [w1, b1, c]
+    elif fixture == "tiny_gemm_residual_add":
+        nodes = [
+            helper.make_node("Gemm", ["input", "W2", "B2"], ["Y"]),
+            helper.make_node("Add", ["Y", "input"], ["Z"]),
+        ]
+        outputs = [y2]
+        initializers = [w2, b2]
+    elif fixture == "tiny_gemm_layernorm":
+        gamma = numpy_helper.from_array(np.ones(2, dtype=np.float32), name="gamma")
+        beta = numpy_helper.from_array(np.zeros(2, dtype=np.float32), name="beta")
+        nodes = [
+            helper.make_node("Gemm", ["input", "W2", "B2"], ["Y"]),
+            helper.make_node("LayerNormalization", ["Y", "gamma", "beta"], ["Z"], axis=-1, epsilon=1e-5),
+        ]
+        outputs = [y2]
+        initializers = [w2, b2, gamma, beta]
+    elif fixture == "tiny_gemm_batchnorm":
+        scale = numpy_helper.from_array(np.array([1.0], dtype=np.float32), name="scale")
+        bias = numpy_helper.from_array(np.array([0.0], dtype=np.float32), name="bias")
+        mean = numpy_helper.from_array(np.array([0.0], dtype=np.float32), name="mean")
+        var = numpy_helper.from_array(np.array([1.0], dtype=np.float32), name="var")
+        nodes = [
+            helper.make_node("Gemm", ["input", "W", "B"], ["Y"]),
+            helper.make_node("BatchNormalization", ["Y", "scale", "bias", "mean", "var"], ["Z"], epsilon=1e-5),
+        ]
+        outputs = [y1]
+        initializers = [w1, b1, scale, bias, mean, var]
+    elif fixture == "tiny_gemm_relu":
+        nodes = [helper.make_node("Gemm", ["input", "W", "B"], ["Y"]), helper.make_node("Relu", ["Y"], ["Z"])]
+        outputs = [y1]
+        initializers = [w1, b1]
+    elif fixture == "tiny_gemm_softmax":
+        nodes = [
+            helper.make_node("Gemm", ["input", "W2", "B2"], ["Y"]),
+            helper.make_node("Softmax", ["Y"], ["Z"], axis=-1),
+        ]
+        outputs = [y2]
+        initializers = [w2, b2]
+    elif fixture == "tiny_matmul_residual_add":
+        nodes = [
+            helper.make_node("MatMul", ["input", "W2"], ["Y"]),
+            helper.make_node("Add", ["Y", "input"], ["Z"]),
+        ]
+        outputs = [y2]
+        initializers = [w2]
+    else:
+        raise JstproveShapeProbeError(f"unknown fixture: {fixture}")
+
+    graph = helper.make_graph(nodes, f"{fixture}_graph", [input_value], outputs, initializer=initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", OPSET)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx_path = out_dir / f"{fixture}.onnx"
+    input_path = out_dir / "input.msgpack"
+    onnx.save(model, onnx_path)
+    input_path.write_bytes(msgpack.packb({"input": input_data}))
+    return {"onnx_bytes": onnx_path.stat().st_size, "input_bytes": input_path.stat().st_size}
+
+
+def _resolve_jstprove_binary(raw: str | None = None) -> pathlib.Path:
+    value = raw or os.environ.get(JSTPROVE_BIN_ENV, "jstprove-remainder")
+    path = pathlib.Path(value)
+    if path.is_absolute():
+        if not path.is_file():
+            raise JstproveShapeProbeError(f"JSTprove Remainder verifier is missing: {value}")
+        if not os.access(path, os.X_OK):
+            raise JstproveShapeProbeError(f"JSTprove Remainder verifier is not executable: {value}")
+        return path
+    resolved = shutil.which(value)
+    if resolved is None:
+        raise JstproveShapeProbeError(f"JSTprove Remainder verifier is not on PATH: {value}")
+    return pathlib.Path(resolved)
+
+
+def _run_command(command: list[str], *, cwd: pathlib.Path, timeout: int = 240) -> dict[str, Any]:
+    started = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as err:
+        return {
+            "returncode": "timeout",
+            "seconds": timeout,
+            "stdout_excerpt": "",
+            "stderr_excerpt": str(err)[:1000],
+        }
+    except OSError as err:
+        raise JstproveShapeProbeError(f"failed to start JSTprove command: {err}") from err
+    return {
+        "returncode": completed.returncode,
+        "seconds": round(time.perf_counter() - started, 6),
+        "stdout_excerpt": completed.stdout.strip()[:1000],
+        "stderr_excerpt": completed.stderr.strip()[:1000],
+    }
+
+
+def classify_failure(step: str | None, message: str) -> str:
+    lowered = message.lower()
+    if "range-check capacity" in lowered:
+        return "range_check_capacity"
+    if "not yet constrained" in lowered or "unconstrained" in lowered:
+        return "unconstrained_backend_op"
+    if "unsupported op type matmul" in lowered:
+        return "unsupported_witness_op"
+    if "unsupported" in lowered:
+        return "unsupported_backend_op"
+    if step is None:
+        return ""
+    return "external_tool_error"
+
+
+def _step_seconds(steps: list[dict[str, Any]], step: str) -> str:
+    for item in steps:
+        if item["step"] == step:
+            return f"{float(item['seconds']):.6f}"
+    return "NA"
+
+
+def run_fixture(fixture: str, *, jstprove_bin: pathlib.Path, work_dir: pathlib.Path) -> dict[str, Any]:
+    fixture_dir = work_dir / fixture
+    if fixture_dir.exists():
+        shutil.rmtree(fixture_dir)
+    fixture_dir.mkdir(parents=True)
+    sizes = write_fixture(fixture, fixture_dir)
+    model = fixture_dir / "model.msgpack"
+    witness = fixture_dir / "witness.msgpack"
+    proof = fixture_dir / "proof.msgpack"
+    onnx_path = fixture_dir / f"{fixture}.onnx"
+    input_path = fixture_dir / "input.msgpack"
+
+    steps: list[dict[str, Any]] = []
+    commands = [
+        ("compile", [str(jstprove_bin), "compile", "--model", str(onnx_path), "--output", str(model)]),
+        ("witness", [str(jstprove_bin), "witness", "--model", str(model), "--input", str(input_path), "--output", str(witness)]),
+        ("prove", [str(jstprove_bin), "prove", "--model", str(model), "--witness", str(witness), "--output", str(proof)]),
+        ("verify", [str(jstprove_bin), "--quiet", "verify", "--model", str(model), "--proof", str(proof), "--input", str(input_path)]),
+    ]
+    failed_step: str | None = None
+    failure_message = ""
+    for step, command in commands:
+        result = _run_command(command, cwd=fixture_dir)
+        result["step"] = step
+        result["argv"] = [pathlib.Path(part).name if str(jstprove_bin) == part else part for part in command]
+        steps.append(result)
+        if result["returncode"] != 0:
+            failed_step = step
+            failure_message = "\n".join(
+                item for item in (str(result.get("stderr_excerpt", "")), str(result.get("stdout_excerpt", ""))) if item
+            )
+            break
+
+    status = "GO" if failed_step is None else "NO_GO"
+    failure_kind = "" if status == "GO" else classify_failure(failed_step, failure_message)
+    catalog = {item["fixture"]: item for item in fixture_catalog()}[fixture]
+    gate = "GO_CHECKED_SMALL_SHAPE" if status == "GO" else f"NO_GO_{failure_kind.upper()}"
+    return {
+        "fixture": fixture,
+        "gate": gate,
+        "op_sequence": catalog["op_sequence"],
+        "transformer_relevance": catalog["transformer_relevance"],
+        "status": status,
+        "failed_step": failed_step or "",
+        "failure_kind": failure_kind,
+        "proof_bytes": proof.stat().st_size if proof.exists() else None,
+        "model_bytes": model.stat().st_size if model.exists() else None,
+        "onnx_bytes": sizes["onnx_bytes"],
+        "input_bytes": sizes["input_bytes"],
+        "prove_seconds": _step_seconds(steps, "prove"),
+        "verify_seconds": _step_seconds(steps, "verify"),
+        "primary_observation": catalog["primary_observation"],
+        "steps": steps,
+    }
+
+
+def run_shape_probe(*, jstprove_bin: pathlib.Path | None = None, work_dir: pathlib.Path | None = None) -> dict[str, Any]:
+    resolved_bin = jstprove_bin or _resolve_jstprove_binary()
+    raw_work_dir = work_dir or DEFAULT_WORK_DIR
+    raw_work_dir.mkdir(parents=True, exist_ok=True)
+    results = [
+        run_fixture(fixture, jstprove_bin=resolved_bin, work_dir=raw_work_dir) for fixture in EXPECTED_FIXTURE_ORDER
+    ]
+    return build_payload(results, jstprove_bin=resolved_bin, work_dir=raw_work_dir)
+
+
+def build_payload(results: list[dict[str, Any]], *, jstprove_bin: pathlib.Path, work_dir: pathlib.Path) -> dict[str, Any]:
+    go_results = [item for item in results if item["status"] == "GO"]
+    no_go_results = [item for item in results if item["status"] == "NO_GO"]
+    payload = {
+        "schema": SCHEMA,
+        "generated_at": _generated_at(),
+        "git_commit": _git_commit(),
+        "decision": DECISION,
+        "question": "Which tiny transformer-adjacent ONNX shapes does JSTprove/Remainder prove today?",
+        "jstprove": {
+            "upstream_commit": JSTPROVE_COMMIT,
+            "remainder_dependency_commit": REMAINDER_COMMIT,
+            "binary": str(jstprove_bin),
+        },
+        "work_dir": str(work_dir),
+        "fixture_catalog": fixture_catalog(),
+        "results": results,
+        "results_commitment": blake2b_commitment(results, "ptvm:zkai:jstprove-shape-results:v1"),
+        "conclusion": {
+            "go_count": len(go_results),
+            "no_go_count": len(no_go_results),
+            "go_transformer_adjacent_fixtures": [
+                item["fixture"] for item in go_results if item["fixture"] in EXPECTED_GO_TRANSFORMER_ADJACENT
+            ],
+            "paper_usage": "engineering_context_only_not_transformer_proof_or_performance_benchmark",
+            "interpretation": (
+                "JSTprove/Remainder can prove tiny projection, residual-add, and normalization-shaped fixtures, "
+                "but the checked Softmax, ReLU, and literal MatMul variants expose separate backend/operator blockers."
+            ),
+        },
+        "non_claims": [
+            "not a JSTprove security finding",
+            "not a full transformer proof",
+            "not a performance benchmark",
+            "not evidence that larger shapes remain small",
+            "not evidence that unsupported shapes are impossible in future JSTprove versions",
+            "not a Tablero result",
+        ],
+    }
+    validate_payload(payload)
+    return payload
+
+
+def validate_payload(payload: dict[str, Any]) -> None:
+    expected_fields = {
+        "schema",
+        "generated_at",
+        "git_commit",
+        "decision",
+        "question",
+        "jstprove",
+        "work_dir",
+        "fixture_catalog",
+        "results",
+        "results_commitment",
+        "conclusion",
+        "non_claims",
+    }
+    expected_conclusion_fields = {
+        "go_count",
+        "no_go_count",
+        "go_transformer_adjacent_fixtures",
+        "paper_usage",
+        "interpretation",
+    }
+    if set(payload) != expected_fields:
+        raise JstproveShapeProbeError("payload field set mismatch")
+    if payload["schema"] != SCHEMA:
+        raise JstproveShapeProbeError("schema drift")
+    if payload["decision"] != DECISION:
+        raise JstproveShapeProbeError("decision drift")
+    if payload["results_commitment"] != blake2b_commitment(payload["results"], "ptvm:zkai:jstprove-shape-results:v1"):
+        raise JstproveShapeProbeError("results commitment mismatch")
+    catalog_names = [item.get("fixture") for item in payload["fixture_catalog"]]
+    if catalog_names != list(EXPECTED_FIXTURE_ORDER):
+        raise JstproveShapeProbeError("fixture catalog drift")
+    result_names = [item.get("fixture") for item in payload["results"]]
+    if result_names != list(EXPECTED_FIXTURE_ORDER):
+        raise JstproveShapeProbeError("fixture result drift")
+
+    for result in payload["results"]:
+        fixture = result["fixture"]
+        if result.get("status") != EXPECTED_STATUS[fixture]:
+            raise JstproveShapeProbeError(f"{fixture} status drift")
+        if result["status"] == "GO":
+            if result.get("failed_step") or result.get("failure_kind"):
+                raise JstproveShapeProbeError(f"{fixture} GO failure metadata drift")
+            if not isinstance(result.get("proof_bytes"), int) or result["proof_bytes"] <= 0:
+                raise JstproveShapeProbeError(f"{fixture} proof size missing")
+            if result.get("gate") != "GO_CHECKED_SMALL_SHAPE":
+                raise JstproveShapeProbeError(f"{fixture} gate drift")
+        else:
+            if result.get("failure_kind") != EXPECTED_FAILURE_KIND[fixture]:
+                raise JstproveShapeProbeError(f"{fixture} failure kind drift")
+            if not str(result.get("gate", "")).startswith("NO_GO_"):
+                raise JstproveShapeProbeError(f"{fixture} gate drift")
+            if not result.get("failed_step"):
+                raise JstproveShapeProbeError(f"{fixture} missing failed step")
+
+    conclusion = payload["conclusion"]
+    if set(conclusion) != expected_conclusion_fields:
+        raise JstproveShapeProbeError("conclusion field set mismatch")
+    if conclusion["paper_usage"] != "engineering_context_only_not_transformer_proof_or_performance_benchmark":
+        raise JstproveShapeProbeError("paper usage overclaim")
+    if conclusion["go_count"] != 5 or conclusion["no_go_count"] != 3:
+        raise JstproveShapeProbeError("summary count drift")
+    if set(conclusion["go_transformer_adjacent_fixtures"]) != EXPECTED_GO_TRANSFORMER_ADJACENT:
+        raise JstproveShapeProbeError("transformer-adjacent GO drift")
+    required_non_claims = {
+        "not a JSTprove security finding",
+        "not a full transformer proof",
+        "not a performance benchmark",
+        "not a Tablero result",
+    }
+    if not required_non_claims.issubset(set(payload["non_claims"])):
+        raise JstproveShapeProbeError("non-claim drift")
+
+
+def rows_for_tsv(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for result in payload["results"]:
+        rows.append({column: result.get(column, "") for column in TSV_COLUMNS})
+    return rows
+
+
+def to_tsv(payload: dict[str, Any]) -> str:
+    out = io.StringIO()
+    writer = csv.DictWriter(out, fieldnames=TSV_COLUMNS, dialect="excel-tab", lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows_for_tsv(payload))
+    return out.getvalue()
+
+
+def _atomic_write_text(path: pathlib.Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
+            tmp.write(text)
+            tmp_path = pathlib.Path(tmp.name)
+        tmp_path.replace(path)
+    except OSError as err:
+        raise JstproveShapeProbeError(f"failed to write {path}: {err}") from err
+
+
+def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
+    validate_payload(payload)
+    if json_path is not None:
+        _atomic_write_text(json_path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if tsv_path is not None:
+        _atomic_write_text(tsv_path, to_tsv(payload))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jstprove-bin", type=pathlib.Path, help=f"path to jstprove-remainder; defaults to ${JSTPROVE_BIN_ENV} or PATH")
+    parser.add_argument("--work-dir", type=pathlib.Path, default=DEFAULT_WORK_DIR, help="temporary fixture/proof work directory")
+    parser.add_argument("--write-json", type=pathlib.Path, help="write checked JSON evidence")
+    parser.add_argument("--write-tsv", type=pathlib.Path, help="write checked TSV evidence")
+    parser.add_argument("--json", action="store_true", help="print JSON to stdout")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    binary = _resolve_jstprove_binary(str(args.jstprove_bin) if args.jstprove_bin else None)
+    payload = run_shape_probe(jstprove_bin=binary, work_dir=args.work_dir)
+    write_outputs(payload, args.write_json, args.write_tsv)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif args.write_json is None and args.write_tsv is None:
+        print(to_tsv(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zkai_jstprove_shape_probe.py
+++ b/scripts/zkai_jstprove_shape_probe.py
@@ -649,21 +649,17 @@ def softmax_source_probe(jstprove_bin: pathlib.Path) -> dict[str, Any]:
 def softmax_alternative_ref_probe(source_root: str) -> list[dict[str, Any]]:
     root = pathlib.Path(source_root) if source_root else None
     if root is None or not (root / ".git").exists():
-        return []
+        raise JstproveShapeProbeError(
+            "Softmax alternative refs require a local JSTprove git checkout; "
+            "use a jstprove-remainder binary built from a fetched JSTprove clone"
+        )
     rows: list[dict[str, Any]] = []
     for ref in SOFTMAX_ALTERNATIVE_REFS:
         commit = _git_output(root, ["rev-parse", "--verify", f"{ref}^{{commit}}"])
         if commit is None:
-            rows.append(
-                {
-                    "ref": ref,
-                    "commit": "unavailable",
-                    "status": "REF_NOT_AVAILABLE",
-                    "remainder_softmax_hits": [],
-                    "observation": "The alternative ref was not available in the local JSTprove checkout.",
-                }
+            raise JstproveShapeProbeError(
+                f"Softmax alternative ref {ref} missing locally; fetch origin heads/tags before checked probe run"
             )
-            continue
         grep = _git_output(root, ["grep", "-n", "Softmax\\|not yet constrained", ref, "--", ":(glob)*.rs"])
         lines = [] if grep is None else grep.splitlines()
         remainder_hits = []
@@ -935,6 +931,15 @@ def validate_payload(payload: dict[str, Any]) -> None:
             raise JstproveShapeProbeError("Softmax source hits missing")
     if [item.get("ref") for item in payload["softmax_alternative_ref_probe"]] != list(SOFTMAX_ALTERNATIVE_REFS):
         raise JstproveShapeProbeError("Softmax alternative ref probe drift")
+    missing_ref = next(
+        (item for item in payload["softmax_alternative_ref_probe"] if item.get("status") == "REF_NOT_AVAILABLE"),
+        None,
+    )
+    if missing_ref is not None:
+        raise JstproveShapeProbeError(
+            f"Softmax alternative ref {missing_ref.get('ref')} missing locally; "
+            "fetch origin heads/tags before checked probe run"
+        )
     for item in payload["softmax_alternative_ref_probe"]:
         if item.get("status") not in {
             "REMAINDER_SOFTMAX_STILL_REFUSED",


### PR DESCRIPTION
## Summary

Adds a production-grade JSTprove/Remainder shape probe for issue #360.

This PR records a bounded operator-support split over tiny ONNX fixtures:

- GO: `tiny_gemm`, `tiny_gemm_add`, `tiny_gemm_residual_add`, `tiny_gemm_layernorm`, `tiny_gemm_batchnorm`
- NO-GO: `tiny_gemm_relu` at the baseline magnitude due `range_check_capacity`
- NO-GO: `tiny_gemm_softmax` due `unconstrained_backend_op`
- NO-GO: `tiny_matmul_residual_add` due `unsupported_witness_op`

Review-driven exploration added before merge:

- `Gemm` dimension sweep at widths `1`, `2`, and `4`: all GO.
- ReLU magnitude sweep: baseline scale `1` NO-GO, scales `0.25`, `0.1`, `0.01`, and `0.001` GO.
- Softmax source probe: pinned JSTprove main refuses Remainder Softmax at proof construction; checked alternative refs `origin/main-b`, `refs/tags/v2.12.1`, and `origin/eliminate/relu-zero-delta-range-check` do not expose a constrained Remainder Softmax path.
- Reproducibility hardening: unique default work dir, explicit `--work-dir` for checked evidence, toolchain/dependency metadata in JSON, fail-closed checked-evidence test, and relative `--jstprove-bin` regression coverage.

The claim boundary is explicit: this is engineering context for proof-stack comparison, not a JSTprove security finding, not a performance benchmark, not a Tablero result, and not a full transformer proof.

Closes #360.
Follow-up operator-blocker exploration is tracked in #362.

## Evidence

- `docs/engineering/zkai-jstprove-shape-probe-2026-05-01.md`
- `docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.json`
- `docs/engineering/evidence/zkai-jstprove-shape-probe-2026-05.tsv`
- `scripts/zkai_jstprove_shape_probe.py`
- `scripts/tests/test_zkai_jstprove_shape_probe.py`

## Validation

```bash
python3 -m unittest scripts.tests.test_zkai_jstprove_shape_probe scripts.tests.test_zkai_jstprove_statement_envelope_benchmark
python3 -m py_compile scripts/zkai_jstprove_shape_probe.py scripts/tests/test_zkai_jstprove_shape_probe.py
ZKAI_JSTPROVE_REMAINDER_BIN=/tmp/jstprove-adapter-check/JSTprove/target/release/jstprove-remainder \
  /tmp/jstprove-adapter-check/onnx-venv/bin/python scripts/zkai_jstprove_shape_probe.py --json
python3 scripts/paper/paper_preflight.py --repo-root .
git diff --check
```

## Hardening

- Payload validation now rejects JSTprove commit drift, Remainder dependency drift, generator dependency drift, ONNX opset drift, stale exploration commitments, missing checked evidence, Softmax constrained-path overclaims, and known fixture status/failure-kind drift.
- The probe resolves relative JSTprove binaries before changing fixture `cwd`, preventing false subprocess failures.
- The default work root is per-run unique; checked evidence uses explicit `--work-dir` for stable reproduction.
- New issue #362 records the remaining interesting research route: ReLU magnitude/range discipline and Softmax constrained-backend support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design specifications with validation findings and operator compatibility results.

* **Tests**
  * Added comprehensive test infrastructure and validation tooling for system behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->