### PR TITLE
[codex] Stabilize zkVM adapter receipt probes

### DIFF
--- a/docs/engineering/evidence/zkai-d128-zkvm-statement-receipt-adapter-2026-05.json
+++ b/docs/engineering/evidence/zkai-d128-zkvm-statement-receipt-adapter-2026-05.json
@@ -19,7 +19,7 @@
     "result": "NO_GO",
     "usable_route_ids": []
   },
-  "case_count": 21,
+  "case_count": 23,
   "cases": [
     {
       "error": "source contract mismatch",
@@ -115,6 +115,20 @@
     {
       "error": "route decisions mismatch",
       "mutation": "receipt_artifact_smuggled",
+      "rejected": true,
+      "rejection_layer": "route_decisions",
+      "surface": "route_decisions"
+    },
+    {
+      "error": "route decisions mismatch",
+      "mutation": "receipt_probe_size_bound_removed",
+      "rejected": true,
+      "rejection_layer": "route_decisions",
+      "surface": "route_decisions"
+    },
+    {
+      "error": "route decisions mismatch",
+      "mutation": "receipt_probe_size_limit_changed",
       "rejected": true,
       "rejection_layer": "route_decisions",
       "surface": "route_decisions"
@@ -311,6 +325,14 @@
       "surface": "route_decisions"
     },
     {
+      "mutation": "receipt_probe_size_bound_removed",
+      "surface": "route_decisions"
+    },
+    {
+      "mutation": "receipt_probe_size_limit_changed",
+      "surface": "route_decisions"
+    },
+    {
       "mutation": "proof_size_metric_smuggled",
       "surface": "backend_decision"
     },
@@ -367,8 +389,9 @@
       "receipt_artifact_probe": {
         "candidate_valid": true,
         "exists": true,
+        "max_size_bytes": 1048576,
         "reason": "receipt_candidate_parseable",
-        "size_bytes": 15573
+        "size_bound_exceeded": false
       },
       "required_commands": [
         "rzup",
@@ -397,8 +420,9 @@
       "receipt_artifact_probe": {
         "candidate_valid": false,
         "exists": false,
+        "max_size_bytes": 1048576,
         "reason": "missing_receipt_artifact",
-        "size_bytes": null
+        "size_bound_exceeded": false
       },
       "required_commands": [
         "sp1up",

--- a/docs/engineering/zkai-d128-zkvm-statement-receipt-adapter-2026-05-04.md
+++ b/docs/engineering/zkai-d128-zkvm-statement-receipt-adapter-2026-05-04.md
@@ -37,6 +37,10 @@ zkVM system, is not bound to the current journal commitment, or lacks a valid
 candidate exists but verifier execution and public-values binding are still not
 implemented. A GO still requires the gate to run the route verifier and check
 that the public journal / public-values bind the exact statement contract below.
+The receipt probe records the configured byte cap and whether the cap was
+exceeded; it intentionally does not record the artifact's exact byte length, so
+local timing-field churn in downstream receipt evidence does not force this
+adapter evidence to be regenerated.
 
 ## Checked Result
 
@@ -53,7 +57,7 @@ that the public journal / public-values bind the exact statement contract below.
 | RISC Zero route | candidate artifact present; adapter gate stops before verifier execution |
 | SP1 route | missing `sp1up`, `cargo-prove`; no receipt artifact |
 | Proof metrics | disabled in this adapter gate; issue `#433` carries the RISC Zero receipt metrics |
-| Mutation coverage | `21 / 21` rejected |
+| Mutation coverage | `23 / 23` rejected |
 
 ## What This Means
 
@@ -74,7 +78,7 @@ of pretending to be the route verifier.
 
 ## Mutation Coverage
 
-The gate rejects `21 / 21` mutations across:
+The gate rejects `23 / 23` mutations across:
 
 - source #424 decision, claim-boundary, and target commitment relabeling;
 - journal schema, policy, action, verifier-domain, source-hash, and commitment
@@ -82,6 +86,7 @@ The gate rejects `21 / 21` mutations across:
 - RISC Zero and SP1 toolchain availability relabeling;
 - route relabeling from NO-GO to GO;
 - fake receipt-artifact presence;
+- receipt-probe byte-bound removal and byte-limit drift;
 - proof-size, verifier-time, and proof-generation metric smuggling;
 - top-level decision relabeling;
 - non-claim removal;

--- a/scripts/tests/test_zkai_d128_zkvm_statement_receipt_adapter_gate.py
+++ b/scripts/tests/test_zkai_d128_zkvm_statement_receipt_adapter_gate.py
@@ -123,6 +123,9 @@ class D128ZkvmStatementReceiptAdapterGateTests(unittest.TestCase):
             self.assertEqual(route["status"], "NO_GO_ZKVM_RECEIPT_VERIFICATION_NOT_IMPLEMENTED")
             self.assertEqual(route["first_blocker"], "missing_receipt_verification_and_public_values_binding")
             self.assertTrue(route["receipt_artifact_candidate_valid"])
+            self.assertEqual(route["receipt_artifact_probe"]["max_size_bytes"], GATE.MAX_RECEIPT_CANDIDATE_BYTES)
+            self.assertFalse(route["receipt_artifact_probe"]["size_bound_exceeded"])
+            self.assertNotIn("size_bytes", route["receipt_artifact_probe"])
 
     def test_backend_blocker_prefers_toolchain_ready_route(self) -> None:
         probe = self.fixture_probe()
@@ -162,6 +165,8 @@ class D128ZkvmStatementReceiptAdapterGateTests(unittest.TestCase):
         self.assertEqual(route["first_blocker"], "missing_or_unreadable_receipt_artifact")
         self.assertFalse(route["receipt_artifact_candidate_valid"])
         self.assertEqual(route["receipt_artifact_probe"]["reason"], "empty_receipt_artifact")
+        self.assertFalse(route["receipt_artifact_probe"]["size_bound_exceeded"])
+        self.assertNotIn("size_bytes", route["receipt_artifact_probe"])
         self.assertEqual(payload["backend_decision"]["first_blocker"], GATE.UNREADABLE_RECEIPT_ARTIFACT_BLOCKER)
         self.assertEqual(payload["summary"], GATE.SUMMARY_BY_BLOCKER[GATE.UNREADABLE_RECEIPT_ARTIFACT_BLOCKER])
 
@@ -189,7 +194,9 @@ class D128ZkvmStatementReceiptAdapterGateTests(unittest.TestCase):
 
         route = payload["route_decisions"][1]
         self.assertEqual(route["receipt_artifact_probe"]["reason"], "oversized_receipt_artifact")
-        self.assertGreater(route["receipt_artifact_probe"]["size_bytes"], GATE.MAX_RECEIPT_CANDIDATE_BYTES)
+        self.assertEqual(route["receipt_artifact_probe"]["max_size_bytes"], GATE.MAX_RECEIPT_CANDIDATE_BYTES)
+        self.assertTrue(route["receipt_artifact_probe"]["size_bound_exceeded"])
+        self.assertNotIn("size_bytes", route["receipt_artifact_probe"])
         self.assertEqual(payload["backend_decision"]["first_blocker"], GATE.UNREADABLE_RECEIPT_ARTIFACT_BLOCKER)
 
     def test_backend_blocker_prefers_route_with_receipt_artifact(self) -> None:
@@ -235,6 +242,20 @@ class D128ZkvmStatementReceiptAdapterGateTests(unittest.TestCase):
         core["route_decisions"][0]["usable_today"] = True
         core["route_decisions"][0]["status"] = "GO_ZKVM_STATEMENT_RECEIPT_AVAILABLE"
         core["route_decisions"][0]["first_blocker"] = "none"
+        with self.assertRaisesRegex(GATE.D128ZkvmStatementReceiptAdapterError, "route decisions mismatch") as err:
+            GATE.validate_core_payload(core)
+        self.assertEqual(err.exception.layer, "route_decisions")
+
+    def test_rejects_receipt_probe_bound_drift(self) -> None:
+        payload = self.payload()
+        core = GATE._core_payload(payload)
+        del core["route_decisions"][0]["receipt_artifact_probe"]["size_bound_exceeded"]
+        with self.assertRaisesRegex(GATE.D128ZkvmStatementReceiptAdapterError, "route decisions mismatch") as err:
+            GATE.validate_core_payload(core)
+        self.assertEqual(err.exception.layer, "route_decisions")
+
+        core = GATE._core_payload(payload)
+        core["route_decisions"][0]["receipt_artifact_probe"]["max_size_bytes"] = 1
         with self.assertRaisesRegex(GATE.D128ZkvmStatementReceiptAdapterError, "route decisions mismatch") as err:
             GATE.validate_core_payload(core)
         self.assertEqual(err.exception.layer, "route_decisions")

--- a/scripts/zkai_d128_zkvm_statement_receipt_adapter_gate.py
+++ b/scripts/zkai_d128_zkvm_statement_receipt_adapter_gate.py
@@ -130,6 +130,8 @@ EXPECTED_MUTATION_INVENTORY = (
     ("risc0_route_relabeling_to_go", "route_decisions"),
     ("sp1_route_relabeling_to_go", "route_decisions"),
     ("receipt_artifact_smuggled", "route_decisions"),
+    ("receipt_probe_size_bound_removed", "route_decisions"),
+    ("receipt_probe_size_limit_changed", "route_decisions"),
     ("proof_size_metric_smuggled", "backend_decision"),
     ("verifier_time_metric_smuggled", "backend_decision"),
     ("proof_generation_time_metric_smuggled", "backend_decision"),
@@ -350,35 +352,125 @@ def command_probe() -> dict[str, Any]:
     return json.loads(_command_probe_cached())
 
 
+def receipt_probe_result(
+    *,
+    exists: bool,
+    candidate_valid: bool,
+    reason: str,
+    size_bound_exceeded: bool = False,
+) -> dict[str, Any]:
+    # Keep this probe stable across harmless receipt-evidence rewrites. The
+    # exact artifact byte length is checked only for the cap decision; it is not
+    # recorded because downstream timing-field churn can otherwise invalidate
+    # this adapter gate without changing the statement boundary.
+    return {
+        "exists": exists,
+        "candidate_valid": candidate_valid,
+        "reason": reason,
+        "max_size_bytes": MAX_RECEIPT_CANDIDATE_BYTES,
+        "size_bound_exceeded": size_bound_exceeded,
+    }
+
+
+def read_receipt_candidate_text(path: pathlib.Path) -> tuple[str | None, dict[str, Any] | None]:
+    try:
+        with path.open("rb") as handle:
+            data = handle.read(MAX_RECEIPT_CANDIDATE_BYTES + 1)
+    except OSError:
+        return None, receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="unreadable_receipt_artifact",
+        )
+    if not data:
+        return None, receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="empty_receipt_artifact",
+        )
+    if len(data) > MAX_RECEIPT_CANDIDATE_BYTES:
+        return None, receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="oversized_receipt_artifact",
+            size_bound_exceeded=True,
+        )
+    try:
+        return data.decode("utf-8"), None
+    except UnicodeDecodeError:
+        return None, receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="unparseable_receipt_artifact",
+        )
+
+
 def receipt_candidate_probe(path: pathlib.Path, route: dict[str, Any], journal: dict[str, Any]) -> dict[str, Any]:
     if not path.is_file():
-        return {"exists": False, "candidate_valid": False, "size_bytes": None, "reason": "missing_receipt_artifact"}
+        return receipt_probe_result(
+            exists=False,
+            candidate_valid=False,
+            reason="missing_receipt_artifact",
+        )
+    text, error_probe = read_receipt_candidate_text(path)
+    if error_probe is not None:
+        return error_probe
+    if text is None:
+        return receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="unreadable_receipt_artifact",
+        )
     try:
-        size = path.stat().st_size
-    except OSError:
-        return {"exists": True, "candidate_valid": False, "size_bytes": None, "reason": "unreadable_receipt_artifact"}
-    if size <= 0:
-        return {"exists": True, "candidate_valid": False, "size_bytes": size, "reason": "empty_receipt_artifact"}
-    if size > MAX_RECEIPT_CANDIDATE_BYTES:
-        return {"exists": True, "candidate_valid": False, "size_bytes": size, "reason": "oversized_receipt_artifact"}
-    try:
-        candidate = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return {"exists": True, "candidate_valid": False, "size_bytes": size, "reason": "unparseable_receipt_artifact"}
+        candidate = json.loads(text)
+    except json.JSONDecodeError:
+        return receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="unparseable_receipt_artifact",
+        )
     if not isinstance(candidate, dict):
-        return {"exists": True, "candidate_valid": False, "size_bytes": size, "reason": "receipt_candidate_not_object"}
+        return receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="receipt_candidate_not_object",
+        )
     if candidate.get("schema") != RECEIPT_CANDIDATE_SCHEMA:
-        return {"exists": True, "candidate_valid": False, "size_bytes": size, "reason": "receipt_candidate_schema_mismatch"}
+        return receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="receipt_candidate_schema_mismatch",
+        )
     if candidate.get("route_id") != route["route_id"]:
-        return {"exists": True, "candidate_valid": False, "size_bytes": size, "reason": "receipt_candidate_route_mismatch"}
+        return receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="receipt_candidate_route_mismatch",
+        )
     if candidate.get("system") != route["system"]:
-        return {"exists": True, "candidate_valid": False, "size_bytes": size, "reason": "receipt_candidate_system_mismatch"}
+        return receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="receipt_candidate_system_mismatch",
+        )
     if candidate.get("journal_commitment") != journal["journal_commitment"]:
-        return {"exists": True, "candidate_valid": False, "size_bytes": size, "reason": "receipt_candidate_journal_mismatch"}
+        return receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="receipt_candidate_journal_mismatch",
+        )
     receipt_commitment = candidate.get("receipt_commitment")
     if not isinstance(receipt_commitment, str) or not receipt_commitment.startswith("blake2b-256:"):
-        return {"exists": True, "candidate_valid": False, "size_bytes": size, "reason": "receipt_candidate_commitment_missing"}
-    return {"exists": True, "candidate_valid": True, "size_bytes": size, "reason": "receipt_candidate_parseable"}
+        return receipt_probe_result(
+            exists=True,
+            candidate_valid=False,
+            reason="receipt_candidate_commitment_missing",
+        )
+    return receipt_probe_result(
+        exists=True,
+        candidate_valid=True,
+        reason="receipt_candidate_parseable",
+    )
 
 
 def route_decisions(probe: dict[str, Any]) -> list[dict[str, Any]]:
@@ -537,6 +629,8 @@ def mutation_cases(payload: dict[str, Any]) -> list[dict[str, Any]]:
         add("risc0_route_relabeling_to_go", "route_decisions", lambda p: p["route_decisions"][0].update({"status": "GO_ZKVM_STATEMENT_RECEIPT_AVAILABLE", "usable_today": True, "first_blocker": "none"})),
         add("sp1_route_relabeling_to_go", "route_decisions", lambda p: p["route_decisions"][1].update({"status": "GO_ZKVM_STATEMENT_RECEIPT_AVAILABLE", "usable_today": True, "first_blocker": "none"})),
         add("receipt_artifact_smuggled", "route_decisions", lambda p: p["route_decisions"][0].__setitem__("receipt_artifact_exists", not p["route_decisions"][0]["receipt_artifact_exists"])),
+        add("receipt_probe_size_bound_removed", "route_decisions", lambda p: p["route_decisions"][0]["receipt_artifact_probe"].pop("size_bound_exceeded", None)),
+        add("receipt_probe_size_limit_changed", "route_decisions", lambda p: p["route_decisions"][0]["receipt_artifact_probe"].__setitem__("max_size_bytes", 1)),
         add("proof_size_metric_smuggled", "backend_decision", lambda p: p["backend_decision"]["proof_metrics"].__setitem__("proof_size_bytes", 1)),
         add("verifier_time_metric_smuggled", "backend_decision", lambda p: p["backend_decision"]["proof_metrics"].__setitem__("verifier_time_ms", 1.0)),
         add("proof_generation_time_metric_smuggled", "backend_decision", lambda p: p["backend_decision"]["proof_metrics"].__setitem__("proof_generation_time_ms", 1.0)),


### PR DESCRIPTION
## Summary

- stabilize the #422 zkVM adapter receipt probe by removing exact `size_bytes` from route evidence
- keep bounded-read fail-closed behavior with `max_size_bytes` and `size_bound_exceeded`
- add mutation coverage for receipt-probe byte-bound removal and byte-limit drift
- update checked adapter evidence and gate note from `21 / 21` to `23 / 23` mutations rejected

Closes #436.

## Validation

- `python3 -m py_compile scripts/zkai_d128_zkvm_statement_receipt_adapter_gate.py scripts/tests/test_zkai_d128_zkvm_statement_receipt_adapter_gate.py scripts/zkai_d128_cryptographic_backend_gate.py scripts/tests/test_zkai_d128_cryptographic_backend_gate.py`
- `PATH="$HOME/.risc0/bin:$HOME/.cargo/bin:$PATH" python3 -m unittest scripts.tests.test_zkai_d128_zkvm_statement_receipt_adapter_gate scripts.tests.test_zkai_d128_cryptographic_backend_gate`
- `PATH="$HOME/.risc0/bin:$HOME/.cargo/bin:$PATH" python3 scripts/zkai_d128_zkvm_statement_receipt_adapter_gate.py --write-json docs/engineering/evidence/zkai-d128-zkvm-statement-receipt-adapter-2026-05.json --write-tsv docs/engineering/evidence/zkai-d128-zkvm-statement-receipt-adapter-2026-05.tsv`
- RISC Zero downstream verifier rerun + aggregate gate rerun, followed by `cmp` proving `zkai-d128-zkvm-statement-receipt-adapter-2026-05.json` remained byte-identical
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `git diff --check`
- `just gate-fast`
- `just gate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated receipt probe documentation clarifying recorded metrics and behavior.

* **Tests**
  * Enhanced receipt artifact probe validation assertions.
  * Added test coverage for receipt-probe bound change detection.

* **Improvements**
  * Receipt probe now records configured byte cap and overflow status instead of exact size.
  * Expanded mutation detection to identify size-bound and limit configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->