### PR TITLE
[codex] Harden single-head lookup gate with native verifier

### DIFF
--- a/scripts/tests/test_zkai_attention_kv_air_private_softmax_table_lookup_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_air_private_softmax_table_lookup_gate.py
@@ -1,4 +1,6 @@
 import copy
+import json
+import os
 import tempfile
 import unittest
 
@@ -16,6 +18,24 @@ class AttentionKvAirPrivateSoftmaxTableLookupGateTests(unittest.TestCase):
         with self.assertRaises(gate.AttentionKvAirPrivateSoftmaxTableLookupGateError) as ctx:
             gate.validate_payload(payload, allow_missing_mutation_summary=True)
         self.assertIn(message, str(ctx.exception))
+
+    def same_digit_mutation(self, value):
+        for candidate in (value + 1, value - 1):
+            if 0 <= candidate <= 255 and len(str(candidate)) == len(str(value)):
+                return candidate
+        self.fail(f"no same-digit mutation available for {value}")
+
+    def same_size_tampered_envelope_json(self):
+        envelope = json.loads(gate.LOOKUP_ENVELOPE_JSON.read_text(encoding="utf-8"))
+        proof_payload = json.loads(bytes(envelope["proof"]).decode("utf-8"))
+        commitments = proof_payload["stark_proof"]["commitments"]
+        commitments[0][0] = self.same_digit_mutation(commitments[0][0])
+        proof_bytes = json.dumps(proof_payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        self.assertEqual(len(proof_bytes), len(envelope["proof"]))
+        envelope["proof"] = list(proof_bytes)
+        serialized = json.dumps(envelope, indent=2, sort_keys=True)
+        self.assertEqual(len(serialized.encode("utf-8")), gate.LOOKUP_ENVELOPE_SIZE_BYTES)
+        return serialized
 
     def test_build_payload_records_logup_sidecar_go(self):
         payload = gate.build_payload()
@@ -89,6 +109,48 @@ class AttentionKvAirPrivateSoftmaxTableLookupGateTests(unittest.TestCase):
         payload = self.strip_mutation_summary(gate.build_payload())
         payload["lookup_receipt"]["lookup_claims"] = 52.0
         self.assert_rejects(payload, "lookup_receipt drift")
+
+    def test_native_verifier_rejects_same_size_tampered_proof_payload(self):
+        serialized = self.same_size_tampered_envelope_json()
+        with tempfile.TemporaryDirectory() as tmp:
+            tampered = gate.pathlib.Path(tmp) / "same-size-tampered-envelope.json"
+            tampered.write_text(serialized, encoding="utf-8")
+            with self.assertRaisesRegex(
+                gate.AttentionKvAirPrivateSoftmaxTableLookupGateError,
+                "native lookup verifier rejected",
+            ):
+                gate.verify_lookup_envelope_with_native_cli(tampered)
+
+    def test_native_verifier_cache_is_bound_to_exact_envelope_bytes(self):
+        gate._LOOKUP_VERIFY_CACHE.clear()
+        envelope = json.loads(gate.LOOKUP_ENVELOPE_JSON.read_text(encoding="utf-8"))
+        original = json.dumps(envelope, indent=2, sort_keys=True)
+        tampered = self.same_size_tampered_envelope_json()
+        self.assertEqual(len(original.encode("utf-8")), len(tampered.encode("utf-8")))
+        with tempfile.TemporaryDirectory() as tmp:
+            path = gate.pathlib.Path(tmp) / "lookup-envelope.json"
+            path.write_text(original, encoding="utf-8")
+            gate.verify_lookup_envelope_with_native_cli(path)
+            stat = path.stat()
+            path.write_text(tampered, encoding="utf-8")
+            os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+            with self.assertRaisesRegex(
+                gate.AttentionKvAirPrivateSoftmaxTableLookupGateError,
+                "native lookup verifier rejected",
+            ):
+                gate.verify_lookup_envelope_with_native_cli(path)
+
+    def test_rejects_embedded_source_input_float_and_bool_relabeling(self):
+        source_input = json.loads(gate.SOURCE_INPUT_JSON.read_text(encoding="utf-8"))
+        envelope = json.loads(gate.LOOKUP_ENVELOPE_JSON.read_text(encoding="utf-8"))
+        for relabel in (8.0, True):
+            mutated = copy.deepcopy(envelope)
+            mutated["source_input"]["score_gap_clip"] = relabel
+            with self.assertRaisesRegex(
+                gate.AttentionKvAirPrivateSoftmaxTableLookupGateError,
+                "lookup envelope source input split-brain drift",
+            ):
+                gate.validate_lookup_envelope(mutated, source_input, gate.LOOKUP_ENVELOPE_SIZE_BYTES)
 
     def test_tsv_summary_matches_payload(self):
         payload = gate.build_payload()

--- a/scripts/zkai_attention_kv_air_private_softmax_table_lookup_gate.py
+++ b/scripts/zkai_attention_kv_air_private_softmax_table_lookup_gate.py
@@ -282,7 +282,10 @@ def verify_lookup_envelope_bytes_with_native_cli(envelope_bytes: bytes, label: s
             f"native lookup verifier failed to run for {label}: {err}"
         ) from err
     finally:
-        tmp_path.unlink(missing_ok=True)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
     if completed.returncode != 0:
         detail = (completed.stderr or completed.stdout).strip().splitlines()
         suffix = detail[-1] if detail else f"exit code {completed.returncode}"

--- a/scripts/zkai_attention_kv_air_private_softmax_table_lookup_gate.py
+++ b/scripts/zkai_attention_kv_air_private_softmax_table_lookup_gate.py
@@ -17,6 +17,8 @@ import hashlib
 import importlib.util
 import json
 import pathlib
+import subprocess
+import tempfile
 from types import ModuleType
 from typing import Any
 
@@ -46,6 +48,7 @@ NEXT_BACKEND_STEP = (
     "then repeat the check on the two-head route"
 )
 TIMING_POLICY = "no_new_timing_proof_existence_and_relation_gate_only"
+LOOKUP_VERIFY_TIMEOUT_SECONDS = 180
 
 SOURCE_DECISION = "GO_INPUT_FOR_STWO_NATIVE_ATTENTION_KV_D8_BOUNDED_SOFTMAX_TABLE_AIR_PROOF"
 SOURCE_STATEMENT_COMMITMENT = "blake2b-256:7d75ce774597ed9ac2a022b954647f685350aa82b70438cb37e57b915f16c79b"
@@ -139,6 +142,8 @@ TSV_COLUMNS = (
     "mutations_rejected",
 )
 
+_LOOKUP_VERIFY_CACHE: set[tuple[str, int]] = set()
+
 
 class AttentionKvAirPrivateSoftmaxTableLookupGateError(ValueError):
     pass
@@ -162,11 +167,24 @@ SOURCE_INPUT_MODULE = load_script_module(
 
 
 def read_bounded_json(path: pathlib.Path, max_bytes: int, label: str) -> Any:
-    bounded_file_size(path, max_bytes, label)
+    raw = read_bounded_bytes(path, max_bytes, label)
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as err:
+        return json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as err:
         raise AttentionKvAirPrivateSoftmaxTableLookupGateError(f"failed to read {label}: {err}") from err
+
+
+def read_bounded_bytes(path: pathlib.Path, max_bytes: int, label: str) -> bytes:
+    expected_size = bounded_file_size(path, max_bytes, label)
+    try:
+        raw = path.read_bytes()
+    except OSError as err:
+        raise AttentionKvAirPrivateSoftmaxTableLookupGateError(f"failed to read {label}: {err}") from err
+    if len(raw) != expected_size:
+        raise AttentionKvAirPrivateSoftmaxTableLookupGateError(
+            f"{label} read size drift: stat={expected_size}, read={len(raw)}"
+        )
+    return raw
 
 
 def bounded_file_size(path: pathlib.Path, max_bytes: int, label: str) -> int:
@@ -224,6 +242,81 @@ def parse_lookup_proof(proof_bytes: list[Any]) -> dict[str, Any]:
     return stark_proof
 
 
+def verify_lookup_envelope_bytes_with_native_cli(envelope_bytes: bytes, label: str) -> None:
+    """Run the real native Stwo verifier on the exact bytes parsed by the gate."""
+    if len(envelope_bytes) <= 0 or len(envelope_bytes) > MAX_LOOKUP_ENVELOPE_JSON_BYTES:
+        raise AttentionKvAirPrivateSoftmaxTableLookupGateError(
+            f"{label} size drift: got {len(envelope_bytes)}, max {MAX_LOOKUP_ENVELOPE_JSON_BYTES}"
+        )
+    digest = hashlib.blake2b(envelope_bytes, digest_size=32).hexdigest()
+    cache_key = (digest, len(envelope_bytes))
+    if cache_key in _LOOKUP_VERIFY_CACHE:
+        return
+    with tempfile.NamedTemporaryFile("wb", suffix=".json", delete=False) as tmp:
+        tmp.write(envelope_bytes)
+        tmp_path = pathlib.Path(tmp.name)
+    command = [
+        "cargo",
+        "+nightly-2025-07-14",
+        "run",
+        "--features",
+        "stwo-backend",
+        "--bin",
+        "zkai_attention_kv_native_d8_softmax_table_lookup_proof",
+        "--",
+        "verify",
+        str(tmp_path),
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=LOOKUP_VERIFY_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as err:
+        raise AttentionKvAirPrivateSoftmaxTableLookupGateError(
+            f"native lookup verifier failed to run for {label}: {err}"
+        ) from err
+    finally:
+        tmp_path.unlink(missing_ok=True)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip().splitlines()
+        suffix = detail[-1] if detail else f"exit code {completed.returncode}"
+        raise AttentionKvAirPrivateSoftmaxTableLookupGateError(
+            f"native lookup verifier rejected {label}: {suffix}"
+        )
+    try:
+        summary = json.loads(completed.stdout)
+    except json.JSONDecodeError as err:
+        raise AttentionKvAirPrivateSoftmaxTableLookupGateError(
+            f"native lookup verifier emitted malformed JSON for {label}: {err}"
+        ) from err
+    expected_summary = {
+        "mode": "verify",
+        "verified": True,
+        "proof_size_bytes": LOOKUP_PROOF_SIZE_BYTES,
+        "envelope_size_bytes": len(envelope_bytes),
+        "source_statement_commitment": SOURCE_STATEMENT_COMMITMENT,
+        "lookup_claims": SOURCE_SCORE_ROWS,
+        "table_rows": SOURCE_TABLE_ROWS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AttentionKvAirPrivateSoftmaxTableLookupGateError(
+                f"native lookup verifier summary drift for {key}: got {summary.get(key)!r}"
+            )
+    _LOOKUP_VERIFY_CACHE.add(cache_key)
+
+
+def verify_lookup_envelope_with_native_cli(path: pathlib.Path) -> None:
+    raw = read_bounded_bytes(path, MAX_LOOKUP_ENVELOPE_JSON_BYTES, "lookup sidecar envelope")
+    verify_lookup_envelope_bytes_with_native_cli(raw, str(path))
+
+
 def validate_source_input(source_input: Any) -> None:
     if not isinstance(source_input, dict):
         raise AttentionKvAirPrivateSoftmaxTableLookupGateError("source input must be an object")
@@ -276,7 +369,7 @@ def validate_lookup_envelope(envelope: Any, source_input: dict[str, Any], envelo
     for key, expected in expected_scalars.items():
         if envelope.get(key) != expected:
             raise AttentionKvAirPrivateSoftmaxTableLookupGateError(f"{key} drift")
-    if envelope.get("source_input") != source_input:
+    if not type_strict_equal(envelope.get("source_input"), source_input):
         raise AttentionKvAirPrivateSoftmaxTableLookupGateError("lookup envelope source input split-brain drift")
     summary = envelope.get("lookup_summary")
     if not isinstance(summary, dict):
@@ -329,11 +422,16 @@ def validate_lookup_envelope(envelope: Any, source_input: dict[str, Any], envelo
 def build_payload() -> dict[str, Any]:
     source_input = read_bounded_json(SOURCE_INPUT_JSON, MAX_SOURCE_INPUT_JSON_BYTES, "source bounded Softmax-table input")
     validate_source_input(source_input)
-    envelope_size_bytes = bounded_file_size(LOOKUP_ENVELOPE_JSON, MAX_LOOKUP_ENVELOPE_JSON_BYTES, "lookup sidecar envelope")
+    envelope_raw = read_bounded_bytes(LOOKUP_ENVELOPE_JSON, MAX_LOOKUP_ENVELOPE_JSON_BYTES, "lookup sidecar envelope")
+    envelope_size_bytes = len(envelope_raw)
     if envelope_size_bytes != LOOKUP_ENVELOPE_SIZE_BYTES:
         raise AttentionKvAirPrivateSoftmaxTableLookupGateError("lookup envelope size drift")
-    envelope = read_bounded_json(LOOKUP_ENVELOPE_JSON, MAX_LOOKUP_ENVELOPE_JSON_BYTES, "lookup sidecar envelope")
+    try:
+        envelope = json.loads(envelope_raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as err:
+        raise AttentionKvAirPrivateSoftmaxTableLookupGateError(f"failed to read lookup sidecar envelope: {err}") from err
     receipt = validate_lookup_envelope(envelope, source_input, envelope_size_bytes)
+    verify_lookup_envelope_bytes_with_native_cli(envelope_raw, str(LOOKUP_ENVELOPE_JSON))
     payload: dict[str, Any] = {
         "schema": SCHEMA,
         "issue": ISSUE,

--- a/scripts/zkai_attention_kv_two_head_air_private_softmax_table_lookup_gate.py
+++ b/scripts/zkai_attention_kv_two_head_air_private_softmax_table_lookup_gate.py
@@ -302,7 +302,10 @@ def verify_lookup_envelope_bytes_with_native_cli(envelope_bytes: bytes, label: s
             f"native lookup verifier failed to run for {label}: {err}"
         ) from err
     finally:
-        tmp_path.unlink(missing_ok=True)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
     if completed.returncode != 0:
         detail = (completed.stderr or completed.stdout).strip().splitlines()
         suffix = detail[-1] if detail else f"exit code {completed.returncode}"


### PR DESCRIPTION
## Summary

- Bind the single-head Softmax-table LogUp gate to the real native Stwo verifier before emitting its GO artifact.
- Parse the lookup envelope from exact bounded bytes, cache verifier success by byte digest and length, and require the native verifier summary to match the checked gate constants.
- Tighten embedded `source_input` comparison to type-strict equality so float/bool relabeling cannot pass through Python value equality.
- Add tests for same-size proof-payload tampering, digest-bound verifier cache behavior, and embedded `source_input` type relabeling.

## Claim Boundary

Hardening only. The checked evidence numbers and GO decision do not change.

Closes #483.

## Validation

- `python3 -m py_compile scripts/zkai_attention_kv_air_private_softmax_table_lookup_gate.py scripts/tests/test_zkai_attention_kv_air_private_softmax_table_lookup_gate.py`
- `python3 -m unittest scripts.tests.test_zkai_attention_kv_air_private_softmax_table_lookup_gate`
- `python3 scripts/zkai_attention_kv_air_private_softmax_table_lookup_gate.py --write-json docs/engineering/evidence/zkai-attention-kv-stwo-native-d8-softmax-table-logup-sidecar-gate-2026-05.json --write-tsv docs/engineering/evidence/zkai-attention-kv-stwo-native-d8-softmax-table-logup-sidecar-gate-2026-05.tsv`
- `python3 -m unittest scripts.tests.test_zkai_attention_kv_air_private_softmax_table_lookup_gate scripts.tests.test_zkai_attention_kv_two_head_air_private_softmax_table_lookup_gate scripts.tests.test_zkai_attention_kv_two_head_bounded_softmax_table_native_gate`
- `cargo +nightly-2025-07-14 run --features stwo-backend --bin zkai_attention_kv_native_d8_softmax_table_lookup_proof -- verify docs/engineering/evidence/zkai-attention-kv-stwo-native-d8-softmax-table-logup-sidecar-proof-2026-05.envelope.json`
- `python3 scripts/paper/paper_preflight.py --repo-root .`
- `just gate-fast`
- `just gate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests ensuring tampered lookup envelopes are rejected even when byte-size is preserved; added validation against split-type relabeling.

* **Improvements**
  * Added native verifier execution for strict byte-level envelope verification with exact-size enforcement.
  * Introduced result caching to avoid redundant verifications.
  * Strengthened JSON/UTF-8 decoding and strict type-structure validation.

* **Bug Fixes**
  * Made cleanup of temporary verifier artifacts robust to removal errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->