### PR TITLE
Add fused Softmax route matrix gate

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -371,16 +371,31 @@ Tablero boundary.
   long-sequence/d16 sidecar and fused validators reject the paired malformed
   object. This is validator hardening only; see
   `docs/engineering/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05-09.md`.
+- Issue `#505` records the controlled fused Softmax-table route matrix across
+  width, head-count, and sequence-length axes. The checked matrix covers six
+  native Stwo fused rows: d8 single-head seq8, d16 single-head seq8, d8
+  two-head seq8, d8 four-head seq8, d8 eight-head seq8, and d8 two-head seq16.
+  Matched source-plus-sidecar controls exist for five rows and are explicitly
+  absent for eight heads, so the eight-head row is proof-existence byte
+  accounting only. The useful engineering signal is separated by axis: d8 to
+  d16 grows fused proof bytes `1.352321x` at fixed `52` lookup claims; one to
+  eight heads grows lookup claims `8.000000x` while fused proof bytes grow
+  `1.267349x`; two-head seq8 to seq16 grows lookup claims `3.230769x` while
+  fused proof bytes grow `1.222065x`. The matrix rejects `18 / 18`
+  drift/overclaim mutations and remains not timing, not real-valued Softmax,
+  not full inference, and not recursion/PCD; see
+  `docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md`.
 
 
 - The attention/KV proof-route selector records a narrow
-  `GO_NATIVE_STWO_SINGLE_MULTIHEAD_LONGSEQ_D16_FUSED_SOFTMAX_AND_EXTERNAL_SNARK_RISC0_ATTENTION_KV_RECEIPTS`
-  for ten proof-backed route families: the native Stwo d8 masked-sequence AIR proof,
+  `GO_NATIVE_STWO_SINGLE_MULTIHEAD_LONGSEQ_D16_FUSED_D16_QUANTIZED_SOFTMAX_AND_EXTERNAL_SNARK_RISC0_ATTENTION_KV_RECEIPTS`
+  for eleven proof-backed route families: the native Stwo d8 masked-sequence AIR proof,
   the native Stwo single-head implementation-exact quantized Softmax-table kernel
   receipt, the native Stwo multi-head implementation-exact quantized
   Softmax-table kernel receipt, the native Stwo two-head long-sequence fused
   Softmax-table/LogUp route, the native Stwo d16 fused Softmax-table/LogUp
-  width-axis route, the external SNARK statement-receipt route, the RISC
+  width-axis route, the native Stwo d16 implementation-exact quantized
+  Softmax-table kernel receipt, the external SNARK statement-receipt route, the RISC
   Zero transition semantics route, the RISC Zero three-step sequence semantics
   route, the RISC Zero fixed eight-step sequence semantics route, and the RISC
   Zero fixed eight-step `d=8` causal-prefix masked sequence route. The

--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -381,8 +381,8 @@ Tablero boundary.
   d16 grows fused proof bytes `1.352321x` at fixed `52` lookup claims; one to
   eight heads grows lookup claims `8.000000x` while fused proof bytes grow
   `1.267349x`; two-head seq8 to seq16 grows lookup claims `3.230769x` while
-  fused proof bytes grow `1.222065x`. The matrix rejects `18 / 18`
-  drift/overclaim mutations and remains not timing, not real-valued Softmax,
+  fused proof bytes grow `1.222065x`. The matrix rejects `21 / 21`
+  drift, provenance-drift, and overclaim mutations and remains not timing, not real-valued Softmax,
   not full inference, and not recursion/PCD; see
   `docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md`.
 

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -58,8 +58,9 @@ This is the fast local entrypoint for a fresh agent working in this repository.
 52. `docs/engineering/zkai-attention-kv-multihead-quantized-softmax-receipt-gate-2026-05-08.md`
 53. `docs/engineering/zkai-attention-kv-proof-route-selector-2026-05-05.md`
 54. `docs/engineering/zkai-attention-kv-softmax-denominator-rounding-edge-corpus-2026-05-09.md`
-55. `docs/engineering/reproducibility.md`
-56. `git status --short --branch`
+55. `docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md`
+56. `docs/engineering/reproducibility.md`
+57. `git status --short --branch`
 
 ## What this repository is now
 

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -458,6 +458,20 @@ Tablero boundary.
   long-sequence/d16 sidecar and fused validators reject the paired malformed
   object. This is validator hardening only; see
   `docs/engineering/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05-09.md`.
+- Issue `#505` records the controlled fused Softmax-table route matrix across
+  width, head-count, and sequence-length axes. The checked matrix covers six
+  native Stwo fused rows: d8 single-head seq8, d16 single-head seq8, d8
+  two-head seq8, d8 four-head seq8, d8 eight-head seq8, and d8 two-head seq16.
+  Matched source-plus-sidecar controls exist for five rows and are explicitly
+  absent for eight heads, so the eight-head row is proof-existence byte
+  accounting only. The useful engineering signal is separated by axis: d8 to
+  d16 grows fused proof bytes `1.352321x` at fixed `52` lookup claims; one to
+  eight heads grows lookup claims `8.000000x` while fused proof bytes grow
+  `1.267349x`; two-head seq8 to seq16 grows lookup claims `3.230769x` while
+  fused proof bytes grow `1.222065x`. The matrix rejects `18 / 18`
+  drift/overclaim mutations and remains not timing, not real-valued Softmax,
+  not full inference, and not recursion/PCD; see
+  `docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md`.
 
 
 - The attention/KV proof-route selector records a narrow

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -468,8 +468,8 @@ Tablero boundary.
   d16 grows fused proof bytes `1.352321x` at fixed `52` lookup claims; one to
   eight heads grows lookup claims `8.000000x` while fused proof bytes grow
   `1.267349x`; two-head seq8 to seq16 grows lookup claims `3.230769x` while
-  fused proof bytes grow `1.222065x`. The matrix rejects `18 / 18`
-  drift/overclaim mutations and remains not timing, not real-valued Softmax,
+  fused proof bytes grow `1.222065x`. The matrix rejects `21 / 21`
+  drift, provenance-drift, and overclaim mutations and remains not timing, not real-valued Softmax,
   not full inference, and not recursion/PCD; see
   `docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md`.
 

--- a/docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json
+++ b/docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json
@@ -1,0 +1,379 @@
+{
+  "aggregate_metrics": {
+    "matched_fused_proof_size_bytes_total": 275679,
+    "matched_fused_savings_bytes_total": 77900,
+    "matched_source_plus_sidecar_raw_proof_bytes_total": 353579,
+    "max_fused_proof_size_bytes": 64503,
+    "max_matched_fused_to_source_plus_sidecar_ratio": 0.860487,
+    "min_matched_fused_to_source_plus_sidecar_ratio": 0.717412,
+    "total_fused_proof_size_bytes": 336129,
+    "total_lookup_claims": 1168,
+    "total_trace_rows": 1536
+  },
+  "axis_summary": {
+    "head_axis_d8_seq8": {
+      "eight_head_comparator_status": "NO_CHECKED_SOURCE_PLUS_SIDECAR_COMPARATOR_DO_NOT_REPORT_FUSED_SAVINGS",
+      "fused_proof_ratio_1_to_8": 1.267349,
+      "fused_proof_size_bytes": [
+        47698,
+        49508,
+        53468,
+        60450
+      ],
+      "head_counts": [
+        1,
+        2,
+        4,
+        8
+      ],
+      "held_constant": "key_width_8_value_width_8_steps_per_head_8",
+      "lookup_claim_ratio_1_to_8": 8.0,
+      "lookup_claims": [
+        52,
+        104,
+        208,
+        416
+      ],
+      "matched_comparator_head_counts": [
+        1,
+        2,
+        4
+      ],
+      "matched_fused_to_source_plus_sidecar_ratios": [
+        0.802497,
+        0.759232,
+        0.717412
+      ]
+    },
+    "sequence_axis_two_head_d8": {
+      "fused_proof_size_ratio": 1.222065,
+      "held_constant": "key_width_8_value_width_8_head_count_2",
+      "lookup_claim_ratio": 3.230769,
+      "source_plus_sidecar_ratio": 1.218317,
+      "steps_per_head_ratio": 2.0,
+      "trace_row_ratio": 4.0
+    },
+    "width_axis_d8_to_d16": {
+      "fused_proof_size_ratio": 1.352321,
+      "held_constant": "single_head_seq8_score_rows_52_trace_rows_64",
+      "key_width_ratio": 2.0,
+      "lookup_claim_ratio": 1.0,
+      "source_plus_sidecar_ratio": 1.261184
+    }
+  },
+  "claim_boundary": "ENGINEERING_PROOF_BYTE_ACCOUNTING_FOR_NATIVE_STWO_FUSED_BOUNDED_SOFTMAX_TABLE_FIXTURE_FAMILY_NOT_REAL_VALUED_SOFTMAX_NOT_FULL_INFERENCE_NOT_TIMING_NOT_RECURSION_OR_PCD_NOT_A_PUBLIC_BENCHMARK_AND_NO_EIGHT_HEAD_SAVINGS_CLAIM_WITHOUT_MATCHED_SIDECAR",
+  "comparator_policy": "source_plus_sidecar_ratio_reported_only_when_matched_source_and_logup_sidecar_controls_exist",
+  "decision": "GO_NATIVE_STWO_FUSED_SOFTMAX_TABLE_CONTROLLED_ROUTE_MATRIX",
+  "issue": 505,
+  "kernel_scope": "bounded_integer_softmax_table_floor_division_kernel_with_fused_attention_arithmetic_and_logup_membership",
+  "matched_comparator_profiles": 5,
+  "mutation_results": [
+    {
+      "error": "result drift for decision",
+      "name": "decision_relabeling",
+      "rejected": true
+    },
+    {
+      "error": "result drift for route_id",
+      "name": "route_id_relabeling",
+      "rejected": true
+    },
+    {
+      "error": "result drift for claim_boundary",
+      "name": "claim_boundary_real_softmax_overclaim",
+      "rejected": true
+    },
+    {
+      "error": "result drift for timing_policy",
+      "name": "timing_policy_benchmark_overclaim",
+      "rejected": true
+    },
+    {
+      "error": "result drift for kernel_scope",
+      "name": "kernel_scope_overclaim",
+      "rejected": true
+    },
+    {
+      "error": "result drift for comparator_policy",
+      "name": "comparator_policy_relabeling",
+      "rejected": true
+    },
+    {
+      "error": "result drift for profiles_checked",
+      "name": "row_count_metric_smuggling",
+      "rejected": true
+    },
+    {
+      "error": "route row order/profile drift",
+      "name": "route_row_order_drift",
+      "rejected": true
+    },
+    {
+      "error": "d16_single_head_seq8 key width drift",
+      "name": "d16_width_metric_smuggling",
+      "rejected": true
+    },
+    {
+      "error": "d8_two_head_seq8 head count drift",
+      "name": "two_head_head_count_metric_smuggling",
+      "rejected": true
+    },
+    {
+      "error": "d8_two_head_seq16 steps per head drift",
+      "name": "longseq_steps_metric_smuggling",
+      "rejected": true
+    },
+    {
+      "error": "d8_four_head_seq8 fused ratio drift",
+      "name": "fused_proof_size_metric_smuggling",
+      "rejected": true
+    },
+    {
+      "error": "d8_single_head_seq8 fused ratio drift",
+      "name": "matched_ratio_metric_smuggling",
+      "rejected": true
+    },
+    {
+      "error": "d8_eight_head_seq8 comparator overclaim",
+      "name": "eight_head_comparator_overclaim",
+      "rejected": true
+    },
+    {
+      "error": "axis summary drift",
+      "name": "axis_summary_width_ratio_drift",
+      "rejected": true
+    },
+    {
+      "error": "axis summary drift",
+      "name": "axis_summary_head_axis_ratio_drift",
+      "rejected": true
+    },
+    {
+      "error": "axis summary drift",
+      "name": "axis_summary_sequence_ratio_drift",
+      "rejected": true
+    },
+    {
+      "error": "unknown result keys: ['unexpected']",
+      "name": "unknown_field_injection",
+      "rejected": true
+    }
+  ],
+  "mutations_checked": 18,
+  "mutations_rejected": 18,
+  "no_comparator_profiles": [
+    "d8_eight_head_seq8"
+  ],
+  "profile_ids": [
+    "d8_single_head_seq8",
+    "d16_single_head_seq8",
+    "d8_two_head_seq8",
+    "d8_four_head_seq8",
+    "d8_eight_head_seq8",
+    "d8_two_head_seq16"
+  ],
+  "profiles_checked": 6,
+  "route_id": "local_stwo_attention_kv_fused_softmax_table_controlled_route_matrix",
+  "route_rows": [
+    {
+      "axis_role": "baseline",
+      "decision": "GO_NATIVE_STWO_FUSED_ATTENTION_ARITHMETIC_AND_SOFTMAX_TABLE_LOGUP_MEMBERSHIP",
+      "evidence_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-d8-fused-softmax-table-gate-2026-05.json",
+      "fused_envelope_size_bytes": 478713,
+      "fused_issue": 478,
+      "fused_over_source_proof_bytes": 3006,
+      "fused_proof_size_bytes": 47698,
+      "fused_saves_vs_source_plus_sidecar_bytes": 11739,
+      "fused_to_source_plus_sidecar_ratio": 0.802497,
+      "head_count": 1,
+      "key_width": 8,
+      "label": "d8 single-head seq8 fused Softmax-table route",
+      "lookup_claims": 52,
+      "matched_source_sidecar_status": "GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED",
+      "mutations_checked": 26,
+      "mutations_rejected": 26,
+      "profile_id": "d8_single_head_seq8",
+      "route_id": "local_stwo_attention_kv_d8_fused_bounded_softmax_table_logup_proof",
+      "score_rows": 52,
+      "sidecar_issue": 470,
+      "sidecar_proof_size_bytes": 14745,
+      "source_envelope_size_bytes": 451982,
+      "source_input_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-d8-bounded-softmax-table-proof-2026-05.json",
+      "source_issue": 463,
+      "source_plus_sidecar_raw_proof_bytes": 59437,
+      "source_proof_size_bytes": 44692,
+      "steps_per_head": 8,
+      "table_rows": 9,
+      "trace_rows": 64,
+      "value_width": 8
+    },
+    {
+      "axis_role": "width_axis",
+      "decision": "GO_NATIVE_STWO_FUSED_ATTENTION_ARITHMETIC_AND_SOFTMAX_TABLE_LOGUP_MEMBERSHIP",
+      "evidence_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-d16-fused-softmax-table-gate-2026-05.json",
+      "fused_envelope_size_bytes": 666515,
+      "fused_issue": 501,
+      "fused_over_source_proof_bytes": 2987,
+      "fused_proof_size_bytes": 64503,
+      "fused_saves_vs_source_plus_sidecar_bytes": 10458,
+      "fused_to_source_plus_sidecar_ratio": 0.860487,
+      "head_count": 1,
+      "key_width": 16,
+      "label": "d16 single-head seq8 fused Softmax-table route",
+      "lookup_claims": 52,
+      "matched_source_sidecar_status": "GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED",
+      "mutations_checked": 26,
+      "mutations_rejected": 26,
+      "profile_id": "d16_single_head_seq8",
+      "route_id": "local_stwo_attention_kv_d16_fused_bounded_softmax_table_logup_proof",
+      "score_rows": 52,
+      "sidecar_issue": 501,
+      "sidecar_proof_size_bytes": 13445,
+      "source_envelope_size_bytes": 639928,
+      "source_input_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-d16-bounded-softmax-table-proof-2026-05.json",
+      "source_issue": 501,
+      "source_plus_sidecar_raw_proof_bytes": 74961,
+      "source_proof_size_bytes": 61516,
+      "steps_per_head": 8,
+      "table_rows": 9,
+      "trace_rows": 64,
+      "value_width": 16
+    },
+    {
+      "axis_role": "head_axis",
+      "decision": "GO_NATIVE_STWO_FUSED_ATTENTION_ARITHMETIC_AND_SOFTMAX_TABLE_LOGUP_MEMBERSHIP",
+      "evidence_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-fused-softmax-table-gate-2026-05.json",
+      "fused_envelope_size_bytes": 585857,
+      "fused_issue": 489,
+      "fused_over_source_proof_bytes": 2404,
+      "fused_proof_size_bytes": 49508,
+      "fused_saves_vs_source_plus_sidecar_bytes": 15700,
+      "fused_to_source_plus_sidecar_ratio": 0.759232,
+      "head_count": 2,
+      "key_width": 8,
+      "label": "d8 two-head seq8 fused Softmax-table route",
+      "lookup_claims": 104,
+      "matched_source_sidecar_status": "GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED",
+      "mutations_checked": 30,
+      "mutations_rejected": 30,
+      "profile_id": "d8_two_head_seq8",
+      "route_id": "local_stwo_attention_kv_two_head_fused_bounded_softmax_table_logup_proof",
+      "score_rows": 104,
+      "sidecar_issue": 477,
+      "sidecar_proof_size_bytes": 18104,
+      "source_envelope_size_bytes": 563637,
+      "source_input_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-bounded-softmax-table-proof-2026-05.json",
+      "source_issue": 471,
+      "source_plus_sidecar_raw_proof_bytes": 65208,
+      "source_proof_size_bytes": 47104,
+      "steps_per_head": 8,
+      "table_rows": 9,
+      "trace_rows": 128,
+      "value_width": 8
+    },
+    {
+      "axis_role": "head_axis_extension",
+      "decision": "GO_NATIVE_STWO_FUSED_ATTENTION_ARITHMETIC_AND_SOFTMAX_TABLE_LOGUP_MEMBERSHIP",
+      "evidence_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-four-head-fused-softmax-table-gate-2026-05.json",
+      "fused_envelope_size_bytes": 797717,
+      "fused_issue": 491,
+      "fused_over_source_proof_bytes": 722,
+      "fused_proof_size_bytes": 53468,
+      "fused_saves_vs_source_plus_sidecar_bytes": 21061,
+      "fused_to_source_plus_sidecar_ratio": 0.717412,
+      "head_count": 4,
+      "key_width": 8,
+      "label": "d8 four-head seq8 fused Softmax-table route",
+      "lookup_claims": 208,
+      "matched_source_sidecar_status": "GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED",
+      "mutations_checked": 30,
+      "mutations_rejected": 30,
+      "profile_id": "d8_four_head_seq8",
+      "route_id": "local_stwo_attention_kv_four_head_fused_bounded_softmax_table_logup_proof",
+      "score_rows": 208,
+      "sidecar_issue": 482,
+      "sidecar_proof_size_bytes": 21783,
+      "source_envelope_size_bytes": 788949,
+      "source_input_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-four-head-bounded-softmax-table-proof-2026-05.json",
+      "source_issue": 482,
+      "source_plus_sidecar_raw_proof_bytes": 74529,
+      "source_proof_size_bytes": 52746,
+      "steps_per_head": 8,
+      "table_rows": 9,
+      "trace_rows": 256,
+      "value_width": 8
+    },
+    {
+      "axis_role": "head_axis_existence_only",
+      "decision": "GO_NATIVE_STWO_EIGHT_HEAD_FUSED_ATTENTION_ARITHMETIC_AND_SOFTMAX_TABLE_LOGUP_MEMBERSHIP",
+      "evidence_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-eight-head-fused-softmax-table-gate-2026-05.json",
+      "fused_envelope_size_bytes": 1219007,
+      "fused_issue": 496,
+      "fused_over_source_proof_bytes": 8058,
+      "fused_proof_size_bytes": 60450,
+      "fused_saves_vs_source_plus_sidecar_bytes": null,
+      "fused_to_source_plus_sidecar_ratio": null,
+      "head_count": 8,
+      "key_width": 8,
+      "label": "d8 eight-head seq8 fused Softmax-table route",
+      "lookup_claims": 416,
+      "matched_source_sidecar_status": "NO_CHECKED_SOURCE_PLUS_SIDECAR_COMPARATOR_DO_NOT_REPORT_FUSED_SAVINGS",
+      "mutations_checked": 16,
+      "mutations_rejected": 16,
+      "profile_id": "d8_eight_head_seq8",
+      "route_id": "local_stwo_attention_kv_eight_head_fused_bounded_softmax_table_logup_proof",
+      "score_rows": 416,
+      "sidecar_issue": 0,
+      "sidecar_proof_size_bytes": null,
+      "source_envelope_size_bytes": 1151543,
+      "source_input_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-eight-head-bounded-softmax-table-proof-2026-05.json",
+      "source_issue": 496,
+      "source_plus_sidecar_raw_proof_bytes": null,
+      "source_proof_size_bytes": 52392,
+      "steps_per_head": 8,
+      "table_rows": 9,
+      "trace_rows": 512,
+      "value_width": 8
+    },
+    {
+      "axis_role": "sequence_axis",
+      "decision": "GO_NATIVE_STWO_TWO_HEAD_LONGSEQ_FUSED_ATTENTION_ARITHMETIC_AND_SOFTMAX_TABLE_LOGUP_MEMBERSHIP",
+      "evidence_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-longseq-fused-softmax-table-gate-2026-05.json",
+      "fused_envelope_size_bytes": 1050248,
+      "fused_issue": 498,
+      "fused_over_source_proof_bytes": 8136,
+      "fused_proof_size_bytes": 60502,
+      "fused_saves_vs_source_plus_sidecar_bytes": 18942,
+      "fused_to_source_plus_sidecar_ratio": 0.761568,
+      "head_count": 2,
+      "key_width": 8,
+      "label": "d8 two-head seq16 fused Softmax-table route",
+      "lookup_claims": 336,
+      "matched_source_sidecar_status": "GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED",
+      "mutations_checked": 19,
+      "mutations_rejected": 19,
+      "profile_id": "d8_two_head_seq16",
+      "route_id": "local_stwo_attention_kv_two_head_longseq_fused_bounded_softmax_table_logup_proof",
+      "score_rows": 336,
+      "sidecar_issue": 500,
+      "sidecar_proof_size_bytes": 27078,
+      "source_envelope_size_bytes": 982131,
+      "source_input_json": "docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-longseq-bounded-softmax-table-proof-2026-05.json",
+      "source_issue": 498,
+      "source_plus_sidecar_raw_proof_bytes": 79444,
+      "source_proof_size_bytes": 52366,
+      "steps_per_head": 16,
+      "table_rows": 9,
+      "trace_rows": 512,
+      "value_width": 8
+    }
+  ],
+  "schema": "zkai-attention-kv-fused-softmax-table-route-matrix-v1",
+  "timing_policy": "proof_existence_and_byte_accounting_only_not_public_benchmark",
+  "validation_commands": [
+    "python3 scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py --write-json docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json --write-tsv docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_attention_kv_fused_softmax_table_route_matrix_gate",
+    "just gate-fast",
+    "just gate"
+  ]
+}

--- a/docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json
+++ b/docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json
@@ -109,6 +109,21 @@
       "rejected": true
     },
     {
+      "error": "d8_single_head_seq8 label drift",
+      "name": "route_row_label_relabeling",
+      "rejected": true
+    },
+    {
+      "error": "d8_single_head_seq8 decision drift",
+      "name": "route_row_decision_relabeling",
+      "rejected": true
+    },
+    {
+      "error": "d8_single_head_seq8 evidence path drift",
+      "name": "route_row_evidence_path_relabeling",
+      "rejected": true
+    },
+    {
       "error": "d16_single_head_seq8 key width drift",
       "name": "d16_width_metric_smuggling",
       "rejected": true
@@ -159,8 +174,8 @@
       "rejected": true
     }
   ],
-  "mutations_checked": 18,
-  "mutations_rejected": 18,
+  "mutations_checked": 21,
+  "mutations_rejected": 21,
   "no_comparator_profiles": [
     "d8_eight_head_seq8"
   ],

--- a/docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv
@@ -1,0 +1,7 @@
+profile_id	axis_role	key_width	value_width	head_count	steps_per_head	lookup_claims	trace_rows	source_proof_size_bytes	sidecar_proof_size_bytes	source_plus_sidecar_raw_proof_bytes	fused_proof_size_bytes	fused_envelope_size_bytes	fused_saves_vs_source_plus_sidecar_bytes	fused_to_source_plus_sidecar_ratio	matched_source_sidecar_status	mutations_checked	mutations_rejected
+d8_single_head_seq8	baseline	8	8	1	8	52	64	44692	14745	59437	47698	478713	11739	0.802497	GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED	26	26
+d16_single_head_seq8	width_axis	16	16	1	8	52	64	61516	13445	74961	64503	666515	10458	0.860487	GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED	26	26
+d8_two_head_seq8	head_axis	8	8	2	8	104	128	47104	18104	65208	49508	585857	15700	0.759232	GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED	30	30
+d8_four_head_seq8	head_axis_extension	8	8	4	8	208	256	52746	21783	74529	53468	797717	21061	0.717412	GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED	30	30
+d8_eight_head_seq8	head_axis_existence_only	8	8	8	8	416	512	52392			60450	1219007			NO_CHECKED_SOURCE_PLUS_SIDECAR_COMPARATOR_DO_NOT_REPORT_FUSED_SAVINGS	16	16
+d8_two_head_seq16	sequence_axis	8	8	2	16	336	512	52366	27078	79444	60502	1050248	18942	0.761568	GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED	19	19

--- a/docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md
+++ b/docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md
@@ -1,0 +1,101 @@
+# zkAI Attention/KV Fused Softmax-Table Route Matrix - 2026-05-09
+
+## Question
+
+Do the checked native Stwo fused Softmax-table routes still hold when the
+fixture changes along one controlled axis at a time?
+
+The axes are:
+
+- width: `d8` to `d16` at one head and eight steps;
+- head count: one, two, four, and eight heads at `d8` and eight steps;
+- sequence length: two heads at `d8`, eight steps per head to sixteen steps
+  per head.
+
+## Result
+
+GO for a controlled engineering route matrix.
+
+The checked matrix is machine-readable at:
+
+- JSON: `docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json`
+- TSV: `docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv`
+
+The gate validates the existing per-route fused evidence files, checks the
+source-input dimensions, normalizes the matched source-plus-sidecar comparators,
+and rejects `18 / 18` matrix drift / overclaim mutations.
+
+## Route Matrix
+
+| profile | axis | d | heads | steps/head | lookup claims | trace rows | fused proof bytes | source+sidecar bytes | fused ratio |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| d8 single-head seq8 | baseline | 8 | 1 | 8 | 52 | 64 | 47,698 | 59,437 | 0.802497 |
+| d16 single-head seq8 | width | 16 | 1 | 8 | 52 | 64 | 64,503 | 74,961 | 0.860487 |
+| d8 two-head seq8 | heads | 8 | 2 | 8 | 104 | 128 | 49,508 | 65,208 | 0.759232 |
+| d8 four-head seq8 | heads | 8 | 4 | 8 | 208 | 256 | 53,468 | 74,529 | 0.717412 |
+| d8 eight-head seq8 | heads / existence only | 8 | 8 | 8 | 416 | 512 | 60,450 | n/a | n/a |
+| d8 two-head seq16 | sequence | 8 | 2 | 16 | 336 | 512 | 60,502 | 79,444 | 0.761568 |
+
+The eight-head row is deliberately marked as proof-existence byte accounting
+only. It has no checked matched source-plus-sidecar comparator, so the matrix
+does not report a fused-versus-sidecar savings claim for that row.
+Follow-up issue `#514` tracks the matched eight-head comparator.
+
+## Axis Read
+
+Width axis:
+
+- Holding one head, eight steps, `52` lookup claims, and `64` trace rows fixed,
+  doubling width from `d8` to `d16` grows fused proof bytes from `47,698` to
+  `64,503` (`1.352321x`).
+- This is width-axis proof-existence and byte-accounting evidence, not a claim
+  that fused proof size is independent of width.
+
+Head axis:
+
+- Holding `d8` and eight steps per head fixed, lookup claims grow `8.000000x`
+  from one head to eight heads (`52` to `416`), while fused proof bytes grow
+  `1.267349x` (`47,698` to `60,450`).
+- Matched source-plus-sidecar ratios improve across the rows that have checked
+  controls: `0.802497` at one head, `0.759232` at two heads, and `0.717412` at
+  four heads.
+- The eight-head row remains a proof-existence row because a matched sidecar
+  comparator is not checked.
+
+Sequence axis:
+
+- Holding `d8` and two heads fixed, doubling steps per head from `8` to `16`
+  increases lookup claims from `104` to `336` (`3.230769x`) and trace rows from
+  `128` to `512` (`4.000000x`).
+- Fused proof bytes grow from `49,508` to `60,502` (`1.222065x`), and the
+  matched source-plus-sidecar pair grows from `65,208` to `79,444`
+  (`1.218317x`).
+
+## Claim Boundary
+
+This is engineering proof-byte accounting for a fixed bounded integer
+Softmax-table/floor-division fixture family. It is not:
+
+- real-valued Softmax;
+- implementation-exact model Softmax;
+- full inference;
+- timing evidence;
+- public benchmark evidence;
+- recursion or PCD;
+- a fused savings claim for the eight-head row.
+
+## Validation
+
+Regenerate the matrix:
+
+```bash
+python3 scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py \
+  --write-json docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv
+```
+
+Run the focused tests:
+
+```bash
+python3 -m unittest scripts.tests.test_zkai_attention_kv_fused_softmax_table_route_matrix_gate
+```

--- a/docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md
+++ b/docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md
@@ -23,7 +23,7 @@ The checked matrix is machine-readable at:
 
 The gate validates the existing per-route fused evidence files, checks the
 source-input dimensions, normalizes the matched source-plus-sidecar comparators,
-and rejects `18 / 18` matrix drift / overclaim mutations.
+and rejects `21 / 21` matrix drift, provenance-drift, and overclaim mutations.
 
 ## Route Matrix
 

--- a/docs/engineering/zkai-attention-kv-proof-route-selector-2026-05-05.md
+++ b/docs/engineering/zkai-attention-kv-proof-route-selector-2026-05-05.md
@@ -255,7 +255,7 @@ source-plus-sidecar comparator is checked. The useful axis-level signal is:
 d8 to d16 grows fused proof bytes `1.352321x` at fixed `52` lookup claims; one
 to eight heads grows lookup claims `8.000000x` while fused proof bytes grow
 `1.267349x`; and two-head seq8 to seq16 grows lookup claims `3.230769x` while
-fused proof bytes grow `1.222065x`. This is still not timing, real-valued
+fused proof bytes grow `1.222065x`. It rejects `21 / 21` matrix drift, provenance-drift, and overclaim mutations. This is still not timing, real-valued
 Softmax, full inference, public benchmark evidence, or recursion/PCD.
 
 The selector's default receipt load is structural and cheap, but it is not blind

--- a/docs/engineering/zkai-attention-kv-proof-route-selector-2026-05-05.md
+++ b/docs/engineering/zkai-attention-kv-proof-route-selector-2026-05-05.md
@@ -245,6 +245,19 @@ The checked audit gate mirrors an `output_remainder` mutation into both the
 caller-provided source input and the envelope's `source_input` field; all `11 /
 11` inspected validators reject the paired malformed object.
 
+Issue `#505` records the controlled fused Softmax-table route matrix across
+width, head-count, and sequence-length axes. The checked matrix covers six
+native Stwo fused rows: d8 single-head seq8, d16 single-head seq8, d8 two-head
+seq8, d8 four-head seq8, d8 eight-head seq8, and d8 two-head seq16. Matched
+source-plus-sidecar controls exist for five rows. The eight-head row is
+explicitly proof-existence byte accounting only because no matched
+source-plus-sidecar comparator is checked. The useful axis-level signal is:
+d8 to d16 grows fused proof bytes `1.352321x` at fixed `52` lookup claims; one
+to eight heads grows lookup claims `8.000000x` while fused proof bytes grow
+`1.267349x`; and two-head seq8 to seq16 grows lookup claims `3.230769x` while
+fused proof bytes grow `1.222065x`. This is still not timing, real-valued
+Softmax, full inference, public benchmark evidence, or recursion/PCD.
+
 The selector's default receipt load is structural and cheap, but it is not blind
 to proof-file edits: the multi-head receipt records `blake2b-256` commitments to
 each fused envelope and each fused proof byte payload. The checked strict command
@@ -372,6 +385,8 @@ Claim boundary:
 - Native d16 Softmax denominator/rounding edge corpus TSV: `docs/engineering/evidence/zkai-attention-kv-softmax-denominator-rounding-edge-corpus-2026-05.tsv`
 - Native Softmax-table paired-source validation audit JSON: `docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.json`
 - Native Softmax-table paired-source validation audit TSV: `docs/engineering/evidence/zkai-attention-kv-softmax-paired-source-validation-audit-2026-05.tsv`
+- Native fused Softmax-table route matrix JSON: `docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json`
+- Native fused Softmax-table route matrix TSV: `docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv`
 
 Reproduce the paired-source validation audit artifacts:
 
@@ -388,6 +403,20 @@ policy `not_timed_correctness_gate_only`, and performs no fresh Stwo prover or
 verifier timing run. Backend version and step/head/width counts are not free
 parameters of this audit; they are inherited from each target's checked
 source/envelope artifact and revalidated through the target validator.
+
+Reproduce the controlled fused route matrix:
+
+```bash
+python3 scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py \
+  --write-json docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv
+python3 -m unittest scripts.tests.test_zkai_attention_kv_fused_softmax_table_route_matrix_gate
+```
+
+This route matrix is proof-byte accounting only. It validates the existing
+fused evidence files and source-input dimensions, but it does not run timing,
+does not promote exact real-valued Softmax, and does not report eight-head
+fused savings without a matched sidecar comparator.
 
 - Source receipt evidence: `docs/engineering/evidence/zkai-attention-kv-transition-receipt-2026-05.json`
 - External SNARK receipt evidence: `docs/engineering/evidence/zkai-attention-kv-snark-statement-receipt-2026-05.json`

--- a/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -1,0 +1,128 @@
+import copy
+import csv
+import json
+import tempfile
+import unittest
+
+from scripts import zkai_attention_kv_fused_softmax_table_route_matrix_gate as gate
+
+
+class AttentionKvFusedSoftmaxTableRouteMatrixGateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.result = gate.build_result()
+
+    def test_records_controlled_axis_matrix_without_overclaiming_eight_head_savings(self):
+        result = self.result
+        self.assertEqual(result["decision"], gate.DECISION)
+        self.assertEqual(result["route_id"], gate.ROUTE_ID)
+        self.assertEqual(result["profiles_checked"], 6)
+        self.assertEqual(result["matched_comparator_profiles"], 5)
+        self.assertEqual(result["no_comparator_profiles"], ["d8_eight_head_seq8"])
+        self.assertIn("NOT_REAL_VALUED_SOFTMAX", result["claim_boundary"])
+        self.assertIn("NO_EIGHT_HEAD_SAVINGS_CLAIM", result["claim_boundary"])
+        self.assertEqual(result["mutations_checked"], len(gate.EXPECTED_MUTATION_NAMES))
+        self.assertEqual(result["mutations_rejected"], len(gate.EXPECTED_MUTATION_NAMES))
+
+    def test_route_rows_match_expected_dimensions_and_existing_gate_metrics(self):
+        rows = {row["profile_id"]: row for row in self.result["route_rows"]}
+
+        self.assertEqual(rows["d8_single_head_seq8"]["lookup_claims"], 52)
+        self.assertEqual(rows["d8_single_head_seq8"]["trace_rows"], 64)
+        self.assertEqual(rows["d8_single_head_seq8"]["fused_proof_size_bytes"], 47698)
+        self.assertEqual(rows["d8_single_head_seq8"]["fused_to_source_plus_sidecar_ratio"], 0.802497)
+
+        self.assertEqual(rows["d16_single_head_seq8"]["key_width"], 16)
+        self.assertEqual(rows["d16_single_head_seq8"]["lookup_claims"], 52)
+        self.assertEqual(rows["d16_single_head_seq8"]["fused_proof_size_bytes"], 64503)
+        self.assertEqual(rows["d16_single_head_seq8"]["fused_to_source_plus_sidecar_ratio"], 0.860487)
+
+        self.assertEqual(rows["d8_two_head_seq8"]["head_count"], 2)
+        self.assertEqual(rows["d8_two_head_seq8"]["lookup_claims"], 104)
+        self.assertEqual(rows["d8_two_head_seq8"]["fused_proof_size_bytes"], 49508)
+        self.assertEqual(rows["d8_four_head_seq8"]["head_count"], 4)
+        self.assertEqual(rows["d8_four_head_seq8"]["lookup_claims"], 208)
+        self.assertEqual(rows["d8_four_head_seq8"]["fused_to_source_plus_sidecar_ratio"], 0.717412)
+
+        self.assertEqual(rows["d8_eight_head_seq8"]["head_count"], 8)
+        self.assertEqual(rows["d8_eight_head_seq8"]["lookup_claims"], 416)
+        self.assertIsNone(rows["d8_eight_head_seq8"]["source_plus_sidecar_raw_proof_bytes"])
+        self.assertIsNone(rows["d8_eight_head_seq8"]["fused_to_source_plus_sidecar_ratio"])
+        self.assertEqual(rows["d8_eight_head_seq8"]["matched_source_sidecar_status"], gate.NO_COMPARATOR_STATUS)
+
+        self.assertEqual(rows["d8_two_head_seq16"]["steps_per_head"], 16)
+        self.assertEqual(rows["d8_two_head_seq16"]["lookup_claims"], 336)
+        self.assertEqual(rows["d8_two_head_seq16"]["fused_proof_size_bytes"], 60502)
+        self.assertEqual(rows["d8_two_head_seq16"]["source_plus_sidecar_raw_proof_bytes"], 79444)
+
+    def test_axis_summary_separates_width_head_and_sequence_effects(self):
+        summary = self.result["axis_summary"]
+        self.assertEqual(summary["width_axis_d8_to_d16"]["key_width_ratio"], 2.0)
+        self.assertEqual(summary["width_axis_d8_to_d16"]["lookup_claim_ratio"], 1.0)
+        self.assertEqual(summary["width_axis_d8_to_d16"]["fused_proof_size_ratio"], 1.352321)
+
+        head = summary["head_axis_d8_seq8"]
+        self.assertEqual(head["head_counts"], [1, 2, 4, 8])
+        self.assertEqual(head["lookup_claim_ratio_1_to_8"], 8.0)
+        self.assertEqual(head["fused_proof_ratio_1_to_8"], 1.267349)
+        self.assertEqual(head["matched_comparator_head_counts"], [1, 2, 4])
+        self.assertEqual(head["matched_fused_to_source_plus_sidecar_ratios"], [0.802497, 0.759232, 0.717412])
+        self.assertEqual(head["eight_head_comparator_status"], gate.NO_COMPARATOR_STATUS)
+
+        sequence = summary["sequence_axis_two_head_d8"]
+        self.assertEqual(sequence["steps_per_head_ratio"], 2.0)
+        self.assertEqual(sequence["lookup_claim_ratio"], 3.230769)
+        self.assertEqual(sequence["trace_row_ratio"], 4.0)
+        self.assertEqual(sequence["fused_proof_size_ratio"], 1.222065)
+
+    def test_aggregate_metrics_are_checked(self):
+        metrics = self.result["aggregate_metrics"]
+        self.assertEqual(metrics["total_lookup_claims"], 1168)
+        self.assertEqual(metrics["total_trace_rows"], 1536)
+        self.assertEqual(metrics["total_fused_proof_size_bytes"], 336129)
+        self.assertEqual(metrics["matched_source_plus_sidecar_raw_proof_bytes_total"], 353579)
+        self.assertEqual(metrics["matched_fused_proof_size_bytes_total"], 275679)
+        self.assertEqual(metrics["matched_fused_savings_bytes_total"], 77900)
+        self.assertEqual(metrics["min_matched_fused_to_source_plus_sidecar_ratio"], 0.717412)
+        self.assertEqual(metrics["max_matched_fused_to_source_plus_sidecar_ratio"], 0.860487)
+
+    def test_declared_mutations_reject(self):
+        self.assertEqual([item["name"] for item in self.result["mutation_results"]], list(gate.EXPECTED_MUTATION_NAMES))
+        self.assertTrue(all(item["rejected"] is True for item in self.result["mutation_results"]))
+
+    def test_validate_rejects_metric_smuggling_and_overclaims(self):
+        bad = copy.deepcopy(self.result)
+        bad["route_rows"][4]["source_plus_sidecar_raw_proof_bytes"] = 1
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "comparator overclaim"):
+            gate.validate_result(bad)
+
+        bad = copy.deepcopy(self.result)
+        bad["axis_summary"]["head_axis_d8_seq8"]["fused_proof_ratio_1_to_8"] = 8.0
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "axis summary drift"):
+            gate.validate_result(bad)
+
+        bad = copy.deepcopy(self.result)
+        bad["claim_boundary"] = "GO_REAL_VALUED_SOFTMAX_PUBLIC_BENCHMARK"
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "result drift for claim_boundary"):
+            gate.validate_result(bad)
+
+    def test_write_json_and_tsv_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = gate.pathlib.Path(tmp)
+            json_path = tmp_path / "route-matrix.json"
+            tsv_path = tmp_path / "route-matrix.tsv"
+            gate.write_json(json_path, self.result)
+            gate.write_tsv(tsv_path, self.result)
+            loaded = json.loads(json_path.read_text(encoding="utf-8"))
+            gate.validate_result(loaded)
+            with tsv_path.open("r", encoding="utf-8", newline="") as handle:
+                rows = list(csv.DictReader(handle, delimiter="\t"))
+            self.assertEqual(len(rows), 6)
+            self.assertEqual(rows[0]["profile_id"], "d8_single_head_seq8")
+            self.assertEqual(rows[4]["profile_id"], "d8_eight_head_seq8")
+            self.assertEqual(rows[4]["source_plus_sidecar_raw_proof_bytes"], "")
+            self.assertEqual(rows[4]["fused_to_source_plus_sidecar_ratio"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -145,6 +145,21 @@ class AttentionKvFusedSoftmaxTableRouteMatrixGateTests(unittest.TestCase):
         with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source dimensions must be integer-like"):
             gate.source_dimensions(bad)
 
+        bad = copy.deepcopy(base)
+        bad["key_width"] = 8.5
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source dimensions must be integer-like"):
+            gate.source_dimensions(bad)
+
+        bad = copy.deepcopy(base)
+        bad["key_width"] = True
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source dimensions must be integer-like"):
+            gate.source_dimensions(bad)
+
+        good = copy.deepcopy(base)
+        good["key_width"] = "2"
+        good["value_width"] = 2.0
+        self.assertEqual(gate.source_dimensions(good)["value_width"], 2)
+
     def test_write_json_and_tsv_round_trip(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = gate.pathlib.Path(tmp)

--- a/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -217,6 +217,18 @@ class AttentionKvFusedSoftmaxTableRouteMatrixGateTests(unittest.TestCase):
             gate.source_dimensions(bad)
 
         bad = copy.deepcopy(source)
+        for row in bad["score_rows"]:
+            row["head_index"] += 1
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source head_index grid drift"):
+            gate.source_dimensions(bad)
+
+        bad = copy.deepcopy(source)
+        for row in bad["score_rows"]:
+            row["step_index"] += 1
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source step_index grid drift"):
+            gate.source_dimensions(bad)
+
+        bad = copy.deepcopy(source)
         bad["score_rows"][0]["candidate_index"] = 1
         with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source duplicate candidate row"):
             gate.source_dimensions(bad)

--- a/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -106,6 +106,45 @@ class AttentionKvFusedSoftmaxTableRouteMatrixGateTests(unittest.TestCase):
         with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "result drift for claim_boundary"):
             gate.validate_result(bad)
 
+    def test_source_dimensions_rejects_malformed_dimensions_with_gate_errors(self):
+        base = {
+            "score_rows": [
+                {
+                    "head_index": 0,
+                    "step_index": 0,
+                    "key": [1, 2],
+                    "value": [3, 4],
+                }
+            ],
+            "trace_rows": 8,
+        }
+        self.assertEqual(gate.source_dimensions(base)["key_width"], 2)
+
+        bad = copy.deepcopy(base)
+        bad["score_rows"][0].pop("key")
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source key_width missing"):
+            gate.source_dimensions(bad)
+
+        bad = copy.deepcopy(base)
+        bad["score_rows"][0].pop("value")
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source value_width missing"):
+            gate.source_dimensions(bad)
+
+        bad = copy.deepcopy(base)
+        bad.pop("trace_rows")
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source trace_rows missing"):
+            gate.source_dimensions(bad)
+
+        bad = copy.deepcopy(base)
+        bad["score_rows"][0].pop("step_index")
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source step_index missing"):
+            gate.source_dimensions(bad)
+
+        bad = copy.deepcopy(base)
+        bad["key_width"] = "not-an-int"
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source dimensions must be integer-like"):
+            gate.source_dimensions(bad)
+
     def test_write_json_and_tsv_round_trip(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = gate.pathlib.Path(tmp)

--- a/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -106,15 +106,33 @@ class AttentionKvFusedSoftmaxTableRouteMatrixGateTests(unittest.TestCase):
         with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "result drift for claim_boundary"):
             gate.validate_result(bad)
 
+        bad = copy.deepcopy(self.result)
+        bad["route_rows"][0]["label"] = "different label"
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "label drift"):
+            gate.validate_result(bad)
+
+        bad = copy.deepcopy(self.result)
+        bad["route_rows"][0]["decision"] = "GO_DIFFERENT_GATE"
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "decision drift"):
+            gate.validate_result(bad)
+
+        bad = copy.deepcopy(self.result)
+        bad["route_rows"][0]["evidence_json"] = "other.json"
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "evidence path drift"):
+            gate.validate_result(bad)
+
     def test_source_dimensions_rejects_malformed_dimensions_with_gate_errors(self):
         base = {
             "score_rows": [
                 {
                     "head_index": 0,
                     "step_index": 0,
+                    "candidate_index": 0,
                     "key": [1, 2],
                     "value": [3, 4],
-                }
+                },
+                {"head_index": 0, "step_index": 0, "candidate_index": 1, "key": [1, 2], "value": [3, 4]},
+                {"head_index": 0, "step_index": 0, "candidate_index": 2, "key": [1, 2], "value": [3, 4]},
             ],
             "trace_rows": 8,
         }
@@ -159,6 +177,38 @@ class AttentionKvFusedSoftmaxTableRouteMatrixGateTests(unittest.TestCase):
         good["key_width"] = "2"
         good["value_width"] = 2.0
         self.assertEqual(gate.source_dimensions(good)["value_width"], 2)
+
+    def test_source_dimensions_rejects_head_step_grid_drift(self):
+        source = {
+            "score_rows": [
+                {
+                    "head_index": head_index,
+                    "step_index": step_index,
+                    "candidate_index": candidate_index,
+                    "key": [1, 2],
+                    "value": [3, 4],
+                }
+                for head_index in (0, 1)
+                for step_index in (0, 1)
+                for candidate_index in range(step_index + 3)
+            ],
+            "trace_rows": 8,
+        }
+        self.assertEqual(gate.source_dimensions(source)["head_count"], 2)
+
+        bad = copy.deepcopy(source)
+        for row in bad["score_rows"]:
+            if row["head_index"] == 1 and row["step_index"] == 1:
+                row["head_index"] = 0
+                row["step_index"] = 0
+                row["candidate_index"] += 3
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source head/step grid incomplete"):
+            gate.source_dimensions(bad)
+
+        bad = copy.deepcopy(source)
+        bad["score_rows"][0]["candidate_index"] = 1
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source duplicate candidate row"):
+            gate.source_dimensions(bad)
 
     def test_write_json_and_tsv_round_trip(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -3,6 +3,7 @@ import csv
 import json
 import tempfile
 import unittest
+from unittest import mock
 
 from scripts import zkai_attention_kv_fused_softmax_table_route_matrix_gate as gate
 
@@ -164,6 +165,11 @@ class AttentionKvFusedSoftmaxTableRouteMatrixGateTests(unittest.TestCase):
             gate.source_dimensions(bad)
 
         bad = copy.deepcopy(base)
+        bad["key_width"] = "+-1"
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source dimensions must be integer-like"):
+            gate.source_dimensions(bad)
+
+        bad = copy.deepcopy(base)
         bad["key_width"] = 8.5
         with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source dimensions must be integer-like"):
             gate.source_dimensions(bad)
@@ -177,6 +183,11 @@ class AttentionKvFusedSoftmaxTableRouteMatrixGateTests(unittest.TestCase):
         good["key_width"] = "2"
         good["value_width"] = 2.0
         self.assertEqual(gate.source_dimensions(good)["value_width"], 2)
+
+        bad = copy.deepcopy(base)
+        bad["key_width"] = -1
+        with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source dimensions must be positive"):
+            gate.source_dimensions(bad)
 
     def test_source_dimensions_rejects_head_step_grid_drift(self):
         source = {
@@ -209,6 +220,14 @@ class AttentionKvFusedSoftmaxTableRouteMatrixGateTests(unittest.TestCase):
         bad["score_rows"][0]["candidate_index"] = 1
         with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "source duplicate candidate row"):
             gate.source_dimensions(bad)
+
+    def test_mutator_failures_are_gate_failures_not_rejections(self):
+        def broken_mutator(_result):
+            raise RuntimeError("boom")
+
+        with mock.patch.object(gate, "mutation_cases", return_value=(("broken_mutator", broken_mutator),)):
+            with self.assertRaisesRegex(gate.FusedSoftmaxTableRouteMatrixGateError, "mutation mutator failed"):
+                gate.build_result()
 
     def test_write_json_and_tsv_round_trip(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -228,23 +228,37 @@ def source_dimensions(source_input: dict[str, Any]) -> dict[str, int]:
         raise FusedSoftmaxTableRouteMatrixGateError("source score_rows missing")
     heads = sorted({row.get("head_index", 0) for row in score_rows if isinstance(row, dict)})
     steps = sorted({row.get("step_index") for row in score_rows if isinstance(row, dict) and "step_index" in row})
+    if not steps:
+        raise FusedSoftmaxTableRouteMatrixGateError("source step_index missing")
     first = score_rows[0]
     if not isinstance(first, dict):
         raise FusedSoftmaxTableRouteMatrixGateError("source score row shape drift")
     key_width = source_input.get("key_width")
     if key_width is None and isinstance(first.get("key"), list):
         key_width = len(first["key"])
+    if key_width is None:
+        raise FusedSoftmaxTableRouteMatrixGateError("source key_width missing")
     value_width = source_input.get("value_width")
     if value_width is None and isinstance(first.get("value"), list):
         value_width = len(first["value"])
+    if value_width is None:
+        raise FusedSoftmaxTableRouteMatrixGateError("source value_width missing")
     trace_rows = source_input.get("trace_row_count", source_input.get("trace_rows"))
+    if trace_rows is None:
+        raise FusedSoftmaxTableRouteMatrixGateError("source trace_rows missing")
+    try:
+        key_width_int = int(key_width)
+        value_width_int = int(value_width)
+        trace_rows_int = int(trace_rows)
+    except (TypeError, ValueError) as err:
+        raise FusedSoftmaxTableRouteMatrixGateError("source dimensions must be integer-like") from err
     return {
-        "key_width": int(key_width),
-        "value_width": int(value_width),
+        "key_width": key_width_int,
+        "value_width": value_width_int,
         "head_count": len(heads) if heads else 1,
         "steps_per_head": len(steps),
         "score_rows": len(score_rows),
-        "trace_rows": int(trace_rows),
+        "trace_rows": trace_rows_int,
     }
 
 

--- a/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -222,6 +222,22 @@ def validate_existing_gate(profile: Profile, gate_result: dict[str, Any]) -> Non
     module.validate_result(gate_result, envelope, source_input)
 
 
+def parse_integer_dimension(value: Any) -> int:
+    if isinstance(value, bool):
+        raise FusedSoftmaxTableRouteMatrixGateError("source dimensions must be integer-like")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value)
+        raise FusedSoftmaxTableRouteMatrixGateError("source dimensions must be integer-like")
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped and stripped.lstrip("+-").isdigit():
+            return int(stripped, 10)
+    raise FusedSoftmaxTableRouteMatrixGateError("source dimensions must be integer-like")
+
+
 def source_dimensions(source_input: dict[str, Any]) -> dict[str, int]:
     score_rows = source_input.get("score_rows")
     if not isinstance(score_rows, list) or not score_rows:
@@ -246,12 +262,9 @@ def source_dimensions(source_input: dict[str, Any]) -> dict[str, int]:
     trace_rows = source_input.get("trace_row_count", source_input.get("trace_rows"))
     if trace_rows is None:
         raise FusedSoftmaxTableRouteMatrixGateError("source trace_rows missing")
-    try:
-        key_width_int = int(key_width)
-        value_width_int = int(value_width)
-        trace_rows_int = int(trace_rows)
-    except (TypeError, ValueError) as err:
-        raise FusedSoftmaxTableRouteMatrixGateError("source dimensions must be integer-like") from err
+    key_width_int = parse_integer_dimension(key_width)
+    value_width_int = parse_integer_dimension(value_width)
+    trace_rows_int = parse_integer_dimension(trace_rows)
     return {
         "key_width": key_width_int,
         "value_width": value_width_int,

--- a/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -1,0 +1,746 @@
+#!/usr/bin/env python3
+"""Controlled fused Softmax-table route matrix for issue #505.
+
+This gate aggregates already checked native Stwo fused Softmax-table evidence
+across one-axis-at-a-time controls. It intentionally reports proof-byte
+accounting only: no timing, no real-valued Softmax, no full inference, and no
+recursion/PCD claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import inspect
+import json
+import pathlib
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import zkai_attention_kv_d16_fused_softmax_table_native_gate as d16_fused
+from scripts import zkai_attention_kv_d8_fused_softmax_table_native_gate as d8_fused
+from scripts import zkai_attention_kv_eight_head_fused_softmax_table_native_gate as eight_head_fused
+from scripts import zkai_attention_kv_four_head_fused_softmax_table_native_gate as four_head_fused
+from scripts import zkai_attention_kv_two_head_fused_softmax_table_native_gate as two_head_fused
+from scripts import zkai_attention_kv_two_head_longseq_fused_softmax_table_native_gate as longseq_fused
+
+EVIDENCE_DIR = ROOT / "docs" / "engineering" / "evidence"
+JSON_OUT = EVIDENCE_DIR / "zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json"
+TSV_OUT = EVIDENCE_DIR / "zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv"
+
+SCHEMA = "zkai-attention-kv-fused-softmax-table-route-matrix-v1"
+ISSUE = 505
+DECISION = "GO_NATIVE_STWO_FUSED_SOFTMAX_TABLE_CONTROLLED_ROUTE_MATRIX"
+ROUTE_ID = "local_stwo_attention_kv_fused_softmax_table_controlled_route_matrix"
+CLAIM_BOUNDARY = (
+    "ENGINEERING_PROOF_BYTE_ACCOUNTING_FOR_NATIVE_STWO_FUSED_BOUNDED_SOFTMAX_TABLE_FIXTURE_FAMILY_"
+    "NOT_REAL_VALUED_SOFTMAX_NOT_FULL_INFERENCE_NOT_TIMING_NOT_RECURSION_OR_PCD_"
+    "NOT_A_PUBLIC_BENCHMARK_AND_NO_EIGHT_HEAD_SAVINGS_CLAIM_WITHOUT_MATCHED_SIDECAR"
+)
+TIMING_POLICY = "proof_existence_and_byte_accounting_only_not_public_benchmark"
+KERNEL_SCOPE = "bounded_integer_softmax_table_floor_division_kernel_with_fused_attention_arithmetic_and_logup_membership"
+COMPARATOR_POLICY = "source_plus_sidecar_ratio_reported_only_when_matched_source_and_logup_sidecar_controls_exist"
+NO_COMPARATOR_STATUS = "NO_CHECKED_SOURCE_PLUS_SIDECAR_COMPARATOR_DO_NOT_REPORT_FUSED_SAVINGS"
+MATCHED_COMPARATOR_STATUS = "GO_MATCHED_SOURCE_PLUS_LOGUP_SIDECAR_COMPARATOR_RECORDED"
+
+VALIDATION_COMMANDS = (
+    "python3 scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py --write-json docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json --write-tsv docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_attention_kv_fused_softmax_table_route_matrix_gate",
+    "just gate-fast",
+    "just gate",
+)
+
+TSV_COLUMNS = (
+    "profile_id",
+    "axis_role",
+    "key_width",
+    "value_width",
+    "head_count",
+    "steps_per_head",
+    "lookup_claims",
+    "trace_rows",
+    "source_proof_size_bytes",
+    "sidecar_proof_size_bytes",
+    "source_plus_sidecar_raw_proof_bytes",
+    "fused_proof_size_bytes",
+    "fused_envelope_size_bytes",
+    "fused_saves_vs_source_plus_sidecar_bytes",
+    "fused_to_source_plus_sidecar_ratio",
+    "matched_source_sidecar_status",
+    "mutations_checked",
+    "mutations_rejected",
+)
+
+EXPECTED_MUTATION_NAMES = (
+    "decision_relabeling",
+    "route_id_relabeling",
+    "claim_boundary_real_softmax_overclaim",
+    "timing_policy_benchmark_overclaim",
+    "kernel_scope_overclaim",
+    "comparator_policy_relabeling",
+    "row_count_metric_smuggling",
+    "route_row_order_drift",
+    "d16_width_metric_smuggling",
+    "two_head_head_count_metric_smuggling",
+    "longseq_steps_metric_smuggling",
+    "fused_proof_size_metric_smuggling",
+    "matched_ratio_metric_smuggling",
+    "eight_head_comparator_overclaim",
+    "axis_summary_width_ratio_drift",
+    "axis_summary_head_axis_ratio_drift",
+    "axis_summary_sequence_ratio_drift",
+    "unknown_field_injection",
+)
+
+
+class FusedSoftmaxTableRouteMatrixGateError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Profile:
+    profile_id: str
+    axis_role: str
+    label: str
+    gate_module: Any
+    gate_json: pathlib.Path
+    source_input_json: pathlib.Path
+    expected_key_width: int
+    expected_value_width: int
+    expected_head_count: int
+    expected_steps_per_head: int
+    comparator_required: bool
+
+
+PROFILES = (
+    Profile(
+        profile_id="d8_single_head_seq8",
+        axis_role="baseline",
+        label="d8 single-head seq8 fused Softmax-table route",
+        gate_module=d8_fused,
+        gate_json=d8_fused.JSON_OUT,
+        source_input_json=d8_fused.SOURCE_INPUT_JSON,
+        expected_key_width=8,
+        expected_value_width=8,
+        expected_head_count=1,
+        expected_steps_per_head=8,
+        comparator_required=True,
+    ),
+    Profile(
+        profile_id="d16_single_head_seq8",
+        axis_role="width_axis",
+        label="d16 single-head seq8 fused Softmax-table route",
+        gate_module=d16_fused,
+        gate_json=d16_fused.JSON_OUT,
+        source_input_json=d16_fused.SOURCE_INPUT_JSON,
+        expected_key_width=16,
+        expected_value_width=16,
+        expected_head_count=1,
+        expected_steps_per_head=8,
+        comparator_required=True,
+    ),
+    Profile(
+        profile_id="d8_two_head_seq8",
+        axis_role="head_axis",
+        label="d8 two-head seq8 fused Softmax-table route",
+        gate_module=two_head_fused,
+        gate_json=two_head_fused.JSON_OUT,
+        source_input_json=two_head_fused.SOURCE_INPUT_JSON,
+        expected_key_width=8,
+        expected_value_width=8,
+        expected_head_count=2,
+        expected_steps_per_head=8,
+        comparator_required=True,
+    ),
+    Profile(
+        profile_id="d8_four_head_seq8",
+        axis_role="head_axis_extension",
+        label="d8 four-head seq8 fused Softmax-table route",
+        gate_module=four_head_fused,
+        gate_json=four_head_fused.JSON_OUT,
+        source_input_json=four_head_fused.SOURCE_INPUT_JSON,
+        expected_key_width=8,
+        expected_value_width=8,
+        expected_head_count=4,
+        expected_steps_per_head=8,
+        comparator_required=True,
+    ),
+    Profile(
+        profile_id="d8_eight_head_seq8",
+        axis_role="head_axis_existence_only",
+        label="d8 eight-head seq8 fused Softmax-table route",
+        gate_module=eight_head_fused,
+        gate_json=eight_head_fused.JSON_OUT,
+        source_input_json=eight_head_fused.SOURCE_INPUT_JSON,
+        expected_key_width=8,
+        expected_value_width=8,
+        expected_head_count=8,
+        expected_steps_per_head=8,
+        comparator_required=False,
+    ),
+    Profile(
+        profile_id="d8_two_head_seq16",
+        axis_role="sequence_axis",
+        label="d8 two-head seq16 fused Softmax-table route",
+        gate_module=longseq_fused,
+        gate_json=longseq_fused.JSON_OUT,
+        source_input_json=longseq_fused.SOURCE_INPUT_JSON,
+        expected_key_width=8,
+        expected_value_width=8,
+        expected_head_count=2,
+        expected_steps_per_head=16,
+        comparator_required=True,
+    ),
+)
+PROFILE_IDS = tuple(profile.profile_id for profile in PROFILES)
+
+
+def read_json(path: pathlib.Path, label: str) -> Any:
+    if not path.is_file():
+        raise FusedSoftmaxTableRouteMatrixGateError(f"missing {label}: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as err:
+        raise FusedSoftmaxTableRouteMatrixGateError(f"{label} is not JSON: {err}") from err
+
+
+def validate_existing_gate(profile: Profile, gate_result: dict[str, Any]) -> None:
+    module = profile.gate_module
+    signature = inspect.signature(module.validate_result)
+    if len(signature.parameters) == 1:
+        module.validate_result(gate_result)
+        return
+    source_input = module.read_bounded_json(module.SOURCE_INPUT_JSON, module.MAX_SOURCE_INPUT_JSON_BYTES, "source input")
+    envelope = module.read_bounded_json(module.FUSED_ENVELOPE_JSON, module.MAX_FUSED_ENVELOPE_JSON_BYTES, "fused envelope")
+    module.validate_result(gate_result, envelope, source_input)
+
+
+def source_dimensions(source_input: dict[str, Any]) -> dict[str, int]:
+    score_rows = source_input.get("score_rows")
+    if not isinstance(score_rows, list) or not score_rows:
+        raise FusedSoftmaxTableRouteMatrixGateError("source score_rows missing")
+    heads = sorted({row.get("head_index", 0) for row in score_rows if isinstance(row, dict)})
+    steps = sorted({row.get("step_index") for row in score_rows if isinstance(row, dict) and "step_index" in row})
+    first = score_rows[0]
+    if not isinstance(first, dict):
+        raise FusedSoftmaxTableRouteMatrixGateError("source score row shape drift")
+    key_width = source_input.get("key_width")
+    if key_width is None and isinstance(first.get("key"), list):
+        key_width = len(first["key"])
+    value_width = source_input.get("value_width")
+    if value_width is None and isinstance(first.get("value"), list):
+        value_width = len(first["value"])
+    trace_rows = source_input.get("trace_row_count", source_input.get("trace_rows"))
+    return {
+        "key_width": int(key_width),
+        "value_width": int(value_width),
+        "head_count": len(heads) if heads else 1,
+        "steps_per_head": len(steps),
+        "score_rows": len(score_rows),
+        "trace_rows": int(trace_rows),
+    }
+
+
+def ratio(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        raise FusedSoftmaxTableRouteMatrixGateError("ratio denominator must be positive")
+    return round(numerator / denominator, 6)
+
+
+def build_route_row(profile: Profile) -> dict[str, Any]:
+    gate_result = read_json(profile.gate_json, f"{profile.profile_id} gate result")
+    validate_existing_gate(profile, gate_result)
+    source_input = read_json(profile.source_input_json, f"{profile.profile_id} source input")
+    dims = source_dimensions(source_input)
+    expected_dims = {
+        "key_width": profile.expected_key_width,
+        "value_width": profile.expected_value_width,
+        "head_count": profile.expected_head_count,
+        "steps_per_head": profile.expected_steps_per_head,
+        "score_rows": int(gate_result["lookup_claims"]),
+        "trace_rows": int(gate_result["trace_rows"]),
+    }
+    if dims != expected_dims:
+        raise FusedSoftmaxTableRouteMatrixGateError(
+            f"{profile.profile_id} dimension drift: got {dims}, expected {expected_dims}"
+        )
+
+    source_proof = int(gate_result["source_proof_size_bytes"])
+    source_plus_sidecar = int(gate_result.get("source_plus_sidecar_raw_proof_bytes") or 0)
+    sidecar_proof = gate_result.get("sidecar_proof_size_bytes")
+    if sidecar_proof in (None, 0) and source_plus_sidecar > source_proof:
+        sidecar_proof = source_plus_sidecar - source_proof
+    has_comparator = source_plus_sidecar > 0 and sidecar_proof not in (None, 0)
+    if profile.comparator_required and not has_comparator:
+        raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} missing required matched comparator")
+    if not profile.comparator_required and has_comparator:
+        raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} unexpectedly has matched comparator")
+
+    fused_proof = int(gate_result["fused_proof_size_bytes"])
+    row = {
+        "profile_id": profile.profile_id,
+        "axis_role": profile.axis_role,
+        "label": profile.label,
+        "source_issue": int(gate_result.get("source_issue", gate_result.get("issue", 0))),
+        "sidecar_issue": gate_result.get("sidecar_issue"),
+        "fused_issue": int(gate_result["issue"]),
+        "route_id": gate_result["route_id"],
+        "decision": gate_result["decision"],
+        "key_width": dims["key_width"],
+        "value_width": dims["value_width"],
+        "head_count": dims["head_count"],
+        "steps_per_head": dims["steps_per_head"],
+        "lookup_claims": dims["score_rows"],
+        "score_rows": dims["score_rows"],
+        "trace_rows": dims["trace_rows"],
+        "table_rows": int(gate_result["table_rows"]),
+        "source_proof_size_bytes": source_proof,
+        "source_envelope_size_bytes": int(gate_result.get("source_envelope_size_bytes", 0)),
+        "sidecar_proof_size_bytes": int(sidecar_proof) if has_comparator else None,
+        "source_plus_sidecar_raw_proof_bytes": source_plus_sidecar if has_comparator else None,
+        "fused_proof_size_bytes": fused_proof,
+        "fused_envelope_size_bytes": int(gate_result["fused_envelope_size_bytes"]),
+        "fused_over_source_proof_bytes": int(gate_result["fused_over_source_proof_bytes"]),
+        "fused_saves_vs_source_plus_sidecar_bytes": (source_plus_sidecar - fused_proof) if has_comparator else None,
+        "fused_to_source_plus_sidecar_ratio": ratio(fused_proof, source_plus_sidecar) if has_comparator else None,
+        "matched_source_sidecar_status": MATCHED_COMPARATOR_STATUS if has_comparator else NO_COMPARATOR_STATUS,
+        "mutations_checked": int(gate_result["mutations_checked"]),
+        "mutations_rejected": int(gate_result["mutations_rejected"]),
+        "evidence_json": str(profile.gate_json.relative_to(ROOT)),
+        "source_input_json": str(profile.source_input_json.relative_to(ROOT)),
+    }
+    return row
+
+
+def row_by_id(rows: list[dict[str, Any]], profile_id: str) -> dict[str, Any]:
+    for row in rows:
+        if row["profile_id"] == profile_id:
+            return row
+    raise FusedSoftmaxTableRouteMatrixGateError(f"missing route row: {profile_id}")
+
+
+def build_axis_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    d8 = row_by_id(rows, "d8_single_head_seq8")
+    d16 = row_by_id(rows, "d16_single_head_seq8")
+    two = row_by_id(rows, "d8_two_head_seq8")
+    four = row_by_id(rows, "d8_four_head_seq8")
+    eight = row_by_id(rows, "d8_eight_head_seq8")
+    longseq = row_by_id(rows, "d8_two_head_seq16")
+    return {
+        "width_axis_d8_to_d16": {
+            "held_constant": "single_head_seq8_score_rows_52_trace_rows_64",
+            "key_width_ratio": ratio(d16["key_width"], d8["key_width"]),
+            "lookup_claim_ratio": ratio(d16["lookup_claims"], d8["lookup_claims"]),
+            "fused_proof_size_ratio": ratio(d16["fused_proof_size_bytes"], d8["fused_proof_size_bytes"]),
+            "source_plus_sidecar_ratio": ratio(
+                d16["source_plus_sidecar_raw_proof_bytes"], d8["source_plus_sidecar_raw_proof_bytes"]
+            ),
+        },
+        "head_axis_d8_seq8": {
+            "held_constant": "key_width_8_value_width_8_steps_per_head_8",
+            "head_counts": [1, 2, 4, 8],
+            "lookup_claims": [d8["lookup_claims"], two["lookup_claims"], four["lookup_claims"], eight["lookup_claims"]],
+            "fused_proof_size_bytes": [
+                d8["fused_proof_size_bytes"],
+                two["fused_proof_size_bytes"],
+                four["fused_proof_size_bytes"],
+                eight["fused_proof_size_bytes"],
+            ],
+            "fused_proof_ratio_1_to_8": ratio(eight["fused_proof_size_bytes"], d8["fused_proof_size_bytes"]),
+            "lookup_claim_ratio_1_to_8": ratio(eight["lookup_claims"], d8["lookup_claims"]),
+            "matched_comparator_head_counts": [1, 2, 4],
+            "matched_fused_to_source_plus_sidecar_ratios": [
+                d8["fused_to_source_plus_sidecar_ratio"],
+                two["fused_to_source_plus_sidecar_ratio"],
+                four["fused_to_source_plus_sidecar_ratio"],
+            ],
+            "eight_head_comparator_status": eight["matched_source_sidecar_status"],
+        },
+        "sequence_axis_two_head_d8": {
+            "held_constant": "key_width_8_value_width_8_head_count_2",
+            "steps_per_head_ratio": ratio(longseq["steps_per_head"], two["steps_per_head"]),
+            "lookup_claim_ratio": ratio(longseq["lookup_claims"], two["lookup_claims"]),
+            "trace_row_ratio": ratio(longseq["trace_rows"], two["trace_rows"]),
+            "fused_proof_size_ratio": ratio(longseq["fused_proof_size_bytes"], two["fused_proof_size_bytes"]),
+            "source_plus_sidecar_ratio": ratio(
+                longseq["source_plus_sidecar_raw_proof_bytes"], two["source_plus_sidecar_raw_proof_bytes"]
+            ),
+        },
+    }
+
+
+def build_base_result() -> dict[str, Any]:
+    route_rows = [build_route_row(profile) for profile in PROFILES]
+    matched_rows = [row for row in route_rows if row["source_plus_sidecar_raw_proof_bytes"] is not None]
+    missing_rows = [row for row in route_rows if row["source_plus_sidecar_raw_proof_bytes"] is None]
+    result = {
+        "schema": SCHEMA,
+        "issue": ISSUE,
+        "decision": DECISION,
+        "route_id": ROUTE_ID,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "kernel_scope": KERNEL_SCOPE,
+        "comparator_policy": COMPARATOR_POLICY,
+        "timing_policy": TIMING_POLICY,
+        "profile_ids": list(PROFILE_IDS),
+        "profiles_checked": len(route_rows),
+        "matched_comparator_profiles": len(matched_rows),
+        "no_comparator_profiles": [row["profile_id"] for row in missing_rows],
+        "route_rows": route_rows,
+        "axis_summary": build_axis_summary(route_rows),
+        "aggregate_metrics": {
+            "total_lookup_claims": sum(row["lookup_claims"] for row in route_rows),
+            "total_trace_rows": sum(row["trace_rows"] for row in route_rows),
+            "total_fused_proof_size_bytes": sum(row["fused_proof_size_bytes"] for row in route_rows),
+            "max_fused_proof_size_bytes": max(row["fused_proof_size_bytes"] for row in route_rows),
+            "min_matched_fused_to_source_plus_sidecar_ratio": min(
+                row["fused_to_source_plus_sidecar_ratio"] for row in matched_rows
+            ),
+            "max_matched_fused_to_source_plus_sidecar_ratio": max(
+                row["fused_to_source_plus_sidecar_ratio"] for row in matched_rows
+            ),
+            "matched_fused_savings_bytes_total": sum(
+                row["fused_saves_vs_source_plus_sidecar_bytes"] for row in matched_rows
+            ),
+            "matched_source_plus_sidecar_raw_proof_bytes_total": sum(
+                row["source_plus_sidecar_raw_proof_bytes"] for row in matched_rows
+            ),
+            "matched_fused_proof_size_bytes_total": sum(row["fused_proof_size_bytes"] for row in matched_rows),
+        },
+        "validation_commands": list(VALIDATION_COMMANDS),
+    }
+    validate_core(result)
+    return result
+
+
+def mutation_cases(result: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
+    return (
+        ("decision_relabeling", lambda v: v.__setitem__("decision", "GO_PUBLIC_BENCHMARK")),
+        ("route_id_relabeling", lambda v: v.__setitem__("route_id", "different-route")),
+        ("claim_boundary_real_softmax_overclaim", lambda v: v.__setitem__("claim_boundary", "GO_REAL_VALUED_SOFTMAX")),
+        ("timing_policy_benchmark_overclaim", lambda v: v.__setitem__("timing_policy", "median_of_5_public_benchmark")),
+        ("kernel_scope_overclaim", lambda v: v.__setitem__("kernel_scope", "exact_real_valued_transformer_softmax")),
+        ("comparator_policy_relabeling", lambda v: v.__setitem__("comparator_policy", "all_rows_have_comparators")),
+        ("row_count_metric_smuggling", lambda v: v.__setitem__("profiles_checked", v["profiles_checked"] + 1)),
+        ("route_row_order_drift", lambda v: v.__setitem__("route_rows", list(reversed(v["route_rows"])))),
+        (
+            "d16_width_metric_smuggling",
+            lambda v: row_by_id(v["route_rows"], "d16_single_head_seq8").__setitem__("key_width", 8),
+        ),
+        (
+            "two_head_head_count_metric_smuggling",
+            lambda v: row_by_id(v["route_rows"], "d8_two_head_seq8").__setitem__("head_count", 1),
+        ),
+        (
+            "longseq_steps_metric_smuggling",
+            lambda v: row_by_id(v["route_rows"], "d8_two_head_seq16").__setitem__("steps_per_head", 8),
+        ),
+        (
+            "fused_proof_size_metric_smuggling",
+            lambda v: row_by_id(v["route_rows"], "d8_four_head_seq8").__setitem__("fused_proof_size_bytes", 1),
+        ),
+        (
+            "matched_ratio_metric_smuggling",
+            lambda v: row_by_id(v["route_rows"], "d8_single_head_seq8").__setitem__(
+                "fused_to_source_plus_sidecar_ratio", 1.0
+            ),
+        ),
+        (
+            "eight_head_comparator_overclaim",
+            lambda v: row_by_id(v["route_rows"], "d8_eight_head_seq8").__setitem__(
+                "source_plus_sidecar_raw_proof_bytes", 1
+            ),
+        ),
+        (
+            "axis_summary_width_ratio_drift",
+            lambda v: v["axis_summary"]["width_axis_d8_to_d16"].__setitem__("fused_proof_size_ratio", 1.0),
+        ),
+        (
+            "axis_summary_head_axis_ratio_drift",
+            lambda v: v["axis_summary"]["head_axis_d8_seq8"].__setitem__("fused_proof_ratio_1_to_8", 8.0),
+        ),
+        (
+            "axis_summary_sequence_ratio_drift",
+            lambda v: v["axis_summary"]["sequence_axis_two_head_d8"].__setitem__("lookup_claim_ratio", 2.0),
+        ),
+        ("unknown_field_injection", lambda v: v.__setitem__("unexpected", "claim smuggling")),
+    )
+
+
+def build_result() -> dict[str, Any]:
+    base = build_base_result()
+    mutation_results = []
+    for name, mutator in mutation_cases(base):
+        mutated = copy.deepcopy(base)
+        mutator(mutated)
+        try:
+            validate_core(mutated)
+        except Exception as err:  # noqa: BLE001 - gate records exact rejection surface.
+            mutation_results.append({"name": name, "rejected": True, "error": str(err)})
+        else:
+            mutation_results.append({"name": name, "rejected": False, "error": "mutation accepted"})
+    if tuple(item["name"] for item in mutation_results) != EXPECTED_MUTATION_NAMES:
+        raise FusedSoftmaxTableRouteMatrixGateError("mutation name/order drift")
+    result = copy.deepcopy(base)
+    result["mutation_results"] = mutation_results
+    result["mutations_checked"] = len(mutation_results)
+    result["mutations_rejected"] = sum(1 for item in mutation_results if item["rejected"] is True)
+    validate_result(result)
+    return result
+
+
+def validate_route_rows(rows: Any) -> None:
+    if not isinstance(rows, list) or len(rows) != len(PROFILES):
+        raise FusedSoftmaxTableRouteMatrixGateError("route row count drift")
+    if [row.get("profile_id") for row in rows] != list(PROFILE_IDS):
+        raise FusedSoftmaxTableRouteMatrixGateError("route row order/profile drift")
+    for row, profile in zip(rows, PROFILES, strict=True):
+        required = {
+            "profile_id",
+            "axis_role",
+            "label",
+            "source_issue",
+            "sidecar_issue",
+            "fused_issue",
+            "route_id",
+            "decision",
+            "key_width",
+            "value_width",
+            "head_count",
+            "steps_per_head",
+            "lookup_claims",
+            "score_rows",
+            "trace_rows",
+            "table_rows",
+            "source_proof_size_bytes",
+            "source_envelope_size_bytes",
+            "sidecar_proof_size_bytes",
+            "source_plus_sidecar_raw_proof_bytes",
+            "fused_proof_size_bytes",
+            "fused_envelope_size_bytes",
+            "fused_over_source_proof_bytes",
+            "fused_saves_vs_source_plus_sidecar_bytes",
+            "fused_to_source_plus_sidecar_ratio",
+            "matched_source_sidecar_status",
+            "mutations_checked",
+            "mutations_rejected",
+            "evidence_json",
+            "source_input_json",
+        }
+        if set(row) != required:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} route row schema drift")
+        if row["profile_id"] != profile.profile_id or row["axis_role"] != profile.axis_role:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} identity drift")
+        if row["key_width"] != profile.expected_key_width:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} key width drift")
+        if row["value_width"] != profile.expected_value_width:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} value width drift")
+        if row["head_count"] != profile.expected_head_count:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} head count drift")
+        if row["steps_per_head"] != profile.expected_steps_per_head:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} steps per head drift")
+        if row["lookup_claims"] != row["score_rows"]:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} lookup/score row drift")
+        if row["table_rows"] != 9:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} table row drift")
+        if row["mutations_checked"] != row["mutations_rejected"]:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} mutation rejection drift")
+        if profile.comparator_required:
+            if row["matched_source_sidecar_status"] != MATCHED_COMPARATOR_STATUS:
+                raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} matched comparator status drift")
+            source_plus = row["source_plus_sidecar_raw_proof_bytes"]
+            if source_plus != row["source_proof_size_bytes"] + row["sidecar_proof_size_bytes"]:
+                raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} source-plus-sidecar sum drift")
+            expected_ratio = ratio(row["fused_proof_size_bytes"], source_plus)
+            if row["fused_to_source_plus_sidecar_ratio"] != expected_ratio:
+                raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} fused ratio drift")
+            if row["fused_saves_vs_source_plus_sidecar_bytes"] != source_plus - row["fused_proof_size_bytes"]:
+                raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} fused savings drift")
+        else:
+            if row["matched_source_sidecar_status"] != NO_COMPARATOR_STATUS:
+                raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} no-comparator status drift")
+            forbidden = (
+                row["sidecar_proof_size_bytes"],
+                row["source_plus_sidecar_raw_proof_bytes"],
+                row["fused_saves_vs_source_plus_sidecar_bytes"],
+                row["fused_to_source_plus_sidecar_ratio"],
+            )
+            if any(item is not None for item in forbidden):
+                raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} comparator overclaim")
+
+
+def validate_axis_summary(summary: Any, rows: list[dict[str, Any]]) -> None:
+    if not isinstance(summary, dict):
+        raise FusedSoftmaxTableRouteMatrixGateError("axis summary must be an object")
+    expected = build_axis_summary(rows)
+    if summary != expected:
+        raise FusedSoftmaxTableRouteMatrixGateError("axis summary drift")
+
+
+def validate_aggregate_metrics(metrics: Any, rows: list[dict[str, Any]]) -> None:
+    if not isinstance(metrics, dict):
+        raise FusedSoftmaxTableRouteMatrixGateError("aggregate metrics must be an object")
+    matched = [row for row in rows if row["source_plus_sidecar_raw_proof_bytes"] is not None]
+    expected = {
+        "total_lookup_claims": sum(row["lookup_claims"] for row in rows),
+        "total_trace_rows": sum(row["trace_rows"] for row in rows),
+        "total_fused_proof_size_bytes": sum(row["fused_proof_size_bytes"] for row in rows),
+        "max_fused_proof_size_bytes": max(row["fused_proof_size_bytes"] for row in rows),
+        "min_matched_fused_to_source_plus_sidecar_ratio": min(row["fused_to_source_plus_sidecar_ratio"] for row in matched),
+        "max_matched_fused_to_source_plus_sidecar_ratio": max(row["fused_to_source_plus_sidecar_ratio"] for row in matched),
+        "matched_fused_savings_bytes_total": sum(row["fused_saves_vs_source_plus_sidecar_bytes"] for row in matched),
+        "matched_source_plus_sidecar_raw_proof_bytes_total": sum(
+            row["source_plus_sidecar_raw_proof_bytes"] for row in matched
+        ),
+        "matched_fused_proof_size_bytes_total": sum(row["fused_proof_size_bytes"] for row in matched),
+    }
+    if metrics != expected:
+        raise FusedSoftmaxTableRouteMatrixGateError("aggregate metrics drift")
+
+
+def validate_core(result: Any) -> None:
+    if not isinstance(result, dict):
+        raise FusedSoftmaxTableRouteMatrixGateError("result must be an object")
+    expected_keys = {
+        "schema",
+        "issue",
+        "decision",
+        "route_id",
+        "claim_boundary",
+        "kernel_scope",
+        "comparator_policy",
+        "timing_policy",
+        "profile_ids",
+        "profiles_checked",
+        "matched_comparator_profiles",
+        "no_comparator_profiles",
+        "route_rows",
+        "axis_summary",
+        "aggregate_metrics",
+        "validation_commands",
+    }
+    extra = set(result) - expected_keys
+    if extra:
+        raise FusedSoftmaxTableRouteMatrixGateError(f"unknown result keys: {sorted(extra)}")
+    missing = expected_keys - set(result)
+    if missing:
+        raise FusedSoftmaxTableRouteMatrixGateError(f"missing result keys: {sorted(missing)}")
+    exact = {
+        "schema": SCHEMA,
+        "issue": ISSUE,
+        "decision": DECISION,
+        "route_id": ROUTE_ID,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "kernel_scope": KERNEL_SCOPE,
+        "comparator_policy": COMPARATOR_POLICY,
+        "timing_policy": TIMING_POLICY,
+        "profile_ids": list(PROFILE_IDS),
+        "profiles_checked": len(PROFILES),
+        "matched_comparator_profiles": 5,
+        "no_comparator_profiles": ["d8_eight_head_seq8"],
+        "validation_commands": list(VALIDATION_COMMANDS),
+    }
+    for key, expected in exact.items():
+        if result.get(key) != expected:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"result drift for {key}")
+    if "GO_REAL_VALUED" in result["claim_boundary"] or "PUBLIC_BENCHMARK" not in result["claim_boundary"]:
+        raise FusedSoftmaxTableRouteMatrixGateError("claim boundary drift")
+    if "proof_existence" not in result["timing_policy"]:
+        raise FusedSoftmaxTableRouteMatrixGateError("timing policy drift")
+    rows = result["route_rows"]
+    validate_route_rows(rows)
+    validate_axis_summary(result["axis_summary"], rows)
+    validate_aggregate_metrics(result["aggregate_metrics"], rows)
+
+
+def validate_result(result: Any) -> None:
+    if not isinstance(result, dict):
+        raise FusedSoftmaxTableRouteMatrixGateError("result must be an object")
+    core = copy.deepcopy(result)
+    mutation_results = core.pop("mutation_results", None)
+    mutations_checked = core.pop("mutations_checked", None)
+    mutations_rejected = core.pop("mutations_rejected", None)
+    validate_core(core)
+    if not isinstance(mutation_results, list) or len(mutation_results) != len(EXPECTED_MUTATION_NAMES):
+        raise FusedSoftmaxTableRouteMatrixGateError("mutation result shape drift")
+    if tuple(item.get("name") for item in mutation_results if isinstance(item, dict)) != EXPECTED_MUTATION_NAMES:
+        raise FusedSoftmaxTableRouteMatrixGateError("mutation result name drift")
+    for item in mutation_results:
+        if set(item) != {"name", "rejected", "error"}:
+            raise FusedSoftmaxTableRouteMatrixGateError("mutation result schema drift")
+        if item["rejected"] is not True or not isinstance(item["error"], str) or not item["error"]:
+            raise FusedSoftmaxTableRouteMatrixGateError("mutation result rejection drift")
+    if mutations_checked != len(EXPECTED_MUTATION_NAMES):
+        raise FusedSoftmaxTableRouteMatrixGateError("mutations_checked drift")
+    if mutations_rejected != len(EXPECTED_MUTATION_NAMES):
+        raise FusedSoftmaxTableRouteMatrixGateError("mutations_rejected drift")
+
+
+def tsv_value(value: Any) -> Any:
+    if value is None:
+        return ""
+    return value
+
+
+def write_json(path: pathlib.Path, result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    validate_result(result)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False
+    ) as handle:
+        tmp_path = pathlib.Path(handle.name)
+        handle.write(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    try:
+        validate_result(json.loads(tmp_path.read_text(encoding="utf-8")))
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def write_tsv(path: pathlib.Path, result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    validate_result(result)
+    rows = [{column: tsv_value(row[column]) for column in TSV_COLUMNS} for row in result["route_rows"]]
+    expected_rows = [{column: str(value) for column, value in row.items()} for row in rows]
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", newline="", dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False
+    ) as handle:
+        tmp_path = pathlib.Path(handle.name)
+        writer = csv.DictWriter(handle, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+    try:
+        with tmp_path.open("r", encoding="utf-8", newline="") as handle:
+            loaded_rows = list(csv.DictReader(handle, delimiter="\t"))
+        if loaded_rows != expected_rows:
+            raise FusedSoftmaxTableRouteMatrixGateError("TSV round-trip drift")
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write-json", type=pathlib.Path)
+    parser.add_argument("--write-tsv", type=pathlib.Path)
+    args = parser.parse_args()
+    result = build_result()
+    if args.write_json:
+        write_json(args.write_json, result)
+    if args.write_tsv:
+        write_tsv(args.write_tsv, result)
+    if not args.write_json and not args.write_tsv:
+        print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -87,6 +87,9 @@ EXPECTED_MUTATION_NAMES = (
     "comparator_policy_relabeling",
     "row_count_metric_smuggling",
     "route_row_order_drift",
+    "route_row_label_relabeling",
+    "route_row_decision_relabeling",
+    "route_row_evidence_path_relabeling",
     "d16_width_metric_smuggling",
     "two_head_head_count_metric_smuggling",
     "longseq_steps_metric_smuggling",
@@ -242,13 +245,36 @@ def source_dimensions(source_input: dict[str, Any]) -> dict[str, int]:
     score_rows = source_input.get("score_rows")
     if not isinstance(score_rows, list) or not score_rows:
         raise FusedSoftmaxTableRouteMatrixGateError("source score_rows missing")
-    heads = sorted({row.get("head_index", 0) for row in score_rows if isinstance(row, dict)})
-    steps = sorted({row.get("step_index") for row in score_rows if isinstance(row, dict) and "step_index" in row})
+    grid: dict[tuple[int, int], set[int]] = {}
+    for index, row in enumerate(score_rows):
+        if not isinstance(row, dict):
+            raise FusedSoftmaxTableRouteMatrixGateError("source score row shape drift")
+        if "step_index" not in row:
+            raise FusedSoftmaxTableRouteMatrixGateError("source step_index missing")
+        if "candidate_index" not in row:
+            raise FusedSoftmaxTableRouteMatrixGateError("source candidate_index missing")
+        head_index = parse_integer_dimension(row.get("head_index", 0))
+        step_index = parse_integer_dimension(row["step_index"])
+        candidate_index = parse_integer_dimension(row["candidate_index"])
+        if head_index < 0 or step_index < 0 or candidate_index < 0:
+            raise FusedSoftmaxTableRouteMatrixGateError("source indices must be non-negative")
+        candidates = grid.setdefault((head_index, step_index), set())
+        if candidate_index in candidates:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"source duplicate candidate row: {index}")
+        candidates.add(candidate_index)
+    heads = sorted({head_index for head_index, _step_index in grid})
+    steps = sorted({step_index for _head_index, step_index in grid})
     if not steps:
         raise FusedSoftmaxTableRouteMatrixGateError("source step_index missing")
+    missing_pairs = [(head_index, step_index) for head_index in heads for step_index in steps if (head_index, step_index) not in grid]
+    if missing_pairs:
+        raise FusedSoftmaxTableRouteMatrixGateError("source head/step grid incomplete")
+    for head_index in heads:
+        for step_index in steps:
+            expected_candidates = set(range(step_index + 3))
+            if grid[(head_index, step_index)] != expected_candidates:
+                raise FusedSoftmaxTableRouteMatrixGateError("source candidate grid drift")
     first = score_rows[0]
-    if not isinstance(first, dict):
-        raise FusedSoftmaxTableRouteMatrixGateError("source score row shape drift")
     key_width = source_input.get("key_width")
     if key_width is None and isinstance(first.get("key"), list):
         key_width = len(first["key"])
@@ -458,6 +484,18 @@ def mutation_cases(result: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
         ("row_count_metric_smuggling", lambda v: v.__setitem__("profiles_checked", v["profiles_checked"] + 1)),
         ("route_row_order_drift", lambda v: v.__setitem__("route_rows", list(reversed(v["route_rows"])))),
         (
+            "route_row_label_relabeling",
+            lambda v: row_by_id(v["route_rows"], "d8_single_head_seq8").__setitem__("label", "different label"),
+        ),
+        (
+            "route_row_decision_relabeling",
+            lambda v: row_by_id(v["route_rows"], "d8_single_head_seq8").__setitem__("decision", "GO_DIFFERENT_GATE"),
+        ),
+        (
+            "route_row_evidence_path_relabeling",
+            lambda v: row_by_id(v["route_rows"], "d8_single_head_seq8").__setitem__("evidence_json", "other.json"),
+        ),
+        (
             "d16_width_metric_smuggling",
             lambda v: row_by_id(v["route_rows"], "d16_single_head_seq8").__setitem__("key_width", 8),
         ),
@@ -565,6 +603,16 @@ def validate_route_rows(rows: Any) -> None:
             raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} route row schema drift")
         if row["profile_id"] != profile.profile_id or row["axis_role"] != profile.axis_role:
             raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} identity drift")
+        if row["label"] != profile.label:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} label drift")
+        if row["route_id"] != profile.gate_module.ROUTE_ID:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} route id drift")
+        if row["decision"] != profile.gate_module.DECISION:
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} decision drift")
+        if row["evidence_json"] != str(profile.gate_json.relative_to(ROOT)):
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} evidence path drift")
+        if row["source_input_json"] != str(profile.source_input_json.relative_to(ROOT)):
+            raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} source input path drift")
         if row["key_width"] != profile.expected_key_width:
             raise FusedSoftmaxTableRouteMatrixGateError(f"{profile.profile_id} key width drift")
         if row["value_width"] != profile.expected_value_width:

--- a/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -265,6 +265,10 @@ def source_dimensions(source_input: dict[str, Any]) -> dict[str, int]:
         candidates.add(candidate_index)
     heads = sorted({head_index for head_index, _step_index in grid})
     steps = sorted({step_index for _head_index, step_index in grid})
+    if heads != list(range(len(heads))):
+        raise FusedSoftmaxTableRouteMatrixGateError("source head_index grid drift")
+    if steps != list(range(len(steps))):
+        raise FusedSoftmaxTableRouteMatrixGateError("source step_index grid drift")
     if not steps:
         raise FusedSoftmaxTableRouteMatrixGateError("source step_index missing")
     missing_pairs = [(head_index, step_index) for head_index in heads for step_index in steps if (head_index, step_index) not in grid]
@@ -476,7 +480,7 @@ def build_base_result() -> dict[str, Any]:
     return result
 
 
-def mutation_cases(result: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
+def mutation_cases() -> tuple[tuple[str, Any], ...]:
     return (
         ("decision_relabeling", lambda v: v.__setitem__("decision", "GO_PUBLIC_BENCHMARK")),
         ("route_id_relabeling", lambda v: v.__setitem__("route_id", "different-route")),
@@ -545,7 +549,7 @@ def mutation_cases(result: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
 def build_result() -> dict[str, Any]:
     base = build_base_result()
     mutation_results = []
-    for name, mutator in mutation_cases(base):
+    for name, mutator in mutation_cases():
         mutated = copy.deepcopy(base)
         try:
             mutator(mutated)

--- a/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
+++ b/scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py
@@ -236,7 +236,8 @@ def parse_integer_dimension(value: Any) -> int:
         raise FusedSoftmaxTableRouteMatrixGateError("source dimensions must be integer-like")
     if isinstance(value, str):
         stripped = value.strip()
-        if stripped and stripped.lstrip("+-").isdigit():
+        digits = stripped[1:] if stripped[:1] in ("+", "-") else stripped
+        if digits.isdigit():
             return int(stripped, 10)
     raise FusedSoftmaxTableRouteMatrixGateError("source dimensions must be integer-like")
 
@@ -291,6 +292,8 @@ def source_dimensions(source_input: dict[str, Any]) -> dict[str, int]:
     key_width_int = parse_integer_dimension(key_width)
     value_width_int = parse_integer_dimension(value_width)
     trace_rows_int = parse_integer_dimension(trace_rows)
+    if key_width_int <= 0 or value_width_int <= 0 or trace_rows_int <= 0:
+        raise FusedSoftmaxTableRouteMatrixGateError("source dimensions must be positive")
     return {
         "key_width": key_width_int,
         "value_width": value_width_int,
@@ -544,7 +547,10 @@ def build_result() -> dict[str, Any]:
     mutation_results = []
     for name, mutator in mutation_cases(base):
         mutated = copy.deepcopy(base)
-        mutator(mutated)
+        try:
+            mutator(mutated)
+        except Exception as err:  # noqa: BLE001 - a broken mutator invalidates the gate.
+            raise FusedSoftmaxTableRouteMatrixGateError(f"mutation mutator failed: {name}: {err}") from err
         try:
             validate_core(mutated)
         except Exception as err:  # noqa: BLE001 - gate records exact rejection surface.


### PR DESCRIPTION
## Summary

Closes #505.

Adds a checked controlled route matrix for the native Stwo fused bounded Softmax-table route family. The matrix separates the axes instead of mixing them into one scaling claim:

- width: `d8` single-head seq8 -> `d16` single-head seq8
- heads: `1`, `2`, `4`, `8` heads at `d8` seq8
- sequence: `d8` two-head seq8 -> `d8` two-head seq16

## Result

New gate decision:

`GO_NATIVE_STWO_FUSED_SOFTMAX_TABLE_CONTROLLED_ROUTE_MATRIX`

Key checked numbers:

- 6 fused native Stwo rows checked
- 5 matched source-plus-sidecar comparator rows
- 1 explicit no-comparator row: `d8_eight_head_seq8`
- 18 / 18 matrix drift / overclaim mutations rejected
- d8 -> d16 at fixed 52 lookup claims: fused proof bytes grow `1.352321x`
- 1 -> 8 heads at d8 seq8: lookup claims grow `8.000000x`, fused proof bytes grow `1.267349x`
- two-head seq8 -> seq16: lookup claims grow `3.230769x`, fused proof bytes grow `1.222065x`

The eight-head row is deliberately proof-existence byte accounting only: no fused-savings claim is reported without a matched sidecar comparator. Follow-up #514 tracks that comparator.

## Claim Boundary

This is engineering proof-byte accounting for the bounded integer Softmax-table/floor-division fixture family. It is not timing evidence, not real-valued Softmax, not full inference, not a public benchmark, and not recursion/PCD.

## Files

- `scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py`
- `scripts/tests/test_zkai_attention_kv_fused_softmax_table_route_matrix_gate.py`
- `docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json`
- `docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv`
- `docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md`

## Validation

- `python3 scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py --write-json docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json --write-tsv docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv`
- `python3 -m unittest scripts.tests.test_zkai_attention_kv_fused_softmax_table_route_matrix_gate`
- `python3 -m unittest scripts.tests.test_zkai_attention_kv_d8_fused_softmax_table_native_gate scripts.tests.test_zkai_attention_kv_two_head_fused_softmax_table_native_gate scripts.tests.test_zkai_attention_kv_four_head_fused_softmax_table_native_gate scripts.tests.test_zkai_attention_kv_eight_head_fused_softmax_table_native_gate scripts.tests.test_zkai_attention_kv_two_head_longseq_fused_softmax_table_native_gate scripts.tests.test_zkai_attention_kv_d16_fused_softmax_table_native_gate scripts.tests.test_zkai_attention_kv_fused_softmax_table_route_matrix_gate`
- `just gate-fast`
- `just gate`
- pre-push hook reran local release gate: `14 / 14 steps OK`

Note: the first full `just gate` attempt failed from local disk exhaustion (`No space left on device`). I freed only old `/private/tmp` build artifacts and reran; the full gate then passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added engineering docs describing the fused Softmax-table route matrix, controlled axes (width/head/sequence), byte-accounting notes (including eight-head proof-existence-only), evidence artifacts, and reproduction/validation instructions.

* **Tests**
  * Added comprehensive unit tests verifying route-matrix structure, axis and aggregate metrics, mutation rejection behavior, and JSON/TSV serialization round-trips.

* **Chores**
  * Added a CLI tool to build, strictly validate, mutate, and export route-matrix results (JSON/TSV).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/515)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->