### PR TITLE
Disable automatic GitHub Actions

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -681,7 +681,9 @@ Use these in order of authority for current state:
 - Use `gh pr merge --rebase`.
 - Do not merge while review threads are still actionable.
 - Treat bot review summaries as non-blocking only after checking whether they produced actual review threads.
-- After the latest AI-reviewer activity, wait at least `5` minutes, then recheck threads and findings before merging.
+- Qodo and CodeRabbit are cheap adversarial reviewers. Fix relevant findings locally, push again, and restart the merge quiet window.
+- GitHub Actions are not part of the research/debugging/merge-readiness loop. Workflows are manual-only dormant guardrails for rare owner-directed release, paper-bundle, security, or final-review checks; routine PRs use scoped local validation as the proof of readiness.
+- After the latest relevant AI-reviewer activity, wait at least `5` minutes, then recheck threads and findings before merging.
 
 ## Research culture
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,35 +3,14 @@ name: CI
 permissions:
   contents: read
 
+# CI is manual-only by policy. Local scoped validation plus cheap bot review is
+# the normal PR loop; run this workflow only as an intentional guardrail.
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/**"
-      - "src/**/*.rs"
-      - "tests/**"
-      - "programs/**"
-      - "scripts/*.sh"
-      - "scripts/**/*.sh"
-      - "docs/engineering/hardening-policy.md"
-      - "docs/engineering/hardening-strategy.md"
-      - "zizmor.yml"
-      - "deny.toml"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "fuzz/Cargo.toml"
-      - "fuzz/Cargo.lock"
-      - "vendor/onnx-protobuf/**"
-  push:
-    branches:
-      - "main"
-  schedule:
-    - cron: "17 4 * * *"
   workflow_dispatch:
 
 jobs:
-  pr-smoke:
-    name: lightweight PR lib smoke
-    if: github.event_name == 'pull_request'
+  local-guardrails:
+    name: local guardrail parity
     runs-on: ubuntu-latest
 
     steps:
@@ -58,51 +37,17 @@ jobs:
             ~/.rustup/update-hashes
           key: rustup-nightly-2025-07-14-${{ runner.os }}-${{ runner.arch }}
 
-      - name: Validate local merge gate script
+      - name: Validate local guardrail scripts
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck python3-pip
           bash scripts/run_shellcheck_suite.sh
-
-      - name: Run workflow audit when workflow surfaces change
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          changed_workflow_inputs="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- .github/workflows/ zizmor.yml)" || {
-            echo "workflow audit diff computation failed" >&2
-            exit 1
-          }
-          if [[ -z "$changed_workflow_inputs" ]]; then
-            echo "workflow audit not required for this PR"
-            exit 0
-          fi
           python3 -m pip install --user uv
           export PATH="$HOME/.local/bin:$PATH"
           bash scripts/run_workflow_audit_suite.sh
 
-      - name: Run dependency audit when dependency surfaces change
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          changed_dependency_inputs="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- Cargo.toml Cargo.lock fuzz/Cargo.toml fuzz/Cargo.lock deny.toml scripts/run_dependency_audit_suite.sh vendor/onnx-protobuf/)" || {
-            echo "dependency audit diff computation failed" >&2
-            exit 1
-          }
-          if [[ -z "$changed_dependency_inputs" ]]; then
-            echo "dependency audit not required for this PR"
-            exit 0
-          fi
-          audit_root="$RUNNER_TEMP/dependency-audit-tools"
-          cargo install --locked cargo-audit --version 0.22.1 --root "$audit_root"
-          cargo install --locked cargo-deny --version 0.19.4 --root "$audit_root"
-          export PATH="$audit_root/bin:$PATH"
-          bash scripts/run_dependency_audit_suite.sh
-
   dependency-audit:
     name: dependency audit
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/paper-preflight.yml
+++ b/.github/workflows/paper-preflight.yml
@@ -1,18 +1,9 @@
 name: paper preflight
 
+# Paper preflight is manual-only by policy. Run local preflight first, then
+# dispatch this workflow intentionally for release or paper-bundle checks.
 on:
-  pull_request:
-    paths:
-      - "docs/paper/**"
-      - "scripts/paper/**"
-      - ".github/workflows/paper-preflight.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "docs/paper/**"
-      - "scripts/paper/**"
-      - ".github/workflows/paper-preflight.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/pr-hardening-contract.yml
+++ b/.github/workflows/pr-hardening-contract.yml
@@ -1,9 +1,14 @@
 name: PR hardening contract
 
+# The hardening contract is manual-only by policy. Trusted-core PRs still need
+# local validation and the hardening checklist in the PR body before review.
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to validate"
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -14,50 +19,76 @@ jobs:
     name: hardening contract
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Validate PR hardening contract
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          python3 - <<'PY'
-          import os
-          import subprocess
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Invalid PR_NUMBER: must be a positive integer" >&2
+            exit 1
+          }
+
+          pr_metadata="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json body,changedFiles)"
+          files_json="$(
+            gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+              --jq '.[] | {path: .filename, previous_path: (.previous_filename // "")} | @json' |
+            python3 -c 'import json, sys; print(json.dumps([json.loads(line) for line in sys.stdin if line.strip()]))'
+          )"
+          pr_json_path="${RUNNER_TEMP:-/tmp}/pr-hardening-contract.json"
+          python3 - "$pr_metadata" "$files_json" > "$pr_json_path" <<'PY'
+          import json
           import sys
 
+          pr = json.loads(sys.argv[1])
+          pr["files"] = json.loads(sys.argv[2])
+          print(json.dumps(pr))
+          PY
+          export PR_JSON_PATH="$pr_json_path"
+
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
           pr_number = os.environ.get("PR_NUMBER") or ""
-          base = os.environ.get("BASE_SHA") or ""
-          head = os.environ.get("HEAD_SHA") or ""
-          body = os.environ.get("PR_BODY") or ""
+          raw_pr_path = os.environ.get("PR_JSON_PATH") or ""
 
-          if not pr_number:
-              print("No pull_request context; skipping hardening contract.")
-              sys.exit(0)
+          if not pr_number.isdigit() or int(pr_number) <= 0:
+              print("PR number input must be a positive integer.")
+              sys.exit(1)
 
-          for rev_name, rev in (("BASE_SHA", base), ("HEAD_SHA", head)):
-              if not rev:
-                  print(f"{rev_name} is missing; skipping hardening contract.")
-                  sys.exit(0)
-              result = subprocess.run(
-                  ["git", "rev-parse", "--verify", "--quiet", rev],
-                  stdout=subprocess.DEVNULL,
-                  stderr=subprocess.DEVNULL,
+          if not raw_pr_path:
+              print("PR metadata path is required.")
+              sys.exit(1)
+
+          try:
+              raw_pr = Path(raw_pr_path).read_text(encoding="utf-8")
+              pr = json.loads(raw_pr)
+          except OSError as exc:
+              print(f"Could not read PR metadata file {raw_pr_path}: {exc}")
+              sys.exit(1)
+          except json.JSONDecodeError as exc:
+              print(f"Could not parse PR metadata file {raw_pr_path}: {exc}")
+              sys.exit(1)
+
+          body = pr.get("body") or ""
+          file_entries = pr.get("files", [])
+          changed = []
+          for file_entry in file_entries:
+              for key in ("path", "previous_path"):
+                  path = file_entry.get(key) or ""
+                  if path:
+                      changed.append(path)
+          changed_total = pr.get("changedFiles")
+          if isinstance(changed_total, int) and changed_total != len(file_entries):
+              print(
+                  "Paginated PR file list length does not match changedFiles: "
+                  f"{len(file_entries)} != {changed_total}"
               )
-              if result.returncode != 0:
-                  print(f"{rev_name} does not resolve locally; skipping hardening contract.")
-                  sys.exit(0)
-
-          changed = subprocess.check_output(
-              ["git", "diff", "--name-only", f"{base}...{head}"],
-              text=True,
-          ).splitlines()
+              sys.exit(1)
 
           trusted_prefixes = (
               "src/stwo_backend/",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 - Use `gh pr merge --rebase`; do not create merge commits in this repository.
 - Do not merge while review threads are still actionable. Clear human and bot threads or explicitly confirm they are stale before merging.
 - After the latest AI-reviewer activity, wait at least `5` minutes before merging, then recheck that no actionable bot threads or findings appeared during the quiet window.
+- GitHub Actions are not part of the research, debugging, or merge-readiness loop. Workflows are manual-only dormant guardrails for rare owner-directed release, paper-bundle, security, or final-review checks; routine PRs must rely on scoped local validation plus bot review.
 
 ## Trusted-core paths
 
@@ -56,6 +57,7 @@ Review and edit with extra caution:
 
 - If proof semantics, carried-state structure, manifest schemas, version constants, or backend routing change, add or update at least one negative, tamper-path, or compatibility test.
 - Start with the narrowest relevant test or workflow surface first, then expand only as needed.
+- For PRs, list the exact local validation commands in the PR body. Qodo and CodeRabbit feedback is part of the normal cheap review loop; fix relevant findings, push again, and restart the merge quiet window.
 - For trusted-core changes, consult `docs/engineering/hardening-policy.md` and `docs/security/threat-model.md` before widening claims.
 - For docs or handoff changes that move claim boundaries, lane status, or merge policy, update exact backend versions, timing modes, evidence paths, and reproduction commands where relevant.
 

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -756,7 +756,9 @@ Tablero boundary.
 - Use `gh pr merge --rebase`.
 - Do not merge while review threads remain actionable.
 - When a bot leaves only a summary comment, check whether it actually opened review threads before treating it as a blocker.
-- After the latest AI-reviewer activity, wait at least `5` minutes, then recheck the review surface before merging.
+- Qodo and CodeRabbit are cheap adversarial reviewers. Fix relevant findings locally, push again, and restart the merge quiet window.
+- GitHub Actions are not part of the research/debugging/merge-readiness loop. Workflows are manual-only dormant guardrails for rare owner-directed release, paper-bundle, security, or final-review checks; routine PRs use scoped local validation as the proof of readiness.
+- After the latest relevant AI-reviewer activity, wait at least `5` minutes, then recheck the review surface before merging.
 
 ## Research and evidence culture
 

--- a/docs/engineering/hardening-policy.md
+++ b/docs/engineering/hardening-policy.md
@@ -13,31 +13,30 @@ change requires.
 - Do not use automatic `push`, `pull_request`, or `schedule` triggers for
   heavyweight GitHub Actions compute such as full CI matrix, mutation testing,
   Miri, sanitizers, or formal contracts.
-- Keep any automatic PR GitHub Actions compute lightweight and path-scoped; the
-  CI workflow only runs a core library contract plus integration-test smoke for
-  Rust, Cargo, program fixture, or CI workflow changes, plus one exact
-  pinned-nightly `stwo-backend` smoke with the pinned nightly toolchain cached.
-- Keep dependency-advisory drift under continuous watch with a lightweight
-  scheduled and `main`-branch dependency-audit job instead of widening the full
-  PR matrix.
-- Keep heavyweight GitHub Actions workflows available through
-  `workflow_dispatch` for intentional release, baseline, or emergency
-  GitHub-hosted validation.
+- Do not use automatic lightweight PR GitHub Actions compute either. The CI
+  workflow has no automatic PR path; local shellcheck, workflow audit,
+  dependency audit, smoke tests, and proof gates are the normal readiness
+  signal.
+- Keep dependency-advisory drift under local watch with
+  `scripts/run_dependency_audit_suite.sh` rather than scheduled or `main`-branch
+  GitHub Actions runs.
+- Keep GitHub Actions workflows available only through `workflow_dispatch` as
+  dormant guardrails for rare owner-directed release, paper-bundle, security, or
+  final-review validation.
 - Before opening or merging trusted-core PRs, run the matching tests and
   hardening suite locally, preferably inside a Lima Ubuntu 22.04 environment for
   Linux parity.
-- Keep CodeRabbit, Greptile, and Qodo as GitHub PR review signals, and keep the
-  PR hardening contract workflow (`.github/workflows/pr-hardening-contract.yml`)
-  as the enforced PR-body checklist gate.
-- `main` does not get automatic post-merge runs for heavyweight GitHub Actions
-  workflows; dispatch those workflows manually when release or baseline
-  validation needs a GitHub-hosted run on the merge commit.
+- Keep CodeRabbit, Greptile, and Qodo as GitHub PR review signals. The PR
+  hardening contract remains a local/PR-body discipline first; the
+  `workflow_dispatch` workflow is only a dormant mirror.
+- `main` does not get automatic post-merge GitHub Actions runs.
 - If a PR cannot run a local hardening command, document the blocker in the PR
-  validation notes and use `workflow_dispatch` intentionally.
+  validation notes instead of using GitHub Actions as a debugging loop.
 - Merge trusted-core PRs through `scripts/local_merge_gate.sh` so the final
   merge decision is tied to the exact PR head SHA, local evidence logs, a clean
-  GitHub check rollup, zero unresolved review threads, and a seven-minute quiet
-  window after the last CodeRabbit, Greptile, or Qodo event.
+  absence of unexpected GitHub check failures, zero unresolved review threads,
+  and a five-minute quiet window after the last relevant CodeRabbit, Greptile,
+  or Qodo event.
 
 ## Local Commands
 
@@ -186,7 +185,7 @@ Available local command tiers:
   delta, not the whole worktree. Prefer running this tier inside Lima for Linux
   parity.
 - `--mode none`: only checks GitHub status, review-thread state, and the
-  seven-minute AI-review quiet window. Use this only after a prior evidence run
+  five-minute AI-review quiet window. Use this only after a prior evidence run
   for the same PR head SHA.
 
 The GitHub side of the merge gate is intentionally narrow:
@@ -203,7 +202,7 @@ The GitHub side of the merge gate is intentionally narrow:
   fails closed if any individual review thread has more than 100 comments,
   because the gate cannot safely inspect that nested comment stream.
 - No CodeRabbit, Greptile, or Qodo review/comment event may have occurred in the
-  previous 420 seconds. If no AI review/comment event exists yet, the gate
+  previous 300 seconds. If no AI review/comment event exists yet, the gate
   refuses to merge. Passing `--wait` sleeps through the remaining quiet window
   and then rechecks without rerunning local tests; any PR head change causes the
   recheck to fail.

--- a/docs/engineering/hardening-strategy.md
+++ b/docs/engineering/hardening-strategy.md
@@ -12,8 +12,8 @@ work.
 - Catch verifier drift before a malformed artifact can be accepted.
 - Catch parser/decoder failures before malformed or adversarial input can panic,
   trigger UB, or silently decode to the wrong value.
-- Catch supply-chain and workflow drift before new advisories or CI regressions
-  land unnoticed.
+- Catch supply-chain and workflow drift before new advisories or workflow
+  regressions land unnoticed.
 - Tie every merge decision to reproducible local evidence rather than reviewer
   opinion.
 
@@ -27,8 +27,8 @@ The repository treats the following as primary failure modes:
 | Verifier acceptance bug | malformed proof/artifact/manifest is accepted | tamper-path unit tests, CLI rejection tests, schema/statement checks |
 | Parser/decoder unsoundness | malformed input panics, misdecodes, or triggers UB | unit tests, fuzzing, Miri, UB checks, ASAN, no-panic fallbacks |
 | Statement drift | code and documented public statement stop matching | statement-spec contract tests, manifest schema checks, proof claim round-trips |
-| Workflow drift | CI or merge policy stops enforcing the intended guarantees | workflow audit, shellcheck, local merge gate evidence |
-| Dependency drift | new RustSec/license/source risk lands without code changes | dependency audit on PR deltas plus scheduled and `main`-branch audit |
+| Workflow drift | workflow files or merge policy stop matching the intended local-only guarantees | workflow audit, shellcheck, local merge gate evidence |
+| Dependency drift | new RustSec/license/source risk lands without code changes | local dependency audit and Dependabot security alerts |
 | Overclaiming from AI review | bots approve while the artifact is still weak | zero unresolved threads plus local evidence and merge gate |
 
 ## Assurance Tiers
@@ -41,7 +41,7 @@ do not let trusted-core changes merge on smoke alone.
 | `smoke` | Fast confidence on ordinary PRs | `git diff --check`, `cargo fmt --check`, shellcheck/workflow audit when touched, statement-spec contract, allowlisted smoke targets, exact pinned-nightly `stwo` smokes |
 | `full` | Merge proof for most code changes | `smoke` plus `cargo test -q --lib`, `cargo test -q --lib --tests`, `cargo test -q --workspace --doc`, dependency audit, exact pinned-nightly `stwo` smokes |
 | `hardening` | Adversarial confidence for parser/verifier/trusted-core changes | `full` plus mutation, fuzz smoke, UB checks, ASAN, Miri, formal contracts |
-| scheduled baseline | Detect drift that diff-scoped PR checks cannot see | scheduled or `main`-branch dependency audit, manually dispatched heavy CI baselines when needed |
+| owner-dispatched baseline | Rare GitHub-hosted cross-check outside the normal merge loop | manually dispatched dormant workflows only when owner-directed |
 
 The merge gate in `scripts/local_merge_gate.sh` enforces the first three tiers.
 Mutation-testing evidence is tracked through
@@ -166,7 +166,7 @@ This is the minimum expected evidence for each change class.
 | --- | --- | --- |
 | docs-only publication edits | `smoke` | format and policy/doc consistency |
 | ordinary runtime logic | `full` | unit/integration coverage for changed behavior |
-| workflow or merge-gate logic | `full` | workflow audit, shellcheck, clean GitHub check rollup |
+| workflow or merge-gate logic | `full` | workflow audit, shellcheck, no unexpected GitHub check failures |
 | dependency or vendored third-party patch | `full` | dependency audit, targeted regression tests, documented exception policy if any |
 | parser/decoder/verifier path | `hardening` preferred | tamper tests, fuzz coverage, no-panic behavior, UB/ASAN/Miri when applicable |
 | public statement/schema/manifest change | `full` minimum | round-trip tests, mismatch detection, CLI/load/verify rejection tests |
@@ -252,7 +252,7 @@ Do not do these:
 - merge parser/verifier changes without tamper-path tests,
 - add `unsafe` or vendor patches without targeted coverage,
 - widen dependency exceptions without an owner and exit condition,
-- rely only on diff-scoped PR audits for advisory drift,
+- rely only on diff-scoped or GitHub-hosted audits for advisory drift,
 - claim a hardening tier ran when it did not.
 
 ## Current Default
@@ -263,7 +263,7 @@ For this repository today:
 - `full` is the normal merge gate for code changes,
 - `hardening` is the preferred gate for parser/verifier/trusted-core boundary
   work,
-- scheduled and `main`-branch dependency audit covers advisory drift that PR
-  diff-gating cannot catch.
+- local dependency audit plus Dependabot security alerts cover advisory drift
+  without scheduled or `main`-branch GitHub Actions runs.
 
 When in doubt, choose the stricter tier and record the evidence.

--- a/docs/engineering/release-gates/local-only-policy.md
+++ b/docs/engineering/release-gates/local-only-policy.md
@@ -1,13 +1,14 @@
 # Local-only release gate
 
-GitHub Actions is intentionally disabled at the repository level for cost
-reasons. The release gate runs entirely on a workstation. Server-side
+GitHub Actions is intentionally not part of the release gate for cost reasons.
+Automatic `pull_request`, `push`, and `schedule` triggers are disabled in the
+workflow files. The release gate runs entirely on a workstation. Server-side
 enforcement is reduced to repository policy that does not consume Actions
-minutes: a pull request must exist before a merge into `main`, the merge
-must be a fast-forward / linear-history merge, and the branch cannot be
-deleted or rewritten. Review approval and signed commits are intentionally
-NOT required because this is a solo-maintainer repository where requiring
-either would block every merge without adding meaningful security.
+minutes: a pull request must exist before a merge into `main`, the merge must
+be a fast-forward / linear-history merge, and the branch cannot be deleted or
+rewritten. Review approval and signed commits are intentionally NOT required
+because this is a solo-maintainer repository where requiring either would block
+every merge without adding meaningful security.
 
 ## What enforces what
 
@@ -19,9 +20,9 @@ either would block every merge without adding meaningful security.
 | linear history                               | `main` ruleset                                                |
 | pull request required before merge           | `main` ruleset (review approval not required)                 |
 | Dependabot security alerts                   | repository security & analysis settings                       |
-| AI commenter pre-merge review                | CodeRabbit, Greptile, pr-agent webhooks (do not use Actions) |
+| AI commenter pre-merge review                | CodeRabbit, Qodo, Greptile, pr-agent webhooks (do not use Actions) |
 
-The AI commenters (CodeRabbit, Greptile, pr-agent) run via GitHub App
+The AI commenters (CodeRabbit, Qodo, Greptile, pr-agent) run via GitHub App
 webhooks and are unaffected by Actions being disabled. They will continue
 to comment on every PR, including PRs that propose changes to the local gate
 itself.
@@ -70,14 +71,15 @@ ln -sf ../../docs/engineering/release-gates/pre-push-hook.sh .git/hooks/pre-push
 
 ## Why workflow files are still in `.github/workflows/`
 
-The CI workflows are kept on disk so that:
+The CI workflows are kept on disk with `workflow_dispatch` only so that:
 
-1. Re-enabling Actions (or migrating to a different runner) is one repository
-   setting change away.
+1. A repository owner can intentionally dispatch a rare release, paper-bundle,
+   security, or final-review run if local evidence needs a GitHub-hosted
+   cross-check.
 2. `zizmor` still has something to lint, which keeps the workflow files from
    bit-rotting.
-3. The cost / hardening posture is a documented, reversible policy decision
-   rather than a code-deletion event.
+3. Re-enabling automatic Actions (or migrating to a different runner) remains a
+   documented, reversible policy decision rather than a code-deletion event.
 
 If Actions is later re-enabled, restore the `required_status_checks` rule in
 `branch-protection-ruleset.json` (the prior version listed

--- a/scripts/local_merge_gate.sh
+++ b/scripts/local_merge_gate.sh
@@ -8,7 +8,7 @@ cd "$ROOT_DIR"
 
 REPO="${MERGE_GATE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)}"
 PR_NUMBER="${MERGE_GATE_PR:-}"
-QUIET_SECONDS="${MERGE_GATE_QUIET_SECONDS:-420}"
+QUIET_SECONDS="${MERGE_GATE_QUIET_SECONDS:-300}"
 MAX_WAIT_SECONDS="${MERGE_GATE_MAX_WAIT_SECONDS:-1800}"
 WAIT_STARTED_AT="${MERGE_GATE_WAIT_STARTED_AT:-}"
 EVIDENCE_DIR="${MERGE_GATE_EVIDENCE_DIR:-target/local-hardening}"
@@ -32,7 +32,7 @@ Options:
   --pr NUMBER            Pull request number. Can also be positional.
   --mode smoke|full|hardening|none
                           Local command tier. Default: smoke.
-  --quiet-seconds N      AI-review quiet window. Default: 420.
+  --quiet-seconds N      AI-review quiet window. Default: 300.
   --max-wait-seconds N   Maximum total --wait wall time. Default: 1800; 0 disables.
   --evidence-dir DIR     Evidence output directory. Default: target/local-hardening.
   --wait                 Wait until the quiet window is satisfied.


### PR DESCRIPTION
## Summary
- Convert CI, paper preflight, and PR hardening workflows from automatic triggers to manual `workflow_dispatch` only.
- Keep the PR hardening contract useful under manual dispatch with an explicit positive-integer PR number input.
- Harden the manual PR metadata path: paginated file listing, rename `previous_filename` coverage, changed-file count checks, and temp-file handoff instead of a large env var.
- Document the repo policy: local scoped validation first, Qodo/CodeRabbit as cheap adversarial reviewers, GitHub Actions only as intentional dormant guardrails.

## Validation
- [x] `actionlint .github/workflows/ci.yml .github/workflows/paper-preflight.yml .github/workflows/pr-hardening-contract.yml`
- [x] `bash scripts/run_workflow_audit_suite.sh`
- [x] `bash -n scripts/local_merge_gate.sh`
- [x] `bash scripts/run_shellcheck_suite.sh`
- [x] `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "parsed #{f}" }'`
- [x] `git diff --check`
- [x] `rg -n "420|Default: 420|seven-minute|7-minute|export PR_JSON=|os\.environ\.get\(\"PR_JSON\"|--json body,files|\.\[\]\.filename" .github/workflows/pr-hardening-contract.yml docs/engineering/hardening-policy.md scripts/local_merge_gate.sh` returned no matches.
- [x] No automatic `pull_request`, `push`, or `schedule` triggers remain in workflow `on` blocks.
- [x] GitHub Actions intentionally not run; this PR disables automatic CI.

## Hardening
- [x] targeted regression and tamper-path coverage added or updated: N/A, workflow trigger policy only; actionlint, shellcheck, workflow audit, and stale-pattern scans cover the changed workflow surface.
- [x] oracle or differential checks added/updated, or marked not applicable below: N/A, no proof semantics changed.
- [x] resource-bound / untrusted-input impact reviewed, or marked not applicable below: reviewed; removes automatic CI spend, keeps manual dispatch, validates PR number input, avoids large metadata env vars, and uses paginated PR file metadata including rename source paths.
- [x] Kani / formal-kernel impact reviewed, or marked not applicable below: N/A, no Rust or proof-kernel code changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/preflight workflows are manual-only (workflow_dispatch); dependency-audit is no longer event-gated. PR hardening runs manually with a required PR number input. Local guardrail validation simplified to a single validation step during manual runs.
  * Default AI-review quiet window reduced from 7 to 5 minutes.

* **Documentation**
  * Updated review and hardening guidance: workflows treated as dormant/manual guardrails; AI reviewers framed as adversarial signals; quiet-window guidance set to 5 minutes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/540)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/540)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->