### PR TITLE
[codex] Add d128 layerwise comparator target gate

### DIFF
--- a/docs/engineering/design/README.md
+++ b/docs/engineering/design/README.md
@@ -29,5 +29,6 @@ Tablero itself proves agents, reasoning, tool truth, or policy semantics.
 - [d64 block receipt composition gate](../zkai-d64-block-receipt-composition-gate-2026-05-02.md)
 - [d64 recursive/PCD aggregation feasibility gate](../zkai-d64-recursive-pcd-aggregation-feasibility-2026-05-02.md)
 - [d64 nested-verifier backend spike gate](../zkai-d64-nested-verifier-backend-spike-2026-05-02.md)
+- [d128 layerwise comparator target gate](../zkai-d128-layerwise-comparator-target-2026-05-02.md)
 - [Agent-step zkAI Stwo composition gate](../agent-step-zkai-stwo-composition-gate-2026-04-29.md)
 - [Agent-step model subreceipt callback gate](../agent-step-model-subreceipt-callback-gate-2026-04-29.md)

--- a/docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json
+++ b/docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json
@@ -1,6 +1,6 @@
 {
   "all_mutations_rejected": true,
-  "case_count": 16,
+  "case_count": 19,
   "cases": [
     {
       "baseline_result": "BOUNDED_NO_GO",
@@ -43,6 +43,33 @@
       "error": "target spec mismatch",
       "mutated_accepted": false,
       "mutation": "target_linear_mul_estimate_drift",
+      "rejected": true,
+      "rejection_layer": "target_spec",
+      "surface": "target_spec"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "target spec mismatch",
+      "mutated_accepted": false,
+      "mutation": "target_residual_row_count_drift",
+      "rejected": true,
+      "rejection_layer": "target_spec",
+      "surface": "target_spec"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "target spec mismatch",
+      "mutated_accepted": false,
+      "mutation": "target_scale_decision_promoted_to_go",
+      "rejected": true,
+      "rejection_layer": "target_spec",
+      "surface": "target_spec"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "target spec mismatch",
+      "mutated_accepted": false,
+      "mutation": "target_d64_slice_generalization_overclaim",
       "rejected": true,
       "rejection_layer": "target_spec",
       "surface": "target_spec"
@@ -233,6 +260,7 @@
   "local_proof_result": "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
   "local_proof_status": {
     "blocked_before_metrics": true,
+    "d64_to_d128_scale_decision": "NO_GO_CURRENT_STWO_SURFACE_FOR_D128_PROOF_GO_TARGET_SPEC_ONLY",
     "first_blocker": "current checked Stwo proof surface is width-4, fixture-gated, and not a d128 RMSNorm-SwiGLU proof",
     "inherited_feasibility_row": {
       "blockers": [
@@ -277,6 +305,7 @@
     "proof_artifact_exists": false,
     "proof_size_bytes": null,
     "result": "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
+    "scale_decision_rationale": "the d64 slice interfaces generalize structurally, but the current Stwo-native proof surface does not scale to a d128 proof because it is fixture-gated and lacks a parameterized vector-block AIR/verifier handle",
     "statement_relabeling_suite_exists": false,
     "verifier_handle_exists": false,
     "verifier_time_ms": null
@@ -309,56 +338,71 @@
     },
     {
       "index": 5,
-      "mutation": "target_commitment_drift",
+      "mutation": "target_residual_row_count_drift",
       "surface": "target_spec"
     },
     {
       "index": 6,
+      "mutation": "target_scale_decision_promoted_to_go",
+      "surface": "target_spec"
+    },
+    {
+      "index": 7,
+      "mutation": "target_d64_slice_generalization_overclaim",
+      "surface": "target_spec"
+    },
+    {
+      "index": 8,
+      "mutation": "target_commitment_drift",
+      "surface": "target_spec"
+    },
+    {
+      "index": 9,
       "mutation": "local_proof_result_changed_to_go",
       "surface": "local_proof_status"
     },
     {
-      "index": 7,
+      "index": 10,
       "mutation": "local_proof_size_metric_smuggled",
       "surface": "local_proof_status"
     },
     {
-      "index": 8,
+      "index": 11,
       "mutation": "local_verify_time_metric_smuggled",
       "surface": "local_proof_status"
     },
     {
-      "index": 9,
+      "index": 12,
       "mutation": "nanozk_source_row_verify_seconds_drift",
       "surface": "source_context"
     },
     {
-      "index": 10,
+      "index": 13,
       "mutation": "nanozk_source_context_promoted_to_matched",
       "surface": "source_context"
     },
     {
-      "index": 11,
+      "index": 14,
       "mutation": "external_adapter_result_changed_to_go",
       "surface": "external_adapter_status"
     },
     {
-      "index": 12,
+      "index": 15,
       "mutation": "deepprove_public_artifact_overclaim",
       "surface": "external_adapter_status"
     },
     {
-      "index": 13,
+      "index": 16,
       "mutation": "nanozk_public_verifier_overclaim",
       "surface": "external_adapter_status"
     },
     {
-      "index": 14,
+      "index": 17,
       "mutation": "non_claim_removed",
       "surface": "claim_boundary"
     },
     {
-      "index": 15,
+      "index": 18,
       "mutation": "result_changed_to_go",
       "surface": "parser_or_schema"
     }
@@ -411,16 +455,18 @@
     }
   },
   "summary": {
+    "d64_to_d128_scale_decision": "NO_GO_CURRENT_STWO_SURFACE_FOR_D128_PROOF_GO_TARGET_SPEC_ONLY",
     "decision": "NO_GO_D128_LAYERWISE_PROOF_ARTIFACT_MISSING",
     "external_adapter_result": "NO_GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK",
     "first_blocker": "the d128 RMSNorm-SwiGLU-residual receipt target is pinned, but the repository does not contain a local d128 proof artifact, verifier handle, or relabeling suite",
     "local_proof_result": "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
-    "mutation_cases": 16,
-    "mutations_rejected": 16,
+    "mutation_cases": 19,
+    "mutations_rejected": 19,
     "result": "BOUNDED_NO_GO",
     "source_context_result": "GO_SOURCE_BACKED_PUBLIC_LAYERWISE_CONTEXT",
-    "target_commitment": "blake2b-256:f2660bd0371cd242472a5b9fb6939067f21ca0af48cbfb2ce6ac78b8f5ee8206",
+    "target_commitment": "blake2b-256:d6a6ce9312fa7afa87899bea33f060336d79e215de95a64af4b7c9161df0ec18",
     "target_estimated_linear_muls": 196608,
+    "target_estimated_residual_rows": 128,
     "target_ff_dim": 512,
     "target_result": "GO_D128_LAYERWISE_COMPARATOR_TARGET_SPEC",
     "target_width": 128
@@ -429,9 +475,55 @@
   "target_spec": {
     "activation": "SwiGLU",
     "comparator_target_kind": "d128-layerwise-rmsnorm-swiglu-residual-receipt",
+    "d64_slice_generalization": [
+      {
+        "blocked_on": "no local d128 RMSNorm proof artifact or verifier handle",
+        "d128_rows": 128,
+        "d64_rows": 64,
+        "decision": "GENERALIZES_STRUCTURALLY_WITH_WIDTH_PARAMETER",
+        "slice": "rmsnorm_public_rows"
+      },
+      {
+        "blocked_on": "needs a d128 RMSNorm output commitment to bridge",
+        "d128_rows": 1,
+        "d64_rows": 1,
+        "decision": "GENERALIZES_STRUCTURALLY_AS_COMMITMENT_BRIDGE",
+        "slice": "rmsnorm_projection_bridge"
+      },
+      {
+        "blocked_on": "current proof generator is fixture-gated and not a parameterized vector-block AIR",
+        "d128_linear_muls": 131072,
+        "d64_linear_muls": 32768,
+        "decision": "GENERALIZES_OPERATOR_FAMILY_BUT_NOT_CURRENT_PROOF_SURFACE",
+        "slice": "gate_value_projection"
+      },
+      {
+        "blocked_on": "no d128 activation/range proof artifact or relabeling suite",
+        "d128_rows": 512,
+        "d64_rows": 256,
+        "decision": "GENERALIZES_OPERATOR_FAMILY_BUT_REQUIRES_D128_RANGE_LOOKUP_SURFACE",
+        "slice": "activation_swiglu"
+      },
+      {
+        "blocked_on": "current proof generator is fixture-gated and not a parameterized vector-block AIR",
+        "d128_linear_muls": 65536,
+        "d64_linear_muls": 16384,
+        "decision": "GENERALIZES_OPERATOR_FAMILY_BUT_NOT_CURRENT_PROOF_SURFACE",
+        "slice": "down_projection"
+      },
+      {
+        "blocked_on": "no local d128 residual-add proof artifact or verifier handle",
+        "d128_rows": 128,
+        "d64_rows": 64,
+        "decision": "GENERALIZES_STRUCTURALLY_WITH_WIDTH_PARAMETER",
+        "slice": "residual_add"
+      }
+    ],
+    "d64_to_d128_scale_decision": "NO_GO_CURRENT_STWO_SURFACE_FOR_D128_PROOF_GO_TARGET_SPEC_ONLY",
     "estimated_activation_rows": 512,
     "estimated_linear_muls": 196608,
     "estimated_norm_rows": 1,
+    "estimated_residual_rows": 128,
     "ff_dim": 512,
     "local_feasibility_blockers": [
       {
@@ -479,8 +571,14 @@
       "proof_system_version"
     ],
     "residual": true,
+    "row_operator_pressure": {
+      "linear_projection_multiplications": 196608,
+      "residual_add_rows": 128,
+      "rmsnorm_rows": 1,
+      "swiglu_activation_rows": 512
+    },
     "statement_kind": "transformer-block",
-    "target_commitment": "blake2b-256:f2660bd0371cd242472a5b9fb6939067f21ca0af48cbfb2ce6ac78b8f5ee8206",
+    "target_commitment": "blake2b-256:d6a6ce9312fa7afa87899bea33f060336d79e215de95a64af4b7c9161df0ec18",
     "target_id": "rmsnorm-swiglu-residual-d128-v1",
     "width": 128
   },

--- a/docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json
+++ b/docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json
@@ -1,0 +1,494 @@
+{
+  "all_mutations_rejected": true,
+  "case_count": 16,
+  "cases": [
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "matched source evidence mismatch",
+      "mutated_accepted": false,
+      "mutation": "matched_source_file_hash_drift",
+      "rejected": true,
+      "rejection_layer": "source_evidence",
+      "surface": "source_evidence"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "external source evidence mismatch",
+      "mutated_accepted": false,
+      "mutation": "external_source_payload_hash_drift",
+      "rejected": true,
+      "rejection_layer": "source_evidence",
+      "surface": "source_evidence"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "target spec mismatch",
+      "mutated_accepted": false,
+      "mutation": "target_width_drift",
+      "rejected": true,
+      "rejection_layer": "target_spec",
+      "surface": "target_spec"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "target spec mismatch",
+      "mutated_accepted": false,
+      "mutation": "target_binding_removed",
+      "rejected": true,
+      "rejection_layer": "target_spec",
+      "surface": "target_spec"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "target spec mismatch",
+      "mutated_accepted": false,
+      "mutation": "target_linear_mul_estimate_drift",
+      "rejected": true,
+      "rejection_layer": "target_spec",
+      "surface": "target_spec"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "target spec mismatch",
+      "mutated_accepted": false,
+      "mutation": "target_commitment_drift",
+      "rejected": true,
+      "rejection_layer": "target_spec",
+      "surface": "target_spec"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "local proof result mismatch",
+      "mutated_accepted": false,
+      "mutation": "local_proof_result_changed_to_go",
+      "rejected": true,
+      "rejection_layer": "local_proof_status",
+      "surface": "local_proof_status"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "local d128 proof-size metric supplied before proof exists",
+      "mutated_accepted": false,
+      "mutation": "local_proof_size_metric_smuggled",
+      "rejected": true,
+      "rejection_layer": "local_proof_status",
+      "surface": "local_proof_status"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "local d128 verifier-time metric supplied before proof exists",
+      "mutated_accepted": false,
+      "mutation": "local_verify_time_metric_smuggled",
+      "rejected": true,
+      "rejection_layer": "local_proof_status",
+      "surface": "local_proof_status"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "source-backed context mismatch",
+      "mutated_accepted": false,
+      "mutation": "nanozk_source_row_verify_seconds_drift",
+      "rejected": true,
+      "rejection_layer": "source_context",
+      "surface": "source_context"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "source-backed context mismatch",
+      "mutated_accepted": false,
+      "mutation": "nanozk_source_context_promoted_to_matched",
+      "rejected": true,
+      "rejection_layer": "source_context",
+      "surface": "source_context"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "external adapter status mismatch",
+      "mutated_accepted": false,
+      "mutation": "external_adapter_result_changed_to_go",
+      "rejected": true,
+      "rejection_layer": "external_adapter_status",
+      "surface": "external_adapter_status"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "external adapter status mismatch",
+      "mutated_accepted": false,
+      "mutation": "deepprove_public_artifact_overclaim",
+      "rejected": true,
+      "rejection_layer": "external_adapter_status",
+      "surface": "external_adapter_status"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "external adapter status mismatch",
+      "mutated_accepted": false,
+      "mutation": "nanozk_public_verifier_overclaim",
+      "rejected": true,
+      "rejection_layer": "external_adapter_status",
+      "surface": "external_adapter_status"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "non-claims mismatch",
+      "mutated_accepted": false,
+      "mutation": "non_claim_removed",
+      "rejected": true,
+      "rejection_layer": "claim_boundary",
+      "surface": "claim_boundary"
+    },
+    {
+      "baseline_result": "BOUNDED_NO_GO",
+      "error": "result mismatch",
+      "mutated_accepted": false,
+      "mutation": "result_changed_to_go",
+      "rejected": true,
+      "rejection_layer": "parser_or_schema",
+      "surface": "parser_or_schema"
+    }
+  ],
+  "decision": "NO_GO_D128_LAYERWISE_PROOF_ARTIFACT_MISSING",
+  "external_adapter_result": "NO_GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK",
+  "external_adapter_status": {
+    "paper_usage": "source_backed_context_only_not_empirical_adapter_row",
+    "result": "NO_GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK",
+    "systems": {
+      "DeepProve-1": {
+        "adapter_gate": "NO_GO_PUBLIC_GPT2_ARTIFACT_NOT_REPRODUCIBLE",
+        "baseline_verification_reproducible": false,
+        "claim_scope": "reported full GPT-2 inference proof and transformer graph/layer support",
+        "next_action": "Revisit if Lagrange publishes a DeepProve-1 proof package with proof bytes, verifier inputs, model/input/output commitments, and a runnable verifier command.",
+        "primary_blocker": "The public deep-prove repository exposes research code and MLP/CNN benchmark paths, but this probe did not find a public DeepProve-1 GPT-2 proof artifact plus verifier test vector matching the blog claim.",
+        "public_proof_artifact_available": false,
+        "public_verifier_available": false,
+        "relabeling_benchmark_run": false,
+        "source_inspection": {
+          "checked_commit": "7d21c35e5e1cb006e413f4a9676333e9e1506a87",
+          "clone_command": "git clone --depth 1 https://github.com/Lagrange-Labs/deep-prove.git",
+          "deep_prove_1_gpt2_artifacts_found": [],
+          "nearby_llm_file": "zkml/assets/scripts/llms/gpt2_internal.py",
+          "public_repo_readme_scope": "MLP/CNN public benchmark path; zkml README says supported layers are dense, ReLU, maxpool, and convolution",
+          "why_nearby_file_is_insufficient": "The script dumps GPT-2 internals, but it is not a public proof artifact, verification key, or reproducible DeepProve-1 proof verifier input."
+        },
+        "sources": [
+          {
+            "label": "DeepProve-1 blog",
+            "url": "https://lagrange.dev/blog/deepprove-1",
+            "used_for": "claim scope and transformer-feature context"
+          },
+          {
+            "checked_commit": "7d21c35e5e1cb006e413f4a9676333e9e1506a87",
+            "label": "deep-prove public repository",
+            "url": "https://github.com/Lagrange-Labs/deep-prove",
+            "used_for": "public artifact and verifier-surface inspection"
+          }
+        ],
+        "system": "DeepProve-1"
+      },
+      "NANOZK": {
+        "adapter_gate": "NO_GO_NO_PUBLIC_VERIFIER_OR_PROOF_ARTIFACT",
+        "baseline_verification_reproducible": false,
+        "claim_scope": "reported layerwise constant-size transformer proofs up to d=128",
+        "next_action": "Revisit if a NANOZK repository, artifact bundle, or verifier command is published; until then use NANOZK only as source-backed field context.",
+        "primary_blocker": "The arXiv paper/source exposes the method, theorem framing, and reported numbers, but this probe did not find a public verifier implementation or proof artifact for baseline acceptance and relabeling mutations.",
+        "public_proof_artifact_available": false,
+        "public_verifier_available": false,
+        "relabeling_benchmark_run": false,
+        "source_inspection": {
+          "direct_code_links_found": [
+            "https://github.com/zkonduit/ezkl",
+            "https://github.com/zcash/halo2"
+          ],
+          "download_command": "curl -fsSL https://arxiv.org/e-print/2603.18046 -o nanozk-src.tar",
+          "source_files": [
+            "00README.json",
+            "fancyhdr.sty",
+            "iclr2026_conference.bst",
+            "iclr2026_conference.sty",
+            "main.bbl",
+            "main.tex",
+            "natbib.sty",
+            "references.bib"
+          ],
+          "source_sha256": "c505715f18d2bbb8dc01852a764b171984eb51f54a74d03790e29294e78ef2b4",
+          "why_direct_code_links_are_insufficient": "The source links dependency projects, not a NANOZK proof artifact, verifier command, or benchmark reproduction package."
+        },
+        "sources": [
+          {
+            "label": "NANOZK arXiv page",
+            "url": "https://arxiv.org/abs/2603.18046",
+            "used_for": "claim scope, reported d=128 proof size, and verification time"
+          },
+          {
+            "label": "NANOZK arXiv source",
+            "sha256": "c505715f18d2bbb8dc01852a764b171984eb51f54a74d03790e29294e78ef2b4",
+            "url": "https://arxiv.org/e-print/2603.18046",
+            "used_for": "artifact-link inspection"
+          }
+        ],
+        "system": "NANOZK"
+      }
+    }
+  },
+  "local_proof_result": "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
+  "local_proof_status": {
+    "blocked_before_metrics": true,
+    "first_blocker": "current checked Stwo proof surface is width-4, fixture-gated, and not a d128 RMSNorm-SwiGLU proof",
+    "inherited_feasibility_row": {
+      "blockers": [
+        {
+          "current": 36,
+          "id": "proof_claim_d_model_mismatch",
+          "required": 128,
+          "why_it_matters": "the checked proof public claim is not a d64/d128 transformer block claim"
+        },
+        {
+          "current": 4,
+          "id": "statement_profile_width_mismatch",
+          "required": 128,
+          "why_it_matters": "the statement receipt binds a width-4 profile, not a matched public benchmark width"
+        },
+        {
+          "current_mul_memory_ops": 7,
+          "estimated_required_linear_muls": 196608,
+          "id": "instruction_surface_too_small_for_swiglu",
+          "why_it_matters": "a matched SwiGLU block needs gate, value, and down projections over d x ff_dim matrices"
+        },
+        {
+          "id": "proof_generator_fixture_allowlist",
+          "pinned_fixture_version": "stwo-phase10-linear-block-v4-with-lookup",
+          "proof_backend_version": "stwo-phase10-linear-block-v4-with-lookup",
+          "why_it_matters": "the current Stwo generator is scoped to shipped fixtures/decoding families, not arbitrary matched MLP programs"
+        }
+      ],
+      "current_d_model": 36,
+      "current_logical_width": 4,
+      "current_mul_memory_ops": 7,
+      "mul_gap_factor": 28086.85714285714,
+      "reason": "current checked Stwo proof surface is a bounded statement-binding fixture, not a matched d64/d128 RMSNorm-SwiGLU proof",
+      "status": "NO_GO_CURRENT_SURFACE",
+      "target_activation_rows": 512,
+      "target_estimated_linear_muls": 196608,
+      "target_ff_dim": 512,
+      "target_id": "rmsnorm-swiglu-residual-d128-v1",
+      "target_norm_rows": 1,
+      "target_width": 128
+    },
+    "proof_artifact_exists": false,
+    "proof_size_bytes": null,
+    "result": "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
+    "statement_relabeling_suite_exists": false,
+    "verifier_handle_exists": false,
+    "verifier_time_ms": null
+  },
+  "mutation_inventory": [
+    {
+      "index": 0,
+      "mutation": "matched_source_file_hash_drift",
+      "surface": "source_evidence"
+    },
+    {
+      "index": 1,
+      "mutation": "external_source_payload_hash_drift",
+      "surface": "source_evidence"
+    },
+    {
+      "index": 2,
+      "mutation": "target_width_drift",
+      "surface": "target_spec"
+    },
+    {
+      "index": 3,
+      "mutation": "target_binding_removed",
+      "surface": "target_spec"
+    },
+    {
+      "index": 4,
+      "mutation": "target_linear_mul_estimate_drift",
+      "surface": "target_spec"
+    },
+    {
+      "index": 5,
+      "mutation": "target_commitment_drift",
+      "surface": "target_spec"
+    },
+    {
+      "index": 6,
+      "mutation": "local_proof_result_changed_to_go",
+      "surface": "local_proof_status"
+    },
+    {
+      "index": 7,
+      "mutation": "local_proof_size_metric_smuggled",
+      "surface": "local_proof_status"
+    },
+    {
+      "index": 8,
+      "mutation": "local_verify_time_metric_smuggled",
+      "surface": "local_proof_status"
+    },
+    {
+      "index": 9,
+      "mutation": "nanozk_source_row_verify_seconds_drift",
+      "surface": "source_context"
+    },
+    {
+      "index": 10,
+      "mutation": "nanozk_source_context_promoted_to_matched",
+      "surface": "source_context"
+    },
+    {
+      "index": 11,
+      "mutation": "external_adapter_result_changed_to_go",
+      "surface": "external_adapter_status"
+    },
+    {
+      "index": 12,
+      "mutation": "deepprove_public_artifact_overclaim",
+      "surface": "external_adapter_status"
+    },
+    {
+      "index": 13,
+      "mutation": "nanozk_public_verifier_overclaim",
+      "surface": "external_adapter_status"
+    },
+    {
+      "index": 14,
+      "mutation": "non_claim_removed",
+      "surface": "claim_boundary"
+    },
+    {
+      "index": 15,
+      "mutation": "result_changed_to_go",
+      "surface": "parser_or_schema"
+    }
+  ],
+  "non_claims": [
+    "not a local d128 proof result",
+    "not a matched NANOZK benchmark",
+    "not a DeepProve-1 adapter benchmark",
+    "not evidence that NANOZK or DeepProve-1 are insecure",
+    "not full transformer inference",
+    "not proof-size or verifier-time evidence for this repository"
+  ],
+  "result": "BOUNDED_NO_GO",
+  "schema": "zkai-d128-layerwise-comparator-target-v1",
+  "source_backed_context": {
+    "NANOZK": {
+      "backend_family": "Halo2 IPA SNARK + lookups",
+      "claim_boundary": "source-backed compact/layerwise context only; not a matched local benchmark",
+      "model_or_dims": "Transformer models up to d=128",
+      "notes": "Abstract reports constant-size layer proofs of 5.5KB with 24ms verification time; use only against the repo's compact-handoff row as narrow compact-object calibration, explicitly not as a matched workload benchmark.",
+      "proof_size_reported": "5.5 KB",
+      "source_kind": "arxiv",
+      "source_locator": "Abstract",
+      "source_url": "https://arxiv.org/abs/2603.18046",
+      "system": "NANOZK",
+      "verify_seconds": "0.024",
+      "workload_label": "Layer proof",
+      "workload_scope": "Per-layer compact verifier object"
+    }
+  },
+  "source_context_result": "GO_SOURCE_BACKED_PUBLIC_LAYERWISE_CONTEXT",
+  "source_evidence": {
+    "external_adapter_feasibility": {
+      "decision": "NO_GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK",
+      "file_sha256": "4b20943c9bf09722744a11d2d18b05e6da1d30ea2d205d864bae2dc864c0dee3",
+      "path": "docs/engineering/evidence/zkai-deepprove-nanozk-adapter-feasibility-2026-05.json",
+      "payload_sha256": "23a9602af324c34513b76e9c12d1ddef438523ab00496ee2a0e26ec34022bf4b",
+      "schema": "zkai-deepprove-nanozk-adapter-feasibility-v1"
+    },
+    "matched_feasibility": {
+      "decision": "NO_GO_CURRENT_STWO_PROOF_SURFACE",
+      "file_sha256": "2005f04ce1ba4d51c5cf7122be624116c850fcd10b9c4a010955d137733dc42c",
+      "path": "docs/engineering/evidence/zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json",
+      "payload_sha256": "d3eed2829e423372df0f8dd01e488402a20cc7c5e28ab03573d70a9074724034",
+      "schema": "zkai-matched-rmsnorm-swiglu-block-feasibility-v1"
+    },
+    "published_zkml_numbers": {
+      "file_sha256": "aa16aa98493ecf9f984d238875890c81b4525ebde21463b76010c92f6767390b",
+      "path": "docs/paper/evidence/published-zkml-numbers-2026-04.tsv"
+    }
+  },
+  "summary": {
+    "decision": "NO_GO_D128_LAYERWISE_PROOF_ARTIFACT_MISSING",
+    "external_adapter_result": "NO_GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK",
+    "first_blocker": "the d128 RMSNorm-SwiGLU-residual receipt target is pinned, but the repository does not contain a local d128 proof artifact, verifier handle, or relabeling suite",
+    "local_proof_result": "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
+    "mutation_cases": 16,
+    "mutations_rejected": 16,
+    "result": "BOUNDED_NO_GO",
+    "source_context_result": "GO_SOURCE_BACKED_PUBLIC_LAYERWISE_CONTEXT",
+    "target_commitment": "blake2b-256:f2660bd0371cd242472a5b9fb6939067f21ca0af48cbfb2ce6ac78b8f5ee8206",
+    "target_estimated_linear_muls": 196608,
+    "target_ff_dim": 512,
+    "target_result": "GO_D128_LAYERWISE_COMPARATOR_TARGET_SPEC",
+    "target_width": 128
+  },
+  "target_result": "GO_D128_LAYERWISE_COMPARATOR_TARGET_SPEC",
+  "target_spec": {
+    "activation": "SwiGLU",
+    "comparator_target_kind": "d128-layerwise-rmsnorm-swiglu-residual-receipt",
+    "estimated_activation_rows": 512,
+    "estimated_linear_muls": 196608,
+    "estimated_norm_rows": 1,
+    "ff_dim": 512,
+    "local_feasibility_blockers": [
+      {
+        "current": 36,
+        "id": "proof_claim_d_model_mismatch",
+        "required": 128,
+        "why_it_matters": "the checked proof public claim is not a d64/d128 transformer block claim"
+      },
+      {
+        "current": 4,
+        "id": "statement_profile_width_mismatch",
+        "required": 128,
+        "why_it_matters": "the statement receipt binds a width-4 profile, not a matched public benchmark width"
+      },
+      {
+        "current_mul_memory_ops": 7,
+        "estimated_required_linear_muls": 196608,
+        "id": "instruction_surface_too_small_for_swiglu",
+        "why_it_matters": "a matched SwiGLU block needs gate, value, and down projections over d x ff_dim matrices"
+      },
+      {
+        "id": "proof_generator_fixture_allowlist",
+        "pinned_fixture_version": "stwo-phase10-linear-block-v4-with-lookup",
+        "proof_backend_version": "stwo-phase10-linear-block-v4-with-lookup",
+        "why_it_matters": "the current Stwo generator is scoped to shipped fixtures/decoding families, not arbitrary matched MLP programs"
+      }
+    ],
+    "local_feasibility_status": "NO_GO_CURRENT_SURFACE",
+    "model_id": "urn:zkai:ptvm:rmsnorm-swiglu-residual-d128-v1",
+    "normalization": "RMSNorm",
+    "required_proof_backend_version": "stwo-rmsnorm-swiglu-residual-d128-v1",
+    "required_statement_bindings": [
+      "model_artifact_commitment",
+      "model_config_commitment",
+      "weight_commitment",
+      "input_activation_commitment",
+      "output_activation_commitment",
+      "normalization_config_commitment",
+      "activation_lookup_commitment",
+      "public_instance_commitment",
+      "proof_commitment",
+      "verifying_key_commitment",
+      "setup_commitment",
+      "verifier_domain",
+      "proof_system_version"
+    ],
+    "residual": true,
+    "statement_kind": "transformer-block",
+    "target_commitment": "blake2b-256:f2660bd0371cd242472a5b9fb6939067f21ca0af48cbfb2ce6ac78b8f5ee8206",
+    "target_id": "rmsnorm-swiglu-residual-d128-v1",
+    "width": 128
+  },
+  "validation_commands": [
+    "just gate-fast",
+    "python3 scripts/zkai_d128_layerwise_comparator_target_gate.py --write-json docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json --write-tsv docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_d128_layerwise_comparator_target_gate",
+    "python3 scripts/paper/paper_preflight.py --repo-root .",
+    "just gate"
+  ]
+}

--- a/docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.tsv
@@ -1,0 +1,5 @@
+surface	status	width	source	prove_seconds	verify_seconds	proof_size_reported	claim_boundary	blocker
+local_d128_target_spec	GO_D128_LAYERWISE_COMPARATOR_TARGET_SPEC	128	local target gate	NA	NA	NA	statement target only	NA
+local_d128_proof_artifact	NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING	128	local Stwo surface	NA	NA	NA	no local d128 proof metrics before artifact exists	current checked Stwo proof surface is width-4, fixture-gated, and not a d128 RMSNorm-SwiGLU proof
+nanozk_d128_source_context	GO_SOURCE_BACKED_PUBLIC_LAYERWISE_CONTEXT	128	https://arxiv.org/abs/2603.18046	NA	0.024	5.5 KB	source-backed compact/layerwise context only; not a matched local benchmark	not locally reproduced
+deepprove_nanozk_adapter_context	NO_GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK	128	source_backed_context_only_not_empirical_adapter_row	NA	NA	NA	source-backed context only, not empirical adapter row	public proof artifact plus verifier inputs unavailable for this adapter benchmark

--- a/docs/engineering/zkai-d128-layerwise-comparator-target-2026-05-02.md
+++ b/docs/engineering/zkai-d128-layerwise-comparator-target-2026-05-02.md
@@ -1,0 +1,137 @@
+# d128 layerwise comparator target gate - 2026-05-02
+
+## Question
+
+Can the repository define a matched `d=128` transformer-block receipt target
+that can be compared against public layerwise zkML systems without claiming a
+local `d=128` proof?
+
+The gate separates three claims:
+
+- target-shape specification;
+- local proof artifact availability;
+- source-backed public context.
+
+## Decision
+
+**GO for the comparator target spec. Bounded NO-GO for local `d=128` proof
+evidence.**
+
+This is not a benchmark. It is a checked target definition and an anti-overclaim
+gate: the repository can now name the `d=128` RMSNorm-SwiGLU-residual receipt it
+would need to prove, but it cannot report local proof size, verifier time, or
+relabeling resistance for that target until a proof artifact exists.
+
+## Result
+
+| Field | Value |
+| --- | --- |
+| Decision | `NO_GO_D128_LAYERWISE_PROOF_ARTIFACT_MISSING` |
+| Result | `BOUNDED_NO_GO` |
+| Target result | `GO_D128_LAYERWISE_COMPARATOR_TARGET_SPEC` |
+| Local proof result | `NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING` |
+| Source context result | `GO_SOURCE_BACKED_PUBLIC_LAYERWISE_CONTEXT` |
+| External adapter result | `NO_GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK` |
+| Target width | `128` |
+| Target FF dimension | `512` |
+| Estimated linear multiplications | `196608` |
+| Target commitment | `blake2b-256:f2660bd0371cd242472a5b9fb6939067f21ca0af48cbfb2ce6ac78b8f5ee8206` |
+| Mutation checks | `16 / 16` rejected |
+
+## Target shape
+
+The target is a `d=128` RMSNorm-SwiGLU-residual receipt:
+
+- statement kind: `transformer-block`;
+- normalization: `RMSNorm`;
+- activation: `SwiGLU`;
+- residual: `true`;
+- hidden width: `128`;
+- FF dimension: `512`;
+- required backend version:
+  `stwo-rmsnorm-swiglu-residual-d128-v1`.
+
+The required statement bindings include model, config, weights, input
+activation, output activation, lookup, public instance, proof, verifying key,
+setup, verifier domain, and proof-system version commitments.
+
+## Exact blocker
+
+The first blocker is:
+
+> the d128 RMSNorm-SwiGLU-residual receipt target is pinned, but the repository
+> does not contain a local d128 proof artifact, verifier handle, or relabeling
+> suite
+
+The inherited local-surface blockers are:
+
+- the checked proof claim is not a `d=64` or `d=128` transformer-block claim;
+- the checked statement profile is width `4`, not width `128`;
+- a matched SwiGLU block needs gate, value, and down projections over
+  `d x ff_dim` matrices;
+- the current Stwo generator is fixture-gated and not an arbitrary matched MLP
+  proof generator.
+
+## Source-backed context
+
+The gate uses the checked public zkML numbers table as context only. Public
+NANOZK material reports a `5.5 KB`, `24 ms` verifier-facing layer proof for
+transformer models up to `d=128`.
+
+That row is explicitly **not** treated as:
+
+- a matched local benchmark;
+- a local reproduction;
+- an adapter benchmark;
+- evidence about this repository's proof size or verifier time.
+
+## External adapter status
+
+The DeepProve-1 / NANOZK adapter probe remains a NO-GO for empirical relabeling
+adapter benchmarking because this repository does not have the public proof
+artifact plus verifier input bundle needed to run the same statement-envelope
+mutation tests against those systems.
+
+## Metrics policy
+
+No local proof-size, verifier-time, proof-generation-time, or relabeling-resistance
+metric is reported for the `d=128` target. Those metrics are blocked until a
+local proof artifact, verifier handle, and mutation suite exist.
+
+## Non-claims
+
+This result does **not** claim:
+
+- a local `d=128` proof result;
+- a matched NANOZK benchmark;
+- a DeepProve-1 adapter benchmark;
+- a soundness finding against NANOZK or DeepProve-1;
+- full transformer inference;
+- proof-size or verifier-time evidence for this repository.
+
+## Evidence
+
+- JSON:
+  `docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json`
+- TSV:
+  `docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.tsv`
+- Script:
+  `scripts/zkai_d128_layerwise_comparator_target_gate.py`
+- Tests:
+  `scripts/tests/test_zkai_d128_layerwise_comparator_target_gate.py`
+
+## Reproduce
+
+```bash
+just gate-fast
+
+python3 scripts/zkai_d128_layerwise_comparator_target_gate.py \
+  --write-json docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.tsv
+
+python3 -m unittest scripts.tests.test_zkai_d128_layerwise_comparator_target_gate
+
+python3 scripts/paper/paper_preflight.py --repo-root .
+
+just gate
+```

--- a/docs/engineering/zkai-d128-layerwise-comparator-target-2026-05-02.md
+++ b/docs/engineering/zkai-d128-layerwise-comparator-target-2026-05-02.md
@@ -12,6 +12,19 @@ The gate separates three claims:
 - local proof artifact availability;
 - source-backed public context.
 
+Starting anchors:
+
+- `docs/engineering/zkai-matched-rmsnorm-swiglu-block-feasibility-gate-2026-05-01.md`
+  for the d64/d128 target-shape and local-surface feasibility probe;
+- `docs/engineering/zkai-d64-block-receipt-composition-gate-2026-05-02.md`
+  for the checked d64 slice-chain receipt surface;
+- `docs/engineering/zkai-d64-nested-verifier-backend-spike-2026-05-02.md`
+  for the current recursive/PCD backend NO-GO boundary;
+- `docs/engineering/zkai-deepprove-nanozk-adapter-feasibility-2026-05-01.md`
+  for the public-artifact adapter feasibility result;
+- `docs/paper/evidence/published-zkml-numbers-2026-04.tsv` for source-backed
+  NANOZK context.
+
 ## Decision
 
 **GO for the comparator target spec. Bounded NO-GO for local `d=128` proof
@@ -21,6 +34,11 @@ This is not a benchmark. It is a checked target definition and an anti-overclaim
 gate: the repository can now name the `d=128` RMSNorm-SwiGLU-residual receipt it
 would need to prove, but it cannot report local proof size, verifier time, or
 relabeling resistance for that target until a proof artifact exists.
+
+Scale decision: `NO_GO_CURRENT_STWO_SURFACE_FOR_D128_PROOF_GO_TARGET_SPEC_ONLY`.
+The existing d64 slice interfaces generalize structurally, but the current
+Stwo-native proof surface does not scale to a d128 proof because it remains
+fixture-gated and lacks a parameterized vector-block AIR plus verifier handle.
 
 ## Result
 
@@ -35,8 +53,10 @@ relabeling resistance for that target until a proof artifact exists.
 | Target width | `128` |
 | Target FF dimension | `512` |
 | Estimated linear multiplications | `196608` |
-| Target commitment | `blake2b-256:f2660bd0371cd242472a5b9fb6939067f21ca0af48cbfb2ce6ac78b8f5ee8206` |
-| Mutation checks | `16 / 16` rejected |
+| Estimated residual rows | `128` |
+| d64 to d128 scale decision | `NO_GO_CURRENT_STWO_SURFACE_FOR_D128_PROOF_GO_TARGET_SPEC_ONLY` |
+| Target commitment | `blake2b-256:d6a6ce9312fa7afa87899bea33f060336d79e215de95a64af4b7c9161df0ec18` |
+| Mutation checks | `19 / 19` rejected |
 
 ## Target shape
 
@@ -48,6 +68,8 @@ The target is a `d=128` RMSNorm-SwiGLU-residual receipt:
 - residual: `true`;
 - hidden width: `128`;
 - FF dimension: `512`;
+- row/operator pressure: `1` RMSNorm row, `512` SwiGLU activation rows, `128`
+  residual-add rows, and `196608` linear projection multiplications;
 - required backend version:
   `stwo-rmsnorm-swiglu-residual-d128-v1`.
 
@@ -71,6 +93,22 @@ The inherited local-surface blockers are:
   `d x ff_dim` matrices;
 - the current Stwo generator is fixture-gated and not an arbitrary matched MLP
   proof generator.
+
+## d64 slice generalization
+
+The d64 receipt chain gives useful interfaces, but not a direct d128 proof.
+
+| d64 slice | d128 decision |
+| --- | --- |
+| `rmsnorm_public_rows` | Generalizes structurally with width parameter (`64` rows to `128` rows), but needs a d128 RMSNorm proof artifact and verifier handle. |
+| `rmsnorm_projection_bridge` | Generalizes structurally as a commitment bridge, but needs a d128 RMSNorm output commitment. |
+| `gate_value_projection` | Same operator family, but not the current proof surface; linear multiplications grow from `32768` to `131072`, and the current generator is fixture-gated. |
+| `activation_swiglu` | Same operator family, but needs a d128 range/lookup proof surface; activation rows grow from `256` to `512`. |
+| `down_projection` | Same operator family, but not the current proof surface; linear multiplications grow from `16384` to `65536`. |
+| `residual_add` | Generalizes structurally with width parameter (`64` rows to `128` rows), but needs a d128 residual-add proof artifact and verifier handle. |
+
+This is why the gate records a target-spec GO and a local-proof NO-GO instead
+of a scale-up benchmark.
 
 ## Source-backed context
 

--- a/docs/paper/stark-transformer-alignment-2026.md
+++ b/docs/paper/stark-transformer-alignment-2026.md
@@ -1086,6 +1086,16 @@ Use that pairing as compact-object calibration only. It is explicitly not a matc
 workload benchmark, but it is still informative: the local receipt surface is smaller,
 while the public `NANOZK` compact proof verifies faster.
 
+A follow-up `d=128` gate now makes the next comparison target explicit without
+turning it into a result. It pins a `d=128`, `ff_dim=512`
+RMSNorm-SwiGLU-residual receipt target with model/config/weight, activation,
+lookup, proof, verifying-key, setup, domain, and proof-system-version
+commitments. That is a GO for the target specification and source-backed public
+context, but a bounded NO-GO for local proof size or verifier time until a
+local `d=128` proof artifact and relabeling suite exist. This is the correct
+shape of the next comparison: define the same layerwise object first, then
+measure only after the proof object exists.
+
 Against that external landscape, the remaining question is practical sequencing: which
 engineering steps most directly strengthen the next paper without diluting scope
 discipline.

--- a/docs/paper/stark-transformer-alignment-2026.md
+++ b/docs/paper/stark-transformer-alignment-2026.md
@@ -1090,11 +1090,14 @@ A follow-up `d=128` gate now makes the next comparison target explicit without
 turning it into a result. It pins a `d=128`, `ff_dim=512`
 RMSNorm-SwiGLU-residual receipt target with model/config/weight, activation,
 lookup, proof, verifying-key, setup, domain, and proof-system-version
-commitments. That is a GO for the target specification and source-backed public
-context, but a bounded NO-GO for local proof size or verifier time until a
-local `d=128` proof artifact and relabeling suite exist. This is the correct
-shape of the next comparison: define the same layerwise object first, then
-measure only after the proof object exists.
+commitments. It explicitly records `1` RMSNorm row, `512` SwiGLU activation
+rows, `128` residual-add rows, and `196608` linear projection multiplications,
+then records a bounded NO-GO for the current Stwo-native surface scaling from
+d64 to a local d128 proof. That is a GO for the target specification and
+source-backed public context, but a bounded NO-GO for local proof size or
+verifier time until a local `d=128` proof artifact and relabeling suite exist.
+This is the correct shape of the next comparison: define the same layerwise
+object first, then measure only after the proof object exists.
 
 Against that external landscape, the remaining question is practical sequencing: which
 engineering steps most directly strengthen the next paper without diluting scope

--- a/docs/paper/tablero-typed-verifier-boundaries-2026.md
+++ b/docs/paper/tablero-typed-verifier-boundaries-2026.md
@@ -917,11 +917,13 @@ competitor-facing transformer-block shape without pretending a local proof
 exists. The target is a `d=128`, `ff_dim=512` RMSNorm-SwiGLU-residual receipt
 with explicit statement bindings for model/config/weights, input and output
 activations, lookup/public-instance material, proof, verifying key, setup,
-verifier domain, and proof-system version. The gate is a GO for that target
-specification and source-backed NANOZK context, but a bounded NO-GO for local
+verifier domain, and proof-system version. It also records the target pressure
+explicitly: `1` RMSNorm row, `512` SwiGLU activation rows, `128` residual-add
+rows, and `196608` linear projection multiplications. The gate is a GO for that
+target specification and source-backed NANOZK context, but a bounded NO-GO for local
 proof size, verifier time, proof-generation time, or relabeling-resistance
 metrics because the repository still lacks a local `d=128` proof artifact,
-verifier handle, and mutation suite. It rejects `16 / 16` checked mutations and
+verifier handle, and mutation suite. It rejects `19 / 19` checked mutations and
 is anchored to
 `docs/engineering/zkai-d128-layerwise-comparator-target-2026-05-02.md` and
 `docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json`.

--- a/docs/paper/tablero-typed-verifier-boundaries-2026.md
+++ b/docs/paper/tablero-typed-verifier-boundaries-2026.md
@@ -912,6 +912,20 @@ It is anchored to
 `docs/engineering/zkai-d64-nested-verifier-backend-spike-2026-05-02.md` and
 `docs/engineering/evidence/zkai-d64-nested-verifier-backend-spike-2026-05.json`.
 
+A separate `d=128` comparator-target gate now pins the next honest
+competitor-facing transformer-block shape without pretending a local proof
+exists. The target is a `d=128`, `ff_dim=512` RMSNorm-SwiGLU-residual receipt
+with explicit statement bindings for model/config/weights, input and output
+activations, lookup/public-instance material, proof, verifying key, setup,
+verifier domain, and proof-system version. The gate is a GO for that target
+specification and source-backed NANOZK context, but a bounded NO-GO for local
+proof size, verifier time, proof-generation time, or relabeling-resistance
+metrics because the repository still lacks a local `d=128` proof artifact,
+verifier handle, and mutation suite. It rejects `16 / 16` checked mutations and
+is anchored to
+`docs/engineering/zkai-d128-layerwise-comparator-target-2026-05-02.md` and
+`docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json`.
+
 A separate composition gate then consumes the checked Stwo statement receipt as
 the model subreceipt inside an agent-step receipt. The composed
 `AgentStepReceiptV1` binds its model identity, model artifact, model

--- a/scripts/tests/test_zkai_d128_layerwise_comparator_target_gate.py
+++ b/scripts/tests/test_zkai_d128_layerwise_comparator_target_gate.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "zkai_d128_layerwise_comparator_target_gate.py"
+SPEC = importlib.util.spec_from_file_location("zkai_d128_layerwise_comparator_target_gate", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load d128 comparator target gate from {SCRIPT_PATH}")
+GATE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = GATE
+SPEC.loader.exec_module(GATE)
+
+
+class ZkAiD128LayerwiseComparatorTargetGateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.payload = GATE.build_gate_result()
+
+    def fresh_payload(self) -> dict:
+        return copy.deepcopy(self.payload)
+
+    def test_gate_records_target_go_and_proof_no_go(self) -> None:
+        payload = self.fresh_payload()
+        GATE.validate_payload(payload)
+        self.assertEqual(payload["schema"], GATE.SCHEMA)
+        self.assertEqual(payload["decision"], GATE.DECISION)
+        self.assertEqual(payload["result"], GATE.RESULT)
+        self.assertEqual(payload["target_result"], GATE.TARGET_RESULT)
+        self.assertEqual(payload["local_proof_result"], GATE.LOCAL_PROOF_RESULT)
+        self.assertEqual(payload["source_context_result"], GATE.SOURCE_CONTEXT_RESULT)
+        self.assertEqual(payload["external_adapter_result"], GATE.EXTERNAL_ADAPTER_RESULT)
+        self.assertEqual(payload["case_count"], 16)
+        self.assertTrue(payload["all_mutations_rejected"])
+        self.assertEqual(payload["validation_commands"][0], "just gate-fast")
+        self.assertEqual(payload["validation_commands"][-1], "just gate")
+
+    def test_target_spec_is_the_d128_rmsnorm_swiglu_shape(self) -> None:
+        target = self.fresh_payload()["target_spec"]
+        self.assertEqual(target["width"], 128)
+        self.assertEqual(target["ff_dim"], 512)
+        self.assertEqual(target["estimated_linear_muls"], 196_608)
+        self.assertEqual(target["estimated_activation_rows"], 512)
+        self.assertEqual(target["required_proof_backend_version"], "stwo-rmsnorm-swiglu-residual-d128-v1")
+        self.assertEqual(target["local_feasibility_status"], "NO_GO_CURRENT_SURFACE")
+        self.assertTrue(target["target_commitment"].startswith("blake2b-256:"))
+        for required in (
+            "model_artifact_commitment",
+            "input_activation_commitment",
+            "output_activation_commitment",
+            "proof_commitment",
+            "verifying_key_commitment",
+            "verifier_domain",
+        ):
+            self.assertIn(required, target["required_statement_bindings"])
+
+    def test_local_proof_status_blocks_metrics(self) -> None:
+        status = self.fresh_payload()["local_proof_status"]
+        self.assertFalse(status["proof_artifact_exists"])
+        self.assertFalse(status["verifier_handle_exists"])
+        self.assertFalse(status["statement_relabeling_suite_exists"])
+        self.assertIsNone(status["proof_size_bytes"])
+        self.assertIsNone(status["verifier_time_ms"])
+        self.assertTrue(status["blocked_before_metrics"])
+        blocker_ids = {blocker["id"] for blocker in status["inherited_feasibility_row"]["blockers"]}
+        self.assertIn("proof_claim_d_model_mismatch", blocker_ids)
+        self.assertIn("instruction_surface_too_small_for_swiglu", blocker_ids)
+
+    def test_source_context_uses_nanozk_as_non_matched_calibration(self) -> None:
+        nanozk = self.fresh_payload()["source_backed_context"]["NANOZK"]
+        self.assertEqual(nanozk["system"], "NANOZK")
+        self.assertEqual(nanozk["verify_seconds"], "0.024")
+        self.assertEqual(nanozk["proof_size_reported"], "5.5 KB")
+        self.assertIn("d=128", nanozk["model_or_dims"])
+        self.assertIn("not a matched local benchmark", nanozk["claim_boundary"])
+        self.assertIn("not as a matched workload benchmark", nanozk["notes"])
+
+    def test_external_adapter_context_remains_not_run(self) -> None:
+        external = self.fresh_payload()["external_adapter_status"]
+        self.assertEqual(external["result"], GATE.EXTERNAL_ADAPTER_RESULT)
+        self.assertEqual(external["paper_usage"], "source_backed_context_only_not_empirical_adapter_row")
+        self.assertFalse(external["systems"]["DeepProve-1"]["public_proof_artifact_available"])
+        self.assertFalse(external["systems"]["NANOZK"]["public_verifier_available"])
+        self.assertFalse(external["systems"]["NANOZK"]["relabeling_benchmark_run"])
+
+    def test_mutation_layers_cover_sources_target_metrics_and_external_context(self) -> None:
+        cases = {case["mutation"]: case for case in self.fresh_payload()["cases"]}
+        self.assertEqual(cases["matched_source_file_hash_drift"]["rejection_layer"], "source_evidence")
+        self.assertEqual(cases["target_width_drift"]["rejection_layer"], "target_spec")
+        self.assertEqual(cases["local_proof_size_metric_smuggled"]["rejection_layer"], "local_proof_status")
+        self.assertEqual(cases["nanozk_source_context_promoted_to_matched"]["rejection_layer"], "source_context")
+        self.assertEqual(cases["deepprove_public_artifact_overclaim"]["rejection_layer"], "external_adapter_status")
+        self.assertEqual(cases["result_changed_to_go"]["rejection_layer"], "parser_or_schema")
+
+    def test_rejects_local_d128_metric_smuggling(self) -> None:
+        payload = self.fresh_payload()
+        payload["local_proof_status"]["verifier_time_ms"] = 24.0
+        with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "verifier-time metric"):
+            GATE.validate_payload(payload)
+
+    def test_rejects_source_context_promotion_to_matched_benchmark(self) -> None:
+        payload = self.fresh_payload()
+        payload["source_backed_context"]["NANOZK"]["claim_boundary"] = "matched local benchmark"
+        with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "source-backed context"):
+            GATE.validate_payload(payload)
+
+    def test_rejects_external_public_artifact_overclaim(self) -> None:
+        payload = self.fresh_payload()
+        payload["external_adapter_status"]["systems"]["DeepProve-1"]["public_proof_artifact_available"] = True
+        with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "external adapter status"):
+            GATE.validate_payload(payload)
+
+    def test_rejects_removed_non_claim(self) -> None:
+        payload = self.fresh_payload()
+        payload["non_claims"].remove("not a matched NANOZK benchmark")
+        with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "non-claims"):
+            GATE.validate_payload(payload)
+
+    def test_rejects_duplicate_mutation_case(self) -> None:
+        payload = self.fresh_payload()
+        payload["cases"][1] = copy.deepcopy(payload["cases"][0])
+        with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "duplicate mutation case"):
+            GATE.validate_payload(payload)
+
+    def test_rejects_rejected_mutation_case_without_error_message(self) -> None:
+        payload = self.fresh_payload()
+        payload["cases"][0]["error"] = ""
+        with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "error must be non-empty"):
+            GATE.validate_payload(payload)
+
+    def test_rejects_missing_mutation_metadata_on_serialized_result(self) -> None:
+        payload = self.fresh_payload()
+        del payload["mutation_inventory"]
+        del payload["cases"]
+        del payload["case_count"]
+        del payload["all_mutations_rejected"]
+        payload["summary"].pop("mutation_cases")
+        payload["summary"].pop("mutations_rejected")
+        with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "mutation metadata"):
+            GATE.validate_payload(payload)
+
+    def test_tsv_rows_are_stable_and_contextual(self) -> None:
+        rows = GATE.rows_for_tsv(self.fresh_payload())
+        self.assertEqual([row["surface"] for row in rows], [
+            "local_d128_target_spec",
+            "local_d128_proof_artifact",
+            "nanozk_d128_source_context",
+            "deepprove_nanozk_adapter_context",
+        ])
+        self.assertEqual(rows[0]["status"], GATE.TARGET_RESULT)
+        self.assertEqual(rows[1]["status"], GATE.LOCAL_PROOF_RESULT)
+        self.assertEqual(rows[2]["verify_seconds"], "0.024")
+        self.assertEqual(rows[2]["proof_size_reported"], "5.5 KB")
+        self.assertIn("not empirical adapter", rows[3]["claim_boundary"])
+
+    def test_write_outputs_round_trips(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_path = tmp / "d128-target.json"
+            tsv_path = tmp / "d128-target.tsv"
+            GATE.write_outputs(payload, json_path, tsv_path)
+            self.assertEqual(json.loads(json_path.read_text(encoding="utf-8")), payload)
+            tsv = tsv_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(tsv[0].split("\t"), list(GATE.TSV_COLUMNS))
+            self.assertIn("nanozk_d128_source_context", tsv[3])
+
+    def test_write_outputs_rejects_paths_outside_repo(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_path = tmp / "d128-target.json"
+            tsv_path = tmp / "d128-target.tsv"
+            with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "output path escapes repository"):
+                GATE.write_outputs(payload, json_path, tsv_path)
+            self.assertFalse(json_path.exists())
+            self.assertFalse(tsv_path.exists())
+
+    def test_write_outputs_rejects_directory_paths_inside_repo(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_dir = tmp / "json-output"
+            tsv_path = tmp / "d128-target.tsv"
+            json_dir.mkdir()
+            with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "not a directory"):
+                GATE.write_outputs(payload, json_dir, tsv_path)
+            self.assertFalse(tsv_path.exists())
+
+    def test_write_outputs_rejects_parent_paths_that_are_files(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            parent_file = tmp / "not-a-directory"
+            parent_file.write_text("not a directory\n", encoding="utf-8")
+            json_path = parent_file / "d128-target.json"
+            tsv_path = tmp / "d128-target.tsv"
+            with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "parent is not a directory"):
+                GATE.write_outputs(payload, json_path, tsv_path)
+            self.assertFalse(tsv_path.exists())
+
+    def test_write_outputs_does_not_replace_first_output_when_second_stage_fails(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_path = tmp / "d128-target.json"
+            tsv_path = tmp / "d128-target.tsv"
+            json_path.write_text("old-json\n", encoding="utf-8")
+            tsv_path.write_text("old-tsv\n", encoding="utf-8")
+            original_stage_text = GATE._stage_text
+            call_count = 0
+
+            def flaky_stage_text(path: pathlib.Path, text: str) -> pathlib.Path:
+                nonlocal call_count
+                call_count += 1
+                if call_count == 2:
+                    raise GATE.D128ComparatorTargetError("forced second output stage failure")
+                return original_stage_text(path, text)
+
+            try:
+                GATE._stage_text = flaky_stage_text
+                with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "forced second output stage failure"):
+                    GATE.write_outputs(payload, json_path, tsv_path)
+            finally:
+                GATE._stage_text = original_stage_text
+
+            self.assertEqual(json_path.read_text(encoding="utf-8"), "old-json\n")
+            self.assertEqual(tsv_path.read_text(encoding="utf-8"), "old-tsv\n")
+
+    def test_write_outputs_rejects_before_writing_partial_artifacts(self) -> None:
+        payload = self.fresh_payload()
+        payload["local_proof_status"]["proof_size_bytes"] = 5500
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_path = tmp / "d128-target.json"
+            tsv_path = tmp / "d128-target.tsv"
+            with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "proof-size metric"):
+                GATE.write_outputs(payload, json_path, tsv_path)
+            self.assertFalse(json_path.exists())
+            self.assertFalse(tsv_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_d128_layerwise_comparator_target_gate.py
+++ b/scripts/tests/test_zkai_d128_layerwise_comparator_target_gate.py
@@ -129,6 +129,22 @@ class ZkAiD128LayerwiseComparatorTargetGateTests(unittest.TestCase):
         with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "duplicate mutation case"):
             GATE.validate_payload(payload)
 
+    def test_empty_mutation_generation_errors_get_non_empty_diagnostics(self) -> None:
+        payload = GATE.build_payload()
+        original_mutated_cases = GATE._mutated_cases
+
+        def empty_generation_error(_payload: dict) -> list[tuple[str, str, dict, Exception]]:
+            return [("matched_source_file_hash_drift", "source_evidence", copy.deepcopy(payload), RuntimeError())]
+
+        try:
+            GATE._mutated_cases = empty_generation_error
+            cases = GATE.mutation_cases(payload)
+        finally:
+            GATE._mutated_cases = original_mutated_cases
+
+        self.assertEqual(cases[0]["error"], "RuntimeError with empty message")
+        self.assertTrue(cases[0]["rejected"])
+
     def test_rejects_rejected_mutation_case_without_error_message(self) -> None:
         payload = self.fresh_payload()
         payload["cases"][0]["error"] = ""
@@ -206,6 +222,19 @@ class ZkAiD128LayerwiseComparatorTargetGateTests(unittest.TestCase):
                 GATE.write_outputs(payload, json_path, tsv_path)
             self.assertFalse(tsv_path.exists())
 
+    def test_write_outputs_rejects_symlink_outputs(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            real_json = tmp / "real.json"
+            json_link = tmp / "linked.json"
+            tsv_path = tmp / "d128-target.tsv"
+            real_json.write_text("old-json\n", encoding="utf-8")
+            json_link.symlink_to(real_json)
+            with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "must not be a symlink"):
+                GATE.write_outputs(payload, json_link, tsv_path)
+            self.assertFalse(tsv_path.exists())
+
     def test_write_outputs_does_not_replace_first_output_when_second_stage_fails(self) -> None:
         payload = self.fresh_payload()
         with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
@@ -233,6 +262,72 @@ class ZkAiD128LayerwiseComparatorTargetGateTests(unittest.TestCase):
 
             self.assertEqual(json_path.read_text(encoding="utf-8"), "old-json\n")
             self.assertEqual(tsv_path.read_text(encoding="utf-8"), "old-tsv\n")
+
+    def test_write_outputs_rolls_back_with_atomic_replace_not_write_bytes(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_path = tmp / "d128-target.json"
+            tsv_path = tmp / "d128-target.tsv"
+            json_path.write_text("old-json\n", encoding="utf-8")
+            tsv_path.write_text("old-tsv\n", encoding="utf-8")
+            original_replace = pathlib.Path.replace
+            original_write_bytes = pathlib.Path.write_bytes
+            replace_count = 0
+
+            def fail_second_replace(self: pathlib.Path, target: pathlib.Path) -> pathlib.Path:
+                nonlocal replace_count
+                replace_count += 1
+                if replace_count == 2:
+                    raise OSError("forced second replace failure")
+                return original_replace(self, target)
+
+            def forbid_write_bytes(self: pathlib.Path, data: bytes) -> int:
+                raise AssertionError(f"rollback used in-place write_bytes on {self}")
+
+            try:
+                pathlib.Path.replace = fail_second_replace
+                pathlib.Path.write_bytes = forbid_write_bytes
+                with self.assertRaisesRegex(GATE.D128ComparatorTargetError, "forced second replace failure"):
+                    GATE.write_outputs(payload, json_path, tsv_path)
+            finally:
+                pathlib.Path.replace = original_replace
+                pathlib.Path.write_bytes = original_write_bytes
+
+            self.assertEqual(json_path.read_text(encoding="utf-8"), "old-json\n")
+            self.assertEqual(tsv_path.read_text(encoding="utf-8"), "old-tsv\n")
+
+    def test_write_outputs_preserves_stage_error_when_cleanup_fails(self) -> None:
+        payload = self.fresh_payload()
+        original_stage_text = GATE._stage_text
+
+        class UnlinkFailingTmp:
+            def __str__(self) -> str:
+                return "unlink-failing.tmp"
+
+            def unlink(self, missing_ok: bool = False) -> None:
+                raise OSError("cleanup denied")
+
+        call_count = 0
+
+        def stage_then_fail(_path: pathlib.Path, _text: str) -> UnlinkFailingTmp:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return UnlinkFailingTmp()
+            raise OSError("stage failed")
+
+        try:
+            GATE._stage_text = stage_then_fail
+            with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+                tmp = pathlib.Path(raw_tmp)
+                with self.assertRaisesRegex(
+                    GATE.D128ComparatorTargetError,
+                    "stage failed.*cleanup failed.*cleanup denied",
+                ):
+                    GATE.write_outputs(payload, tmp / "d128-target.json", tmp / "d128-target.tsv")
+        finally:
+            GATE._stage_text = original_stage_text
 
     def test_write_outputs_rejects_before_writing_partial_artifacts(self) -> None:
         payload = self.fresh_payload()

--- a/scripts/tests/test_zkai_d128_layerwise_comparator_target_gate.py
+++ b/scripts/tests/test_zkai_d128_layerwise_comparator_target_gate.py
@@ -200,6 +200,25 @@ class ZkAiD128LayerwiseComparatorTargetGateTests(unittest.TestCase):
             self.assertEqual(tsv[0].split("\t"), list(GATE.TSV_COLUMNS))
             self.assertIn("nanozk_d128_source_context", tsv[3])
 
+    def test_write_outputs_fsyncs_parent_directory_after_replace(self) -> None:
+        payload = self.fresh_payload()
+        original_fsync_parent_directories = GATE._fsync_parent_directories
+        synced_paths: list[pathlib.Path] = []
+
+        def record_fsync_parent_directories(paths: list[pathlib.Path]) -> None:
+            synced_paths.extend(paths)
+
+        try:
+            GATE._fsync_parent_directories = record_fsync_parent_directories
+            with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+                tmp = pathlib.Path(raw_tmp)
+                json_path = tmp / "d128-target.json"
+                tsv_path = tmp / "d128-target.tsv"
+                GATE.write_outputs(payload, json_path, tsv_path)
+                self.assertEqual(synced_paths, [json_path.resolve(), tsv_path.resolve()])
+        finally:
+            GATE._fsync_parent_directories = original_fsync_parent_directories
+
     def test_write_outputs_rejects_paths_outside_repo(self) -> None:
         payload = self.fresh_payload()
         with tempfile.TemporaryDirectory() as raw_tmp:

--- a/scripts/tests/test_zkai_d128_layerwise_comparator_target_gate.py
+++ b/scripts/tests/test_zkai_d128_layerwise_comparator_target_gate.py
@@ -37,7 +37,7 @@ class ZkAiD128LayerwiseComparatorTargetGateTests(unittest.TestCase):
         self.assertEqual(payload["local_proof_result"], GATE.LOCAL_PROOF_RESULT)
         self.assertEqual(payload["source_context_result"], GATE.SOURCE_CONTEXT_RESULT)
         self.assertEqual(payload["external_adapter_result"], GATE.EXTERNAL_ADAPTER_RESULT)
-        self.assertEqual(payload["case_count"], 16)
+        self.assertEqual(payload["case_count"], 19)
         self.assertTrue(payload["all_mutations_rejected"])
         self.assertEqual(payload["validation_commands"][0], "just gate-fast")
         self.assertEqual(payload["validation_commands"][-1], "just gate")
@@ -48,9 +48,18 @@ class ZkAiD128LayerwiseComparatorTargetGateTests(unittest.TestCase):
         self.assertEqual(target["ff_dim"], 512)
         self.assertEqual(target["estimated_linear_muls"], 196_608)
         self.assertEqual(target["estimated_activation_rows"], 512)
+        self.assertEqual(target["estimated_residual_rows"], 128)
+        self.assertEqual(target["row_operator_pressure"]["rmsnorm_rows"], 1)
+        self.assertEqual(target["row_operator_pressure"]["swiglu_activation_rows"], 512)
+        self.assertEqual(target["row_operator_pressure"]["residual_add_rows"], 128)
+        self.assertEqual(target["d64_to_d128_scale_decision"], GATE.D128_SCALE_DECISION)
         self.assertEqual(target["required_proof_backend_version"], "stwo-rmsnorm-swiglu-residual-d128-v1")
         self.assertEqual(target["local_feasibility_status"], "NO_GO_CURRENT_SURFACE")
         self.assertTrue(target["target_commitment"].startswith("blake2b-256:"))
+        generalization = {row["slice"]: row for row in target["d64_slice_generalization"]}
+        self.assertEqual(generalization["rmsnorm_public_rows"]["d128_rows"], 128)
+        self.assertIn("NOT_CURRENT_PROOF_SURFACE", generalization["gate_value_projection"]["decision"])
+        self.assertEqual(generalization["residual_add"]["d128_rows"], 128)
         for required in (
             "model_artifact_commitment",
             "input_activation_commitment",
@@ -94,6 +103,9 @@ class ZkAiD128LayerwiseComparatorTargetGateTests(unittest.TestCase):
         cases = {case["mutation"]: case for case in self.fresh_payload()["cases"]}
         self.assertEqual(cases["matched_source_file_hash_drift"]["rejection_layer"], "source_evidence")
         self.assertEqual(cases["target_width_drift"]["rejection_layer"], "target_spec")
+        self.assertEqual(cases["target_residual_row_count_drift"]["rejection_layer"], "target_spec")
+        self.assertEqual(cases["target_scale_decision_promoted_to_go"]["rejection_layer"], "target_spec")
+        self.assertEqual(cases["target_d64_slice_generalization_overclaim"]["rejection_layer"], "target_spec")
         self.assertEqual(cases["local_proof_size_metric_smuggled"]["rejection_layer"], "local_proof_status")
         self.assertEqual(cases["nanozk_source_context_promoted_to_matched"]["rejection_layer"], "source_context")
         self.assertEqual(cases["deepprove_public_artifact_overclaim"]["rejection_layer"], "external_adapter_status")

--- a/scripts/zkai_d128_layerwise_comparator_target_gate.py
+++ b/scripts/zkai_d128_layerwise_comparator_target_gate.py
@@ -514,13 +514,24 @@ def classify_error(error: Exception) -> str:
     return "parser_or_schema"
 
 
-def _mutated_cases(baseline: dict[str, Any]) -> list[tuple[str, str, dict[str, Any]]]:
-    cases: list[tuple[str, str, dict[str, Any]]] = []
+def exception_message(error: Exception) -> str:
+    text = str(error)
+    if text:
+        return text
+    return f"{type(error).__name__} with empty message"
+
+
+def _mutated_cases(baseline: dict[str, Any]) -> list[tuple[str, str, dict[str, Any], Exception | None]]:
+    cases: list[tuple[str, str, dict[str, Any], Exception | None]] = []
 
     def add(name: str, surface: str, mutator: Callable[[dict[str, Any]], None]) -> None:
         mutated = copy.deepcopy(baseline)
-        mutator(mutated)
-        cases.append((name, surface, mutated))
+        generation_error = None
+        try:
+            mutator(mutated)
+        except Exception as err:  # noqa: BLE001 - mutation failures are recorded as rejected cases.
+            generation_error = err
+        cases.append((name, surface, mutated, generation_error))
 
     add("matched_source_file_hash_drift", "source_evidence", lambda p: p["source_evidence"]["matched_feasibility"].__setitem__("file_sha256", "11" * 32))
     add("external_source_payload_hash_drift", "source_evidence", lambda p: p["source_evidence"]["external_adapter_feasibility"].__setitem__("payload_sha256", "22" * 32))
@@ -545,16 +556,21 @@ def mutation_cases(baseline: dict[str, Any] | None = None) -> list[dict[str, Any
     baseline = copy.deepcopy(baseline or build_payload())
     _validate_draft_payload(baseline)
     cases = []
-    for mutation, surface, mutated in _mutated_cases(baseline):
-        try:
-            _validate_draft_payload(mutated)
-            accepted = True
-            error = ""
-            layer = "accepted"
-        except D128ComparatorTargetError as err:
+    for mutation, surface, mutated, generation_error in _mutated_cases(baseline):
+        if generation_error is not None:
             accepted = False
-            error = str(err)
-            layer = classify_error(err)
+            error = exception_message(generation_error)
+            layer = classify_error(generation_error)
+        else:
+            try:
+                _validate_draft_payload(mutated)
+                accepted = True
+                error = ""
+                layer = "accepted"
+            except D128ComparatorTargetError as err:
+                accepted = False
+                error = str(err)
+                layer = classify_error(err)
         cases.append(
             {
                 "mutation": mutation,
@@ -655,6 +671,8 @@ def to_mutation_tsv(payload: dict[str, Any]) -> str:
 
 
 def _validated_output_path(path: pathlib.Path) -> pathlib.Path:
+    if path.is_symlink():
+        raise D128ComparatorTargetError(f"output path must not be a symlink: {path}")
     resolved = path.resolve()
     root = ROOT.resolve()
     if resolved != root and root not in resolved.parents:
@@ -670,6 +688,13 @@ def _stage_text(path: pathlib.Path, text: str) -> pathlib.Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
         handle.write(text)
+        return pathlib.Path(handle.name)
+
+
+def _stage_bytes(path: pathlib.Path, data: bytes) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as handle:
+        handle.write(data)
         return pathlib.Path(handle.name)
 
 
@@ -693,15 +718,29 @@ def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_p
             tmp_path.replace(output_path)
             committed.append((output_path, existed, previous))
     except Exception as err:
+        cleanup_errors: list[str] = []
         for tmp_path, _ in staged:
-            tmp_path.unlink(missing_ok=True)
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError as cleanup_err:
+                cleanup_errors.append(f"cleanup failed for {tmp_path}: {cleanup_err}")
         for output_path, existed, previous in reversed(committed):
-            if existed and previous is not None:
-                output_path.write_bytes(previous)
-            else:
-                output_path.unlink(missing_ok=True)
+            try:
+                if existed and previous is not None:
+                    rollback_tmp = _stage_bytes(output_path, previous)
+                    try:
+                        rollback_tmp.replace(output_path)
+                    finally:
+                        rollback_tmp.unlink(missing_ok=True)
+                else:
+                    output_path.unlink(missing_ok=True)
+            except OSError as rollback_err:
+                cleanup_errors.append(f"rollback failed for {output_path}: {rollback_err}")
         if isinstance(err, OSError):
-            raise D128ComparatorTargetError(f"failed to write outputs: {err}") from err
+            detail = f"failed to write outputs: {err}"
+            if cleanup_errors:
+                detail += "; " + "; ".join(cleanup_errors)
+            raise D128ComparatorTargetError(detail) from err
         raise
 
 

--- a/scripts/zkai_d128_layerwise_comparator_target_gate.py
+++ b/scripts/zkai_d128_layerwise_comparator_target_gate.py
@@ -774,6 +774,30 @@ def _stage_bytes(path: pathlib.Path, data: bytes) -> pathlib.Path:
         return pathlib.Path(handle.name)
 
 
+def _fsync_parent_directory(path: pathlib.Path) -> None:
+    directory_flag = getattr(os, "O_DIRECTORY", None)
+    if directory_flag is None:
+        return
+    try:
+        fd = os.open(str(path.parent), os.O_RDONLY | directory_flag)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _fsync_parent_directories(paths: list[pathlib.Path]) -> None:
+    seen: set[pathlib.Path] = set()
+    for path in paths:
+        parent = path.parent
+        if parent in seen:
+            continue
+        seen.add(parent)
+        _fsync_parent_directory(path)
+
+
 def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
     validate_payload(payload)
     json_output = _validated_output_path(json_path) if json_path is not None else None
@@ -793,6 +817,7 @@ def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_p
             previous = output_path.read_bytes() if existed else None
             tmp_path.replace(output_path)
             committed.append((output_path, existed, previous))
+        _fsync_parent_directories([output_path for _, output_path in staged])
     except Exception as err:
         cleanup_errors: list[str] = []
         for tmp_path, _ in staged:
@@ -806,10 +831,12 @@ def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_p
                     rollback_tmp = _stage_bytes(output_path, previous)
                     try:
                         rollback_tmp.replace(output_path)
+                        _fsync_parent_directory(output_path)
                     finally:
                         rollback_tmp.unlink(missing_ok=True)
                 else:
                     output_path.unlink(missing_ok=True)
+                    _fsync_parent_directory(output_path)
             except OSError as rollback_err:
                 cleanup_errors.append(f"rollback failed for {output_path}: {rollback_err}")
         if isinstance(err, OSError):

--- a/scripts/zkai_d128_layerwise_comparator_target_gate.py
+++ b/scripts/zkai_d128_layerwise_comparator_target_gate.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+"""Gate a d128 layerwise receipt comparator target without claiming a d128 proof.
+
+The gate consumes the existing matched d64/d128 target-shape probe, the
+DeepProve/NANOZK public-adapter feasibility probe, and the source-backed
+published zkML numbers table. It produces a target-spec GO plus a proof-artifact
+NO-GO: the d128 receipt shape is ready to compare against public layerwise zkML
+context, but this repository does not yet contain a local d128 proof artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import hashlib
+import importlib.util
+import io
+import json
+import pathlib
+import sys
+import tempfile
+from typing import Any, Callable
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+EVIDENCE_DIR = ROOT / "docs" / "engineering" / "evidence"
+PAPER_EVIDENCE_DIR = ROOT / "docs" / "paper" / "evidence"
+MATCHED_SCRIPT = ROOT / "scripts" / "zkai_matched_rmsnorm_swiglu_block_feasibility.py"
+EXTERNAL_SCRIPT = ROOT / "scripts" / "zkai_deepprove_nanozk_adapter_feasibility.py"
+MATCHED_EVIDENCE = EVIDENCE_DIR / "zkai-matched-rmsnorm-swiglu-block-feasibility-2026-05.json"
+EXTERNAL_EVIDENCE = EVIDENCE_DIR / "zkai-deepprove-nanozk-adapter-feasibility-2026-05.json"
+PUBLISHED_ZKML_NUMBERS = PAPER_EVIDENCE_DIR / "published-zkml-numbers-2026-04.tsv"
+JSON_OUT = EVIDENCE_DIR / "zkai-d128-layerwise-comparator-target-2026-05.json"
+TSV_OUT = EVIDENCE_DIR / "zkai-d128-layerwise-comparator-target-2026-05.tsv"
+
+SCHEMA = "zkai-d128-layerwise-comparator-target-v1"
+DECISION = "NO_GO_D128_LAYERWISE_PROOF_ARTIFACT_MISSING"
+RESULT = "BOUNDED_NO_GO"
+TARGET_RESULT = "GO_D128_LAYERWISE_COMPARATOR_TARGET_SPEC"
+LOCAL_PROOF_RESULT = "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING"
+SOURCE_CONTEXT_RESULT = "GO_SOURCE_BACKED_PUBLIC_LAYERWISE_CONTEXT"
+EXTERNAL_ADAPTER_RESULT = "NO_GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK"
+TARGET_WIDTH = 128
+TARGET_DOMAIN = "ptvm:zkai:d128-layerwise-comparator-target:v1"
+FIRST_BLOCKER = (
+    "the d128 RMSNorm-SwiGLU-residual receipt target is pinned, but the repository "
+    "does not contain a local d128 proof artifact, verifier handle, or relabeling suite"
+)
+
+NON_CLAIMS = [
+    "not a local d128 proof result",
+    "not a matched NANOZK benchmark",
+    "not a DeepProve-1 adapter benchmark",
+    "not evidence that NANOZK or DeepProve-1 are insecure",
+    "not full transformer inference",
+    "not proof-size or verifier-time evidence for this repository",
+]
+
+VALIDATION_COMMANDS = [
+    "just gate-fast",
+    "python3 scripts/zkai_d128_layerwise_comparator_target_gate.py --write-json docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json --write-tsv docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_d128_layerwise_comparator_target_gate",
+    "python3 scripts/paper/paper_preflight.py --repo-root .",
+    "just gate",
+]
+
+TSV_COLUMNS = (
+    "surface",
+    "status",
+    "width",
+    "source",
+    "prove_seconds",
+    "verify_seconds",
+    "proof_size_reported",
+    "claim_boundary",
+    "blocker",
+)
+
+MUTATION_TSV_COLUMNS = (
+    "mutation",
+    "surface",
+    "baseline_result",
+    "mutated_accepted",
+    "rejected",
+    "rejection_layer",
+    "error",
+)
+
+EXPECTED_MUTATION_INVENTORY = (
+    ("matched_source_file_hash_drift", "source_evidence"),
+    ("external_source_payload_hash_drift", "source_evidence"),
+    ("target_width_drift", "target_spec"),
+    ("target_binding_removed", "target_spec"),
+    ("target_linear_mul_estimate_drift", "target_spec"),
+    ("target_commitment_drift", "target_spec"),
+    ("local_proof_result_changed_to_go", "local_proof_status"),
+    ("local_proof_size_metric_smuggled", "local_proof_status"),
+    ("local_verify_time_metric_smuggled", "local_proof_status"),
+    ("nanozk_source_row_verify_seconds_drift", "source_context"),
+    ("nanozk_source_context_promoted_to_matched", "source_context"),
+    ("external_adapter_result_changed_to_go", "external_adapter_status"),
+    ("deepprove_public_artifact_overclaim", "external_adapter_status"),
+    ("nanozk_public_verifier_overclaim", "external_adapter_status"),
+    ("non_claim_removed", "claim_boundary"),
+    ("result_changed_to_go", "parser_or_schema"),
+)
+
+
+class D128ComparatorTargetError(ValueError):
+    pass
+
+
+def _load_module(path: pathlib.Path, module_name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise D128ComparatorTargetError(f"failed to load {module_name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MATCHED = _load_module(MATCHED_SCRIPT, "zkai_matched_rmsnorm_swiglu_for_d128_target")
+EXTERNAL = _load_module(EXTERNAL_SCRIPT, "zkai_deepprove_nanozk_for_d128_target")
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_hex_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_hex_json(value: Any) -> str:
+    return sha256_hex_bytes(canonical_json_bytes(value))
+
+
+def blake2b_commitment(value: Any, domain: str) -> str:
+    digest = hashlib.blake2b(digest_size=32)
+    digest.update(domain.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(canonical_json_bytes(value))
+    return f"blake2b-256:{digest.hexdigest()}"
+
+
+def file_sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def relative_path(path: pathlib.Path) -> str:
+    return str(path.resolve().relative_to(ROOT.resolve()))
+
+
+def expect_equal(actual: Any, expected: Any, field: str) -> None:
+    if actual != expected:
+        raise D128ComparatorTargetError(f"{field} mismatch")
+
+
+def require_object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise D128ComparatorTargetError(f"{field} must be an object")
+    return value
+
+
+def require_list(value: Any, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise D128ComparatorTargetError(f"{field} must be a list")
+    return value
+
+
+def expected_mutation_inventory() -> list[dict[str, Any]]:
+    return [
+        {"index": index, "mutation": mutation, "surface": surface}
+        for index, (mutation, surface) in enumerate(EXPECTED_MUTATION_INVENTORY)
+    ]
+
+
+def load_json(path: pathlib.Path) -> dict[str, Any]:
+    resolved = path.resolve()
+    if not resolved.is_file():
+        raise D128ComparatorTargetError(f"source evidence is not a regular file: {path}")
+    if ROOT.resolve() not in resolved.parents:
+        raise D128ComparatorTargetError(f"source evidence path escapes repository: {path}")
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as err:
+        raise D128ComparatorTargetError(f"failed to load source evidence {path}: {err}") from err
+    if not isinstance(payload, dict):
+        raise D128ComparatorTargetError(f"source evidence must be a JSON object: {path}")
+    return payload
+
+
+def source_descriptor(path: pathlib.Path, payload: dict[str, Any], *, include_schema: bool = False, include_decision: bool = False) -> dict[str, Any]:
+    descriptor = {
+        "path": relative_path(path),
+        "file_sha256": file_sha256(path),
+        "payload_sha256": sha256_hex_json(payload),
+    }
+    if include_schema:
+        descriptor["schema"] = payload.get("schema")
+    if include_decision:
+        descriptor["decision"] = payload.get("decision")
+    return descriptor
+
+
+def load_checked_matched() -> dict[str, Any]:
+    payload = load_json(MATCHED_EVIDENCE)
+    if payload.get("schema") != MATCHED.SCHEMA:
+        raise D128ComparatorTargetError("matched feasibility schema mismatch")
+    if payload.get("decision") != MATCHED.DECISION_NO_GO:
+        raise D128ComparatorTargetError("matched feasibility decision mismatch")
+    summary = require_object(payload.get("summary"), "matched feasibility summary")
+    expect_equal(summary.get("target_count"), 2, "matched target count")
+    expect_equal(summary.get("no_go_count"), 2, "matched no-go count")
+    d128_rows = [row for row in require_list(payload.get("rows"), "matched feasibility rows") if row.get("target_width") == TARGET_WIDTH]
+    if len(d128_rows) != 1:
+        raise D128ComparatorTargetError("matched feasibility must contain exactly one d128 row")
+    d128_row = d128_rows[0]
+    expect_equal(d128_row.get("status"), "NO_GO_CURRENT_SURFACE", "matched d128 row status")
+    expect_equal(d128_row.get("target_estimated_linear_muls"), 196_608, "matched d128 linear mul estimate")
+    d128_targets = [target for target in require_list(payload.get("targets"), "matched feasibility targets") if target.get("width") == TARGET_WIDTH]
+    if len(d128_targets) != 1:
+        raise D128ComparatorTargetError("matched feasibility must contain exactly one d128 target")
+    expect_equal(d128_targets[0], MATCHED.matched_target(TARGET_WIDTH), "matched d128 target")
+    return payload
+
+
+def load_checked_external() -> dict[str, Any]:
+    payload = load_json(EXTERNAL_EVIDENCE)
+    try:
+        EXTERNAL.validate_probe(payload)
+    except Exception as err:  # noqa: BLE001 - normalize imported validator errors.
+        raise D128ComparatorTargetError(f"external adapter feasibility validation failed: {err}") from err
+    if payload.get("decision") != EXTERNAL.DECISION:
+        raise D128ComparatorTargetError("external adapter decision mismatch")
+    return payload
+
+
+def load_published_rows(path: pathlib.Path = PUBLISHED_ZKML_NUMBERS) -> list[dict[str, str]]:
+    try:
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            rows = list(csv.DictReader(handle, delimiter="\t"))
+    except OSError as err:
+        raise D128ComparatorTargetError(f"failed to load published zkML numbers: {err}") from err
+    if not rows:
+        raise D128ComparatorTargetError("published zkML numbers table is empty")
+    return rows
+
+
+def nanozk_layerwise_context(rows: list[dict[str, str]]) -> dict[str, Any]:
+    matches = [
+        row
+        for row in rows
+        if row.get("system") == "NANOZK"
+        and row.get("source_kind") == "arxiv"
+        and row.get("source_locator") == "Abstract"
+        and "d=128" in row.get("model_or_dims", "")
+    ]
+    if len(matches) != 1:
+        raise D128ComparatorTargetError("expected exactly one NANOZK d128 source-backed calibration row")
+    row = matches[0]
+    if row.get("verify_seconds") != "0.024":
+        raise D128ComparatorTargetError("NANOZK d128 verify_seconds drift")
+    if row.get("proof_size_reported") != "5.5 KB":
+        raise D128ComparatorTargetError("NANOZK d128 proof_size_reported drift")
+    if "not as a matched workload benchmark" not in row.get("notes", ""):
+        raise D128ComparatorTargetError("NANOZK row must remain non-matched context")
+    return {
+        "system": row["system"],
+        "source_kind": row["source_kind"],
+        "source_url": row["source_url"],
+        "source_locator": row["source_locator"],
+        "backend_family": row["backend_family"],
+        "workload_label": row["workload_label"],
+        "workload_scope": row["workload_scope"],
+        "model_or_dims": row["model_or_dims"],
+        "verify_seconds": row["verify_seconds"],
+        "proof_size_reported": row["proof_size_reported"],
+        "claim_boundary": "source-backed compact/layerwise context only; not a matched local benchmark",
+        "notes": row["notes"],
+    }
+
+
+def target_spec(matched_payload: dict[str, Any]) -> dict[str, Any]:
+    target = copy.deepcopy(MATCHED.matched_target(TARGET_WIDTH))
+    row = next(row for row in matched_payload["rows"] if row["target_width"] == TARGET_WIDTH)
+    target["local_feasibility_status"] = row["status"]
+    target["local_feasibility_blockers"] = copy.deepcopy(row["blockers"])
+    target["comparator_target_kind"] = "d128-layerwise-rmsnorm-swiglu-residual-receipt"
+    target["target_commitment"] = blake2b_commitment(target, TARGET_DOMAIN)
+    return target
+
+
+def local_proof_status(matched_payload: dict[str, Any]) -> dict[str, Any]:
+    row = next(row for row in matched_payload["rows"] if row["target_width"] == TARGET_WIDTH)
+    return {
+        "result": LOCAL_PROOF_RESULT,
+        "proof_artifact_exists": False,
+        "verifier_handle_exists": False,
+        "statement_relabeling_suite_exists": False,
+        "proof_size_bytes": None,
+        "verifier_time_ms": None,
+        "blocked_before_metrics": True,
+        "first_blocker": "current checked Stwo proof surface is width-4, fixture-gated, and not a d128 RMSNorm-SwiGLU proof",
+        "inherited_feasibility_row": copy.deepcopy(row),
+    }
+
+
+def external_adapter_status(external_payload: dict[str, Any]) -> dict[str, Any]:
+    systems = {system["system"]: copy.deepcopy(system) for system in external_payload["systems"]}
+    return {
+        "result": EXTERNAL_ADAPTER_RESULT,
+        "paper_usage": external_payload["conclusion"]["paper_usage"],
+        "systems": systems,
+    }
+
+
+def build_payload() -> dict[str, Any]:
+    matched = load_checked_matched()
+    external = load_checked_external()
+    published_rows = load_published_rows()
+    source_context = nanozk_layerwise_context(published_rows)
+    target = target_spec(matched)
+    payload = {
+        "schema": SCHEMA,
+        "decision": DECISION,
+        "result": RESULT,
+        "target_result": TARGET_RESULT,
+        "local_proof_result": LOCAL_PROOF_RESULT,
+        "source_context_result": SOURCE_CONTEXT_RESULT,
+        "external_adapter_result": EXTERNAL_ADAPTER_RESULT,
+        "source_evidence": {
+            "matched_feasibility": source_descriptor(MATCHED_EVIDENCE, matched, include_schema=True, include_decision=True),
+            "external_adapter_feasibility": source_descriptor(EXTERNAL_EVIDENCE, external, include_schema=True, include_decision=True),
+            "published_zkml_numbers": {
+                "path": relative_path(PUBLISHED_ZKML_NUMBERS),
+                "file_sha256": file_sha256(PUBLISHED_ZKML_NUMBERS),
+            },
+        },
+        "target_spec": target,
+        "local_proof_status": local_proof_status(matched),
+        "source_backed_context": {"NANOZK": source_context},
+        "external_adapter_status": external_adapter_status(external),
+        "summary": {
+            "decision": DECISION,
+            "result": RESULT,
+            "target_result": TARGET_RESULT,
+            "target_width": TARGET_WIDTH,
+            "target_ff_dim": target["ff_dim"],
+            "target_estimated_linear_muls": target["estimated_linear_muls"],
+            "target_commitment": target["target_commitment"],
+            "local_proof_result": LOCAL_PROOF_RESULT,
+            "source_context_result": SOURCE_CONTEXT_RESULT,
+            "external_adapter_result": EXTERNAL_ADAPTER_RESULT,
+            "first_blocker": FIRST_BLOCKER,
+        },
+        "non_claims": NON_CLAIMS,
+        "validation_commands": VALIDATION_COMMANDS,
+    }
+    _validate_draft_payload(payload)
+    return payload
+
+
+def _validate_source_evidence(payload: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    source = require_object(payload.get("source_evidence"), "source evidence")
+    matched = load_checked_matched()
+    external = load_checked_external()
+    published_rows = load_published_rows()
+    expect_equal(source.get("matched_feasibility"), source_descriptor(MATCHED_EVIDENCE, matched, include_schema=True, include_decision=True), "matched source evidence")
+    expect_equal(source.get("external_adapter_feasibility"), source_descriptor(EXTERNAL_EVIDENCE, external, include_schema=True, include_decision=True), "external source evidence")
+    expect_equal(source.get("published_zkml_numbers"), {"path": relative_path(PUBLISHED_ZKML_NUMBERS), "file_sha256": file_sha256(PUBLISHED_ZKML_NUMBERS)}, "published zkML source evidence")
+    return matched, external, {"NANOZK": nanozk_layerwise_context(published_rows)}
+
+
+def _validate_local_proof_status(status: dict[str, Any], matched: dict[str, Any]) -> None:
+    expect_equal(status.get("result"), LOCAL_PROOF_RESULT, "local proof result")
+    if status.get("proof_artifact_exists") is not False:
+        raise D128ComparatorTargetError("local d128 proof artifact overclaim")
+    if status.get("verifier_handle_exists") is not False:
+        raise D128ComparatorTargetError("local d128 verifier handle overclaim")
+    if status.get("statement_relabeling_suite_exists") is not False:
+        raise D128ComparatorTargetError("local d128 relabeling suite overclaim")
+    if status.get("proof_size_bytes") is not None:
+        raise D128ComparatorTargetError("local d128 proof-size metric supplied before proof exists")
+    if status.get("verifier_time_ms") is not None:
+        raise D128ComparatorTargetError("local d128 verifier-time metric supplied before proof exists")
+    if status.get("blocked_before_metrics") is not True:
+        raise D128ComparatorTargetError("local d128 metrics must remain blocked before proof exists")
+    expect_equal(status, local_proof_status(matched), "local proof status")
+
+
+def _validate_external_adapter_status(status: dict[str, Any], external: dict[str, Any]) -> None:
+    expect_equal(status, external_adapter_status(external), "external adapter status")
+    systems = require_object(status.get("systems"), "external adapter systems")
+    for name in ("DeepProve-1", "NANOZK"):
+        system = require_object(systems.get(name), f"external adapter system {name}")
+        if system.get("public_proof_artifact_available") is not False:
+            raise D128ComparatorTargetError(f"{name} public proof artifact overclaim")
+        if system.get("public_verifier_available") is not False:
+            raise D128ComparatorTargetError(f"{name} public verifier overclaim")
+        if system.get("relabeling_benchmark_run") is not False:
+            raise D128ComparatorTargetError(f"{name} relabeling benchmark overclaim")
+
+
+def _validate_common_payload(payload: Any) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    payload = require_object(payload, "d128 comparator target payload")
+    expect_equal(payload.get("schema"), SCHEMA, "schema")
+    expect_equal(payload.get("decision"), DECISION, "decision")
+    expect_equal(payload.get("result"), RESULT, "result")
+    expect_equal(payload.get("target_result"), TARGET_RESULT, "target result")
+    expect_equal(payload.get("local_proof_result"), LOCAL_PROOF_RESULT, "local proof result")
+    expect_equal(payload.get("source_context_result"), SOURCE_CONTEXT_RESULT, "source context result")
+    expect_equal(payload.get("external_adapter_result"), EXTERNAL_ADAPTER_RESULT, "external adapter result")
+    matched, external, context = _validate_source_evidence(payload)
+    target = target_spec(matched)
+    expect_equal(payload.get("target_spec"), target, "target spec")
+    _validate_local_proof_status(require_object(payload.get("local_proof_status"), "local proof status"), matched)
+    expect_equal(payload.get("source_backed_context"), context, "source-backed context")
+    if "not a matched local benchmark" not in context["NANOZK"]["claim_boundary"]:
+        raise D128ComparatorTargetError("source context promoted to matched benchmark")
+    _validate_external_adapter_status(require_object(payload.get("external_adapter_status"), "external adapter status"), external)
+    expected_summary = {
+        "decision": DECISION,
+        "result": RESULT,
+        "target_result": TARGET_RESULT,
+        "target_width": TARGET_WIDTH,
+        "target_ff_dim": target["ff_dim"],
+        "target_estimated_linear_muls": target["estimated_linear_muls"],
+        "target_commitment": target["target_commitment"],
+        "local_proof_result": LOCAL_PROOF_RESULT,
+        "source_context_result": SOURCE_CONTEXT_RESULT,
+        "external_adapter_result": EXTERNAL_ADAPTER_RESULT,
+        "first_blocker": FIRST_BLOCKER,
+    }
+    expect_equal(payload.get("non_claims"), NON_CLAIMS, "non-claims")
+    expect_equal(payload.get("validation_commands"), VALIDATION_COMMANDS, "validation commands")
+    return matched, external, expected_summary
+
+
+def _validate_draft_payload(payload: Any) -> None:
+    _, _, expected_summary = _validate_common_payload(payload)
+    if any(field in payload for field in ("mutation_inventory", "cases", "case_count", "all_mutations_rejected")):
+        raise D128ComparatorTargetError("draft payload must not include mutation metadata")
+    expect_equal(payload.get("summary"), expected_summary, "summary")
+
+
+def _validate_case_metadata(payload: dict[str, Any]) -> tuple[int, int]:
+    if not all(field in payload for field in ("mutation_inventory", "cases", "case_count", "all_mutations_rejected")):
+        raise D128ComparatorTargetError("mutation metadata must include inventory, cases, count, and all_mutations_rejected")
+    expect_equal(require_list(payload.get("mutation_inventory"), "mutation inventory"), expected_mutation_inventory(), "mutation inventory")
+    cases = require_list(payload.get("cases"), "mutation cases")
+    case_pairs: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    rejected = 0
+    for index, raw_case in enumerate(cases):
+        case = require_object(raw_case, f"mutation case {index}")
+        for column in MUTATION_TSV_COLUMNS:
+            if column not in case:
+                raise D128ComparatorTargetError(f"mutation case {index} missing {column}")
+        pair = (case["mutation"], case["surface"])
+        if pair in seen:
+            raise D128ComparatorTargetError(f"duplicate mutation case {index}")
+        seen.add(pair)
+        case_pairs.append(pair)
+        if case["baseline_result"] != RESULT:
+            raise D128ComparatorTargetError(f"mutation case {index} baseline_result mismatch")
+        if not isinstance(case["mutated_accepted"], bool) or not isinstance(case["rejected"], bool):
+            raise D128ComparatorTargetError(f"mutation case {index} boolean fields malformed")
+        if case["mutated_accepted"] == case["rejected"]:
+            raise D128ComparatorTargetError(f"mutation case {index} accepted/rejected fields inconsistent")
+        if not isinstance(case["error"], str):
+            raise D128ComparatorTargetError(f"mutation case {index} error must be a string")
+        if case["rejected"] and not case["error"]:
+            raise D128ComparatorTargetError(f"mutation case {index} rejected case error must be non-empty")
+        if case["rejected"]:
+            rejected += 1
+    expect_equal(tuple(case_pairs), EXPECTED_MUTATION_INVENTORY, "mutation case inventory")
+    expect_equal(payload.get("case_count"), len(cases), "mutation case_count")
+    expect_equal(payload.get("all_mutations_rejected"), all(case["rejected"] for case in cases), "all_mutations_rejected")
+    return len(cases), rejected
+
+
+def validate_payload(payload: Any) -> None:
+    payload = require_object(payload, "d128 comparator target payload")
+    _, _, expected_summary = _validate_common_payload(payload)
+    case_count, rejected = _validate_case_metadata(payload)
+    if case_count != rejected:
+        raise D128ComparatorTargetError("not all d128 comparator target mutations rejected")
+    expected_summary["mutation_cases"] = case_count
+    expected_summary["mutations_rejected"] = rejected
+    expect_equal(payload.get("summary"), expected_summary, "summary")
+
+
+def classify_error(error: Exception) -> str:
+    text = str(error).lower()
+    if "nanozk row" in text or "source context" in text or "source-backed context" in text or "matched benchmark" in text:
+        return "source_context"
+    if "source" in text or "evidence" in text or "file_sha" in text or "payload_sha" in text:
+        return "source_evidence"
+    if "target" in text or "commitment" in text or "binding" in text:
+        return "target_spec"
+    if "local d128" in text or "local proof" in text or "metric" in text:
+        return "local_proof_status"
+    if "external adapter" in text or "deepprove" in text or "public verifier" in text or "public proof" in text:
+        return "external_adapter_status"
+    if "non-claims" in text:
+        return "claim_boundary"
+    return "parser_or_schema"
+
+
+def _mutated_cases(baseline: dict[str, Any]) -> list[tuple[str, str, dict[str, Any]]]:
+    cases: list[tuple[str, str, dict[str, Any]]] = []
+
+    def add(name: str, surface: str, mutator: Callable[[dict[str, Any]], None]) -> None:
+        mutated = copy.deepcopy(baseline)
+        mutator(mutated)
+        cases.append((name, surface, mutated))
+
+    add("matched_source_file_hash_drift", "source_evidence", lambda p: p["source_evidence"]["matched_feasibility"].__setitem__("file_sha256", "11" * 32))
+    add("external_source_payload_hash_drift", "source_evidence", lambda p: p["source_evidence"]["external_adapter_feasibility"].__setitem__("payload_sha256", "22" * 32))
+    add("target_width_drift", "target_spec", lambda p: p["target_spec"].__setitem__("width", 64))
+    add("target_binding_removed", "target_spec", lambda p: p["target_spec"]["required_statement_bindings"].pop())
+    add("target_linear_mul_estimate_drift", "target_spec", lambda p: p["target_spec"].__setitem__("estimated_linear_muls", 1))
+    add("target_commitment_drift", "target_spec", lambda p: p["target_spec"].__setitem__("target_commitment", "blake2b-256:" + "33" * 32))
+    add("local_proof_result_changed_to_go", "local_proof_status", lambda p: p["local_proof_status"].__setitem__("result", "GO_LOCAL_D128_PROOF"))
+    add("local_proof_size_metric_smuggled", "local_proof_status", lambda p: p["local_proof_status"].__setitem__("proof_size_bytes", 5500))
+    add("local_verify_time_metric_smuggled", "local_proof_status", lambda p: p["local_proof_status"].__setitem__("verifier_time_ms", 24.0))
+    add("nanozk_source_row_verify_seconds_drift", "source_context", lambda p: p["source_backed_context"]["NANOZK"].__setitem__("verify_seconds", "0.001"))
+    add("nanozk_source_context_promoted_to_matched", "source_context", lambda p: p["source_backed_context"]["NANOZK"].__setitem__("claim_boundary", "matched local benchmark"))
+    add("external_adapter_result_changed_to_go", "external_adapter_status", lambda p: p["external_adapter_status"].__setitem__("result", "GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK"))
+    add("deepprove_public_artifact_overclaim", "external_adapter_status", lambda p: p["external_adapter_status"]["systems"]["DeepProve-1"].__setitem__("public_proof_artifact_available", True))
+    add("nanozk_public_verifier_overclaim", "external_adapter_status", lambda p: p["external_adapter_status"]["systems"]["NANOZK"].__setitem__("public_verifier_available", True))
+    add("non_claim_removed", "claim_boundary", lambda p: p["non_claims"].remove("not a matched NANOZK benchmark"))
+    add("result_changed_to_go", "parser_or_schema", lambda p: p.__setitem__("result", "GO"))
+    return cases
+
+
+def mutation_cases(baseline: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    baseline = copy.deepcopy(baseline or build_payload())
+    _validate_draft_payload(baseline)
+    cases = []
+    for mutation, surface, mutated in _mutated_cases(baseline):
+        try:
+            _validate_draft_payload(mutated)
+            accepted = True
+            error = ""
+            layer = "accepted"
+        except D128ComparatorTargetError as err:
+            accepted = False
+            error = str(err)
+            layer = classify_error(err)
+        cases.append(
+            {
+                "mutation": mutation,
+                "surface": surface,
+                "baseline_result": RESULT,
+                "mutated_accepted": accepted,
+                "rejected": not accepted,
+                "rejection_layer": layer,
+                "error": error,
+            }
+        )
+    return cases
+
+
+def build_gate_result() -> dict[str, Any]:
+    payload = build_payload()
+    cases = mutation_cases(payload)
+    result = copy.deepcopy(payload)
+    result["mutation_inventory"] = expected_mutation_inventory()
+    result["case_count"] = len(cases)
+    result["all_mutations_rejected"] = all(case["rejected"] for case in cases)
+    result["cases"] = cases
+    result["summary"]["mutation_cases"] = len(cases)
+    result["summary"]["mutations_rejected"] = sum(1 for case in cases if case["rejected"])
+    validate_payload(result)
+    if not result["all_mutations_rejected"]:
+        raise D128ComparatorTargetError("not all d128 comparator target mutations rejected")
+    return result
+
+
+def rows_for_tsv(payload: dict[str, Any]) -> list[dict[str, str]]:
+    target = payload["target_spec"]
+    local = payload["local_proof_status"]
+    nanozk = payload["source_backed_context"]["NANOZK"]
+    external = payload["external_adapter_status"]
+    return [
+        {
+            "surface": "local_d128_target_spec",
+            "status": payload["target_result"],
+            "width": str(target["width"]),
+            "source": "local target gate",
+            "prove_seconds": "NA",
+            "verify_seconds": "NA",
+            "proof_size_reported": "NA",
+            "claim_boundary": "statement target only",
+            "blocker": "NA",
+        },
+        {
+            "surface": "local_d128_proof_artifact",
+            "status": local["result"],
+            "width": str(target["width"]),
+            "source": "local Stwo surface",
+            "prove_seconds": "NA",
+            "verify_seconds": "NA",
+            "proof_size_reported": "NA",
+            "claim_boundary": "no local d128 proof metrics before artifact exists",
+            "blocker": local["first_blocker"],
+        },
+        {
+            "surface": "nanozk_d128_source_context",
+            "status": payload["source_context_result"],
+            "width": str(target["width"]),
+            "source": nanozk["source_url"],
+            "prove_seconds": "NA",
+            "verify_seconds": nanozk["verify_seconds"],
+            "proof_size_reported": nanozk["proof_size_reported"],
+            "claim_boundary": nanozk["claim_boundary"],
+            "blocker": "not locally reproduced",
+        },
+        {
+            "surface": "deepprove_nanozk_adapter_context",
+            "status": external["result"],
+            "width": str(target["width"]),
+            "source": external["paper_usage"],
+            "prove_seconds": "NA",
+            "verify_seconds": "NA",
+            "proof_size_reported": "NA",
+            "claim_boundary": "source-backed context only, not empirical adapter row",
+            "blocker": "public proof artifact plus verifier inputs unavailable for this adapter benchmark",
+        },
+    ]
+
+
+def to_tsv(payload: dict[str, Any]) -> str:
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows_for_tsv(payload))
+    return buffer.getvalue()
+
+
+def to_mutation_tsv(payload: dict[str, Any]) -> str:
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=MUTATION_TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+    writer.writeheader()
+    writer.writerows({key: case[key] for key in MUTATION_TSV_COLUMNS} for case in payload["cases"])
+    return buffer.getvalue()
+
+
+def _validated_output_path(path: pathlib.Path) -> pathlib.Path:
+    resolved = path.resolve()
+    root = ROOT.resolve()
+    if resolved != root and root not in resolved.parents:
+        raise D128ComparatorTargetError(f"output path escapes repository: {path}")
+    if resolved.exists() and resolved.is_dir():
+        raise D128ComparatorTargetError(f"output path must be a file, not a directory: {path}")
+    if resolved.parent.exists() and not resolved.parent.is_dir():
+        raise D128ComparatorTargetError(f"output path parent is not a directory: {path}")
+    return resolved
+
+
+def _stage_text(path: pathlib.Path, text: str) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+        handle.write(text)
+        return pathlib.Path(handle.name)
+
+
+def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
+    validate_payload(payload)
+    json_output = _validated_output_path(json_path) if json_path is not None else None
+    tsv_output = _validated_output_path(tsv_path) if tsv_path is not None else None
+    json_text = json.dumps(payload, indent=2, sort_keys=True) + "\n" if json_path is not None else None
+    tsv_text = to_tsv(payload) if tsv_path is not None else None
+
+    staged: list[tuple[pathlib.Path, pathlib.Path]] = []
+    committed: list[tuple[pathlib.Path, bool, bytes | None]] = []
+    try:
+        if json_output is not None:
+            staged.append((_stage_text(json_output, json_text), json_output))
+        if tsv_output is not None:
+            staged.append((_stage_text(tsv_output, tsv_text), tsv_output))
+        for tmp_path, output_path in staged:
+            existed = output_path.exists()
+            previous = output_path.read_bytes() if existed else None
+            tmp_path.replace(output_path)
+            committed.append((output_path, existed, previous))
+    except Exception as err:
+        for tmp_path, _ in staged:
+            tmp_path.unlink(missing_ok=True)
+        for output_path, existed, previous in reversed(committed):
+            if existed and previous is not None:
+                output_path.write_bytes(previous)
+            else:
+                output_path.unlink(missing_ok=True)
+        if isinstance(err, OSError):
+            raise D128ComparatorTargetError(f"failed to write outputs: {err}") from err
+        raise
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write-json", type=pathlib.Path, default=None)
+    parser.add_argument("--write-tsv", type=pathlib.Path, default=None)
+    parser.add_argument("--print-mutation-tsv", action="store_true")
+    args = parser.parse_args(argv)
+    payload = build_gate_result()
+    write_outputs(payload, args.write_json, args.write_tsv)
+    if args.print_mutation_tsv:
+        print(to_mutation_tsv(payload), end="")
+    else:
+        print(json.dumps(payload["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zkai_d128_layerwise_comparator_target_gate.py
+++ b/scripts/zkai_d128_layerwise_comparator_target_gate.py
@@ -17,10 +17,12 @@ import hashlib
 import importlib.util
 import io
 import json
+import os
 import pathlib
 import sys
 import tempfile
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -43,6 +45,7 @@ SOURCE_CONTEXT_RESULT = "GO_SOURCE_BACKED_PUBLIC_LAYERWISE_CONTEXT"
 EXTERNAL_ADAPTER_RESULT = "NO_GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK"
 TARGET_WIDTH = 128
 TARGET_DOMAIN = "ptvm:zkai:d128-layerwise-comparator-target:v1"
+D128_SCALE_DECISION = "NO_GO_CURRENT_STWO_SURFACE_FOR_D128_PROOF_GO_TARGET_SPEC_ONLY"
 FIRST_BLOCKER = (
     "the d128 RMSNorm-SwiGLU-residual receipt target is pinned, but the repository "
     "does not contain a local d128 proof artifact, verifier handle, or relabeling suite"
@@ -93,6 +96,9 @@ EXPECTED_MUTATION_INVENTORY = (
     ("target_width_drift", "target_spec"),
     ("target_binding_removed", "target_spec"),
     ("target_linear_mul_estimate_drift", "target_spec"),
+    ("target_residual_row_count_drift", "target_spec"),
+    ("target_scale_decision_promoted_to_go", "target_spec"),
+    ("target_d64_slice_generalization_overclaim", "target_spec"),
     ("target_commitment_drift", "target_spec"),
     ("local_proof_result_changed_to_go", "local_proof_status"),
     ("local_proof_size_metric_smuggled", "local_proof_status"),
@@ -290,9 +296,62 @@ def nanozk_layerwise_context(rows: list[dict[str, str]]) -> dict[str, Any]:
 def target_spec(matched_payload: dict[str, Any]) -> dict[str, Any]:
     target = copy.deepcopy(MATCHED.matched_target(TARGET_WIDTH))
     row = next(row for row in matched_payload["rows"] if row["target_width"] == TARGET_WIDTH)
+    residual_rows = TARGET_WIDTH
     target["local_feasibility_status"] = row["status"]
     target["local_feasibility_blockers"] = copy.deepcopy(row["blockers"])
     target["comparator_target_kind"] = "d128-layerwise-rmsnorm-swiglu-residual-receipt"
+    target["estimated_residual_rows"] = residual_rows
+    target["row_operator_pressure"] = {
+        "rmsnorm_rows": target["estimated_norm_rows"],
+        "swiglu_activation_rows": target["estimated_activation_rows"],
+        "residual_add_rows": residual_rows,
+        "linear_projection_multiplications": target["estimated_linear_muls"],
+    }
+    target["d64_to_d128_scale_decision"] = D128_SCALE_DECISION
+    target["d64_slice_generalization"] = [
+        {
+            "slice": "rmsnorm_public_rows",
+            "decision": "GENERALIZES_STRUCTURALLY_WITH_WIDTH_PARAMETER",
+            "d64_rows": 64,
+            "d128_rows": 128,
+            "blocked_on": "no local d128 RMSNorm proof artifact or verifier handle",
+        },
+        {
+            "slice": "rmsnorm_projection_bridge",
+            "decision": "GENERALIZES_STRUCTURALLY_AS_COMMITMENT_BRIDGE",
+            "d64_rows": 1,
+            "d128_rows": 1,
+            "blocked_on": "needs a d128 RMSNorm output commitment to bridge",
+        },
+        {
+            "slice": "gate_value_projection",
+            "decision": "GENERALIZES_OPERATOR_FAMILY_BUT_NOT_CURRENT_PROOF_SURFACE",
+            "d64_linear_muls": 32768,
+            "d128_linear_muls": 131072,
+            "blocked_on": "current proof generator is fixture-gated and not a parameterized vector-block AIR",
+        },
+        {
+            "slice": "activation_swiglu",
+            "decision": "GENERALIZES_OPERATOR_FAMILY_BUT_REQUIRES_D128_RANGE_LOOKUP_SURFACE",
+            "d64_rows": 256,
+            "d128_rows": 512,
+            "blocked_on": "no d128 activation/range proof artifact or relabeling suite",
+        },
+        {
+            "slice": "down_projection",
+            "decision": "GENERALIZES_OPERATOR_FAMILY_BUT_NOT_CURRENT_PROOF_SURFACE",
+            "d64_linear_muls": 16384,
+            "d128_linear_muls": 65536,
+            "blocked_on": "current proof generator is fixture-gated and not a parameterized vector-block AIR",
+        },
+        {
+            "slice": "residual_add",
+            "decision": "GENERALIZES_STRUCTURALLY_WITH_WIDTH_PARAMETER",
+            "d64_rows": 64,
+            "d128_rows": 128,
+            "blocked_on": "no local d128 residual-add proof artifact or verifier handle",
+        },
+    ]
     target["target_commitment"] = blake2b_commitment(target, TARGET_DOMAIN)
     return target
 
@@ -308,6 +367,12 @@ def local_proof_status(matched_payload: dict[str, Any]) -> dict[str, Any]:
         "verifier_time_ms": None,
         "blocked_before_metrics": True,
         "first_blocker": "current checked Stwo proof surface is width-4, fixture-gated, and not a d128 RMSNorm-SwiGLU proof",
+        "d64_to_d128_scale_decision": D128_SCALE_DECISION,
+        "scale_decision_rationale": (
+            "the d64 slice interfaces generalize structurally, but the current Stwo-native proof "
+            "surface does not scale to a d128 proof because it is fixture-gated and lacks a "
+            "parameterized vector-block AIR/verifier handle"
+        ),
         "inherited_feasibility_row": copy.deepcopy(row),
     }
 
@@ -354,6 +419,8 @@ def build_payload() -> dict[str, Any]:
             "target_width": TARGET_WIDTH,
             "target_ff_dim": target["ff_dim"],
             "target_estimated_linear_muls": target["estimated_linear_muls"],
+            "target_estimated_residual_rows": target["estimated_residual_rows"],
+            "d64_to_d128_scale_decision": D128_SCALE_DECISION,
             "target_commitment": target["target_commitment"],
             "local_proof_result": LOCAL_PROOF_RESULT,
             "source_context_result": SOURCE_CONTEXT_RESULT,
@@ -432,6 +499,8 @@ def _validate_common_payload(payload: Any) -> tuple[dict[str, Any], dict[str, An
         "target_width": TARGET_WIDTH,
         "target_ff_dim": target["ff_dim"],
         "target_estimated_linear_muls": target["estimated_linear_muls"],
+        "target_estimated_residual_rows": target["estimated_residual_rows"],
+        "d64_to_d128_scale_decision": D128_SCALE_DECISION,
         "target_commitment": target["target_commitment"],
         "local_proof_result": LOCAL_PROOF_RESULT,
         "source_context_result": SOURCE_CONTEXT_RESULT,
@@ -538,6 +607,9 @@ def _mutated_cases(baseline: dict[str, Any]) -> list[tuple[str, str, dict[str, A
     add("target_width_drift", "target_spec", lambda p: p["target_spec"].__setitem__("width", 64))
     add("target_binding_removed", "target_spec", lambda p: p["target_spec"]["required_statement_bindings"].pop())
     add("target_linear_mul_estimate_drift", "target_spec", lambda p: p["target_spec"].__setitem__("estimated_linear_muls", 1))
+    add("target_residual_row_count_drift", "target_spec", lambda p: p["target_spec"].__setitem__("estimated_residual_rows", 0))
+    add("target_scale_decision_promoted_to_go", "target_spec", lambda p: p["target_spec"].__setitem__("d64_to_d128_scale_decision", "GO_CURRENT_STWO_SURFACE_SCALES_TO_D128"))
+    add("target_d64_slice_generalization_overclaim", "target_spec", lambda p: p["target_spec"]["d64_slice_generalization"][2].__setitem__("decision", "GENERALIZES_DIRECTLY_TO_CURRENT_PROOF_SURFACE"))
     add("target_commitment_drift", "target_spec", lambda p: p["target_spec"].__setitem__("target_commitment", "blake2b-256:" + "33" * 32))
     add("local_proof_result_changed_to_go", "local_proof_status", lambda p: p["local_proof_status"].__setitem__("result", "GO_LOCAL_D128_PROOF"))
     add("local_proof_size_metric_smuggled", "local_proof_status", lambda p: p["local_proof_status"].__setitem__("proof_size_bytes", 5500))
@@ -688,6 +760,8 @@ def _stage_text(path: pathlib.Path, text: str) -> pathlib.Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
         handle.write(text)
+        handle.flush()
+        os.fsync(handle.fileno())
         return pathlib.Path(handle.name)
 
 
@@ -695,6 +769,8 @@ def _stage_bytes(path: pathlib.Path, data: bytes) -> pathlib.Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as handle:
         handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
         return pathlib.Path(handle.name)
 
 


### PR DESCRIPTION
## Summary

- adds a checked d=128 RMSNorm-SwiGLU-residual comparator target gate
- records the honest split: GO for target specification and source-backed public context, bounded NO-GO for local d128 proof metrics
- adds strict mutation checks and artifact-writer hardening before any JSON/TSV outputs are emitted
- updates both paper drafts so this is framed as a target/comparison boundary, not as a benchmark result

Refs #376.

## Result

- `GO_D128_LAYERWISE_COMPARATOR_TARGET_SPEC`
- `NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING`
- `GO_SOURCE_BACKED_PUBLIC_LAYERWISE_CONTEXT`
- `NO_GO_PUBLIC_RELABELING_ADAPTER_BENCHMARK`
- `16 / 16` checked mutations rejected

## Validation

- [x] `just gate-fast`
- [x] `python3 scripts/zkai_d128_layerwise_comparator_target_gate.py --write-json docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json --write-tsv docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.tsv`
- [x] `python3 -m unittest scripts.tests.test_zkai_d128_layerwise_comparator_target_gate` (24 tests)
- [x] `python3 -m py_compile scripts/zkai_d128_layerwise_comparator_target_gate.py scripts/tests/test_zkai_d128_layerwise_comparator_target_gate.py`
- [x] `python3 scripts/paper/paper_preflight.py --repo-root .`
- [x] `git diff --check`
- [x] `just gate` (14/14)

## Claim Boundary

This PR does not claim a local d128 proof, proof size, verifier time, DeepProve-1 adapter benchmark, NANOZK adapter benchmark, or soundness finding against external systems. It defines the next honest comparator target and blocks those metrics until the proof artifact and relabeling suite exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design specification for d=128 layerwise comparator target gate
  * Updated architecture papers with new target specification details and verification boundaries

* **Tests**
  * Added comprehensive test suite for d=128 layerwise comparator target validation, including schema verification, mutation case coverage, and output integrity checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->