### PR TITLE
Harden Softmax paired-source validation

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -358,12 +358,19 @@ Tablero boundary.
 - Issue `#506` applies the same implementation-exact receipt discipline to the
   d16 fused width-axis route, and issue `#507` hardens it with a deterministic
   denominator/rounding edge corpus. The edge corpus checks `7` integer-kernel
-  edge cases, records denominator range `256..852`, rejects `7 / 7`
+  edge cases, records denominator range `256..852`, rejects `9 / 9`
   source/sidecar/fused denominator and remainder mutations, and hardens the d16
   sidecar/fused validator APIs so matching malformed source/envelope pairs are
   rejected by direct source-input validation. This is correctness hardening, not
   a new proof, not real-valued Softmax, and not a benchmark; see
   `docs/engineering/zkai-attention-kv-softmax-denominator-rounding-edge-corpus-2026-05-09.md`.
+- Issue `#510` applies the same paired-source API audit across adjacent
+  Softmax-table validators. The checked gate mirrors an `output_remainder`
+  mutation into both the caller-provided source input and the envelope
+  `source_input`, and all `11 / 11` inspected d8/two-head/four-head/
+  long-sequence/d16 sidecar and fused validators reject the paired malformed
+  object. This is validator hardening only; see
+  `docs/engineering/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05-09.md`.
 
 
 - The attention/KV proof-route selector records a narrow

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -451,6 +451,13 @@ Tablero boundary.
   rejected by direct source-input validation. This is correctness hardening, not
   a new proof, not real-valued Softmax, and not a benchmark; see
   `docs/engineering/zkai-attention-kv-softmax-denominator-rounding-edge-corpus-2026-05-09.md`.
+- Issue `#510` applies the same paired-source API audit across adjacent
+  Softmax-table validators. The checked gate mirrors an `output_remainder`
+  mutation into both the caller-provided source input and the envelope
+  `source_input`, and all `11 / 11` inspected d8/two-head/four-head/
+  long-sequence/d16 sidecar and fused validators reject the paired malformed
+  object. This is validator hardening only; see
+  `docs/engineering/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05-09.md`.
 
 
 - The attention/KV proof-route selector records a narrow

--- a/docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json
+++ b/docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json
@@ -1,0 +1,87 @@
+{
+  "accepted_targets": [],
+  "claim_boundary": "VALIDATOR_API_HARDENING_FOR_MATCHING_MALFORMED_SOFTMAX_TABLE_SOURCE_ENVELOPE_PAIRS_NOT_NEW_PROOF_NOT_BENCHMARK_NOT_REAL_VALUED_SOFTMAX_NOT_MODEL_ACCURACY_EVIDENCE",
+  "decision": "GO_SOFTMAX_TABLE_PAIRED_SOURCE_VALIDATION_AUDIT",
+  "fused_targets_checked": 6,
+  "issue": 510,
+  "mutation": "score_rows[0].output_remainder[0] += 1",
+  "schema": "zkai-attention-kv-softmax-paired-source-validation-audit-v1",
+  "sidecar_targets_checked": 5,
+  "target_results": [
+    {
+      "error": "AttentionKvAirPrivateSoftmaxTableLookupGateError",
+      "rejected": true,
+      "route": "sidecar",
+      "target_id": "d8_sidecar"
+    },
+    {
+      "error": "AttentionKvAirPrivateSoftmaxTableLookupGateError",
+      "rejected": true,
+      "route": "sidecar",
+      "target_id": "two_head_sidecar"
+    },
+    {
+      "error": "AttentionKvAirPrivateSoftmaxTableLookupGateError",
+      "rejected": true,
+      "route": "sidecar",
+      "target_id": "four_head_sidecar"
+    },
+    {
+      "error": "AttentionKvAirPrivateSoftmaxTableLookupGateError",
+      "rejected": true,
+      "route": "sidecar",
+      "target_id": "two_head_longseq_sidecar"
+    },
+    {
+      "error": "AttentionKvAirPrivateSoftmaxTableLookupGateError",
+      "rejected": true,
+      "route": "sidecar",
+      "target_id": "d16_sidecar"
+    },
+    {
+      "error": "AttentionKvD8FusedSoftmaxTableGateError",
+      "rejected": true,
+      "route": "fused",
+      "target_id": "d8_fused"
+    },
+    {
+      "error": "AttentionKvTwoHeadFusedSoftmaxTableGateError",
+      "rejected": true,
+      "route": "fused",
+      "target_id": "two_head_fused"
+    },
+    {
+      "error": "AttentionKvFourHeadFusedSoftmaxTableGateError",
+      "rejected": true,
+      "route": "fused",
+      "target_id": "four_head_fused"
+    },
+    {
+      "error": "AttentionKvEightHeadBoundedSoftmaxTableInputError",
+      "rejected": true,
+      "route": "fused",
+      "target_id": "eight_head_fused"
+    },
+    {
+      "error": "AttentionKvTwoHeadLongseqBoundedSoftmaxTableInputError",
+      "rejected": true,
+      "route": "fused",
+      "target_id": "two_head_longseq_fused"
+    },
+    {
+      "error": "AttentionKvD16FusedSoftmaxTableGateError",
+      "rejected": true,
+      "route": "fused",
+      "target_id": "d16_fused"
+    }
+  ],
+  "targets_checked": 11,
+  "targets_rejected": 11,
+  "timing_policy": "not_timed_correctness_gate_only",
+  "validation_commands": [
+    "python3 scripts/zkai_attention_kv_softmax_paired_source_validation_audit_gate.py --write-json docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json --write-tsv docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_attention_kv_softmax_paired_source_validation_audit_gate",
+    "just gate-fast",
+    "just gate"
+  ]
+}

--- a/docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv
@@ -1,0 +1,2 @@
+decision	targets_checked	targets_rejected	accepted_targets	sidecar_targets_checked	fused_targets_checked	mutation
+GO_SOFTMAX_TABLE_PAIRED_SOURCE_VALIDATION_AUDIT	11	11		5	6	score_rows[0].output_remainder[0] += 1

--- a/docs/engineering/zkai-attention-kv-proof-route-selector-2026-05-05.md
+++ b/docs/engineering/zkai-attention-kv-proof-route-selector-2026-05-05.md
@@ -239,6 +239,12 @@ source input, so a caller cannot pass a matching malformed source/envelope pair
 with denominator or remainder drift. This is correctness hardening only, not a
 new proof, not real-valued Softmax, and not a benchmark row.
 
+Issue `#510` applies the same paired-source API audit across the adjacent
+d8/two-head/four-head/long-sequence sidecar and fused Softmax-table validators.
+The checked audit gate mirrors an `output_remainder` mutation into both the
+caller-provided source input and the envelope's `source_input` field; all `11 /
+11` inspected validators reject the paired malformed object.
+
 The selector's default receipt load is structural and cheap, but it is not blind
 to proof-file edits: the multi-head receipt records `blake2b-256` commitments to
 each fused envelope and each fused proof byte payload. The checked strict command
@@ -364,6 +370,8 @@ Claim boundary:
 - Native d16 quantized Softmax-table receipt TSV: `docs/engineering/evidence/zkai-attention-kv-d16-quantized-softmax-receipt-gate-2026-05.tsv`
 - Native d16 Softmax denominator/rounding edge corpus JSON: `docs/engineering/evidence/zkai-attention-kv-softmax-denominator-rounding-edge-corpus-2026-05.json`
 - Native d16 Softmax denominator/rounding edge corpus TSV: `docs/engineering/evidence/zkai-attention-kv-softmax-denominator-rounding-edge-corpus-2026-05.tsv`
+- Native Softmax-table paired-source validation audit JSON: `docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json`
+- Native Softmax-table paired-source validation audit TSV: `docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv`
 - Source receipt evidence: `docs/engineering/evidence/zkai-attention-kv-transition-receipt-2026-05.json`
 - External SNARK receipt evidence: `docs/engineering/evidence/zkai-attention-kv-snark-statement-receipt-2026-05.json`
 - External RISC Zero semantics receipt evidence: `docs/engineering/evidence/zkai-attention-kv-risc0-semantics-receipt-2026-05.json`

--- a/docs/engineering/zkai-attention-kv-proof-route-selector-2026-05-05.md
+++ b/docs/engineering/zkai-attention-kv-proof-route-selector-2026-05-05.md
@@ -372,6 +372,23 @@ Claim boundary:
 - Native d16 Softmax denominator/rounding edge corpus TSV: `docs/engineering/evidence/zkai-attention-kv-softmax-denominator-rounding-edge-corpus-2026-05.tsv`
 - Native Softmax-table paired-source validation audit JSON: `docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json`
 - Native Softmax-table paired-source validation audit TSV: `docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv`
+
+Reproduce the paired-source validation audit artifacts:
+
+```bash
+python3 scripts/zkai_attention_kv_softmax_paired_source_validation_audit_gate.py \
+  --write-json docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv
+python3 -m unittest scripts.tests.test_zkai_attention_kv_softmax_paired_source_validation_audit_gate
+```
+
+This audit is a correctness-only validator API gate. It uses the checked source
+inputs and envelopes already recorded by each target route, records timing
+policy `not_timed_correctness_gate_only`, and performs no fresh Stwo prover or
+verifier timing run. Backend version and step/head/width counts are not free
+parameters of this audit; they are inherited from each target's checked
+source/envelope artifact and revalidated through the target validator.
+
 - Source receipt evidence: `docs/engineering/evidence/zkai-attention-kv-transition-receipt-2026-05.json`
 - External SNARK receipt evidence: `docs/engineering/evidence/zkai-attention-kv-snark-statement-receipt-2026-05.json`
 - External RISC Zero semantics receipt evidence: `docs/engineering/evidence/zkai-attention-kv-risc0-semantics-receipt-2026-05.json`

--- a/docs/engineering/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05-09.md
+++ b/docs/engineering/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05-09.md
@@ -1,0 +1,82 @@
+# zkAI Attention/KV Softmax Paired-Source Validation Audit
+
+Date: 2026-05-09  
+Issue: #510  
+Result: GO for paired-source validator API hardening
+
+## Question
+
+Can a caller pass a malformed Softmax-table source input and a matching malformed
+proof envelope to a standalone sidecar or fused validator, bypassing checks that
+are only applied during artifact construction?
+
+This is a validator API hardening question. It is not a new proof result,
+benchmark, real-valued Softmax claim, or model-accuracy claim.
+
+## Finding
+
+The audit reproduced a real paired-source boundary gap in older d8/two-head/
+four-head and long-sequence sidecar/fused validator APIs: if the caller mutated
+`score_rows[0].output_remainder[0]` and mirrored that same malformed source into
+the envelope, several validators accepted because they only checked that the two
+copies matched.
+
+The fix is direct source-input validation at the standalone validator boundary.
+After the patch, the checked audit gate rejects the same paired malformed object
+across all inspected targets.
+
+## Checked Targets
+
+| Target | Route | Result |
+| --- | --- | --- |
+| `d8_sidecar` | sidecar | rejected |
+| `two_head_sidecar` | sidecar | rejected |
+| `four_head_sidecar` | sidecar | rejected |
+| `two_head_longseq_sidecar` | sidecar | rejected |
+| `d16_sidecar` | sidecar | rejected |
+| `d8_fused` | fused | rejected |
+| `two_head_fused` | fused | rejected |
+| `four_head_fused` | fused | rejected |
+| `eight_head_fused` | fused | rejected |
+| `two_head_longseq_fused` | fused | rejected |
+| `d16_fused` | fused | rejected |
+
+Summary: `11 / 11` checked targets reject the paired malformed source/envelope
+mutation.
+
+## Evidence
+
+Machine-readable evidence:
+
+- `docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json`
+- `docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv`
+
+The mutation is deterministic:
+
+```text
+score_rows[0].output_remainder[0] += 1
+```
+
+The mutation is intentionally mirrored into both the caller-provided source input
+and the envelope's `source_input` field. The gate therefore checks the API
+boundary directly instead of only checking split-brain mismatch.
+
+## Validation Commands
+
+```bash
+python3 scripts/zkai_attention_kv_softmax_paired_source_validation_audit_gate.py \
+  --write-json docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv
+python3 -m unittest scripts.tests.test_zkai_attention_kv_softmax_paired_source_validation_audit_gate
+just gate-fast
+just gate
+```
+
+## Claim Boundary
+
+This result strengthens the bounded Softmax-table track by closing a validator
+API class that could otherwise make evidence look stronger than the standalone
+acceptance logic actually was. It does not change the core claim boundary:
+bounded integer Softmax-table receipts are checked; exact real-valued Softmax,
+full inference, privacy, recursion/PCD, and public benchmark claims remain out of
+scope.

--- a/scripts/tests/test_zkai_attention_kv_softmax_paired_source_validation_audit_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_softmax_paired_source_validation_audit_gate.py
@@ -104,7 +104,10 @@ class AttentionKvSoftmaxPairedSourceValidationAuditGateTests(unittest.TestCase):
             gate.validate_result(loaded)
             tsv = tsv_path.read_text(encoding="utf-8")
             self.assertIn(gate.DECISION, tsv)
-            self.assertIn("11", tsv)
+            header, row = [line.split("\t") for line in tsv.strip().splitlines()]
+            fields = dict(zip(header, row, strict=True))
+            self.assertEqual(fields["targets_checked"], "11")
+            self.assertEqual(fields["targets_rejected"], "11")
             self.assertIn(gate.MUTATION, tsv)
 
 

--- a/scripts/tests/test_zkai_attention_kv_softmax_paired_source_validation_audit_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_softmax_paired_source_validation_audit_gate.py
@@ -37,6 +37,36 @@ class AttentionKvSoftmaxPairedSourceValidationAuditGateTests(unittest.TestCase):
         with self.assertRaisesRegex(gate.PairedSourceValidationAuditGateError, "target result order drift"):
             gate.validate_result(mutated)
 
+    def test_unexpected_validator_exception_fails_gate(self):
+        class CrashModule:
+            class ExpectedValidationError(ValueError):
+                pass
+
+            SOURCE_INPUT_JSON = "source.json"
+            MAX_SOURCE_INPUT_JSON_BYTES = 1024
+            LOOKUP_ENVELOPE_JSON = "lookup.json"
+            MAX_LOOKUP_ENVELOPE_JSON_BYTES = 1024
+            LOOKUP_ENVELOPE_SIZE_BYTES = 1
+
+            @staticmethod
+            def read_bounded_json(path, _max_bytes, _label):
+                if path == CrashModule.SOURCE_INPUT_JSON:
+                    return {"score_rows": [{"output_remainder": [0]}]}
+                return {}
+
+            @staticmethod
+            def validate_lookup_envelope(_envelope, _source_input, _envelope_size_bytes):
+                raise KeyError("internal crash")
+
+        target = gate.Target(
+            "crash_sidecar",
+            "sidecar",
+            CrashModule,
+            (CrashModule.ExpectedValidationError,),
+        )
+        with self.assertRaisesRegex(gate.PairedSourceValidationAuditGateError, "unexpected exception: KeyError"):
+            gate.run_target(target)
+
     def test_sidecar_direct_validator_rejects_matching_malformed_pair(self):
         source_input = d8_sidecar.read_bounded_json(
             d8_sidecar.SOURCE_INPUT_JSON, d8_sidecar.MAX_SOURCE_INPUT_JSON_BYTES, "source input"

--- a/scripts/tests/test_zkai_attention_kv_softmax_paired_source_validation_audit_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_softmax_paired_source_validation_audit_gate.py
@@ -1,0 +1,82 @@
+import copy
+import json
+import tempfile
+import unittest
+
+from scripts import zkai_attention_kv_air_private_softmax_table_lookup_gate as d8_sidecar
+from scripts import zkai_attention_kv_d8_fused_softmax_table_native_gate as d8_fused
+from scripts import zkai_attention_kv_softmax_paired_source_validation_audit_gate as gate
+
+
+class AttentionKvSoftmaxPairedSourceValidationAuditGateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.result = gate.build_result()
+
+    def test_build_result_rejects_all_paired_source_mutations(self):
+        gate.validate_result(self.result)
+        self.assertEqual(self.result["decision"], gate.DECISION)
+        self.assertEqual(self.result["targets_checked"], 11)
+        self.assertEqual(self.result["targets_rejected"], 11)
+        self.assertEqual(self.result["accepted_targets"], [])
+        self.assertEqual(self.result["sidecar_targets_checked"], 5)
+        self.assertEqual(self.result["fused_targets_checked"], 6)
+        self.assertIn("NOT_NEW_PROOF", self.result["claim_boundary"])
+
+    def test_rejects_target_acceptance_drift(self):
+        mutated = copy.deepcopy(self.result)
+        mutated["target_results"][0]["rejected"] = False
+        mutated["targets_rejected"] -= 1
+        mutated["accepted_targets"] = [mutated["target_results"][0]["target_id"]]
+        with self.assertRaisesRegex(gate.PairedSourceValidationAuditGateError, "result drift for targets_rejected"):
+            gate.validate_result(mutated)
+
+    def test_rejects_target_order_drift(self):
+        mutated = copy.deepcopy(self.result)
+        mutated["target_results"] = list(reversed(mutated["target_results"]))
+        with self.assertRaisesRegex(gate.PairedSourceValidationAuditGateError, "target result order drift"):
+            gate.validate_result(mutated)
+
+    def test_sidecar_direct_validator_rejects_matching_malformed_pair(self):
+        source_input = d8_sidecar.read_bounded_json(
+            d8_sidecar.SOURCE_INPUT_JSON, d8_sidecar.MAX_SOURCE_INPUT_JSON_BYTES, "source input"
+        )
+        envelope = d8_sidecar.read_bounded_json(
+            d8_sidecar.LOOKUP_ENVELOPE_JSON, d8_sidecar.MAX_LOOKUP_ENVELOPE_JSON_BYTES, "lookup envelope"
+        )
+        source_input = gate.mutate_source(source_input)
+        envelope = copy.deepcopy(envelope)
+        envelope["source_input"] = source_input
+        with self.assertRaisesRegex(d8_sidecar.AttentionKvAirPrivateSoftmaxTableLookupGateError, "source input"):
+            d8_sidecar.validate_lookup_envelope(envelope, source_input, d8_sidecar.LOOKUP_ENVELOPE_SIZE_BYTES)
+
+    def test_fused_direct_validator_rejects_matching_malformed_pair(self):
+        source_input = d8_fused.read_bounded_json(
+            d8_fused.SOURCE_INPUT_JSON, d8_fused.MAX_SOURCE_INPUT_JSON_BYTES, "source input"
+        )
+        envelope = d8_fused.read_bounded_json(
+            d8_fused.FUSED_ENVELOPE_JSON, d8_fused.MAX_FUSED_ENVELOPE_JSON_BYTES, "fused envelope"
+        )
+        source_input = gate.mutate_source(source_input)
+        envelope = copy.deepcopy(envelope)
+        envelope["source_input"] = source_input
+        with self.assertRaisesRegex(d8_fused.AttentionKvD8FusedSoftmaxTableGateError, "source input"):
+            d8_fused.validate_fused_envelope(envelope, source_input, run_native=False)
+
+    def test_write_json_and_tsv_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = gate.pathlib.Path(tmp)
+            json_path = tmp_path / "paired-source-audit.json"
+            tsv_path = tmp_path / "paired-source-audit.tsv"
+            gate.write_json(json_path, self.result)
+            gate.write_tsv(tsv_path, self.result)
+            loaded = json.loads(json_path.read_text(encoding="utf-8"))
+            gate.validate_result(loaded)
+            tsv = tsv_path.read_text(encoding="utf-8")
+            self.assertIn(gate.DECISION, tsv)
+            self.assertIn("11", tsv)
+            self.assertIn(gate.MUTATION, tsv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/zkai_attention_kv_air_private_softmax_table_lookup_gate.py
+++ b/scripts/zkai_attention_kv_air_private_softmax_table_lookup_gate.py
@@ -345,6 +345,7 @@ def validate_source_input(source_input: Any) -> None:
 
 
 def validate_lookup_envelope(envelope: Any, source_input: dict[str, Any], envelope_size_bytes: int) -> dict[str, Any]:
+    validate_source_input(source_input)
     if not isinstance(envelope, dict):
         raise AttentionKvAirPrivateSoftmaxTableLookupGateError("lookup envelope must be an object")
     allowed = {

--- a/scripts/zkai_attention_kv_d8_fused_softmax_table_native_gate.py
+++ b/scripts/zkai_attention_kv_d8_fused_softmax_table_native_gate.py
@@ -397,6 +397,10 @@ def validate_source_artifacts(source_input: dict[str, Any], source_envelope: dic
 
 
 def validate_fused_envelope(envelope: dict[str, Any], source_input: dict[str, Any], *, run_native: bool) -> None:
+    try:
+        SOURCE_INPUT_MODULE.validate_payload(source_input)
+    except Exception as err:
+        raise AttentionKvD8FusedSoftmaxTableGateError(f"source input validation drift: {err}") from err
     allowed_keys = {
         "proof_backend",
         "proof_backend_version",

--- a/scripts/zkai_attention_kv_four_head_air_private_softmax_table_lookup_gate.py
+++ b/scripts/zkai_attention_kv_four_head_air_private_softmax_table_lookup_gate.py
@@ -380,6 +380,7 @@ def validate_source_input(source_input: Any) -> None:
 
 
 def validate_lookup_envelope(envelope: Any, source_input: dict[str, Any], envelope_size_bytes: int) -> dict[str, Any]:
+    validate_source_input(source_input)
     if not isinstance(envelope, dict):
         raise AttentionKvAirPrivateSoftmaxTableLookupGateError("lookup envelope must be an object")
     allowed = {

--- a/scripts/zkai_attention_kv_four_head_fused_softmax_table_native_gate.py
+++ b/scripts/zkai_attention_kv_four_head_fused_softmax_table_native_gate.py
@@ -713,6 +713,11 @@ def validate_source_artifacts(
 
 
 def validate_fused_envelope(envelope: dict[str, Any], source_input: dict[str, Any], *, run_native: bool) -> None:
+    try:
+        SOURCE_INPUT_MODULE.validate_payload(source_input)
+    except Exception as err:
+        raise AttentionKvFourHeadFusedSoftmaxTableGateError(f"source input validation drift: {err}") from err
+    validate_source_input_contract(source_input)
     allowed_keys = {
         "proof_backend",
         "proof_backend_version",

--- a/scripts/zkai_attention_kv_softmax_paired_source_validation_audit_gate.py
+++ b/scripts/zkai_attention_kv_softmax_paired_source_validation_audit_gate.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Paired-source validation audit for Softmax-table sidecar/fused validators.
+
+This gate answers issue #510 narrowly. It mutates a caller-provided source input
+and mirrors the same malformed object into the proof envelope. Validators must
+reject that paired malformed source/envelope object instead of accepting it just
+because the two copies match.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import io
+import json
+import os
+import pathlib
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import zkai_attention_kv_air_private_softmax_table_lookup_gate as d8_sidecar
+from scripts import zkai_attention_kv_d16_air_private_softmax_table_lookup_gate as d16_sidecar
+from scripts import zkai_attention_kv_d16_fused_softmax_table_native_gate as d16_fused
+from scripts import zkai_attention_kv_d8_fused_softmax_table_native_gate as d8_fused
+from scripts import zkai_attention_kv_eight_head_fused_softmax_table_native_gate as eight_fused
+from scripts import zkai_attention_kv_four_head_air_private_softmax_table_lookup_gate as four_sidecar
+from scripts import zkai_attention_kv_four_head_fused_softmax_table_native_gate as four_fused
+from scripts import zkai_attention_kv_two_head_air_private_softmax_table_lookup_gate as two_sidecar
+from scripts import zkai_attention_kv_two_head_fused_softmax_table_native_gate as two_fused
+from scripts import zkai_attention_kv_two_head_longseq_air_private_softmax_table_lookup_gate as longseq_sidecar
+from scripts import zkai_attention_kv_two_head_longseq_fused_softmax_table_native_gate as longseq_fused
+
+EVIDENCE_DIR = ROOT / "docs" / "engineering" / "evidence"
+JSON_OUT = EVIDENCE_DIR / "zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json"
+TSV_OUT = EVIDENCE_DIR / "zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv"
+
+SCHEMA = "zkai-attention-kv-softmax-paired-source-validation-audit-v1"
+ISSUE = 510
+DECISION = "GO_SOFTMAX_TABLE_PAIRED_SOURCE_VALIDATION_AUDIT"
+CLAIM_BOUNDARY = (
+    "VALIDATOR_API_HARDENING_FOR_MATCHING_MALFORMED_SOFTMAX_TABLE_SOURCE_ENVELOPE_PAIRS_"
+    "NOT_NEW_PROOF_NOT_BENCHMARK_NOT_REAL_VALUED_SOFTMAX_NOT_MODEL_ACCURACY_EVIDENCE"
+)
+MUTATION = "score_rows[0].output_remainder[0] += 1"
+TIMING_POLICY = "not_timed_correctness_gate_only"
+
+VALIDATION_COMMANDS = (
+    "python3 scripts/zkai_attention_kv_softmax_paired_source_validation_audit_gate.py --write-json docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json --write-tsv docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_attention_kv_softmax_paired_source_validation_audit_gate",
+    "just gate-fast",
+    "just gate",
+)
+
+TSV_COLUMNS = (
+    "decision",
+    "targets_checked",
+    "targets_rejected",
+    "accepted_targets",
+    "sidecar_targets_checked",
+    "fused_targets_checked",
+    "mutation",
+)
+
+
+class PairedSourceValidationAuditGateError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Target:
+    target_id: str
+    route: str
+    module: Any
+
+
+TARGETS = (
+    Target("d8_sidecar", "sidecar", d8_sidecar),
+    Target("two_head_sidecar", "sidecar", two_sidecar),
+    Target("four_head_sidecar", "sidecar", four_sidecar),
+    Target("two_head_longseq_sidecar", "sidecar", longseq_sidecar),
+    Target("d16_sidecar", "sidecar", d16_sidecar),
+    Target("d8_fused", "fused", d8_fused),
+    Target("two_head_fused", "fused", two_fused),
+    Target("four_head_fused", "fused", four_fused),
+    Target("eight_head_fused", "fused", eight_fused),
+    Target("two_head_longseq_fused", "fused", longseq_fused),
+    Target("d16_fused", "fused", d16_fused),
+)
+
+
+def mutate_source(source_input: dict[str, Any]) -> dict[str, Any]:
+    mutated = copy.deepcopy(source_input)
+    try:
+        mutated["score_rows"][0]["output_remainder"][0] += 1
+    except (KeyError, IndexError, TypeError) as err:
+        raise PairedSourceValidationAuditGateError("source mutation target missing") from err
+    return mutated
+
+
+def run_sidecar_target(target: Target) -> dict[str, Any]:
+    module = target.module
+    source_input = module.read_bounded_json(module.SOURCE_INPUT_JSON, module.MAX_SOURCE_INPUT_JSON_BYTES, "source input")
+    envelope = module.read_bounded_json(
+        module.LOOKUP_ENVELOPE_JSON, module.MAX_LOOKUP_ENVELOPE_JSON_BYTES, "lookup envelope"
+    )
+    mutated_source = mutate_source(source_input)
+    mutated_envelope = copy.deepcopy(envelope)
+    mutated_envelope["source_input"] = mutated_source
+    try:
+        module.validate_lookup_envelope(mutated_envelope, mutated_source, module.LOOKUP_ENVELOPE_SIZE_BYTES)
+    except Exception as err:
+        return {
+            "target_id": target.target_id,
+            "route": target.route,
+            "rejected": True,
+            "error": type(err).__name__,
+        }
+    return {
+        "target_id": target.target_id,
+        "route": target.route,
+        "rejected": False,
+        "error": "paired malformed source/envelope accepted",
+    }
+
+
+def run_fused_target(target: Target) -> dict[str, Any]:
+    module = target.module
+    source_input = module.read_bounded_json(module.SOURCE_INPUT_JSON, module.MAX_SOURCE_INPUT_JSON_BYTES, "source input")
+    envelope = module.read_bounded_json(module.FUSED_ENVELOPE_JSON, module.MAX_FUSED_ENVELOPE_JSON_BYTES, "fused envelope")
+    mutated_source = mutate_source(source_input)
+    mutated_envelope = copy.deepcopy(envelope)
+    mutated_envelope["source_input"] = mutated_source
+    try:
+        module.validate_fused_envelope(mutated_envelope, mutated_source, run_native=False)
+    except Exception as err:
+        return {
+            "target_id": target.target_id,
+            "route": target.route,
+            "rejected": True,
+            "error": type(err).__name__,
+        }
+    return {
+        "target_id": target.target_id,
+        "route": target.route,
+        "rejected": False,
+        "error": "paired malformed source/envelope accepted",
+    }
+
+
+def run_target(target: Target) -> dict[str, Any]:
+    if target.route == "sidecar":
+        return run_sidecar_target(target)
+    if target.route == "fused":
+        return run_fused_target(target)
+    raise PairedSourceValidationAuditGateError(f"unknown target route: {target.route}")
+
+
+def build_result() -> dict[str, Any]:
+    target_results = [run_target(target) for target in TARGETS]
+    result = {
+        "schema": SCHEMA,
+        "issue": ISSUE,
+        "decision": DECISION,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "mutation": MUTATION,
+        "timing_policy": TIMING_POLICY,
+        "target_results": target_results,
+        "targets_checked": len(target_results),
+        "targets_rejected": sum(1 for row in target_results if row["rejected"] is True),
+        "accepted_targets": [row["target_id"] for row in target_results if row["rejected"] is not True],
+        "sidecar_targets_checked": sum(1 for row in target_results if row["route"] == "sidecar"),
+        "fused_targets_checked": sum(1 for row in target_results if row["route"] == "fused"),
+        "validation_commands": list(VALIDATION_COMMANDS),
+    }
+    validate_result(result)
+    return result
+
+
+def validate_result(result: Any) -> None:
+    if not isinstance(result, dict):
+        raise PairedSourceValidationAuditGateError("result must be an object")
+    expected_keys = {
+        "schema",
+        "issue",
+        "decision",
+        "claim_boundary",
+        "mutation",
+        "timing_policy",
+        "target_results",
+        "targets_checked",
+        "targets_rejected",
+        "accepted_targets",
+        "sidecar_targets_checked",
+        "fused_targets_checked",
+        "validation_commands",
+    }
+    if set(result) != expected_keys:
+        raise PairedSourceValidationAuditGateError("result schema drift")
+    expected = {
+        "schema": SCHEMA,
+        "issue": ISSUE,
+        "decision": DECISION,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "mutation": MUTATION,
+        "timing_policy": TIMING_POLICY,
+        "targets_checked": len(TARGETS),
+        "targets_rejected": len(TARGETS),
+        "accepted_targets": [],
+        "sidecar_targets_checked": 5,
+        "fused_targets_checked": 6,
+        "validation_commands": list(VALIDATION_COMMANDS),
+    }
+    for key, value in expected.items():
+        if result.get(key) != value:
+            raise PairedSourceValidationAuditGateError(f"result drift for {key}")
+    expected_ids = [target.target_id for target in TARGETS]
+    target_results = result.get("target_results")
+    if not isinstance(target_results, list) or [row.get("target_id") for row in target_results] != expected_ids:
+        raise PairedSourceValidationAuditGateError("target result order drift")
+    for row, target in zip(target_results, TARGETS, strict=True):
+        if set(row) != {"target_id", "route", "rejected", "error"}:
+            raise PairedSourceValidationAuditGateError("target result schema drift")
+        if row["route"] != target.route:
+            raise PairedSourceValidationAuditGateError("target route drift")
+        if row["rejected"] is not True:
+            raise PairedSourceValidationAuditGateError("paired source mutation accepted")
+        if not isinstance(row["error"], str) or not row["error"].endswith("Error"):
+            raise PairedSourceValidationAuditGateError("target rejection code drift")
+
+
+def write_json(path: pathlib.Path, result: dict[str, Any]) -> None:
+    validate_result(result)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
+        tmp.write(data)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp_path = pathlib.Path(tmp.name)
+    os.replace(tmp_path, path)
+
+
+def to_tsv(result: dict[str, Any]) -> str:
+    validate_result(result)
+    row = {key: result[key] for key in TSV_COLUMNS}
+    row["accepted_targets"] = ",".join(result["accepted_targets"])
+    out = io.StringIO()
+    writer = csv.DictWriter(out, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+    writer.writeheader()
+    writer.writerow(row)
+    return out.getvalue()
+
+
+def write_tsv(path: pathlib.Path, result: dict[str, Any]) -> None:
+    data = to_tsv(result)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", newline="", dir=path.parent, delete=False) as tmp:
+        tmp.write(data)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp_path = pathlib.Path(tmp.name)
+    os.replace(tmp_path, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write-json", type=pathlib.Path)
+    parser.add_argument("--write-tsv", type=pathlib.Path)
+    args = parser.parse_args()
+    result = build_result()
+    if args.write_json:
+        write_json(args.write_json, result)
+    if args.write_tsv:
+        write_tsv(args.write_tsv, result)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zkai_attention_kv_softmax_paired_source_validation_audit_gate.py
+++ b/scripts/zkai_attention_kv_softmax_paired_source_validation_audit_gate.py
@@ -78,20 +78,76 @@ class Target:
     target_id: str
     route: str
     module: Any
+    expected_errors: tuple[type[BaseException], ...]
+
+    @property
+    def expected_error_names(self) -> set[str]:
+        return {error.__name__ for error in self.expected_errors}
 
 
 TARGETS = (
-    Target("d8_sidecar", "sidecar", d8_sidecar),
-    Target("two_head_sidecar", "sidecar", two_sidecar),
-    Target("four_head_sidecar", "sidecar", four_sidecar),
-    Target("two_head_longseq_sidecar", "sidecar", longseq_sidecar),
-    Target("d16_sidecar", "sidecar", d16_sidecar),
-    Target("d8_fused", "fused", d8_fused),
-    Target("two_head_fused", "fused", two_fused),
-    Target("four_head_fused", "fused", four_fused),
-    Target("eight_head_fused", "fused", eight_fused),
-    Target("two_head_longseq_fused", "fused", longseq_fused),
-    Target("d16_fused", "fused", d16_fused),
+    Target(
+        "d8_sidecar",
+        "sidecar",
+        d8_sidecar,
+        (d8_sidecar.AttentionKvAirPrivateSoftmaxTableLookupGateError,),
+    ),
+    Target(
+        "two_head_sidecar",
+        "sidecar",
+        two_sidecar,
+        (two_sidecar.AttentionKvAirPrivateSoftmaxTableLookupGateError,),
+    ),
+    Target(
+        "four_head_sidecar",
+        "sidecar",
+        four_sidecar,
+        (four_sidecar.AttentionKvAirPrivateSoftmaxTableLookupGateError,),
+    ),
+    Target(
+        "two_head_longseq_sidecar",
+        "sidecar",
+        longseq_sidecar,
+        (longseq_sidecar.AttentionKvAirPrivateSoftmaxTableLookupGateError,),
+    ),
+    Target(
+        "d16_sidecar",
+        "sidecar",
+        d16_sidecar,
+        (d16_sidecar.AttentionKvAirPrivateSoftmaxTableLookupGateError,),
+    ),
+    Target("d8_fused", "fused", d8_fused, (d8_fused.AttentionKvD8FusedSoftmaxTableGateError,)),
+    Target(
+        "two_head_fused",
+        "fused",
+        two_fused,
+        (two_fused.AttentionKvTwoHeadFusedSoftmaxTableGateError,),
+    ),
+    Target(
+        "four_head_fused",
+        "fused",
+        four_fused,
+        (four_fused.AttentionKvFourHeadFusedSoftmaxTableGateError,),
+    ),
+    Target(
+        "eight_head_fused",
+        "fused",
+        eight_fused,
+        (
+            eight_fused.AttentionKvEightHeadFusedSoftmaxTableGateError,
+            eight_fused.SOURCE_INPUT_MODULE.AttentionKvEightHeadBoundedSoftmaxTableInputError,
+        ),
+    ),
+    Target(
+        "two_head_longseq_fused",
+        "fused",
+        longseq_fused,
+        (
+            longseq_fused.AttentionKvTwoHeadLongseqFusedSoftmaxTableGateError,
+            longseq_fused.SOURCE_INPUT_MODULE.AttentionKvTwoHeadLongseqBoundedSoftmaxTableInputError,
+        ),
+    ),
+    Target("d16_fused", "fused", d16_fused, (d16_fused.AttentionKvD16FusedSoftmaxTableGateError,)),
 )
 
 
@@ -115,13 +171,17 @@ def run_sidecar_target(target: Target) -> dict[str, Any]:
     mutated_envelope["source_input"] = mutated_source
     try:
         module.validate_lookup_envelope(mutated_envelope, mutated_source, module.LOOKUP_ENVELOPE_SIZE_BYTES)
-    except Exception as err:
+    except target.expected_errors as err:
         return {
             "target_id": target.target_id,
             "route": target.route,
             "rejected": True,
             "error": type(err).__name__,
         }
+    except Exception as err:
+        raise PairedSourceValidationAuditGateError(
+            f"{target.target_id} unexpected exception: {type(err).__name__}: {err}"
+        ) from err
     return {
         "target_id": target.target_id,
         "route": target.route,
@@ -139,13 +199,17 @@ def run_fused_target(target: Target) -> dict[str, Any]:
     mutated_envelope["source_input"] = mutated_source
     try:
         module.validate_fused_envelope(mutated_envelope, mutated_source, run_native=False)
-    except Exception as err:
+    except target.expected_errors as err:
         return {
             "target_id": target.target_id,
             "route": target.route,
             "rejected": True,
             "error": type(err).__name__,
         }
+    except Exception as err:
+        raise PairedSourceValidationAuditGateError(
+            f"{target.target_id} unexpected exception: {type(err).__name__}: {err}"
+        ) from err
     return {
         "target_id": target.target_id,
         "route": target.route,
@@ -231,7 +295,7 @@ def validate_result(result: Any) -> None:
             raise PairedSourceValidationAuditGateError("target route drift")
         if row["rejected"] is not True:
             raise PairedSourceValidationAuditGateError("paired source mutation accepted")
-        if not isinstance(row["error"], str) or not row["error"].endswith("Error"):
+        if row["error"] not in target.expected_error_names:
             raise PairedSourceValidationAuditGateError("target rejection code drift")
 
 

--- a/scripts/zkai_attention_kv_two_head_air_private_softmax_table_lookup_gate.py
+++ b/scripts/zkai_attention_kv_two_head_air_private_softmax_table_lookup_gate.py
@@ -368,6 +368,7 @@ def validate_source_input(source_input: Any) -> None:
 
 
 def validate_lookup_envelope(envelope: Any, source_input: dict[str, Any], envelope_size_bytes: int) -> dict[str, Any]:
+    validate_source_input(source_input)
     if not isinstance(envelope, dict):
         raise AttentionKvAirPrivateSoftmaxTableLookupGateError("lookup envelope must be an object")
     allowed = {

--- a/scripts/zkai_attention_kv_two_head_fused_softmax_table_native_gate.py
+++ b/scripts/zkai_attention_kv_two_head_fused_softmax_table_native_gate.py
@@ -664,6 +664,11 @@ def validate_source_artifacts(
 
 
 def validate_fused_envelope(envelope: dict[str, Any], source_input: dict[str, Any], *, run_native: bool) -> None:
+    try:
+        SOURCE_INPUT_MODULE.validate_payload(source_input)
+    except Exception as err:
+        raise AttentionKvTwoHeadFusedSoftmaxTableGateError(f"source input validation drift: {err}") from err
+    validate_source_input_contract(source_input)
     allowed_keys = {
         "proof_backend",
         "proof_backend_version",

--- a/scripts/zkai_attention_kv_two_head_longseq_air_private_softmax_table_lookup_gate.py
+++ b/scripts/zkai_attention_kv_two_head_longseq_air_private_softmax_table_lookup_gate.py
@@ -382,6 +382,7 @@ def validate_source_input(source_input: Any) -> None:
 
 
 def validate_lookup_envelope(envelope: Any, source_input: dict[str, Any], envelope_size_bytes: int) -> dict[str, Any]:
+    validate_source_input(source_input)
     if not isinstance(envelope, dict):
         raise AttentionKvAirPrivateSoftmaxTableLookupGateError("lookup envelope must be an object")
     allowed = {


### PR DESCRIPTION
Closes #510.

## What changed

- Reproduced and fixed a paired-source validator boundary gap in adjacent Softmax-table routes.
- Adds direct source-input validation to the standalone sidecar/fused validator entrypoints that previously could accept a malformed source input when the same malformed object was mirrored into the proof envelope.
- Adds a checked audit gate over 11 targets:
  - sidecar: d8, two-head, four-head, two-head-longseq, d16
  - fused: d8, two-head, four-head, eight-head, two-head-longseq, d16
- Checks in JSON/TSV evidence and a note documenting the claim boundary.

## Result

The deterministic mutation is:

```text
score_rows[0].output_remainder[0] += 1
```

The audit mirrors that mutation into both the caller-provided `source_input` and the envelope `source_input`. After the patch, all `11 / 11` inspected validators reject the paired malformed source/envelope object.

## Claim boundary

This is validator API hardening only. It is not a new proof, not a benchmark, not a real-valued Softmax claim, and not model-accuracy evidence.

## Validation

- `python3 -m py_compile scripts/zkai_attention_kv_softmax_paired_source_validation_audit_gate.py scripts/tests/test_zkai_attention_kv_softmax_paired_source_validation_audit_gate.py scripts/zkai_attention_kv_air_private_softmax_table_lookup_gate.py scripts/zkai_attention_kv_d8_fused_softmax_table_native_gate.py scripts/zkai_attention_kv_four_head_air_private_softmax_table_lookup_gate.py scripts/zkai_attention_kv_four_head_fused_softmax_table_native_gate.py scripts/zkai_attention_kv_two_head_air_private_softmax_table_lookup_gate.py scripts/zkai_attention_kv_two_head_fused_softmax_table_native_gate.py scripts/zkai_attention_kv_two_head_longseq_air_private_softmax_table_lookup_gate.py`
- `python3 scripts/zkai_attention_kv_softmax_paired_source_validation_audit_gate.py --write-json docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json --write-tsv docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv` (`11 / 11`)
- `python3 -m unittest scripts.tests.test_zkai_attention_kv_softmax_paired_source_validation_audit_gate` (`Ran 6 tests`)
- `python3 -m unittest scripts.tests.test_zkai_attention_kv_softmax_paired_source_validation_audit_gate scripts.tests.test_zkai_attention_kv_air_private_softmax_table_lookup_gate scripts.tests.test_zkai_attention_kv_two_head_air_private_softmax_table_lookup_gate scripts.tests.test_zkai_attention_kv_four_head_air_private_softmax_table_lookup_gate scripts.tests.test_zkai_attention_kv_two_head_longseq_air_private_softmax_table_lookup_gate scripts.tests.test_zkai_attention_kv_d8_fused_softmax_table_native_gate scripts.tests.test_zkai_attention_kv_two_head_fused_softmax_table_native_gate scripts.tests.test_zkai_attention_kv_four_head_fused_softmax_table_native_gate` (`Ran 125 tests`)
- `python3 scripts/paper/paper_preflight.py --repo-root . && git diff --check`
- `just gate-fast`
- `just gate` (`local release gate passed: 14 / 14 steps OK`)

Note: the first `just gate` attempt failed due local disk exhaustion (`No space left on device`) while compiling release dependencies. After removing disposable temp-worktree `target/` directories, the full `just gate` rerun passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI audit tool that runs paired-source validation across sidecar and fused validator routes and emits verified JSON/TSV results.

* **Bug Fixes**
  * Hardened Softmax-table validators to re-validate caller-provided source input during envelope checks, preventing paired-malformed-source bypasses.

* **Tests**
  * Added unit tests covering the audit gate, validator rejection cases, error handling, and JSON/TSV round-trip verification.

* **Documentation**
  * Added comprehensive audit reports, evidence files, and reproduction instructions for the paired-source validation hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->