### PR TITLE
Add research issue templates and lint

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Research OS source of truth
+    url: https://github.com/omarespejel/provable-transformer-vm/tree/main/.codex/research
+    about: Read the structured north star and operating model before opening frontier issues.

--- a/.github/ISSUE_TEMPLATE/hardening-followup.yml
+++ b/.github/ISSUE_TEMPLATE/hardening-followup.yml
@@ -1,0 +1,52 @@
+name: Hardening Follow-Up
+description: Preserve a concrete hardening concern found while working.
+title: "[hardening-followup]: "
+labels:
+  - hardening-followup
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when an agent finds a relevant risk outside the current PR scope.
+  - type: textarea
+    id: observed_risk
+    attributes:
+      label: Observed risk
+      description: What specific verifier, artifact, path-safety, resource, or claim-drift risk was observed?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence_or_location
+    attributes:
+      label: Evidence or location
+      description: Link files, docs, logs, bot comments, or commands that exposed the risk.
+    validations:
+      required: true
+  - type: textarea
+    id: why_not_current_pr
+    attributes:
+      label: Why not current PR
+      description: Explain why this should be tracked separately instead of widening the current PR.
+    validations:
+      required: true
+  - type: textarea
+    id: smallest_fix_or_test
+    attributes:
+      label: Smallest fix or test
+      description: What is the smallest local change that would close or measure this risk?
+    validations:
+      required: true
+  - type: textarea
+    id: go_no_go
+    attributes:
+      label: GO / NO-GO
+      description: What makes this worth fixing now, and what makes it safe to park or kill?
+    validations:
+      required: true
+  - type: textarea
+    id: local_validation_plan
+    attributes:
+      label: Local validation plan
+      description: List expected local commands. Do not use GitHub CI as the research loop.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/paper-claim.yml
+++ b/.github/ISSUE_TEMPLATE/paper-claim.yml
@@ -1,0 +1,59 @@
+name: Paper Claim
+description: Promote a checked engineering result toward paper-facing language.
+title: "[paper-claim]: "
+labels:
+  - paper-claim
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this only when a claim has checked evidence and explicit non-claims.
+  - type: textarea
+    id: claim
+    attributes:
+      label: Claim
+      description: State the exact claim in one bounded sentence.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence_paths
+    attributes:
+      label: Evidence paths
+      description: List checked docs, JSON/TSV artifacts, scripts, tests, and reproduction commands.
+    validations:
+      required: true
+  - type: textarea
+    id: claim_boundary
+    attributes:
+      label: Claim boundary
+      description: Explain the scope, fixture, backend, timing policy, and artifact layer.
+    validations:
+      required: true
+  - type: textarea
+    id: non_claims
+    attributes:
+      label: Non-claims
+      description: What readers must not infer from this claim.
+    validations:
+      required: true
+  - type: textarea
+    id: competitor_context
+    attributes:
+      label: Competitor context
+      description: External systems or papers this claim could be compared against.
+    validations:
+      required: true
+  - type: textarea
+    id: promotion_gate
+    attributes:
+      label: Promotion gate
+      description: What must pass before this enters docs/paper?
+    validations:
+      required: true
+  - type: textarea
+    id: local_validation_plan
+    attributes:
+      label: Local validation plan
+      description: List expected local commands. Do not use GitHub CI as the research loop.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/research-frontier.yml
+++ b/.github/ISSUE_TEMPLATE/research-frontier.yml
@@ -1,0 +1,77 @@
+name: Research Frontier
+description: Open a hypothesis-driven frontier track with explicit GO/NO-GO gates.
+title: "[research-frontier]: "
+labels:
+  - research-frontier
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for exploration that could strengthen, narrow, or kill the STARK-native zkML thesis.
+  - type: dropdown
+    id: owner_role
+    attributes:
+      label: Owner role
+      options:
+        - scout
+        - experimenter
+        - skeptic
+        - integrator
+    validations:
+      required: true
+  - type: textarea
+    id: thesis
+    attributes:
+      label: Thesis
+      description: What might be true?
+    validations:
+      required: true
+  - type: textarea
+    id: why_it_matters_for_serious_paper
+    attributes:
+      label: Why it matters for a serious paper
+      description: Explain the paper upside in concrete terms.
+    validations:
+      required: true
+  - type: textarea
+    id: smallest_falsifying_experiment
+    attributes:
+      label: Smallest falsifying experiment
+      description: What is the smallest local experiment that can kill or narrow this?
+    validations:
+      required: true
+  - type: textarea
+    id: go_gate
+    attributes:
+      label: GO gate
+      description: What exact evidence would make this worth executing further?
+    validations:
+      required: true
+  - type: textarea
+    id: no_go_gate
+    attributes:
+      label: NO-GO gate
+      description: What exact evidence kills this path or narrows the claim?
+    validations:
+      required: true
+  - type: textarea
+    id: required_artifacts
+    attributes:
+      label: Required artifacts
+      description: List gate notes, JSON/TSV evidence, tests, figures, or reproduction outputs.
+    validations:
+      required: true
+  - type: textarea
+    id: non_claims
+    attributes:
+      label: Non-claims
+      description: What must not be inferred from this issue?
+    validations:
+      required: true
+  - type: textarea
+    id: local_validation_plan
+    attributes:
+      label: Local validation plan
+      description: List expected local commands. Do not use GitHub CI as the research loop.
+    validations:
+      required: true

--- a/scripts/research_issue_lint.py
+++ b/scripts/research_issue_lint.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Lint agent-native research issue templates and ledger files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+TEMPLATE_REQUIRED_IDS = {
+    "research-frontier.yml": {
+        "owner_role",
+        "thesis",
+        "why_it_matters_for_serious_paper",
+        "smallest_falsifying_experiment",
+        "go_gate",
+        "no_go_gate",
+        "required_artifacts",
+        "non_claims",
+        "local_validation_plan",
+    },
+    "hardening-followup.yml": {
+        "observed_risk",
+        "evidence_or_location",
+        "why_not_current_pr",
+        "smallest_fix_or_test",
+        "go_no_go",
+        "local_validation_plan",
+    },
+    "paper-claim.yml": {
+        "claim",
+        "evidence_paths",
+        "claim_boundary",
+        "non_claims",
+        "competitor_context",
+        "promotion_gate",
+        "local_validation_plan",
+    },
+}
+
+LEDGER_REQUIRED_FIELDS = {
+    "id",
+    "status",
+    "thesis",
+    "why_it_matters_for_serious_paper",
+    "smallest_falsifying_experiment",
+    "go_gate",
+    "no_go_gate",
+    "required_artifacts",
+    "non_claims",
+}
+
+LEDGER_REQUIRED_STRINGS = {
+    "thesis",
+    "why_it_matters_for_serious_paper",
+    "smallest_falsifying_experiment",
+    "go_gate",
+    "no_go_gate",
+}
+
+LEDGER_REQUIRED_NON_EMPTY_STRING_LISTS = {
+    "required_artifacts",
+    "non_claims",
+}
+
+LEDGER_OPTIONAL_STRING_LISTS = {
+    "evidence_paths",
+    "blocked_by",
+}
+
+LEDGER_ALLOWED_FIELDS = (
+    LEDGER_REQUIRED_FIELDS
+    | {"owner_role"}
+    | LEDGER_OPTIONAL_STRING_LISTS
+)
+
+LEDGER_STATUSES = {
+    "EXPLORE",
+    "EXECUTE",
+    "PAPER_CANDIDATE",
+    "FOLLOWUP",
+    "GO",
+    "NARROW_CLAIM",
+    "FOLLOWUP_ISSUE",
+    "KILL",
+    "NO_GO",
+    "DONE",
+}
+
+LEDGER_OWNER_ROLES = {"scout", "experimenter", "skeptic", "integrator"}
+
+
+def _template_ids(text: str) -> list[str]:
+    ids: list[str] = []
+    block_scalar_indent: int | None = None
+    block_scalar_pattern = re.compile(r"^(?P<indent>\s*)[A-Za-z0-9_-]+:\s*[|>][-+0-9 ]*(?:#.*)?$")
+    id_pattern = re.compile(r"^\s*id:\s*([a-z0-9_-]+)\s*(?:#.*)?$")
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if block_scalar_indent is not None:
+            if not stripped:
+                continue
+            if indent > block_scalar_indent:
+                continue
+            block_scalar_indent = None
+
+        block_match = block_scalar_pattern.match(line)
+        if block_match:
+            block_scalar_indent = len(block_match.group("indent"))
+            continue
+
+        id_match = id_pattern.match(line)
+        if id_match:
+            ids.append(id_match.group(1))
+
+    return ids
+
+
+def lint_issue_templates(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    template_dir = repo_root / ".github" / "ISSUE_TEMPLATE"
+    config_path = template_dir / "config.yml"
+    if not config_path.is_file():
+        if config_path.exists():
+            errors.append(f"{config_path}: issue template config must be a file")
+        else:
+            errors.append(f"missing issue template config file: {config_path}")
+    elif not _blank_issues_disabled(config_path.read_text(encoding="utf-8")):
+        errors.append(f"{config_path}: blank issues must be disabled")
+
+    for filename, required_ids in sorted(TEMPLATE_REQUIRED_IDS.items()):
+        path = template_dir / filename
+        if not path.is_file():
+            if path.exists():
+                errors.append(f"{path}: issue template must be a file")
+            else:
+                errors.append(f"missing issue template: {path}")
+            continue
+        text = path.read_text(encoding="utf-8")
+        found_ids = _template_ids(text)
+        found_id_set = set(found_ids)
+        missing_ids = sorted(required_ids - found_id_set)
+        if missing_ids:
+            errors.append(f"{path}: missing ids: {', '.join(missing_ids)}")
+        duplicate_ids = sorted(id_ for id_, count in Counter(found_ids).items() if count > 1)
+        if duplicate_ids:
+            errors.append(f"{path}: duplicate ids: {', '.join(duplicate_ids)}")
+        if "Do not use GitHub CI as the research loop." not in text:
+            errors.append(f"{path}: must remind agents not to use GitHub CI as the research loop")
+    return errors
+
+
+def lint_research_policy(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    required_files = [
+        repo_root / ".codex" / "research" / "north_star.yml",
+        repo_root / ".codex" / "research" / "operating_model.yml",
+        repo_root / ".codex" / "research" / "schemas" / "frontier_track.schema.json",
+    ]
+    for path in required_files:
+        if not path.is_file():
+            if path.exists():
+                errors.append(f"{path}: research policy path must be a file")
+            else:
+                errors.append(f"missing research policy file: {path}")
+
+    operating_model = repo_root / ".codex" / "research" / "operating_model.yml"
+    if operating_model.is_file():
+        text = operating_model.read_text(encoding="utf-8")
+        for needle in ("qodo", "coderabbit", "local_first", "workflow_dispatch"):
+            if needle not in text:
+                errors.append(f"{operating_model}: missing policy keyword {needle!r}")
+
+    return errors
+
+
+def lint_frontier_ledger(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    path = repo_root / ".codex" / "research" / "frontier_ledger.jsonl"
+    if not path.exists():
+        return errors
+    if not path.is_file():
+        errors.append(f"{path}: frontier ledger must be a file")
+        return errors
+
+    seen_ids: set[str] = set()
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not raw_line.strip():
+            continue
+        try:
+            entry = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            errors.append(f"{path}:{line_number}: invalid JSON: {exc}")
+            continue
+        if not isinstance(entry, dict):
+            errors.append(f"{path}:{line_number}: ledger entry must be a JSON object")
+            continue
+
+        missing = sorted(LEDGER_REQUIRED_FIELDS - set(entry))
+        if missing:
+            errors.append(f"{path}:{line_number}: missing fields: {', '.join(missing)}")
+        extra = sorted(set(entry) - LEDGER_ALLOWED_FIELDS)
+        if extra:
+            errors.append(f"{path}:{line_number}: unknown fields: {', '.join(extra)}")
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, str) or not re.match(r"^[a-z0-9][a-z0-9_-]*$", entry_id):
+            errors.append(f"{path}:{line_number}: invalid id")
+        elif entry_id in seen_ids:
+            errors.append(f"{path}:{line_number}: duplicate id {entry_id}")
+        else:
+            seen_ids.add(entry_id)
+        if entry.get("status") not in LEDGER_STATUSES:
+            errors.append(f"{path}:{line_number}: invalid status {entry.get('status')!r}")
+        for field in LEDGER_REQUIRED_STRINGS:
+            if field in entry and not _non_empty_string(entry[field]):
+                errors.append(f"{path}:{line_number}: {field} must be a non-empty string")
+        for field in LEDGER_REQUIRED_NON_EMPTY_STRING_LISTS:
+            if not isinstance(entry.get(field), list) or not entry.get(field):
+                errors.append(f"{path}:{line_number}: {field} must be a non-empty list")
+            elif not all(_non_empty_string(item) for item in entry[field]):
+                errors.append(f"{path}:{line_number}: {field} entries must be non-empty strings")
+        owner_role = entry.get("owner_role")
+        if "owner_role" in entry and owner_role not in LEDGER_OWNER_ROLES:
+            errors.append(f"{path}:{line_number}: invalid owner_role {owner_role!r}")
+        for field in LEDGER_OPTIONAL_STRING_LISTS:
+            if field in entry:
+                if not isinstance(entry[field], list):
+                    errors.append(f"{path}:{line_number}: {field} must be a list")
+                elif not all(_non_empty_string(item) for item in entry[field]):
+                    errors.append(f"{path}:{line_number}: {field} entries must be non-empty strings")
+
+    return errors
+
+
+def _non_empty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _blank_issues_disabled(text: str) -> bool:
+    for line in text.splitlines():
+        key_value = line.split("#", 1)[0].strip()
+        if not key_value or ":" not in key_value:
+            continue
+        key, value = key_value.split(":", 1)
+        if key.strip() == "blank_issues_enabled":
+            return value.strip().lower() == "false"
+    return False
+
+
+def lint(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    errors.extend(lint_issue_templates(repo_root))
+    errors.extend(lint_research_policy(repo_root))
+    errors.extend(lint_frontier_ledger(repo_root))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    errors = lint(repo_root)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("research issue lint passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_research_issue_lint.py
+++ b/scripts/tests/test_research_issue_lint.py
@@ -1,0 +1,255 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import research_issue_lint
+
+
+class ResearchIssueLintTests(unittest.TestCase):
+    def valid_ledger_entry(self) -> dict[str, object]:
+        return {
+            "id": "valid-track",
+            "status": "EXPLORE",
+            "thesis": "x",
+            "why_it_matters_for_serious_paper": "x",
+            "smallest_falsifying_experiment": "x",
+            "go_gate": "x",
+            "no_go_gate": "x",
+            "required_artifacts": ["gate"],
+            "non_claims": ["timing"],
+        }
+
+    def test_frontier_ledger_rejects_missing_required_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger_dir = root / ".codex" / "research"
+            ledger_dir.mkdir(parents=True)
+            (ledger_dir / "frontier_ledger.jsonl").write_text(
+                json.dumps({"id": "missing-fields", "status": "EXPLORE"}) + "\n",
+                encoding="utf-8",
+            )
+
+            errors = research_issue_lint.lint_frontier_ledger(root)
+
+        self.assertTrue(any("missing fields" in error for error in errors))
+
+    def test_frontier_ledger_rejects_duplicate_ids(self) -> None:
+        entry = self.valid_ledger_entry()
+        entry["id"] = "duplicate-track"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger_dir = root / ".codex" / "research"
+            ledger_dir.mkdir(parents=True)
+            (ledger_dir / "frontier_ledger.jsonl").write_text(
+                json.dumps(entry) + "\n" + json.dumps(entry) + "\n",
+                encoding="utf-8",
+            )
+
+            errors = research_issue_lint.lint_frontier_ledger(root)
+
+        self.assertTrue(any("duplicate id duplicate-track" in error for error in errors))
+
+    def test_frontier_ledger_rejects_empty_required_string(self) -> None:
+        entry = self.valid_ledger_entry()
+        entry["thesis"] = ""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger_dir = root / ".codex" / "research"
+            ledger_dir.mkdir(parents=True)
+            (ledger_dir / "frontier_ledger.jsonl").write_text(
+                json.dumps(entry) + "\n",
+                encoding="utf-8",
+            )
+
+            errors = research_issue_lint.lint_frontier_ledger(root)
+
+        self.assertTrue(any("thesis must be a non-empty string" in error for error in errors))
+
+    def test_frontier_ledger_rejects_whitespace_only_strings(self) -> None:
+        entry = self.valid_ledger_entry()
+        entry["thesis"] = "   "
+        entry["non_claims"] = ["timing", "   "]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger_dir = root / ".codex" / "research"
+            ledger_dir.mkdir(parents=True)
+            (ledger_dir / "frontier_ledger.jsonl").write_text(
+                json.dumps(entry) + "\n",
+                encoding="utf-8",
+            )
+
+            errors = research_issue_lint.lint_frontier_ledger(root)
+
+        self.assertTrue(any("thesis must be a non-empty string" in error for error in errors))
+        self.assertTrue(any("non_claims entries must be non-empty strings" in error for error in errors))
+
+    def test_frontier_ledger_rejects_non_string_list_items(self) -> None:
+        entry = self.valid_ledger_entry()
+        entry["required_artifacts"] = ["gate", ""]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger_dir = root / ".codex" / "research"
+            ledger_dir.mkdir(parents=True)
+            (ledger_dir / "frontier_ledger.jsonl").write_text(
+                json.dumps(entry) + "\n",
+                encoding="utf-8",
+            )
+
+            errors = research_issue_lint.lint_frontier_ledger(root)
+
+        self.assertTrue(
+            any("required_artifacts entries must be non-empty strings" in error for error in errors)
+        )
+
+    def test_frontier_ledger_rejects_unknown_fields(self) -> None:
+        entry = self.valid_ledger_entry()
+        entry["surprise"] = "not in schema"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger_dir = root / ".codex" / "research"
+            ledger_dir.mkdir(parents=True)
+            (ledger_dir / "frontier_ledger.jsonl").write_text(
+                json.dumps(entry) + "\n",
+                encoding="utf-8",
+            )
+
+            errors = research_issue_lint.lint_frontier_ledger(root)
+
+        self.assertTrue(any("unknown fields: surprise" in error for error in errors))
+
+    def test_frontier_ledger_rejects_invalid_optional_fields(self) -> None:
+        entry = self.valid_ledger_entry()
+        entry["owner_role"] = "publisher"
+        entry["evidence_paths"] = ["docs/gate.md", ""]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger_dir = root / ".codex" / "research"
+            ledger_dir.mkdir(parents=True)
+            (ledger_dir / "frontier_ledger.jsonl").write_text(
+                json.dumps(entry) + "\n",
+                encoding="utf-8",
+            )
+
+            errors = research_issue_lint.lint_frontier_ledger(root)
+
+        self.assertTrue(any("invalid owner_role 'publisher'" in error for error in errors))
+        self.assertTrue(
+            any("evidence_paths entries must be non-empty strings" in error for error in errors)
+        )
+
+    def test_frontier_ledger_rejects_non_object_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger_dir = root / ".codex" / "research"
+            ledger_dir.mkdir(parents=True)
+            (ledger_dir / "frontier_ledger.jsonl").write_text("[]\n", encoding="utf-8")
+
+            errors = research_issue_lint.lint_frontier_ledger(root)
+
+        self.assertTrue(any("ledger entry must be a JSON object" in error for error in errors))
+
+    def test_template_ids_accept_variable_indentation(self) -> None:
+        text = "  - type: input\n      id: thesis\n        id: go_gate\n"
+
+        found = research_issue_lint._template_ids(text)
+
+        self.assertEqual(["thesis", "go_gate"], found)
+
+    def test_template_ids_ignore_markdown_literal_block_content(self) -> None:
+        text = (
+            "- type: markdown\n"
+            "  attributes:\n"
+            "    value: |\n"
+            "      id: thesis\n"
+            "      id: go_gate\n"
+            "- type: input\n"
+            "  id: owner_role\n"
+        )
+
+        found = research_issue_lint._template_ids(text)
+
+        self.assertEqual(["owner_role"], found)
+
+    def test_issue_templates_reject_duplicate_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            template_dir = root / ".github" / "ISSUE_TEMPLATE"
+            template_dir.mkdir(parents=True)
+            (template_dir / "config.yml").write_text(
+                "blank_issues_enabled: false\n",
+                encoding="utf-8",
+            )
+            (template_dir / "research-frontier.yml").write_text(
+                "body:\n"
+                "  - type: input\n"
+                "    id: owner_role\n"
+                "  - type: input\n"
+                "    id: owner_role\n"
+                "Do not use GitHub CI as the research loop.\n",
+                encoding="utf-8",
+            )
+
+            errors = research_issue_lint.lint_issue_templates(root)
+
+        self.assertTrue(any("duplicate ids: owner_role" in error for error in errors))
+
+    def test_issue_template_directory_returns_lint_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            template_dir = root / ".github" / "ISSUE_TEMPLATE"
+            template_dir.mkdir(parents=True)
+            (template_dir / "config.yml").write_text(
+                "blank_issues_enabled: false\n",
+                encoding="utf-8",
+            )
+            (template_dir / "research-frontier.yml").mkdir()
+
+            errors = research_issue_lint.lint_issue_templates(root)
+
+        self.assertTrue(any("issue template must be a file" in error for error in errors))
+
+    def test_issue_template_config_rejects_false_in_comment_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            template_dir = root / ".github" / "ISSUE_TEMPLATE"
+            template_dir.mkdir(parents=True)
+            (template_dir / "config.yml").write_text(
+                "blank_issues_enabled: true\n"
+                "# blank_issues_enabled: false\n",
+                encoding="utf-8",
+            )
+
+            errors = research_issue_lint.lint_issue_templates(root)
+
+        self.assertTrue(any("blank issues must be disabled" in error for error in errors))
+
+    def test_research_policy_directory_returns_lint_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            research_dir = root / ".codex" / "research"
+            (research_dir / "schemas").mkdir(parents=True)
+            (research_dir / "north_star.yml").write_text("id: north-star\n", encoding="utf-8")
+            (research_dir / "operating_model.yml").mkdir()
+            (research_dir / "schemas" / "frontier_track.schema.json").write_text(
+                "{}\n",
+                encoding="utf-8",
+            )
+
+            errors = research_issue_lint.lint_research_policy(root)
+
+        self.assertTrue(any("research policy path must be a file" in error for error in errors))
+
+    def test_frontier_ledger_directory_returns_lint_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger_dir = root / ".codex" / "research" / "frontier_ledger.jsonl"
+            ledger_dir.mkdir(parents=True)
+
+            errors = research_issue_lint.lint_frontier_ledger(root)
+
+        self.assertTrue(any("frontier ledger must be a file" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add research-frontier, hardening-followup, and paper-claim issue forms with GO/NO-GO, artifact, non-claim, and local-validation fields.
- Add a local `scripts/research_issue_lint.py` guard for the new templates, Research OS policy, and frontier ledger records when present.
- Add focused unittest coverage for missing ledger fields and duplicate ledger ids.

## Validation
- [x] `python3 scripts/research_issue_lint.py --repo-root .`
- [x] `python3 -m unittest scripts.tests.test_research_issue_lint`
- [x] `git diff --check origin/main...HEAD`
- [x] GitHub Actions intentionally not run; local validation plus Qodo/CodeRabbit review is the normal PR loop.

## Notes
- No proof semantics, backend routing, verifier code, or evidence numbers changed.
- This is PR 3 from the research operating plan: turn issues into falsifiable research hypotheses instead of loose task tickets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three structured research issue templates (Hardening Follow-Up, Paper Claim, Research Frontier) and a project contact link; blank issues are now disabled.

* **Chores**
  * Added a CLI validator to check presence and structure of research templates, policy artifacts, and the research ledger; enforces required reminders and validation rules.

* **Tests**
  * Added unit tests covering the validator and ledger/template validation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/542)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->