### PR TITLE
[codex] Add d128 proof artifact backend spike gate

### DIFF
--- a/docs/engineering/design/README.md
+++ b/docs/engineering/design/README.md
@@ -30,5 +30,6 @@ Tablero itself proves agents, reasoning, tool truth, or policy semantics.
 - [d64 recursive/PCD aggregation feasibility gate](../zkai-d64-recursive-pcd-aggregation-feasibility-2026-05-02.md)
 - [d64 nested-verifier backend spike gate](../zkai-d64-nested-verifier-backend-spike-2026-05-02.md)
 - [d128 layerwise comparator target gate](../zkai-d128-layerwise-comparator-target-2026-05-02.md)
+- [d128 proof artifact backend spike](../zkai-d128-proof-artifact-backend-spike-2026-05-02.md)
 - [Agent-step zkAI Stwo composition gate](../agent-step-zkai-stwo-composition-gate-2026-04-29.md)
 - [Agent-step model subreceipt callback gate](../agent-step-model-subreceipt-callback-gate-2026-04-29.md)

--- a/docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.json
+++ b/docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.json
@@ -1,0 +1,715 @@
+{
+  "all_mutations_rejected": true,
+  "backend_routes": [
+    {
+      "blocker": "d64 slice proofs exist, but this is not the d128 target",
+      "evidence": "docs/engineering/evidence/zkai-d64-block-receipt-composition-gate-2026-05.json",
+      "proof_artifact_exists": true,
+      "proof_size_bytes": null,
+      "route": "existing_d64_slice_chain",
+      "status": "GO_ANCHOR_ONLY",
+      "target_ff_dim": 256,
+      "target_width": 64,
+      "verifier_handle_exists": true,
+      "verifier_time_ms": null
+    },
+    {
+      "blocker": "no d128 native proof modules or exported prove/verify handles exist",
+      "missing_export_symbols": [
+        "prove_zkai_d128_rmsnorm_public_row_envelope",
+        "verify_zkai_d128_rmsnorm_public_row_envelope",
+        "prove_zkai_d128_gate_value_projection_envelope",
+        "verify_zkai_d128_gate_value_projection_envelope",
+        "prove_zkai_d128_activation_swiglu_envelope",
+        "verify_zkai_d128_activation_swiglu_envelope",
+        "prove_zkai_d128_down_projection_envelope",
+        "verify_zkai_d128_down_projection_envelope",
+        "prove_zkai_d128_residual_add_envelope",
+        "verify_zkai_d128_residual_add_envelope",
+        "prove_zkai_d128_transformer_block_envelope",
+        "verify_zkai_d128_transformer_block_envelope"
+      ],
+      "missing_modules": [
+        "src/stwo_backend/d128_native_rmsnorm_public_row_proof.rs",
+        "src/stwo_backend/d128_native_rmsnorm_to_projection_bridge_proof.rs",
+        "src/stwo_backend/d128_native_gate_value_projection_proof.rs",
+        "src/stwo_backend/d128_native_activation_swiglu_proof.rs",
+        "src/stwo_backend/d128_native_down_projection_proof.rs",
+        "src/stwo_backend/d128_native_residual_add_proof.rs",
+        "src/stwo_backend/d128_native_transformer_block_proof.rs"
+      ],
+      "proof_artifact_exists": false,
+      "proof_size_bytes": null,
+      "route": "direct_d128_native_modules",
+      "status": "NO_GO",
+      "target_ff_dim": 512,
+      "target_width": 128,
+      "verifier_handle_exists": false,
+      "verifier_time_ms": null
+    },
+    {
+      "blocker": "d64 modules validate hard-coded width, target id, domains, and log sizes",
+      "hardcoded_markers": [
+        {
+          "markers": [
+            "expect_usize(input.width, ZKAI_D64_WIDTH",
+            "ZKAI_D64_RMSNORM_PUBLIC_ROW_PROOF_VERSION",
+            "ZKAI_D64_TARGET_ID"
+          ],
+          "path": "src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs"
+        },
+        {
+          "markers": [
+            "expect_usize(input.width, ZKAI_D64_WIDTH",
+            "expect_usize(input.ff_dim, ZKAI_D64_FF_DIM",
+            "D64_GATE_VALUE_LOG_SIZE"
+          ],
+          "path": "src/stwo_backend/d64_native_gate_value_projection_proof.rs"
+        },
+        {
+          "markers": [
+            "expect_usize(input.width, ZKAI_D64_WIDTH",
+            "expect_usize(input.ff_dim, ZKAI_D64_FF_DIM",
+            "D64_ACTIVATION_SWIGLU_LOG_SIZE"
+          ],
+          "path": "src/stwo_backend/d64_native_activation_swiglu_proof.rs"
+        },
+        {
+          "markers": [
+            "expect_usize(input.width, ZKAI_D64_WIDTH",
+            "expect_usize(input.ff_dim, ZKAI_D64_FF_DIM",
+            "D64_DOWN_PROJECTION_LOG_SIZE"
+          ],
+          "path": "src/stwo_backend/d64_native_down_projection_proof.rs"
+        },
+        {
+          "markers": [
+            "expect_usize(input.width, ZKAI_D64_WIDTH",
+            "ZKAI_D64_RESIDUAL_ADD_PROOF_VERSION",
+            "D64_RESIDUAL_ADD_LOG_SIZE"
+          ],
+          "path": "src/stwo_backend/d64_native_residual_add_proof.rs"
+        }
+      ],
+      "proof_artifact_exists": false,
+      "proof_size_bytes": null,
+      "route": "lift_existing_d64_modules_by_metadata",
+      "status": "NO_GO",
+      "target_ff_dim": 512,
+      "target_width": 128,
+      "verifier_handle_exists": false,
+      "verifier_time_ms": null
+    },
+    {
+      "blocker": "no parameterized d128 vector-block AIR/prover/verifier handle; current native proof modules are d64 target/domain/width hard-coded and no d128 native module exports exist",
+      "missing_symbols": [
+        "ZkAiVectorBlockProofInput",
+        "ZkAiParameterizedTransformerBlockProof",
+        "prove_zkai_vector_block_envelope",
+        "verify_zkai_vector_block_envelope",
+        "parameterized_vector_block_air"
+      ],
+      "proof_artifact_exists": false,
+      "proof_size_bytes": null,
+      "route": "parameterized_vector_block_air",
+      "status": "NO_GO_FIRST_BLOCKER",
+      "target_ff_dim": 512,
+      "target_width": 128,
+      "verifier_handle_exists": false,
+      "verifier_time_ms": null
+    },
+    {
+      "blocker": "do not report proof size, verifier time, or relabeling resistance until a d128 proof object and verifier handle exist",
+      "proof_artifact_exists": false,
+      "proof_size_bytes": null,
+      "route": "d128_metrics_and_relabeling_suite",
+      "status": "NO_GO_BLOCKED_BEFORE_PROOF_OBJECT",
+      "target_ff_dim": 512,
+      "target_width": 128,
+      "verifier_handle_exists": false,
+      "verifier_time_ms": null
+    }
+  ],
+  "case_count": 14,
+  "cases": [
+    {
+      "error": "decision mismatch",
+      "index": 0,
+      "mutated_accepted": false,
+      "mutation": "decision_promoted_to_go",
+      "rejected": true,
+      "rejection_layer": "top_level",
+      "surface": "top_level"
+    },
+    {
+      "error": "target width mismatch",
+      "index": 1,
+      "mutated_accepted": false,
+      "mutation": "target_width_drift",
+      "rejected": true,
+      "rejection_layer": "target_spec",
+      "surface": "target_spec"
+    },
+    {
+      "error": "target backend version mismatch",
+      "index": 2,
+      "mutated_accepted": false,
+      "mutation": "target_backend_version_drift",
+      "rejected": true,
+      "rejection_layer": "target_spec",
+      "surface": "target_spec"
+    },
+    {
+      "error": "proof artifact exists mismatch",
+      "index": 3,
+      "mutated_accepted": false,
+      "mutation": "local_proof_artifact_smuggled",
+      "rejected": true,
+      "rejection_layer": "proof_status",
+      "surface": "proof_status"
+    },
+    {
+      "error": "verifier handle exists mismatch",
+      "index": 4,
+      "mutated_accepted": false,
+      "mutation": "local_verifier_handle_smuggled",
+      "rejected": true,
+      "rejection_layer": "proof_status",
+      "surface": "proof_status"
+    },
+    {
+      "error": "proof size mismatch",
+      "index": 5,
+      "mutated_accepted": false,
+      "mutation": "proof_size_metric_smuggled",
+      "rejected": true,
+      "rejection_layer": "metrics",
+      "surface": "metrics"
+    },
+    {
+      "error": "verifier time mismatch",
+      "index": 6,
+      "mutated_accepted": false,
+      "mutation": "verifier_time_metric_smuggled",
+      "rejected": true,
+      "rejection_layer": "metrics",
+      "surface": "metrics"
+    },
+    {
+      "error": "direct d128 route status mismatch",
+      "index": 7,
+      "mutated_accepted": false,
+      "mutation": "direct_d128_route_promoted",
+      "rejected": true,
+      "rejection_layer": "backend_routes",
+      "surface": "backend_routes"
+    },
+    {
+      "error": "parameterized route status mismatch",
+      "index": 8,
+      "mutated_accepted": false,
+      "mutation": "parameterized_route_promoted",
+      "rejected": true,
+      "rejection_layer": "backend_routes",
+      "surface": "backend_routes"
+    },
+    {
+      "error": "d64 anchor status mismatch",
+      "index": 9,
+      "mutated_accepted": false,
+      "mutation": "d64_anchor_removed",
+      "rejected": true,
+      "rejection_layer": "d64_anchor",
+      "surface": "d64_anchor"
+    },
+    {
+      "error": "missing d128 module inventory mismatch",
+      "index": 10,
+      "mutated_accepted": false,
+      "mutation": "missing_module_removed",
+      "rejected": true,
+      "rejection_layer": "source_probe",
+      "surface": "source_probe"
+    },
+    {
+      "error": "src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs hardcoded markers mismatch",
+      "index": 11,
+      "mutated_accepted": false,
+      "mutation": "d64_hardcoded_marker_removed",
+      "rejected": true,
+      "rejection_layer": "source_probe",
+      "surface": "source_probe"
+    },
+    {
+      "error": "non-claims inventory mismatch",
+      "index": 12,
+      "mutated_accepted": false,
+      "mutation": "non_claim_removed",
+      "rejected": true,
+      "rejection_layer": "claim_boundary",
+      "surface": "claim_boundary"
+    },
+    {
+      "error": "summary mutation count mismatch",
+      "index": 13,
+      "mutated_accepted": false,
+      "mutation": "mutation_case_accepted",
+      "rejected": true,
+      "rejection_layer": "mutation_harness",
+      "surface": "mutation_harness"
+    }
+  ],
+  "d64_anchor": {
+    "claim_boundary": "working d64 slice proof chain, not a d128 proof route",
+    "decision": "GO_D64_BLOCK_RECEIPT_COMPOSITION_GATE",
+    "slice_count": 6,
+    "slices": [
+      {
+        "evidence": {
+          "decision": "GO_PUBLIC_ROW_INPUT_FOR_D64_RMSNORM_AIR_PROOF",
+          "file_sha256": "24083515ddc3ce7a690ac33698157956f6c35427dad8a41c033012616160db1d",
+          "path": "docs/engineering/evidence/zkai-d64-native-rmsnorm-public-row-proof-2026-05.json",
+          "payload_sha256": "1d1f5ec67a770e8c98088e3924b53bf24e91462946b84a2a8cba3d4387f43c75",
+          "result": null,
+          "schema": "zkai-d64-native-rmsnorm-public-row-air-proof-input-v2"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "ff7be7374f917ca21e2a3f85055c963015e421b56b6dfebc26aebaaa50c15fb6",
+          "path": "src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs"
+        },
+        "proof_version": "stwo-d64-rmsnorm-public-row-air-proof-v2",
+        "prove_symbol": "prove_zkai_d64_rmsnorm_public_row_envelope",
+        "slice": "rmsnorm_public_rows",
+        "verify_symbol": "verify_zkai_d64_rmsnorm_public_row_envelope"
+      },
+      {
+        "evidence": {
+          "decision": "GO_INPUT_FOR_D64_RMSNORM_TO_PROJECTION_BRIDGE_AIR_PROOF",
+          "file_sha256": "84b7998b53679c6dd2f221392ee688c499bfdbc6bca0a737e9df40d720a8fccc",
+          "path": "docs/engineering/evidence/zkai-d64-rmsnorm-to-projection-bridge-proof-2026-05.json",
+          "payload_sha256": "2680f43d467a2da07ef8441e4b8051afef2d381a6cf2569130f322c5ddbe81cd",
+          "result": null,
+          "schema": "zkai-d64-rmsnorm-to-projection-bridge-air-proof-input-v1"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "47539bf485b97dac370ee35c2dd44200d1c017c895fbdedd3a79e43c4efb67d3",
+          "path": "src/stwo_backend/d64_native_rmsnorm_to_projection_bridge_proof.rs"
+        },
+        "proof_version": "stwo-d64-rmsnorm-to-projection-bridge-air-proof-v1",
+        "prove_symbol": "prove_zkai_d64_rmsnorm_to_projection_bridge_envelope",
+        "slice": "rmsnorm_projection_bridge",
+        "verify_symbol": "verify_zkai_d64_rmsnorm_to_projection_bridge_envelope"
+      },
+      {
+        "evidence": {
+          "decision": "GO_INPUT_FOR_D64_GATE_VALUE_PROJECTION_AIR_PROOF",
+          "file_sha256": "69a2f78a1aa181a589fb5694c34faf3a2c0f784f73e3d07441e2a16368722755",
+          "path": "docs/engineering/evidence/zkai-d64-gate-value-projection-proof-2026-05.json",
+          "payload_sha256": "8597373e50dce1f2590179d4eb189add3917d54d7cbf309916193198e7c02ce7",
+          "result": null,
+          "schema": "zkai-d64-gate-value-projection-air-proof-input-v1"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "baa70ad8c741bae962031677d80bcfe51fcf597ce5301775f6043713d722ac42",
+          "path": "src/stwo_backend/d64_native_gate_value_projection_proof.rs"
+        },
+        "proof_version": "stwo-d64-gate-value-projection-air-proof-v1",
+        "prove_symbol": "prove_zkai_d64_gate_value_projection_envelope",
+        "slice": "gate_value_projection",
+        "verify_symbol": "verify_zkai_d64_gate_value_projection_envelope"
+      },
+      {
+        "evidence": {
+          "decision": "GO_INPUT_FOR_D64_ACTIVATION_SWIGLU_AIR_PROOF",
+          "file_sha256": "3cb30766f1665398fc54ea98a686e258eb7f247f0599ffae8d0f28a13c5f313d",
+          "path": "docs/engineering/evidence/zkai-d64-activation-swiglu-proof-2026-05.json",
+          "payload_sha256": "d810411fadb50a8f830c099550942475640708bc7631a47b687640061ab3ced6",
+          "result": null,
+          "schema": "zkai-d64-activation-swiglu-air-proof-input-v1"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "6387e781bb03beacaceed43f6d44fdd25ee2ef0ccbd8f2a7b7e6c2bbe9c6b8c0",
+          "path": "src/stwo_backend/d64_native_activation_swiglu_proof.rs"
+        },
+        "proof_version": "stwo-d64-activation-swiglu-air-proof-v1",
+        "prove_symbol": "prove_zkai_d64_activation_swiglu_envelope",
+        "slice": "activation_swiglu",
+        "verify_symbol": "verify_zkai_d64_activation_swiglu_envelope"
+      },
+      {
+        "evidence": {
+          "decision": "GO_INPUT_FOR_D64_DOWN_PROJECTION_AIR_PROOF",
+          "file_sha256": "547ace4fdee4b773b8559c03cc2ab33b8d43aed885befad84d152a8da205f995",
+          "path": "docs/engineering/evidence/zkai-d64-down-projection-proof-2026-05.json",
+          "payload_sha256": "29011a2c09fcc2131ce0aa0308d93e9e44a8eda42323c6d6fa145817ed57f5dc",
+          "result": null,
+          "schema": "zkai-d64-down-projection-air-proof-input-v1"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "163f3b2c62be8256c7005789bb5e77805836320183c4f04a348ab0e4c45a086f",
+          "path": "src/stwo_backend/d64_native_down_projection_proof.rs"
+        },
+        "proof_version": "stwo-d64-down-projection-air-proof-v1",
+        "prove_symbol": "prove_zkai_d64_down_projection_envelope",
+        "slice": "down_projection",
+        "verify_symbol": "verify_zkai_d64_down_projection_envelope"
+      },
+      {
+        "evidence": {
+          "decision": "GO_INPUT_FOR_D64_RESIDUAL_ADD_AIR_PROOF",
+          "file_sha256": "088a14a2ba54b993798e32b8a39e2a0ecffd3d49d335a4f07c2b9f5ee249c2c3",
+          "path": "docs/engineering/evidence/zkai-d64-residual-add-proof-2026-05.json",
+          "payload_sha256": "90ea0939379010467d56116df9e82355a12dcba05526925cfa53b19c184fa8ba",
+          "result": null,
+          "schema": "zkai-d64-residual-add-air-proof-input-v1"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "9547d8cf3e6cdaeb7dc0e1cb3a28af44700e552417461cdd2bea296c82a39c60",
+          "path": "src/stwo_backend/d64_native_residual_add_proof.rs"
+        },
+        "proof_version": "stwo-d64-residual-add-air-proof-v1",
+        "prove_symbol": "prove_zkai_d64_residual_add_envelope",
+        "slice": "residual_add",
+        "verify_symbol": "verify_zkai_d64_residual_add_envelope"
+      }
+    ],
+    "source": {
+      "decision": "GO_D64_BLOCK_RECEIPT_COMPOSITION_GATE",
+      "file_sha256": "8e924e15535a4f5a57660fed6ea3a11cf8b1ae123f6d05723230416100659206",
+      "path": "docs/engineering/evidence/zkai-d64-block-receipt-composition-gate-2026-05.json",
+      "payload_sha256": "ec98a1fd52bf344b35d586c47608ab80a0b8a771e8c5d7b3a017cc5e564dc599",
+      "result": "GO",
+      "schema": "zkai-d64-block-receipt-composition-gate-v1"
+    },
+    "status": "GO_ANCHOR_ONLY",
+    "total_checked_rows": 49600
+  },
+  "decision": "NO_GO_D128_PROOF_ARTIFACT_PARAMETERIZED_AIR_MISSING",
+  "gate_commitment": "blake2b-256:a87a7e47f496a354a4ebca8b76c057d49bf2ace8e7ff0974b2e96b7b6755bb5d",
+  "issue": 387,
+  "mutation_inventory": [
+    {
+      "index": 0,
+      "mutation": "decision_promoted_to_go",
+      "surface": "top_level"
+    },
+    {
+      "index": 1,
+      "mutation": "target_width_drift",
+      "surface": "target_spec"
+    },
+    {
+      "index": 2,
+      "mutation": "target_backend_version_drift",
+      "surface": "target_spec"
+    },
+    {
+      "index": 3,
+      "mutation": "local_proof_artifact_smuggled",
+      "surface": "proof_status"
+    },
+    {
+      "index": 4,
+      "mutation": "local_verifier_handle_smuggled",
+      "surface": "proof_status"
+    },
+    {
+      "index": 5,
+      "mutation": "proof_size_metric_smuggled",
+      "surface": "metrics"
+    },
+    {
+      "index": 6,
+      "mutation": "verifier_time_metric_smuggled",
+      "surface": "metrics"
+    },
+    {
+      "index": 7,
+      "mutation": "direct_d128_route_promoted",
+      "surface": "backend_routes"
+    },
+    {
+      "index": 8,
+      "mutation": "parameterized_route_promoted",
+      "surface": "backend_routes"
+    },
+    {
+      "index": 9,
+      "mutation": "d64_anchor_removed",
+      "surface": "d64_anchor"
+    },
+    {
+      "index": 10,
+      "mutation": "missing_module_removed",
+      "surface": "source_probe"
+    },
+    {
+      "index": 11,
+      "mutation": "d64_hardcoded_marker_removed",
+      "surface": "source_probe"
+    },
+    {
+      "index": 12,
+      "mutation": "non_claim_removed",
+      "surface": "claim_boundary"
+    },
+    {
+      "index": 13,
+      "mutation": "mutation_case_accepted",
+      "surface": "mutation_harness"
+    }
+  ],
+  "non_claims": [
+    "not a local d128 proof artifact",
+    "not verifier-time evidence for d128",
+    "not proof-size evidence for d128",
+    "not recursive aggregation",
+    "not backend independence evidence",
+    "not a matched NANOZK or DeepProve benchmark",
+    "not a claim that d128 is impossible"
+  ],
+  "proof_status": {
+    "blocked_before_metrics": true,
+    "first_blocker": "no parameterized d128 vector-block AIR/prover/verifier handle; current native proof modules are d64 target/domain/width hard-coded and no d128 native module exports exist",
+    "proof_artifact_exists": false,
+    "proof_size_bytes": null,
+    "required_toolchain": "nightly-2025-07-14",
+    "stable_toolchain_status": "not_supported_by_upstream_stwo_feature_gates",
+    "statement_relabeling_suite_exists": false,
+    "verifier_handle_exists": false,
+    "verifier_time_ms": null
+  },
+  "result": "BOUNDED_NO_GO",
+  "schema": "zkai-d128-proof-artifact-backend-spike-v1",
+  "source_probe": {
+    "d64_hardcoded_markers": [
+      {
+        "markers": [
+          "expect_usize(input.width, ZKAI_D64_WIDTH",
+          "ZKAI_D64_RMSNORM_PUBLIC_ROW_PROOF_VERSION",
+          "ZKAI_D64_TARGET_ID"
+        ],
+        "path": "src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs"
+      },
+      {
+        "markers": [
+          "expect_usize(input.width, ZKAI_D64_WIDTH",
+          "expect_usize(input.ff_dim, ZKAI_D64_FF_DIM",
+          "D64_GATE_VALUE_LOG_SIZE"
+        ],
+        "path": "src/stwo_backend/d64_native_gate_value_projection_proof.rs"
+      },
+      {
+        "markers": [
+          "expect_usize(input.width, ZKAI_D64_WIDTH",
+          "expect_usize(input.ff_dim, ZKAI_D64_FF_DIM",
+          "D64_ACTIVATION_SWIGLU_LOG_SIZE"
+        ],
+        "path": "src/stwo_backend/d64_native_activation_swiglu_proof.rs"
+      },
+      {
+        "markers": [
+          "expect_usize(input.width, ZKAI_D64_WIDTH",
+          "expect_usize(input.ff_dim, ZKAI_D64_FF_DIM",
+          "D64_DOWN_PROJECTION_LOG_SIZE"
+        ],
+        "path": "src/stwo_backend/d64_native_down_projection_proof.rs"
+      },
+      {
+        "markers": [
+          "expect_usize(input.width, ZKAI_D64_WIDTH",
+          "ZKAI_D64_RESIDUAL_ADD_PROOF_VERSION",
+          "D64_RESIDUAL_ADD_LOG_SIZE"
+        ],
+        "path": "src/stwo_backend/d64_native_residual_add_proof.rs"
+      }
+    ],
+    "d64_slices": [
+      {
+        "evidence": {
+          "decision": "GO_PUBLIC_ROW_INPUT_FOR_D64_RMSNORM_AIR_PROOF",
+          "file_sha256": "24083515ddc3ce7a690ac33698157956f6c35427dad8a41c033012616160db1d",
+          "path": "docs/engineering/evidence/zkai-d64-native-rmsnorm-public-row-proof-2026-05.json",
+          "payload_sha256": "1d1f5ec67a770e8c98088e3924b53bf24e91462946b84a2a8cba3d4387f43c75",
+          "result": null,
+          "schema": "zkai-d64-native-rmsnorm-public-row-air-proof-input-v2"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "ff7be7374f917ca21e2a3f85055c963015e421b56b6dfebc26aebaaa50c15fb6",
+          "path": "src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs"
+        },
+        "proof_version": "stwo-d64-rmsnorm-public-row-air-proof-v2",
+        "prove_symbol": "prove_zkai_d64_rmsnorm_public_row_envelope",
+        "slice": "rmsnorm_public_rows",
+        "verify_symbol": "verify_zkai_d64_rmsnorm_public_row_envelope"
+      },
+      {
+        "evidence": {
+          "decision": "GO_INPUT_FOR_D64_RMSNORM_TO_PROJECTION_BRIDGE_AIR_PROOF",
+          "file_sha256": "84b7998b53679c6dd2f221392ee688c499bfdbc6bca0a737e9df40d720a8fccc",
+          "path": "docs/engineering/evidence/zkai-d64-rmsnorm-to-projection-bridge-proof-2026-05.json",
+          "payload_sha256": "2680f43d467a2da07ef8441e4b8051afef2d381a6cf2569130f322c5ddbe81cd",
+          "result": null,
+          "schema": "zkai-d64-rmsnorm-to-projection-bridge-air-proof-input-v1"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "47539bf485b97dac370ee35c2dd44200d1c017c895fbdedd3a79e43c4efb67d3",
+          "path": "src/stwo_backend/d64_native_rmsnorm_to_projection_bridge_proof.rs"
+        },
+        "proof_version": "stwo-d64-rmsnorm-to-projection-bridge-air-proof-v1",
+        "prove_symbol": "prove_zkai_d64_rmsnorm_to_projection_bridge_envelope",
+        "slice": "rmsnorm_projection_bridge",
+        "verify_symbol": "verify_zkai_d64_rmsnorm_to_projection_bridge_envelope"
+      },
+      {
+        "evidence": {
+          "decision": "GO_INPUT_FOR_D64_GATE_VALUE_PROJECTION_AIR_PROOF",
+          "file_sha256": "69a2f78a1aa181a589fb5694c34faf3a2c0f784f73e3d07441e2a16368722755",
+          "path": "docs/engineering/evidence/zkai-d64-gate-value-projection-proof-2026-05.json",
+          "payload_sha256": "8597373e50dce1f2590179d4eb189add3917d54d7cbf309916193198e7c02ce7",
+          "result": null,
+          "schema": "zkai-d64-gate-value-projection-air-proof-input-v1"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "baa70ad8c741bae962031677d80bcfe51fcf597ce5301775f6043713d722ac42",
+          "path": "src/stwo_backend/d64_native_gate_value_projection_proof.rs"
+        },
+        "proof_version": "stwo-d64-gate-value-projection-air-proof-v1",
+        "prove_symbol": "prove_zkai_d64_gate_value_projection_envelope",
+        "slice": "gate_value_projection",
+        "verify_symbol": "verify_zkai_d64_gate_value_projection_envelope"
+      },
+      {
+        "evidence": {
+          "decision": "GO_INPUT_FOR_D64_ACTIVATION_SWIGLU_AIR_PROOF",
+          "file_sha256": "3cb30766f1665398fc54ea98a686e258eb7f247f0599ffae8d0f28a13c5f313d",
+          "path": "docs/engineering/evidence/zkai-d64-activation-swiglu-proof-2026-05.json",
+          "payload_sha256": "d810411fadb50a8f830c099550942475640708bc7631a47b687640061ab3ced6",
+          "result": null,
+          "schema": "zkai-d64-activation-swiglu-air-proof-input-v1"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "6387e781bb03beacaceed43f6d44fdd25ee2ef0ccbd8f2a7b7e6c2bbe9c6b8c0",
+          "path": "src/stwo_backend/d64_native_activation_swiglu_proof.rs"
+        },
+        "proof_version": "stwo-d64-activation-swiglu-air-proof-v1",
+        "prove_symbol": "prove_zkai_d64_activation_swiglu_envelope",
+        "slice": "activation_swiglu",
+        "verify_symbol": "verify_zkai_d64_activation_swiglu_envelope"
+      },
+      {
+        "evidence": {
+          "decision": "GO_INPUT_FOR_D64_DOWN_PROJECTION_AIR_PROOF",
+          "file_sha256": "547ace4fdee4b773b8559c03cc2ab33b8d43aed885befad84d152a8da205f995",
+          "path": "docs/engineering/evidence/zkai-d64-down-projection-proof-2026-05.json",
+          "payload_sha256": "29011a2c09fcc2131ce0aa0308d93e9e44a8eda42323c6d6fa145817ed57f5dc",
+          "result": null,
+          "schema": "zkai-d64-down-projection-air-proof-input-v1"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "163f3b2c62be8256c7005789bb5e77805836320183c4f04a348ab0e4c45a086f",
+          "path": "src/stwo_backend/d64_native_down_projection_proof.rs"
+        },
+        "proof_version": "stwo-d64-down-projection-air-proof-v1",
+        "prove_symbol": "prove_zkai_d64_down_projection_envelope",
+        "slice": "down_projection",
+        "verify_symbol": "verify_zkai_d64_down_projection_envelope"
+      },
+      {
+        "evidence": {
+          "decision": "GO_INPUT_FOR_D64_RESIDUAL_ADD_AIR_PROOF",
+          "file_sha256": "088a14a2ba54b993798e32b8a39e2a0ecffd3d49d335a4f07c2b9f5ee249c2c3",
+          "path": "docs/engineering/evidence/zkai-d64-residual-add-proof-2026-05.json",
+          "payload_sha256": "90ea0939379010467d56116df9e82355a12dcba05526925cfa53b19c184fa8ba",
+          "result": null,
+          "schema": "zkai-d64-residual-add-air-proof-input-v1"
+        },
+        "module": {
+          "exists": true,
+          "file_sha256": "9547d8cf3e6cdaeb7dc0e1cb3a28af44700e552417461cdd2bea296c82a39c60",
+          "path": "src/stwo_backend/d64_native_residual_add_proof.rs"
+        },
+        "proof_version": "stwo-d64-residual-add-air-proof-v1",
+        "prove_symbol": "prove_zkai_d64_residual_add_envelope",
+        "slice": "residual_add",
+        "verify_symbol": "verify_zkai_d64_residual_add_envelope"
+      }
+    ],
+    "missing_d128_export_symbols": [
+      "prove_zkai_d128_rmsnorm_public_row_envelope",
+      "verify_zkai_d128_rmsnorm_public_row_envelope",
+      "prove_zkai_d128_gate_value_projection_envelope",
+      "verify_zkai_d128_gate_value_projection_envelope",
+      "prove_zkai_d128_activation_swiglu_envelope",
+      "verify_zkai_d128_activation_swiglu_envelope",
+      "prove_zkai_d128_down_projection_envelope",
+      "verify_zkai_d128_down_projection_envelope",
+      "prove_zkai_d128_residual_add_envelope",
+      "verify_zkai_d128_residual_add_envelope",
+      "prove_zkai_d128_transformer_block_envelope",
+      "verify_zkai_d128_transformer_block_envelope"
+    ],
+    "missing_d128_modules": [
+      "src/stwo_backend/d128_native_rmsnorm_public_row_proof.rs",
+      "src/stwo_backend/d128_native_rmsnorm_to_projection_bridge_proof.rs",
+      "src/stwo_backend/d128_native_gate_value_projection_proof.rs",
+      "src/stwo_backend/d128_native_activation_swiglu_proof.rs",
+      "src/stwo_backend/d128_native_down_projection_proof.rs",
+      "src/stwo_backend/d128_native_residual_add_proof.rs",
+      "src/stwo_backend/d128_native_transformer_block_proof.rs"
+    ],
+    "missing_parameterized_symbols": [
+      "ZkAiVectorBlockProofInput",
+      "ZkAiParameterizedTransformerBlockProof",
+      "prove_zkai_vector_block_envelope",
+      "verify_zkai_vector_block_envelope",
+      "parameterized_vector_block_air"
+    ]
+  },
+  "summary": {
+    "blocked_before_metrics": true,
+    "d64_anchor_route": "GO_ANCHOR_ONLY",
+    "direct_d128_route": "NO_GO",
+    "first_blocker": "no parameterized d128 vector-block AIR/prover/verifier handle; current native proof modules are d64 target/domain/width hard-coded and no d128 native module exports exist",
+    "issue": 387,
+    "mutation_cases": 14,
+    "mutations_rejected": 14,
+    "parameterized_route": "NO_GO_FIRST_BLOCKER",
+    "target_ff_dim": 512,
+    "target_id": "rmsnorm-swiglu-residual-d128-v1",
+    "target_width": 128
+  },
+  "target": {
+    "ff_dim": 512,
+    "required_backend_version": "stwo-rmsnorm-swiglu-residual-d128-v1",
+    "source": {
+      "decision": "NO_GO_D128_LAYERWISE_PROOF_ARTIFACT_MISSING",
+      "file_sha256": "bf1b5cb0dc3471d5c7421f091b4f94f986e38f2ed80e91f325f26fc8080617a0",
+      "path": "docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json",
+      "payload_sha256": "573cfa48a9e56b722604c51f7210ef405e74d9902a90eeb5b8ed16ca27bca506",
+      "result": "BOUNDED_NO_GO",
+      "schema": "zkai-d128-layerwise-comparator-target-v1"
+    },
+    "statement_kind": "transformer-block",
+    "target_commitment": "blake2b-256:d6a6ce9312fa7afa87899bea33f060336d79e215de95a64af4b7c9161df0ec18",
+    "target_id": "rmsnorm-swiglu-residual-d128-v1",
+    "width": 128
+  },
+  "validation_commands": [
+    "python3 scripts/zkai_d128_proof_artifact_backend_spike_gate.py --write-json docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.json --write-tsv docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_d128_proof_artifact_backend_spike_gate",
+    "cargo +nightly-2025-07-14 test --lib d64 --features stwo-backend -- --nocapture",
+    "python3 scripts/paper/paper_preflight.py --repo-root ."
+  ]
+}

--- a/docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.json
+++ b/docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.json
@@ -18,6 +18,8 @@
       "missing_export_symbols": [
         "prove_zkai_d128_rmsnorm_public_row_envelope",
         "verify_zkai_d128_rmsnorm_public_row_envelope",
+        "prove_zkai_d128_rmsnorm_to_projection_bridge_envelope",
+        "verify_zkai_d128_rmsnorm_to_projection_bridge_envelope",
         "prove_zkai_d128_gate_value_projection_envelope",
         "verify_zkai_d128_gate_value_projection_envelope",
         "prove_zkai_d128_activation_swiglu_envelope",
@@ -57,6 +59,14 @@
             "ZKAI_D64_TARGET_ID"
           ],
           "path": "src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs"
+        },
+        {
+          "markers": [
+            "expect_usize(input.width, ZKAI_D64_WIDTH",
+            "ZKAI_D64_RMSNORM_TO_PROJECTION_BRIDGE_PROOF_VERSION",
+            "D64_BRIDGE_LOG_SIZE"
+          ],
+          "path": "src/stwo_backend/d64_native_rmsnorm_to_projection_bridge_proof.rs"
         },
         {
           "markers": [
@@ -391,7 +401,7 @@
     "total_checked_rows": 49600
   },
   "decision": "NO_GO_D128_PROOF_ARTIFACT_PARAMETERIZED_AIR_MISSING",
-  "gate_commitment": "blake2b-256:a87a7e47f496a354a4ebca8b76c057d49bf2ace8e7ff0974b2e96b7b6755bb5d",
+  "gate_commitment": "blake2b-256:b8b1f02d211e8541e0f8c44a64e94a9041661680c4051dbc33d720c685241163",
   "issue": 387,
   "mutation_inventory": [
     {
@@ -496,6 +506,14 @@
           "ZKAI_D64_TARGET_ID"
         ],
         "path": "src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs"
+      },
+      {
+        "markers": [
+          "expect_usize(input.width, ZKAI_D64_WIDTH",
+          "ZKAI_D64_RMSNORM_TO_PROJECTION_BRIDGE_PROOF_VERSION",
+          "D64_BRIDGE_LOG_SIZE"
+        ],
+        "path": "src/stwo_backend/d64_native_rmsnorm_to_projection_bridge_proof.rs"
       },
       {
         "markers": [
@@ -649,6 +667,8 @@
     "missing_d128_export_symbols": [
       "prove_zkai_d128_rmsnorm_public_row_envelope",
       "verify_zkai_d128_rmsnorm_public_row_envelope",
+      "prove_zkai_d128_rmsnorm_to_projection_bridge_envelope",
+      "verify_zkai_d128_rmsnorm_to_projection_bridge_envelope",
       "prove_zkai_d128_gate_value_projection_envelope",
       "verify_zkai_d128_gate_value_projection_envelope",
       "prove_zkai_d128_activation_swiglu_envelope",

--- a/docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.tsv
@@ -1,0 +1,22 @@
+route	status	target_width	target_ff_dim	proof_artifact_exists	verifier_handle_exists	proof_size_bytes	verifier_time_ms	blocker
+existing_d64_slice_chain	GO_ANCHOR_ONLY	64	256	True	True			d64 slice proofs exist, but this is not the d128 target
+direct_d128_native_modules	NO_GO	128	512	False	False			no d128 native proof modules or exported prove/verify handles exist
+lift_existing_d64_modules_by_metadata	NO_GO	128	512	False	False			d64 modules validate hard-coded width, target id, domains, and log sizes
+parameterized_vector_block_air	NO_GO_FIRST_BLOCKER	128	512	False	False			no parameterized d128 vector-block AIR/prover/verifier handle; current native proof modules are d64 target/domain/width hard-coded and no d128 native module exports exist
+d128_metrics_and_relabeling_suite	NO_GO_BLOCKED_BEFORE_PROOF_OBJECT	128	512	False	False			do not report proof size, verifier time, or relabeling resistance until a d128 proof object and verifier handle exist
+
+mutation	surface	mutated_accepted	rejected	rejection_layer	error
+decision_promoted_to_go	top_level	False	True	top_level	decision mismatch
+target_width_drift	target_spec	False	True	target_spec	target width mismatch
+target_backend_version_drift	target_spec	False	True	target_spec	target backend version mismatch
+local_proof_artifact_smuggled	proof_status	False	True	proof_status	proof artifact exists mismatch
+local_verifier_handle_smuggled	proof_status	False	True	proof_status	verifier handle exists mismatch
+proof_size_metric_smuggled	metrics	False	True	metrics	proof size mismatch
+verifier_time_metric_smuggled	metrics	False	True	metrics	verifier time mismatch
+direct_d128_route_promoted	backend_routes	False	True	backend_routes	direct d128 route status mismatch
+parameterized_route_promoted	backend_routes	False	True	backend_routes	parameterized route status mismatch
+d64_anchor_removed	d64_anchor	False	True	d64_anchor	d64 anchor status mismatch
+missing_module_removed	source_probe	False	True	source_probe	missing d128 module inventory mismatch
+d64_hardcoded_marker_removed	source_probe	False	True	source_probe	src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs hardcoded markers mismatch
+non_claim_removed	claim_boundary	False	True	claim_boundary	non-claims inventory mismatch
+mutation_case_accepted	mutation_harness	False	True	mutation_harness	summary mutation count mismatch

--- a/docs/engineering/zkai-d128-proof-artifact-backend-spike-2026-05-02.md
+++ b/docs/engineering/zkai-d128-proof-artifact-backend-spike-2026-05-02.md
@@ -1,0 +1,139 @@
+# d128 proof artifact backend spike - 2026-05-02
+
+## Question
+
+Can the checked `d=128` RMSNorm-SwiGLU-residual target be routed through the
+current local backend as a real proof artifact with a verifier handle and
+relabeling tests?
+
+This gate starts from the comparator-target result and asks the implementation
+question directly. It separates:
+
+- the pinned `d=128` target shape;
+- the working `d=64` native slice proof chain;
+- the missing backend route for a real `d=128` proof object.
+
+## Decision
+
+**Bounded NO-GO for the current backend route.**
+
+The first blocker is:
+
+> no parameterized d128 vector-block AIR/prover/verifier handle; current native
+> proof modules are d64 target/domain/width hard-coded and no d128 native module
+> exports exist
+
+This does not invalidate the d128 target. It means the target is still a proof
+artifact backlog item, not a metric-producing result.
+
+## Result
+
+| Field | Value |
+| --- | --- |
+| Decision | `NO_GO_D128_PROOF_ARTIFACT_PARAMETERIZED_AIR_MISSING` |
+| Result | `BOUNDED_NO_GO` |
+| Issue | `#387` |
+| Target | `rmsnorm-swiglu-residual-d128-v1` |
+| Width | `128` |
+| FF dimension | `512` |
+| Required backend version | `stwo-rmsnorm-swiglu-residual-d128-v1` |
+| d64 anchor | `GO_ANCHOR_ONLY` |
+| Direct d128 module route | `NO_GO` |
+| Parameterized vector-block route | `NO_GO_FIRST_BLOCKER` |
+| Metrics | blocked before proof object |
+| Mutation checks | `14 / 14` rejected |
+
+## Backend-route classification
+
+| Route | Status | Interpretation |
+| --- | --- | --- |
+| `existing_d64_slice_chain` | `GO_ANCHOR_ONLY` | The six-slice `d=64` proof chain exists and remains the working local anchor. It is not a `d=128` proof. |
+| `direct_d128_native_modules` | `NO_GO` | No `src/stwo_backend/d128_native_*` proof modules or exported d128 prove/verify handles exist. |
+| `lift_existing_d64_modules_by_metadata` | `NO_GO` | The d64 modules validate d64 width, target id, domains, proof versions, and log sizes. A metadata relabel cannot make them d128. |
+| `parameterized_vector_block_air` | `NO_GO_FIRST_BLOCKER` | The repository lacks a parameterized vector-block AIR/prover/verifier surface. |
+| `d128_metrics_and_relabeling_suite` | `NO_GO_BLOCKED_BEFORE_PROOF_OBJECT` | Proof size, verifier time, and relabeling resistance remain unreported until a d128 proof object exists. |
+
+## Working anchor
+
+The current local anchor is the checked `d=64` native slice chain:
+
+- `rmsnorm_public_rows`;
+- `rmsnorm_projection_bridge`;
+- `gate_value_projection`;
+- `activation_swiglu`;
+- `down_projection`;
+- `residual_add`.
+
+The composition gate records six slices and `49600` checked rows. That anchor is
+useful because it proves the receipt discipline and slice interfaces are not
+fiction. It does not provide a direct scale-up route to `d=128`.
+
+## Why this closes a fooling-ourselves gap
+
+Before this gate, the repository had a target-spec NO-GO saying "a d128 proof
+artifact is missing." This gate makes the missing route executable:
+
+- it validates the d128 target evidence before starting;
+- it validates the d64 composition anchor before starting;
+- it checks that the expected d128 modules and exported symbols are absent;
+- it checks that the current d64 modules are hard-coded to d64 width/domain
+  surfaces;
+- it fails closed if a future branch adds a d128 or parameterized route while
+  this evidence still claims NO-GO;
+- it rejects metric smuggling and route-promotion mutations.
+
+## Toolchain note
+
+The Stwo backend requires the repository's pinned nightly toolchain:
+`cargo +nightly-2025-07-14`. A stable-channel invocation fails inside upstream
+`stwo` feature gates before reaching repository proof code, so stable failure is
+not evidence about the d128 route.
+
+## Metrics policy
+
+No local `d=128` proof size, verifier time, proof-generation time, or relabeling
+resistance is reported here. Those numbers are blocked until:
+
+- a local d128 proof artifact exists;
+- a d128 verifier handle exists;
+- the statement envelope binds model/config/input/output/parameter/proof/verifier
+  domain commitments;
+- relabeling tests reject drift in model, config, weights, input, output, proof,
+  verifying key, setup, and verifier-domain fields.
+
+## Non-claims
+
+This result does **not** claim:
+
+- a local d128 proof artifact;
+- verifier-time evidence for d128;
+- proof-size evidence for d128;
+- recursive aggregation;
+- backend independence evidence;
+- a matched NANOZK or DeepProve benchmark;
+- that d128 is impossible.
+
+## Evidence
+
+- JSON:
+  `docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.json`
+- TSV:
+  `docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.tsv`
+- Script:
+  `scripts/zkai_d128_proof_artifact_backend_spike_gate.py`
+- Tests:
+  `scripts/tests/test_zkai_d128_proof_artifact_backend_spike_gate.py`
+
+## Reproduce
+
+```bash
+python3 scripts/zkai_d128_proof_artifact_backend_spike_gate.py \
+  --write-json docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.tsv
+
+python3 -m unittest scripts.tests.test_zkai_d128_proof_artifact_backend_spike_gate
+
+cargo +nightly-2025-07-14 test --lib d64 --features stwo-backend -- --nocapture
+
+python3 scripts/paper/paper_preflight.py --repo-root .
+```

--- a/scripts/tests/test_zkai_d128_proof_artifact_backend_spike_gate.py
+++ b/scripts/tests/test_zkai_d128_proof_artifact_backend_spike_gate.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "zkai_d128_proof_artifact_backend_spike_gate.py"
+SPEC = importlib.util.spec_from_file_location("zkai_d128_proof_artifact_backend_spike_gate", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load d128 backend spike gate from {SCRIPT_PATH}")
+GATE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = GATE
+SPEC.loader.exec_module(GATE)
+
+
+class ZkAiD128ProofArtifactBackendSpikeGateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.payload = GATE.build_gate_result()
+
+    def fresh_payload(self) -> dict:
+        return copy.deepcopy(self.payload)
+
+    def test_gate_records_bounded_no_go_after_d64_anchor(self) -> None:
+        payload = self.fresh_payload()
+        GATE.validate_payload(payload)
+        self.assertEqual(payload["schema"], GATE.SCHEMA)
+        self.assertEqual(payload["decision"], GATE.DECISION)
+        self.assertEqual(payload["result"], GATE.RESULT)
+        self.assertEqual(payload["issue"], 387)
+        self.assertEqual(payload["summary"]["d64_anchor_route"], "GO_ANCHOR_ONLY")
+        self.assertEqual(payload["summary"]["direct_d128_route"], "NO_GO")
+        self.assertEqual(payload["summary"]["parameterized_route"], "NO_GO_FIRST_BLOCKER")
+        self.assertEqual(payload["case_count"], 14)
+        self.assertTrue(payload["all_mutations_rejected"])
+
+    def test_target_matches_pinned_d128_comparator_shape(self) -> None:
+        target = self.fresh_payload()["target"]
+        self.assertEqual(target["target_id"], "rmsnorm-swiglu-residual-d128-v1")
+        self.assertEqual(target["width"], 128)
+        self.assertEqual(target["ff_dim"], 512)
+        self.assertEqual(target["required_backend_version"], "stwo-rmsnorm-swiglu-residual-d128-v1")
+        self.assertTrue(target["target_commitment"].startswith("blake2b-256:"))
+
+    def test_d64_anchor_keeps_six_working_slices_but_not_d128(self) -> None:
+        anchor = self.fresh_payload()["d64_anchor"]
+        self.assertEqual(anchor["status"], "GO_ANCHOR_ONLY")
+        self.assertEqual(anchor["slice_count"], 6)
+        self.assertEqual(anchor["total_checked_rows"], 49600)
+        self.assertIn("not a d128 proof route", anchor["claim_boundary"])
+        self.assertEqual([row["slice"] for row in anchor["slices"]], [
+            "rmsnorm_public_rows",
+            "rmsnorm_projection_bridge",
+            "gate_value_projection",
+            "activation_swiglu",
+            "down_projection",
+            "residual_add",
+        ])
+        for row in anchor["slices"]:
+            self.assertTrue(row["module"]["exists"])
+            self.assertTrue(row["evidence"]["schema"].startswith("zkai-d64"))
+
+    def test_source_probe_is_fail_closed_on_missing_d128_route(self) -> None:
+        probe = self.fresh_payload()["source_probe"]
+        self.assertEqual(probe["missing_d128_modules"], list(GATE.EXPECTED_D128_MODULES))
+        self.assertEqual(probe["missing_d128_export_symbols"], list(GATE.EXPECTED_D128_EXPORT_SYMBOLS))
+        self.assertEqual(probe["missing_parameterized_symbols"], list(GATE.PARAMETERIZED_SYMBOLS))
+        self.assertEqual(len(probe["d64_hardcoded_markers"]), len(GATE.D64_HARDCODE_MARKERS))
+
+    def test_backend_routes_block_metrics_until_proof_exists(self) -> None:
+        routes = {row["route"]: row for row in self.fresh_payload()["backend_routes"]}
+        self.assertEqual(routes["existing_d64_slice_chain"]["status"], "GO_ANCHOR_ONLY")
+        self.assertEqual(routes["direct_d128_native_modules"]["status"], "NO_GO")
+        self.assertEqual(routes["lift_existing_d64_modules_by_metadata"]["status"], "NO_GO")
+        self.assertEqual(routes["parameterized_vector_block_air"]["status"], "NO_GO_FIRST_BLOCKER")
+        self.assertEqual(routes["d128_metrics_and_relabeling_suite"]["status"], "NO_GO_BLOCKED_BEFORE_PROOF_OBJECT")
+        for name, row in routes.items():
+            self.assertIsNone(row["proof_size_bytes"], name)
+            self.assertIsNone(row["verifier_time_ms"], name)
+
+    def test_proof_status_records_toolchain_and_no_metrics(self) -> None:
+        status = self.fresh_payload()["proof_status"]
+        self.assertFalse(status["proof_artifact_exists"])
+        self.assertFalse(status["verifier_handle_exists"])
+        self.assertFalse(status["statement_relabeling_suite_exists"])
+        self.assertTrue(status["blocked_before_metrics"])
+        self.assertIsNone(status["proof_size_bytes"])
+        self.assertIsNone(status["verifier_time_ms"])
+        self.assertEqual(status["required_toolchain"], "nightly-2025-07-14")
+        self.assertEqual(status["stable_toolchain_status"], "not_supported_by_upstream_stwo_feature_gates")
+
+    def test_rejects_metric_smuggling(self) -> None:
+        payload = self.fresh_payload()
+        payload["proof_status"]["verifier_time_ms"] = 1.0
+        with self.assertRaisesRegex(GATE.D128BackendSpikeError, "verifier time"):
+            GATE.validate_payload(payload)
+
+    def test_rejects_route_promotion(self) -> None:
+        payload = self.fresh_payload()
+        route = next(row for row in payload["backend_routes"] if row["route"] == "parameterized_vector_block_air")
+        route["status"] = "GO"
+        with self.assertRaisesRegex(GATE.D128BackendSpikeError, "parameterized route status"):
+            GATE.validate_payload(payload)
+
+    def test_rejects_removed_missing_module(self) -> None:
+        payload = self.fresh_payload()
+        payload["source_probe"]["missing_d128_modules"] = payload["source_probe"]["missing_d128_modules"][1:]
+        with self.assertRaisesRegex(GATE.D128BackendSpikeError, "missing d128 module"):
+            GATE.validate_payload(payload)
+
+    def test_rejects_removed_non_claim(self) -> None:
+        payload = self.fresh_payload()
+        payload["non_claims"].remove("not a local d128 proof artifact")
+        with self.assertRaisesRegex(GATE.D128BackendSpikeError, "non-claims"):
+            GATE.validate_payload(payload)
+
+    def test_mutation_layers_cover_routes_sources_and_metrics(self) -> None:
+        cases = {case["mutation"]: case for case in self.fresh_payload()["cases"]}
+        self.assertEqual(cases["decision_promoted_to_go"]["rejection_layer"], "top_level")
+        self.assertEqual(cases["direct_d128_route_promoted"]["rejection_layer"], "backend_routes")
+        self.assertEqual(cases["parameterized_route_promoted"]["rejection_layer"], "backend_routes")
+        self.assertEqual(cases["missing_module_removed"]["rejection_layer"], "source_probe")
+        self.assertEqual(cases["proof_size_metric_smuggled"]["rejection_layer"], "metrics")
+        for case in cases.values():
+            self.assertTrue(case["rejected"])
+            self.assertFalse(case["mutated_accepted"])
+            self.assertTrue(case["error"])
+
+    def test_write_outputs_round_trips(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_path = tmp / "d128-backend-spike.json"
+            tsv_path = tmp / "d128-backend-spike.tsv"
+            GATE.write_outputs(payload, json_path, tsv_path)
+            self.assertEqual(json.loads(json_path.read_text(encoding="utf-8")), payload)
+            tsv = tsv_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(tsv[0].split("\t"), list(GATE.TSV_COLUMNS))
+            self.assertIn("direct_d128_native_modules", tsv[2])
+            self.assertEqual(tsv[7].split("\t"), list(GATE.MUTATION_TSV_COLUMNS))
+
+    def test_write_outputs_rejects_paths_outside_repo(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            json_path = tmp / "d128-backend-spike.json"
+            tsv_path = tmp / "d128-backend-spike.tsv"
+            with self.assertRaisesRegex(GATE.D128BackendSpikeError, "output path escapes repository"):
+                GATE.write_outputs(payload, json_path, tsv_path)
+            self.assertFalse(json_path.exists())
+            self.assertFalse(tsv_path.exists())
+
+    def test_write_outputs_fsyncs_parent_directory_after_replace(self) -> None:
+        payload = self.fresh_payload()
+        original = GATE._fsync_parent_directories
+        synced: list[pathlib.Path] = []
+
+        def record(paths: list[pathlib.Path]) -> None:
+            synced.extend(paths)
+
+        try:
+            GATE._fsync_parent_directories = record
+            with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+                tmp = pathlib.Path(raw_tmp)
+                json_path = tmp / "d128-backend-spike.json"
+                tsv_path = tmp / "d128-backend-spike.tsv"
+                GATE.write_outputs(payload, json_path, tsv_path)
+            self.assertEqual(synced, [json_path.resolve(), tsv_path.resolve()])
+        finally:
+            GATE._fsync_parent_directories = original
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_d128_proof_artifact_backend_spike_gate.py
+++ b/scripts/tests/test_zkai_d128_proof_artifact_backend_spike_gate.py
@@ -70,8 +70,18 @@ class ZkAiD128ProofArtifactBackendSpikeGateTests(unittest.TestCase):
         probe = self.fresh_payload()["source_probe"]
         self.assertEqual(probe["missing_d128_modules"], list(GATE.EXPECTED_D128_MODULES))
         self.assertEqual(probe["missing_d128_export_symbols"], list(GATE.EXPECTED_D128_EXPORT_SYMBOLS))
+        self.assertIn(
+            "prove_zkai_d128_rmsnorm_to_projection_bridge_envelope",
+            probe["missing_d128_export_symbols"],
+        )
         self.assertEqual(probe["missing_parameterized_symbols"], list(GATE.PARAMETERIZED_SYMBOLS))
         self.assertEqual(len(probe["d64_hardcoded_markers"]), len(GATE.D64_HARDCODE_MARKERS))
+        markers = {row["path"]: row["markers"] for row in probe["d64_hardcoded_markers"]}
+        self.assertIn("src/stwo_backend/d64_native_rmsnorm_to_projection_bridge_proof.rs", markers)
+        self.assertIn(
+            "ZKAI_D64_RMSNORM_TO_PROJECTION_BRIDGE_PROOF_VERSION",
+            markers["src/stwo_backend/d64_native_rmsnorm_to_projection_bridge_proof.rs"],
+        )
 
     def test_backend_routes_block_metrics_until_proof_exists(self) -> None:
         routes = {row["route"]: row for row in self.fresh_payload()["backend_routes"]}
@@ -132,6 +142,20 @@ class ZkAiD128ProofArtifactBackendSpikeGateTests(unittest.TestCase):
             self.assertFalse(case["mutated_accepted"])
             self.assertTrue(case["error"])
 
+    def test_mutation_harness_raises_on_unexpected_validator_bug(self) -> None:
+        payload = self.fresh_payload()
+        original_validate_payload = GATE.validate_payload
+
+        def bugged_validate_payload(_payload: dict, *, require_mutations: bool = True) -> None:
+            raise KeyError("unexpected-validator-bug")
+
+        try:
+            GATE.validate_payload = bugged_validate_payload
+            with self.assertRaisesRegex(RuntimeError, "mutation harness failed"):
+                GATE.mutation_cases(payload)
+        finally:
+            GATE.validate_payload = original_validate_payload
+
     def test_write_outputs_round_trips(self) -> None:
         payload = self.fresh_payload()
         with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
@@ -155,6 +179,37 @@ class ZkAiD128ProofArtifactBackendSpikeGateTests(unittest.TestCase):
                 GATE.write_outputs(payload, json_path, tsv_path)
             self.assertFalse(json_path.exists())
             self.assertFalse(tsv_path.exists())
+
+    def test_write_outputs_rejects_symlink_outputs_inside_repo(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            target = tmp / "target.json"
+            target.write_text("existing\n", encoding="utf-8")
+            symlink = tmp / "linked.json"
+            symlink.symlink_to(target)
+            with self.assertRaisesRegex(GATE.D128BackendSpikeError, "symlink"):
+                GATE.write_outputs(payload, symlink, None)
+            self.assertEqual(target.read_text(encoding="utf-8"), "existing\n")
+
+    def test_atomic_write_cleans_temp_file_when_replace_fails(self) -> None:
+        original_replace = GATE.os.replace
+        with tempfile.TemporaryDirectory(dir=ROOT) as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            out = tmp / "out.json"
+
+            def fail_replace(_src: pathlib.Path, _dst: pathlib.Path) -> None:
+                raise OSError("simulated replace failure")
+
+            try:
+                GATE.os.replace = fail_replace
+                with self.assertRaisesRegex(OSError, "simulated replace failure"):
+                    GATE._atomic_write_text(out, "payload\n")
+                leftovers = [path for path in tmp.iterdir() if path.name != "out.json"]
+                self.assertEqual(leftovers, [])
+                self.assertFalse(out.exists())
+            finally:
+                GATE.os.replace = original_replace
 
     def test_write_outputs_fsyncs_parent_directory_after_replace(self) -> None:
         payload = self.fresh_payload()

--- a/scripts/zkai_d128_proof_artifact_backend_spike_gate.py
+++ b/scripts/zkai_d128_proof_artifact_backend_spike_gate.py
@@ -110,6 +110,8 @@ EXPECTED_D128_MODULES = (
 EXPECTED_D128_EXPORT_SYMBOLS = (
     "prove_zkai_d128_rmsnorm_public_row_envelope",
     "verify_zkai_d128_rmsnorm_public_row_envelope",
+    "prove_zkai_d128_rmsnorm_to_projection_bridge_envelope",
+    "verify_zkai_d128_rmsnorm_to_projection_bridge_envelope",
     "prove_zkai_d128_gate_value_projection_envelope",
     "verify_zkai_d128_gate_value_projection_envelope",
     "prove_zkai_d128_activation_swiglu_envelope",
@@ -135,6 +137,11 @@ D64_HARDCODE_MARKERS = {
         "expect_usize(input.width, ZKAI_D64_WIDTH",
         "ZKAI_D64_RMSNORM_PUBLIC_ROW_PROOF_VERSION",
         "ZKAI_D64_TARGET_ID",
+    ),
+    "src/stwo_backend/d64_native_rmsnorm_to_projection_bridge_proof.rs": (
+        "expect_usize(input.width, ZKAI_D64_WIDTH",
+        "ZKAI_D64_RMSNORM_TO_PROJECTION_BRIDGE_PROOF_VERSION",
+        "D64_BRIDGE_LOG_SIZE",
     ),
     "src/stwo_backend/d64_native_gate_value_projection_proof.rs": (
         "expect_usize(input.width, ZKAI_D64_WIDTH",
@@ -347,6 +354,13 @@ def repo_file_descriptor(path: str) -> dict[str, Any]:
     }
 
 
+def rust_source_corpus() -> str:
+    chunks = []
+    for path in sorted((ROOT / "src").rglob("*.rs")):
+        chunks.append(path.read_text(encoding="utf-8"))
+    return "\n".join(chunks)
+
+
 def build_source_probe() -> dict[str, Any]:
     mod_rs = read_repo_file("src/stwo_backend/mod.rs")
     d64_slices = []
@@ -391,10 +405,7 @@ def build_source_probe() -> dict[str, Any]:
         )
     missing_d128_symbols = list(EXPECTED_D128_EXPORT_SYMBOLS)
 
-    repo_text = "\n".join(
-        (ROOT / path).read_text(encoding="utf-8")
-        for path in ["src/stwo_backend/mod.rs", *[spec["module"] for spec in D64_PROOF_SLICES]]
-    )
+    repo_text = rust_source_corpus()
     present_parameterized_symbols = [
         symbol for symbol in PARAMETERIZED_SYMBOLS if symbol in repo_text
     ]
@@ -626,7 +637,7 @@ def mutation_cases(payload: dict[str, Any]) -> list[dict[str, Any]]:
     for index, (mutation, surface, mutated) in enumerate(_mutated_cases(payload)):
         try:
             validate_payload(mutated, require_mutations=False)
-        except Exception as err:  # noqa: BLE001 - record rejection diagnostics.
+        except D128BackendSpikeError as err:
             error = str(err) or f"{err.__class__.__name__} with empty message"
             results.append(
                 {
@@ -639,6 +650,10 @@ def mutation_cases(payload: dict[str, Any]) -> list[dict[str, Any]]:
                     "error": error,
                 }
             )
+        except Exception as err:  # noqa: BLE001 - harness bugs must fail the gate.
+            raise RuntimeError(
+                f"mutation harness failed for {mutation}: {err.__class__.__name__}: {err}"
+            ) from err
         else:
             results.append(
                 {
@@ -794,6 +809,8 @@ def mutation_rows_for_tsv(payload: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _assert_repo_output_path(path: pathlib.Path) -> pathlib.Path:
+    if path.is_symlink():
+        raise D128BackendSpikeError(f"output path must not be a symlink: {path}")
     resolved = path.resolve()
     try:
         resolved.relative_to(ROOT.resolve())
@@ -805,8 +822,6 @@ def _assert_repo_output_path(path: pathlib.Path) -> pathlib.Path:
     if parent.exists() and not parent.is_dir():
         raise D128BackendSpikeError(f"output parent is not a directory: {parent}")
     parent.mkdir(parents=True, exist_ok=True)
-    if resolved.is_symlink():
-        raise D128BackendSpikeError(f"output path must not be a symlink: {path}")
     return resolved
 
 
@@ -835,7 +850,11 @@ def _atomic_write_text(path: pathlib.Path, text: str) -> None:
         handle.write(text)
         handle.flush()
         os.fsync(handle.fileno())
-    os.replace(tmp, resolved)
+    try:
+        os.replace(tmp, resolved)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:

--- a/scripts/zkai_d128_proof_artifact_backend_spike_gate.py
+++ b/scripts/zkai_d128_proof_artifact_backend_spike_gate.py
@@ -1,0 +1,882 @@
+#!/usr/bin/env python3
+"""Gate the current backend route for a real d128 transformer-block proof.
+
+This is intentionally narrower than the d128 comparator target gate.  It does
+not ask whether the d128 shape is useful; that was already checked.  It asks
+whether today's repository can actually produce a local d128 proof artifact
+with a verifier handle and relabeling tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import hashlib
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+EVIDENCE_DIR = ROOT / "docs" / "engineering" / "evidence"
+TARGET_GATE_PATH = ROOT / "scripts" / "zkai_d128_layerwise_comparator_target_gate.py"
+D64_BLOCK_GATE_PATH = ROOT / "scripts" / "zkai_d64_block_receipt_composition_gate.py"
+TARGET_EVIDENCE = EVIDENCE_DIR / "zkai-d128-layerwise-comparator-target-2026-05.json"
+D64_BLOCK_EVIDENCE = EVIDENCE_DIR / "zkai-d64-block-receipt-composition-gate-2026-05.json"
+JSON_OUT = EVIDENCE_DIR / "zkai-d128-proof-artifact-backend-spike-2026-05.json"
+TSV_OUT = EVIDENCE_DIR / "zkai-d128-proof-artifact-backend-spike-2026-05.tsv"
+
+SCHEMA = "zkai-d128-proof-artifact-backend-spike-v1"
+DECISION = "NO_GO_D128_PROOF_ARTIFACT_PARAMETERIZED_AIR_MISSING"
+RESULT = "BOUNDED_NO_GO"
+ISSUE = 387
+TARGET_ID = "rmsnorm-swiglu-residual-d128-v1"
+TARGET_WIDTH = 128
+TARGET_FF_DIM = 512
+REQUIRED_BACKEND_VERSION = "stwo-rmsnorm-swiglu-residual-d128-v1"
+REQUIRED_TOOLCHAIN = "nightly-2025-07-14"
+FIRST_BLOCKER = (
+    "no parameterized d128 vector-block AIR/prover/verifier handle; current "
+    "native proof modules are d64 target/domain/width hard-coded and no d128 "
+    "native module exports exist"
+)
+
+D64_PROOF_SLICES = (
+    {
+        "slice": "rmsnorm_public_rows",
+        "module": "src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs",
+        "evidence": "docs/engineering/evidence/zkai-d64-native-rmsnorm-public-row-proof-2026-05.json",
+        "prove_symbol": "prove_zkai_d64_rmsnorm_public_row_envelope",
+        "verify_symbol": "verify_zkai_d64_rmsnorm_public_row_envelope",
+        "proof_version": "stwo-d64-rmsnorm-public-row-air-proof-v2",
+    },
+    {
+        "slice": "rmsnorm_projection_bridge",
+        "module": "src/stwo_backend/d64_native_rmsnorm_to_projection_bridge_proof.rs",
+        "evidence": "docs/engineering/evidence/zkai-d64-rmsnorm-to-projection-bridge-proof-2026-05.json",
+        "prove_symbol": "prove_zkai_d64_rmsnorm_to_projection_bridge_envelope",
+        "verify_symbol": "verify_zkai_d64_rmsnorm_to_projection_bridge_envelope",
+        "proof_version": "stwo-d64-rmsnorm-to-projection-bridge-air-proof-v1",
+    },
+    {
+        "slice": "gate_value_projection",
+        "module": "src/stwo_backend/d64_native_gate_value_projection_proof.rs",
+        "evidence": "docs/engineering/evidence/zkai-d64-gate-value-projection-proof-2026-05.json",
+        "prove_symbol": "prove_zkai_d64_gate_value_projection_envelope",
+        "verify_symbol": "verify_zkai_d64_gate_value_projection_envelope",
+        "proof_version": "stwo-d64-gate-value-projection-air-proof-v1",
+    },
+    {
+        "slice": "activation_swiglu",
+        "module": "src/stwo_backend/d64_native_activation_swiglu_proof.rs",
+        "evidence": "docs/engineering/evidence/zkai-d64-activation-swiglu-proof-2026-05.json",
+        "prove_symbol": "prove_zkai_d64_activation_swiglu_envelope",
+        "verify_symbol": "verify_zkai_d64_activation_swiglu_envelope",
+        "proof_version": "stwo-d64-activation-swiglu-air-proof-v1",
+    },
+    {
+        "slice": "down_projection",
+        "module": "src/stwo_backend/d64_native_down_projection_proof.rs",
+        "evidence": "docs/engineering/evidence/zkai-d64-down-projection-proof-2026-05.json",
+        "prove_symbol": "prove_zkai_d64_down_projection_envelope",
+        "verify_symbol": "verify_zkai_d64_down_projection_envelope",
+        "proof_version": "stwo-d64-down-projection-air-proof-v1",
+    },
+    {
+        "slice": "residual_add",
+        "module": "src/stwo_backend/d64_native_residual_add_proof.rs",
+        "evidence": "docs/engineering/evidence/zkai-d64-residual-add-proof-2026-05.json",
+        "prove_symbol": "prove_zkai_d64_residual_add_envelope",
+        "verify_symbol": "verify_zkai_d64_residual_add_envelope",
+        "proof_version": "stwo-d64-residual-add-air-proof-v1",
+    },
+)
+
+EXPECTED_D128_MODULES = (
+    "src/stwo_backend/d128_native_rmsnorm_public_row_proof.rs",
+    "src/stwo_backend/d128_native_rmsnorm_to_projection_bridge_proof.rs",
+    "src/stwo_backend/d128_native_gate_value_projection_proof.rs",
+    "src/stwo_backend/d128_native_activation_swiglu_proof.rs",
+    "src/stwo_backend/d128_native_down_projection_proof.rs",
+    "src/stwo_backend/d128_native_residual_add_proof.rs",
+    "src/stwo_backend/d128_native_transformer_block_proof.rs",
+)
+
+EXPECTED_D128_EXPORT_SYMBOLS = (
+    "prove_zkai_d128_rmsnorm_public_row_envelope",
+    "verify_zkai_d128_rmsnorm_public_row_envelope",
+    "prove_zkai_d128_gate_value_projection_envelope",
+    "verify_zkai_d128_gate_value_projection_envelope",
+    "prove_zkai_d128_activation_swiglu_envelope",
+    "verify_zkai_d128_activation_swiglu_envelope",
+    "prove_zkai_d128_down_projection_envelope",
+    "verify_zkai_d128_down_projection_envelope",
+    "prove_zkai_d128_residual_add_envelope",
+    "verify_zkai_d128_residual_add_envelope",
+    "prove_zkai_d128_transformer_block_envelope",
+    "verify_zkai_d128_transformer_block_envelope",
+)
+
+PARAMETERIZED_SYMBOLS = (
+    "ZkAiVectorBlockProofInput",
+    "ZkAiParameterizedTransformerBlockProof",
+    "prove_zkai_vector_block_envelope",
+    "verify_zkai_vector_block_envelope",
+    "parameterized_vector_block_air",
+)
+
+D64_HARDCODE_MARKERS = {
+    "src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs": (
+        "expect_usize(input.width, ZKAI_D64_WIDTH",
+        "ZKAI_D64_RMSNORM_PUBLIC_ROW_PROOF_VERSION",
+        "ZKAI_D64_TARGET_ID",
+    ),
+    "src/stwo_backend/d64_native_gate_value_projection_proof.rs": (
+        "expect_usize(input.width, ZKAI_D64_WIDTH",
+        "expect_usize(input.ff_dim, ZKAI_D64_FF_DIM",
+        "D64_GATE_VALUE_LOG_SIZE",
+    ),
+    "src/stwo_backend/d64_native_activation_swiglu_proof.rs": (
+        "expect_usize(input.width, ZKAI_D64_WIDTH",
+        "expect_usize(input.ff_dim, ZKAI_D64_FF_DIM",
+        "D64_ACTIVATION_SWIGLU_LOG_SIZE",
+    ),
+    "src/stwo_backend/d64_native_down_projection_proof.rs": (
+        "expect_usize(input.width, ZKAI_D64_WIDTH",
+        "expect_usize(input.ff_dim, ZKAI_D64_FF_DIM",
+        "D64_DOWN_PROJECTION_LOG_SIZE",
+    ),
+    "src/stwo_backend/d64_native_residual_add_proof.rs": (
+        "expect_usize(input.width, ZKAI_D64_WIDTH",
+        "ZKAI_D64_RESIDUAL_ADD_PROOF_VERSION",
+        "D64_RESIDUAL_ADD_LOG_SIZE",
+    ),
+}
+
+NON_CLAIMS = [
+    "not a local d128 proof artifact",
+    "not verifier-time evidence for d128",
+    "not proof-size evidence for d128",
+    "not recursive aggregation",
+    "not backend independence evidence",
+    "not a matched NANOZK or DeepProve benchmark",
+    "not a claim that d128 is impossible",
+]
+
+VALIDATION_COMMANDS = [
+    "python3 scripts/zkai_d128_proof_artifact_backend_spike_gate.py --write-json docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.json --write-tsv docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_d128_proof_artifact_backend_spike_gate",
+    "cargo +nightly-2025-07-14 test --lib d64 --features stwo-backend -- --nocapture",
+    "python3 scripts/paper/paper_preflight.py --repo-root .",
+]
+
+TSV_COLUMNS = (
+    "route",
+    "status",
+    "target_width",
+    "target_ff_dim",
+    "proof_artifact_exists",
+    "verifier_handle_exists",
+    "proof_size_bytes",
+    "verifier_time_ms",
+    "blocker",
+)
+
+MUTATION_TSV_COLUMNS = (
+    "mutation",
+    "surface",
+    "mutated_accepted",
+    "rejected",
+    "rejection_layer",
+    "error",
+)
+
+EXPECTED_MUTATION_INVENTORY = (
+    ("decision_promoted_to_go", "top_level"),
+    ("target_width_drift", "target_spec"),
+    ("target_backend_version_drift", "target_spec"),
+    ("local_proof_artifact_smuggled", "proof_status"),
+    ("local_verifier_handle_smuggled", "proof_status"),
+    ("proof_size_metric_smuggled", "metrics"),
+    ("verifier_time_metric_smuggled", "metrics"),
+    ("direct_d128_route_promoted", "backend_routes"),
+    ("parameterized_route_promoted", "backend_routes"),
+    ("d64_anchor_removed", "d64_anchor"),
+    ("missing_module_removed", "source_probe"),
+    ("d64_hardcoded_marker_removed", "source_probe"),
+    ("non_claim_removed", "claim_boundary"),
+    ("mutation_case_accepted", "mutation_harness"),
+)
+
+
+class D128BackendSpikeError(ValueError):
+    pass
+
+
+def _load_module(path: pathlib.Path, module_name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise D128BackendSpikeError(f"failed to load {module_name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+TARGET_GATE = _load_module(TARGET_GATE_PATH, "zkai_d128_target_for_backend_spike")
+D64_BLOCK_GATE = _load_module(D64_BLOCK_GATE_PATH, "zkai_d64_block_for_d128_backend_spike")
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_hex_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_hex_json(value: Any) -> str:
+    return sha256_hex_bytes(canonical_json_bytes(value))
+
+
+def blake2b_commitment(value: Any, domain: str) -> str:
+    digest = hashlib.blake2b(digest_size=32)
+    digest.update(domain.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(canonical_json_bytes(value))
+    return f"blake2b-256:{digest.hexdigest()}"
+
+
+def file_sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def relative_path(path: pathlib.Path) -> str:
+    return str(path.resolve().relative_to(ROOT.resolve()))
+
+
+def require_object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise D128BackendSpikeError(f"{field} must be an object")
+    return value
+
+
+def require_list(value: Any, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise D128BackendSpikeError(f"{field} must be a list")
+    return value
+
+
+def expect_equal(actual: Any, expected: Any, field: str) -> None:
+    if actual != expected:
+        raise D128BackendSpikeError(f"{field} mismatch")
+
+
+def load_json(path: pathlib.Path) -> dict[str, Any]:
+    resolved = path.resolve()
+    if not resolved.is_file():
+        raise D128BackendSpikeError(f"JSON source is not a regular file: {path}")
+    if ROOT.resolve() not in resolved.parents:
+        raise D128BackendSpikeError(f"JSON source escapes repository: {path}")
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as err:
+        raise D128BackendSpikeError(f"failed to load JSON source {path}: {err}") from err
+    if not isinstance(payload, dict):
+        raise D128BackendSpikeError(f"JSON source must be an object: {path}")
+    return payload
+
+
+def source_descriptor(path: pathlib.Path, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": relative_path(path),
+        "file_sha256": file_sha256(path),
+        "payload_sha256": sha256_hex_json(payload),
+        "schema": payload.get("schema"),
+        "decision": payload.get("decision"),
+        "result": payload.get("result"),
+    }
+
+
+def load_checked_target() -> dict[str, Any]:
+    payload = load_json(TARGET_EVIDENCE)
+    try:
+        TARGET_GATE.validate_payload(payload)
+    except Exception as err:  # noqa: BLE001 - normalize imported validator errors.
+        raise D128BackendSpikeError(f"d128 comparator target validation failed: {err}") from err
+    if payload.get("target_result") != TARGET_GATE.TARGET_RESULT:
+        raise D128BackendSpikeError("d128 target spec is not a GO target")
+    if payload.get("local_proof_result") != TARGET_GATE.LOCAL_PROOF_RESULT:
+        raise D128BackendSpikeError("d128 target evidence no longer records missing local proof")
+    return payload
+
+
+def load_checked_d64_block() -> dict[str, Any]:
+    payload = load_json(D64_BLOCK_EVIDENCE)
+    try:
+        D64_BLOCK_GATE.validate_payload(payload)
+    except Exception as err:  # noqa: BLE001 - normalize imported validator errors.
+        raise D128BackendSpikeError(f"d64 block composition validation failed: {err}") from err
+    if payload.get("decision") != D64_BLOCK_GATE.DECISION:
+        raise D128BackendSpikeError("d64 block composition is not a GO anchor")
+    return payload
+
+
+def read_repo_file(path: str) -> str:
+    full = ROOT / path
+    if not full.is_file():
+        raise D128BackendSpikeError(f"required source file missing: {path}")
+    return full.read_text(encoding="utf-8")
+
+
+def repo_file_descriptor(path: str) -> dict[str, Any]:
+    full = ROOT / path
+    return {
+        "path": path,
+        "exists": full.is_file(),
+        "file_sha256": file_sha256(full) if full.is_file() else None,
+    }
+
+
+def build_source_probe() -> dict[str, Any]:
+    mod_rs = read_repo_file("src/stwo_backend/mod.rs")
+    d64_slices = []
+    for spec in D64_PROOF_SLICES:
+        module_text = read_repo_file(spec["module"])
+        evidence = load_json(ROOT / spec["evidence"])
+        for symbol in (spec["prove_symbol"], spec["verify_symbol"]):
+            if symbol not in mod_rs:
+                raise D128BackendSpikeError(f"d64 exported symbol missing from mod.rs: {symbol}")
+            if symbol not in module_text:
+                raise D128BackendSpikeError(f"d64 module symbol missing from source: {symbol}")
+        expect_equal(evidence.get("target_id"), "rmsnorm-swiglu-residual-d64-v2", f"{spec['slice']} target id")
+        expect_equal(evidence.get("width"), 64, f"{spec['slice']} width")
+        d64_slices.append(
+            {
+                "slice": spec["slice"],
+                "module": repo_file_descriptor(spec["module"]),
+                "evidence": source_descriptor(ROOT / spec["evidence"], evidence),
+                "prove_symbol": spec["prove_symbol"],
+                "verify_symbol": spec["verify_symbol"],
+                "proof_version": spec["proof_version"],
+            }
+        )
+
+    missing_d128_modules = []
+    present_d128_modules = []
+    for path in EXPECTED_D128_MODULES:
+        full = ROOT / path
+        if full.exists():
+            present_d128_modules.append(path)
+        else:
+            missing_d128_modules.append(path)
+    if present_d128_modules:
+        raise D128BackendSpikeError(
+            "d128 module route may now exist; refresh this no-go gate before relying on it"
+        )
+
+    present_d128_symbols = [symbol for symbol in EXPECTED_D128_EXPORT_SYMBOLS if symbol in mod_rs]
+    if present_d128_symbols:
+        raise D128BackendSpikeError(
+            "d128 export route may now exist; refresh this no-go gate before relying on it"
+        )
+    missing_d128_symbols = list(EXPECTED_D128_EXPORT_SYMBOLS)
+
+    repo_text = "\n".join(
+        (ROOT / path).read_text(encoding="utf-8")
+        for path in ["src/stwo_backend/mod.rs", *[spec["module"] for spec in D64_PROOF_SLICES]]
+    )
+    present_parameterized_symbols = [
+        symbol for symbol in PARAMETERIZED_SYMBOLS if symbol in repo_text
+    ]
+    if present_parameterized_symbols:
+        raise D128BackendSpikeError(
+            "parameterized vector-block route may now exist; refresh this no-go gate before relying on it"
+        )
+
+    hardcoded_markers = []
+    for path, markers in D64_HARDCODE_MARKERS.items():
+        text = read_repo_file(path)
+        missing = [marker for marker in markers if marker not in text]
+        if missing:
+            raise D128BackendSpikeError(f"d64 hard-code marker missing unexpectedly in {path}: {missing}")
+        hardcoded_markers.append({"path": path, "markers": list(markers)})
+
+    return {
+        "d64_slices": d64_slices,
+        "missing_d128_modules": missing_d128_modules,
+        "missing_d128_export_symbols": missing_d128_symbols,
+        "missing_parameterized_symbols": list(PARAMETERIZED_SYMBOLS),
+        "d64_hardcoded_markers": hardcoded_markers,
+    }
+
+
+def build_backend_routes(source_probe: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "route": "existing_d64_slice_chain",
+            "status": "GO_ANCHOR_ONLY",
+            "target_width": 64,
+            "target_ff_dim": 256,
+            "proof_artifact_exists": True,
+            "verifier_handle_exists": True,
+            "proof_size_bytes": None,
+            "verifier_time_ms": None,
+            "blocker": "d64 slice proofs exist, but this is not the d128 target",
+            "evidence": "docs/engineering/evidence/zkai-d64-block-receipt-composition-gate-2026-05.json",
+        },
+        {
+            "route": "direct_d128_native_modules",
+            "status": "NO_GO",
+            "target_width": TARGET_WIDTH,
+            "target_ff_dim": TARGET_FF_DIM,
+            "proof_artifact_exists": False,
+            "verifier_handle_exists": False,
+            "proof_size_bytes": None,
+            "verifier_time_ms": None,
+            "blocker": "no d128 native proof modules or exported prove/verify handles exist",
+            "missing_modules": source_probe["missing_d128_modules"],
+            "missing_export_symbols": source_probe["missing_d128_export_symbols"],
+        },
+        {
+            "route": "lift_existing_d64_modules_by_metadata",
+            "status": "NO_GO",
+            "target_width": TARGET_WIDTH,
+            "target_ff_dim": TARGET_FF_DIM,
+            "proof_artifact_exists": False,
+            "verifier_handle_exists": False,
+            "proof_size_bytes": None,
+            "verifier_time_ms": None,
+            "blocker": "d64 modules validate hard-coded width, target id, domains, and log sizes",
+            "hardcoded_markers": source_probe["d64_hardcoded_markers"],
+        },
+        {
+            "route": "parameterized_vector_block_air",
+            "status": "NO_GO_FIRST_BLOCKER",
+            "target_width": TARGET_WIDTH,
+            "target_ff_dim": TARGET_FF_DIM,
+            "proof_artifact_exists": False,
+            "verifier_handle_exists": False,
+            "proof_size_bytes": None,
+            "verifier_time_ms": None,
+            "blocker": FIRST_BLOCKER,
+            "missing_symbols": source_probe["missing_parameterized_symbols"],
+        },
+        {
+            "route": "d128_metrics_and_relabeling_suite",
+            "status": "NO_GO_BLOCKED_BEFORE_PROOF_OBJECT",
+            "target_width": TARGET_WIDTH,
+            "target_ff_dim": TARGET_FF_DIM,
+            "proof_artifact_exists": False,
+            "verifier_handle_exists": False,
+            "proof_size_bytes": None,
+            "verifier_time_ms": None,
+            "blocker": "do not report proof size, verifier time, or relabeling resistance until a d128 proof object and verifier handle exist",
+        },
+    ]
+
+
+def expected_mutation_inventory() -> list[dict[str, Any]]:
+    return [
+        {"index": index, "mutation": mutation, "surface": surface}
+        for index, (mutation, surface) in enumerate(EXPECTED_MUTATION_INVENTORY)
+    ]
+
+
+def build_payload() -> dict[str, Any]:
+    target_payload = load_checked_target()
+    d64_block_payload = load_checked_d64_block()
+    source_probe = build_source_probe()
+    routes = build_backend_routes(source_probe)
+    target_spec = require_object(target_payload.get("target_spec"), "target spec")
+    summary = {
+        "issue": ISSUE,
+        "target_id": TARGET_ID,
+        "target_width": TARGET_WIDTH,
+        "target_ff_dim": TARGET_FF_DIM,
+        "first_blocker": FIRST_BLOCKER,
+        "d64_anchor_route": "GO_ANCHOR_ONLY",
+        "direct_d128_route": "NO_GO",
+        "parameterized_route": "NO_GO_FIRST_BLOCKER",
+        "blocked_before_metrics": True,
+        "mutation_cases": len(EXPECTED_MUTATION_INVENTORY),
+    }
+    proof_status = {
+        "proof_artifact_exists": False,
+        "verifier_handle_exists": False,
+        "statement_relabeling_suite_exists": False,
+        "proof_size_bytes": None,
+        "verifier_time_ms": None,
+        "blocked_before_metrics": True,
+        "first_blocker": FIRST_BLOCKER,
+        "required_toolchain": REQUIRED_TOOLCHAIN,
+        "stable_toolchain_status": "not_supported_by_upstream_stwo_feature_gates",
+    }
+    d64_summary = require_object(d64_block_payload.get("summary"), "d64 block summary")
+    d64_anchor = {
+        "status": "GO_ANCHOR_ONLY",
+        "claim_boundary": "working d64 slice proof chain, not a d128 proof route",
+        "slice_count": d64_summary.get("slice_count"),
+        "total_checked_rows": d64_summary.get("total_checked_rows"),
+        "decision": d64_block_payload.get("decision"),
+        "source": source_descriptor(D64_BLOCK_EVIDENCE, d64_block_payload),
+        "slices": source_probe["d64_slices"],
+    }
+    payload = {
+        "schema": SCHEMA,
+        "decision": DECISION,
+        "result": RESULT,
+        "issue": ISSUE,
+        "summary": summary,
+        "target": {
+            "target_id": TARGET_ID,
+            "statement_kind": target_spec.get("statement_kind"),
+            "width": target_spec.get("width"),
+            "ff_dim": target_spec.get("ff_dim"),
+            "required_backend_version": REQUIRED_BACKEND_VERSION,
+            "target_commitment": target_spec.get("target_commitment"),
+            "source": source_descriptor(TARGET_EVIDENCE, target_payload),
+        },
+        "d64_anchor": d64_anchor,
+        "source_probe": source_probe,
+        "backend_routes": routes,
+        "proof_status": proof_status,
+        "non_claims": list(NON_CLAIMS),
+        "validation_commands": list(VALIDATION_COMMANDS),
+    }
+    payload["gate_commitment"] = blake2b_commitment(
+        {
+            "schema": payload["schema"],
+            "decision": payload["decision"],
+            "target": payload["target"],
+            "backend_routes": payload["backend_routes"],
+            "proof_status": payload["proof_status"],
+            "non_claims": payload["non_claims"],
+        },
+        "ptvm:zkai:d128-proof-artifact-backend-spike:v1",
+    )
+    return payload
+
+
+def _mutated_cases(payload: dict[str, Any]) -> list[tuple[str, str, dict[str, Any]]]:
+    cases: list[tuple[str, str, dict[str, Any]]] = []
+
+    def add(name: str, surface: str, mutator: Any) -> None:
+        mutated = copy.deepcopy(payload)
+        mutator(mutated)
+        cases.append((name, surface, mutated))
+
+    add("decision_promoted_to_go", "top_level", lambda p: p.__setitem__("decision", "GO_D128_PROOF_ARTIFACT"))
+    add("target_width_drift", "target_spec", lambda p: p["target"].__setitem__("width", 64))
+    add(
+        "target_backend_version_drift",
+        "target_spec",
+        lambda p: p["target"].__setitem__("required_backend_version", "stwo-rmsnorm-swiglu-residual-d64-v2"),
+    )
+    add("local_proof_artifact_smuggled", "proof_status", lambda p: p["proof_status"].__setitem__("proof_artifact_exists", True))
+    add("local_verifier_handle_smuggled", "proof_status", lambda p: p["proof_status"].__setitem__("verifier_handle_exists", True))
+    add("proof_size_metric_smuggled", "metrics", lambda p: p["proof_status"].__setitem__("proof_size_bytes", 1_234_567))
+    add("verifier_time_metric_smuggled", "metrics", lambda p: p["proof_status"].__setitem__("verifier_time_ms", 42.0))
+
+    def promote_direct_route(p: dict[str, Any]) -> None:
+        route = next(row for row in p["backend_routes"] if row["route"] == "direct_d128_native_modules")
+        route["status"] = "GO"
+        route["proof_artifact_exists"] = True
+        route["verifier_handle_exists"] = True
+
+    add("direct_d128_route_promoted", "backend_routes", promote_direct_route)
+
+    def promote_parameterized_route(p: dict[str, Any]) -> None:
+        route = next(row for row in p["backend_routes"] if row["route"] == "parameterized_vector_block_air")
+        route["status"] = "GO"
+        route["missing_symbols"] = []
+
+    add("parameterized_route_promoted", "backend_routes", promote_parameterized_route)
+    add("d64_anchor_removed", "d64_anchor", lambda p: p.__setitem__("d64_anchor", {"status": "MISSING"}))
+
+    def remove_missing_module(p: dict[str, Any]) -> None:
+        p["source_probe"]["missing_d128_modules"] = p["source_probe"]["missing_d128_modules"][1:]
+        route = next(row for row in p["backend_routes"] if row["route"] == "direct_d128_native_modules")
+        route["missing_modules"] = route["missing_modules"][1:]
+
+    add("missing_module_removed", "source_probe", remove_missing_module)
+
+    def remove_hardcoded_marker(p: dict[str, Any]) -> None:
+        p["source_probe"]["d64_hardcoded_markers"][0]["markers"] = []
+        route = next(row for row in p["backend_routes"] if row["route"] == "lift_existing_d64_modules_by_metadata")
+        route["hardcoded_markers"][0]["markers"] = []
+
+    add("d64_hardcoded_marker_removed", "source_probe", remove_hardcoded_marker)
+    add("non_claim_removed", "claim_boundary", lambda p: p["non_claims"].remove("not a local d128 proof artifact"))
+    add("mutation_case_accepted", "mutation_harness", lambda p: p["summary"].__setitem__("mutation_cases", 0))
+    return cases
+
+
+def mutation_cases(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for index, (mutation, surface, mutated) in enumerate(_mutated_cases(payload)):
+        try:
+            validate_payload(mutated, require_mutations=False)
+        except Exception as err:  # noqa: BLE001 - record rejection diagnostics.
+            error = str(err) or f"{err.__class__.__name__} with empty message"
+            results.append(
+                {
+                    "index": index,
+                    "mutation": mutation,
+                    "surface": surface,
+                    "mutated_accepted": False,
+                    "rejected": True,
+                    "rejection_layer": surface,
+                    "error": error,
+                }
+            )
+        else:
+            results.append(
+                {
+                    "index": index,
+                    "mutation": mutation,
+                    "surface": surface,
+                    "mutated_accepted": True,
+                    "rejected": False,
+                    "rejection_layer": surface,
+                    "error": "mutation was accepted",
+                }
+            )
+    return results
+
+
+def build_gate_result() -> dict[str, Any]:
+    payload = build_payload()
+    cases = mutation_cases(payload)
+    payload["mutation_inventory"] = expected_mutation_inventory()
+    payload["cases"] = cases
+    payload["case_count"] = len(cases)
+    payload["all_mutations_rejected"] = all(case["rejected"] for case in cases)
+    payload["summary"]["mutations_rejected"] = sum(1 for case in cases if case["rejected"])
+    validate_payload(payload)
+    return payload
+
+
+def validate_payload(payload: Any, *, require_mutations: bool = True) -> None:
+    data = require_object(payload, "payload")
+    expect_equal(data.get("schema"), SCHEMA, "schema")
+    expect_equal(data.get("decision"), DECISION, "decision")
+    expect_equal(data.get("result"), RESULT, "result")
+    expect_equal(data.get("issue"), ISSUE, "issue")
+    summary = require_object(data.get("summary"), "summary")
+    expect_equal(summary.get("target_width"), TARGET_WIDTH, "summary target width")
+    expect_equal(summary.get("target_ff_dim"), TARGET_FF_DIM, "summary target ff_dim")
+    expect_equal(summary.get("first_blocker"), FIRST_BLOCKER, "summary first blocker")
+    expect_equal(summary.get("direct_d128_route"), "NO_GO", "summary direct d128 route")
+    expect_equal(summary.get("parameterized_route"), "NO_GO_FIRST_BLOCKER", "summary parameterized route")
+    expect_equal(summary.get("blocked_before_metrics"), True, "summary blocked-before-metrics")
+    expect_equal(summary.get("mutation_cases"), len(EXPECTED_MUTATION_INVENTORY), "summary mutation count")
+
+    target = require_object(data.get("target"), "target")
+    expect_equal(target.get("target_id"), TARGET_ID, "target id")
+    expect_equal(target.get("width"), TARGET_WIDTH, "target width")
+    expect_equal(target.get("ff_dim"), TARGET_FF_DIM, "target ff_dim")
+    expect_equal(target.get("required_backend_version"), REQUIRED_BACKEND_VERSION, "target backend version")
+
+    d64_anchor = require_object(data.get("d64_anchor"), "d64 anchor")
+    expect_equal(d64_anchor.get("status"), "GO_ANCHOR_ONLY", "d64 anchor status")
+    expect_equal(d64_anchor.get("slice_count"), 6, "d64 anchor slice count")
+    slices = require_list(d64_anchor.get("slices"), "d64 anchor slices")
+    expect_equal(len(slices), len(D64_PROOF_SLICES), "d64 anchor slice list length")
+
+    source_probe = require_object(data.get("source_probe"), "source probe")
+    expect_equal(
+        source_probe.get("missing_d128_modules"),
+        list(EXPECTED_D128_MODULES),
+        "missing d128 module inventory",
+    )
+    expect_equal(
+        source_probe.get("missing_d128_export_symbols"),
+        list(EXPECTED_D128_EXPORT_SYMBOLS),
+        "missing d128 export inventory",
+    )
+    expect_equal(
+        source_probe.get("missing_parameterized_symbols"),
+        list(PARAMETERIZED_SYMBOLS),
+        "missing parameterized symbol inventory",
+    )
+    hardcoded = require_list(source_probe.get("d64_hardcoded_markers"), "d64 hardcoded markers")
+    expect_equal(len(hardcoded), len(D64_HARDCODE_MARKERS), "hardcoded marker file count")
+    for record in hardcoded:
+        record = require_object(record, "hardcoded marker")
+        path = record.get("path")
+        if path not in D64_HARDCODE_MARKERS:
+            raise D128BackendSpikeError(f"unexpected hardcoded marker path: {path}")
+        expect_equal(record.get("markers"), list(D64_HARDCODE_MARKERS[path]), f"{path} hardcoded markers")
+
+    routes = require_list(data.get("backend_routes"), "backend routes")
+    route_by_name = {require_object(route, "backend route").get("route"): route for route in routes}
+    expected_routes = {
+        "existing_d64_slice_chain",
+        "direct_d128_native_modules",
+        "lift_existing_d64_modules_by_metadata",
+        "parameterized_vector_block_air",
+        "d128_metrics_and_relabeling_suite",
+    }
+    if set(route_by_name) != expected_routes:
+        raise D128BackendSpikeError("backend route inventory mismatch")
+    expect_equal(route_by_name["existing_d64_slice_chain"].get("status"), "GO_ANCHOR_ONLY", "d64 anchor route status")
+    expect_equal(route_by_name["direct_d128_native_modules"].get("status"), "NO_GO", "direct d128 route status")
+    expect_equal(
+        route_by_name["parameterized_vector_block_air"].get("status"),
+        "NO_GO_FIRST_BLOCKER",
+        "parameterized route status",
+    )
+    for route in routes:
+        route = require_object(route, "backend route")
+        if route["route"] != "existing_d64_slice_chain":
+            expect_equal(route.get("target_width"), TARGET_WIDTH, f"{route['route']} target width")
+            expect_equal(route.get("proof_artifact_exists"), False, f"{route['route']} proof artifact")
+            expect_equal(route.get("verifier_handle_exists"), False, f"{route['route']} verifier handle")
+        if route.get("proof_size_bytes") is not None:
+            raise D128BackendSpikeError("proof-size metric must remain absent before d128 proof exists")
+        if route.get("verifier_time_ms") is not None:
+            raise D128BackendSpikeError("verifier-time metric must remain absent before d128 proof exists")
+
+    proof_status = require_object(data.get("proof_status"), "proof status")
+    expect_equal(proof_status.get("proof_artifact_exists"), False, "proof artifact exists")
+    expect_equal(proof_status.get("verifier_handle_exists"), False, "verifier handle exists")
+    expect_equal(proof_status.get("statement_relabeling_suite_exists"), False, "relabeling suite exists")
+    expect_equal(proof_status.get("proof_size_bytes"), None, "proof size")
+    expect_equal(proof_status.get("verifier_time_ms"), None, "verifier time")
+    expect_equal(proof_status.get("blocked_before_metrics"), True, "blocked before metrics")
+    expect_equal(proof_status.get("required_toolchain"), REQUIRED_TOOLCHAIN, "required toolchain")
+
+    if set(data.get("non_claims", [])) != set(NON_CLAIMS):
+        raise D128BackendSpikeError("non-claims inventory mismatch")
+    if data.get("validation_commands") != VALIDATION_COMMANDS:
+        raise D128BackendSpikeError("validation command inventory mismatch")
+
+    if require_mutations:
+        if data.get("mutation_inventory") != expected_mutation_inventory():
+            raise D128BackendSpikeError("mutation inventory mismatch")
+        cases = require_list(data.get("cases"), "mutation cases")
+        expect_equal(data.get("case_count"), len(EXPECTED_MUTATION_INVENTORY), "case count")
+        expect_equal(len(cases), len(EXPECTED_MUTATION_INVENTORY), "mutation case length")
+        expect_equal(data.get("all_mutations_rejected"), True, "all mutations rejected")
+        seen = set()
+        for case in cases:
+            case = require_object(case, "mutation case")
+            mutation = case.get("mutation")
+            if mutation in seen:
+                raise D128BackendSpikeError("duplicate mutation case")
+            seen.add(mutation)
+            if not case.get("rejected"):
+                raise D128BackendSpikeError(f"mutation was accepted: {mutation}")
+            if not case.get("error"):
+                raise D128BackendSpikeError(f"mutation case error must be non-empty: {mutation}")
+        expect_equal(seen, {name for name, _surface in EXPECTED_MUTATION_INVENTORY}, "mutation case set")
+
+
+def rows_for_tsv(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for route in payload["backend_routes"]:
+        rows.append({column: route.get(column) for column in TSV_COLUMNS})
+    return rows
+
+
+def mutation_rows_for_tsv(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    return [{column: case.get(column) for column in MUTATION_TSV_COLUMNS} for case in payload["cases"]]
+
+
+def _assert_repo_output_path(path: pathlib.Path) -> pathlib.Path:
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(ROOT.resolve())
+    except ValueError as err:
+        raise D128BackendSpikeError(f"output path escapes repository: {path}") from err
+    if resolved.exists() and resolved.is_dir():
+        raise D128BackendSpikeError(f"output path must not be a directory: {path}")
+    parent = resolved.parent
+    if parent.exists() and not parent.is_dir():
+        raise D128BackendSpikeError(f"output parent is not a directory: {parent}")
+    parent.mkdir(parents=True, exist_ok=True)
+    if resolved.is_symlink():
+        raise D128BackendSpikeError(f"output path must not be a symlink: {path}")
+    return resolved
+
+
+def _fsync_parent_directories(paths: list[pathlib.Path]) -> None:
+    seen: set[pathlib.Path] = set()
+    for path in paths:
+        parent = path.resolve().parent
+        if parent in seen:
+            continue
+        seen.add(parent)
+        flags = getattr(os, "O_DIRECTORY", 0) | os.O_RDONLY
+        try:
+            fd = os.open(parent, flags)
+        except OSError:
+            continue
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+
+def _atomic_write_text(path: pathlib.Path, text: str) -> None:
+    resolved = _assert_repo_output_path(path)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=resolved.parent, delete=False) as handle:
+        tmp = pathlib.Path(handle.name)
+        handle.write(text)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, resolved)
+
+
+def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
+    validate_payload(payload)
+    written: list[pathlib.Path] = []
+    if json_path is not None:
+        text = json.dumps(payload, sort_keys=True, indent=2) + "\n"
+        _atomic_write_text(json_path, text)
+        written.append(json_path.resolve())
+    if tsv_path is not None:
+        from io import StringIO
+
+        buffer = StringIO()
+        writer = csv.DictWriter(buffer, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows_for_tsv(payload))
+        buffer.write("\n")
+        mutation_writer = csv.DictWriter(
+            buffer,
+            fieldnames=MUTATION_TSV_COLUMNS,
+            delimiter="\t",
+            lineterminator="\n",
+        )
+        mutation_writer.writeheader()
+        mutation_writer.writerows(mutation_rows_for_tsv(payload))
+        _atomic_write_text(tsv_path, buffer.getvalue())
+        written.append(tsv_path.resolve())
+    _fsync_parent_directories(written)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write-json", type=pathlib.Path, default=None)
+    parser.add_argument("--write-tsv", type=pathlib.Path, default=None)
+    args = parser.parse_args(argv)
+    payload = build_gate_result()
+    write_outputs(payload, args.write_json, args.write_tsv)
+    if args.write_json is None and args.write_tsv is None:
+        print(json.dumps(payload, sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds an executable backend-route spike for Issue #387: the checked d128 RMSNorm-SwiGLU-residual target is still a real target, but the current local backend cannot produce a d128 proof artifact yet.

The gate records a bounded NO-GO with a specific first blocker: no parameterized d128 vector-block AIR/prover/verifier handle exists; current native proof modules are d64 target/domain/width hard-coded and no d128 native module exports are present.

## What changed

- Added `scripts/zkai_d128_proof_artifact_backend_spike_gate.py`.
- Added checked JSON/TSV evidence for the backend-route classification.
- Added 14 unit tests covering route inventory, metric smuggling, source-probe drift, and mutation inventory.
- Added an engineering note and linked it from the design index.

## Claim boundary

This is not a d128 proof result, verifier-time result, proof-size result, recursive aggregation result, or matched NANOZK/DeepProve benchmark. It is a source-backed implementation-route NO-GO that should fail closed if a future d128 or parameterized route lands.

## Validation

- `python3 scripts/zkai_d128_proof_artifact_backend_spike_gate.py --write-json docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.json --write-tsv docs/engineering/evidence/zkai-d128-proof-artifact-backend-spike-2026-05.tsv`
- `python3 -m py_compile scripts/zkai_d128_proof_artifact_backend_spike_gate.py scripts/tests/test_zkai_d128_proof_artifact_backend_spike_gate.py`
- `python3 -m unittest scripts.tests.test_zkai_d128_proof_artifact_backend_spike_gate`
- `cargo +nightly-2025-07-14 test --lib d64 --features stwo-backend -- --nocapture` (`125 passed`)
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `git diff --check`
- `CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_cargo_target/provable-transformer-vm just gate-fast`
- `CARGO_TARGET_DIR=/Users/espejelomar/StarkNet/zk-ai/_cargo_target/provable-transformer-vm just gate` (`14 / 14`)
- pre-push hook reran `just gate` and passed `14 / 14`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added engineering spike documentation outlining d128 proof artifact backend investigation, including findings on component availability and system constraints
  * Updated design documentation reference index

* **Tests**
  * Added comprehensive test suite validating backend spike assessment results, data integrity, and security constraints

* **Tools**
  * Added backend assessment tool that evaluates d128 proof artifact requirements against current system capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->