### PR TITLE
Add zkML competitor landscape matrix

### DIFF
--- a/docs/engineering/evidence/zkai-competitor-landscape-2026-05.json
+++ b/docs/engineering/evidence/zkai-competitor-landscape-2026-05.json
@@ -1,0 +1,145 @@
+{
+  "schema_version": 1,
+  "schema": "zkai-competitor-landscape-v1",
+  "created_at": "2026-05-12",
+  "generated_at": "1970-01-01T00:00:00Z",
+  "git_commit": "d50c300d4c76428ecfe2df41462ce02988ad2697",
+  "systems_commitment_domain": "ptvm:zkai:competitor-landscape:systems:v1",
+  "systems_commitment": "blake2b-256:2e547d2d302aca970e48e526c9e6a3d1aa280d2f5116577815a09d2ebecc6260",
+  "positioning": {
+    "repo_lane": "STARK-native fused proof architecture for transformer attention/table membership",
+    "compete_on": [
+      "native STARK composition",
+      "fused attention arithmetic plus lookup membership",
+      "shared FRI/opening/decommitment plumbing",
+      "checked artifacts and mutation rejection",
+      "future Starknet/S-two production path"
+    ],
+    "do_not_compete_on_yet": [
+      "first full LLM proof",
+      "smallest generic zkML proof",
+      "public speed benchmark",
+      "production deployment"
+    ]
+  },
+  "validation_commands": [
+    "just gate-fast",
+    "python3 -m json.tool docs/engineering/evidence/zkai-competitor-landscape-2026-05.json >/dev/null",
+    "python3 scripts/zkai_competitor_landscape_commitment_check.py",
+    "python3 scripts/research_issue_lint.py --repo-root .",
+    "python3 -m unittest scripts.tests.test_research_issue_lint",
+    "python3 -m unittest scripts.tests.test_zkai_competitor_landscape_commitment_check",
+    "git diff --check",
+    "just gate-no-nightly"
+  ],
+  "systems": [
+    {
+      "name": "NANOZK",
+      "claim_type": "layerwise zero-knowledge proofs for verifiable LLM inference",
+      "why_it_matters": "Directly competes with broad LLM-verification narratives.",
+      "repo_position": "Do not claim first LLM verification; differentiate on native STARK fused component architecture.",
+      "id": "nanozk",
+      "sources": [
+        {
+          "label": "paper",
+          "url": "https://arxiv.org/abs/2603.18046",
+          "used_for": "external full-LLM verification lane context"
+        }
+      ]
+    },
+    {
+      "name": "Jolt Atlas",
+      "claim_type": "lookup-argument zkML framework for model inference",
+      "why_it_matters": "Lookup-centric zkML is close to the repo's Softmax-table/LogUp theme.",
+      "repo_position": "Compare lookup philosophy, but keep claim scoped to native Stwo attention/table fusion.",
+      "id": "jolt_atlas",
+      "sources": [
+        {
+          "label": "paper",
+          "url": "https://arxiv.org/abs/2602.17452",
+          "used_for": "lookup-centric zkML comparison lane"
+        }
+      ]
+    },
+    {
+      "name": "zkLLM / zkAttn",
+      "claim_type": "specialized zero-knowledge protocols for LLMs and attention",
+      "why_it_matters": "Attention-specific proof systems are the closest conceptual competitor.",
+      "repo_position": "Use as attention-specialization context; do not imply current fixtures prove full LLM attention exactly.",
+      "id": "zkllm_zkattn",
+      "sources": [
+        {
+          "label": "paper",
+          "url": "https://arxiv.org/abs/2404.16109",
+          "used_for": "attention-specialized zkML comparison lane"
+        }
+      ]
+    },
+    {
+      "name": "DeepProve-1",
+      "claim_type": "full LLM inference proof claim for GPT-2-style inference",
+      "why_it_matters": "Dominates the headline lane for full-model zkML demos.",
+      "repo_position": "Do not compete on full inference; use as reason to focus the paper on architecture mechanism.",
+      "id": "deepprove_1",
+      "sources": [
+        {
+          "label": "blog",
+          "url": "https://www.lagrange.dev/blog/deepprove-1",
+          "used_for": "full-model LLM proof claim context"
+        }
+      ]
+    },
+    {
+      "name": "EZKL",
+      "claim_type": "ONNX-to-ZKML tooling using circuit-oriented proving backends",
+      "why_it_matters": "Represents generic model compilation workflows.",
+      "repo_position": "Differentiate from generic compilation by showing transformer-aware STARK proof fusion.",
+      "id": "ezkl",
+      "sources": [
+        {
+          "label": "docs",
+          "url": "https://docs.ezkl.xyz/",
+          "used_for": "generic ONNX-to-ZKML tooling comparison"
+        }
+      ]
+    },
+    {
+      "name": "RISC Zero",
+      "claim_type": "zkVM computational receipts for arbitrary guest programs",
+      "why_it_matters": "Useful baseline for statement receipts and semantic checks.",
+      "repo_position": "Repo already uses zkVM receipts as control surfaces; native Stwo fusion is the distinct lane.",
+      "id": "risc_zero",
+      "sources": [
+        {
+          "label": "proof-system-docs",
+          "url": "https://dev.risczero.com/proof-system-in-detail.pdf",
+          "used_for": "zkVM receipt baseline context"
+        }
+      ]
+    },
+    {
+      "name": "StarkWare S-two / LogUp",
+      "claim_type": "open STARK prover stack with LogUp lookup machinery",
+      "why_it_matters": "Primary ecosystem and mechanism alignment for the repo.",
+      "repo_position": "Use as the production-path anchor for native lookup-heavy transformer components.",
+      "id": "stwo_logup",
+      "sources": [
+        {
+          "label": "stwo-crate-version",
+          "url": "https://docs.rs/crate/stwo/2.2.0",
+          "used_for": "pinned stwo 2.2.0 backend-version context"
+        },
+        {
+          "label": "logup-docs",
+          "url": "https://docs.starknet.io/learn/S-two-book/how-it-works/lookups",
+          "used_for": "LogUp lookup mechanism context"
+        },
+        {
+          "label": "release-blog",
+          "url": "https://starkware.co/blog/s-two-2-0-0-prover-for-developers/",
+          "used_for": "S-two developer-toolkit and production-path context"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/engineering/zkai-competitor-landscape-2026-05.md
+++ b/docs/engineering/zkai-competitor-landscape-2026-05.md
@@ -1,0 +1,139 @@
+# zkAI Competitor Landscape - 2026-05
+
+## Question
+
+Where should this repository compete in the May 2026 zkML landscape?
+
+## Decision
+
+Compete on STARK-native fused proof architecture, not on first full LLM proof,
+smallest generic zkML proof, or public speed benchmark.
+
+The repo's credible lane is:
+
+> Native Stwo attention/table proofs can fuse transformer arithmetic and
+> lookup-heavy Softmax-table membership into one proof object, sharing
+> commitment, opening, and decommitment structure that separate proof objects
+> duplicate.
+
+This positioning is subordinate to the canonical frontier sources:
+`.codex/research/north_star.yml` and `.codex/research/operating_model.yml`.
+It should update the frontier ledger rather than replace those files as the
+research source of truth.
+
+## Scope And Backend Context
+
+The local evidence basis for the architectural claim is the native
+`stwo-backend` attention/table lane with `stwo 2.2.0`. The strongest checked
+component grid is an engineering proof-size accounting gate, not a timing
+benchmark: timing mode
+`proof_component_size_accounting_only_not_timing_not_public_benchmark`, ten
+checked native Stwo attention/table profiles, and one explicit `seq32` row with
+`d=8`, `2` heads, `32` steps/head, `1,184` lookup claims, and `2,048` trace
+rows.
+
+The evidence paths for that context are:
+
+- `docs/engineering/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05-09.md`
+- `docs/engineering/zkai-attention-kv-stwo-controlled-component-grid-2026-05-10.md`
+- `docs/engineering/zkai-attention-kv-stwo-native-two-head-seq32-fused-softmax-table-gate-2026-05-10.md`
+- `docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json`
+- `docs/engineering/evidence/zkai-attention-kv-stwo-controlled-component-grid-2026-05.json`
+- `docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-seq32-fused-softmax-table-gate-2026-05.json`
+
+## Evidence File
+
+- JSON: `docs/engineering/evidence/zkai-competitor-landscape-2026-05.json`
+
+## Reproduce / Validate
+
+This PR adds a source-cited landscape artifact; it does not regenerate external
+papers or rerun native proof generation. Validate the checked-in matrix and the
+underlying local evidence with:
+
+```bash
+just gate-fast
+python3 -m json.tool docs/engineering/evidence/zkai-competitor-landscape-2026-05.json >/dev/null
+python3 scripts/zkai_competitor_landscape_commitment_check.py
+python3 scripts/research_issue_lint.py --repo-root .
+python3 -m unittest scripts.tests.test_research_issue_lint
+python3 -m unittest scripts.tests.test_zkai_competitor_landscape_commitment_check
+git diff --check
+just gate-no-nightly
+```
+
+Underlying local Stwo evidence can be regenerated with:
+
+```bash
+python3 scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py \
+  --write-json docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv
+python3 scripts/zkai_attention_kv_stwo_controlled_component_grid_gate.py \
+  --write-json docs/engineering/evidence/zkai-attention-kv-stwo-controlled-component-grid-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-attention-kv-stwo-controlled-component-grid-2026-05.tsv
+```
+
+The cited `seq32` fused gate is checked-in evidence for this landscape note, not
+rerun by this doc-only workflow. To refresh that gate artifact specifically,
+use:
+
+```bash
+python3 scripts/zkai_attention_kv_two_head_seq32_fused_softmax_table_native_gate.py \
+  --write-json docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-seq32-fused-softmax-table-gate-2026-05.json \
+  --write-tsv docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-seq32-fused-softmax-table-gate-2026-05.tsv
+```
+
+The full `seq32` proof-generation and verification sequence lives in
+`docs/engineering/zkai-attention-kv-stwo-native-two-head-seq32-fused-softmax-table-gate-2026-05-10.md`.
+
+## Landscape Matrix
+
+| System | Public lane | Why it matters | Repo position |
+|---|---|---|---|
+| NANOZK | Layerwise verifiable LLM inference | Directly competes with broad LLM-verification narratives | Do not claim first LLM verification; differentiate on native STARK fused component architecture |
+| Jolt Atlas | Lookup-argument zkML framework for model inference | Lookup-centric zkML is close to the Softmax-table/LogUp theme | Compare lookup philosophy, but keep the repo claim scoped to native Stwo attention/table fusion |
+| zkLLM / zkAttn | Specialized protocols for LLMs and attention | Attention-specific proving is the closest conceptual competitor | Use as attention-specialization context; do not imply current fixtures prove full LLM attention exactly |
+| DeepProve-1 | Full LLM inference proof claim for GPT-2-style inference | Dominates the headline lane for full-model zkML demos | Do not compete on full inference; use as reason to focus the paper on architecture mechanism |
+| EZKL | ONNX-to-ZKML tooling | Represents generic model compilation workflows | Differentiate from generic compilation by showing transformer-aware STARK proof fusion |
+| RISC Zero | zkVM computational receipts for arbitrary guest programs | Useful baseline for statement receipts and semantic checks | Keep zkVM receipts as control surfaces; native Stwo fusion is the distinct lane |
+| StarkWare S-two / LogUp | Open STARK prover stack with LogUp lookup machinery | Primary ecosystem and mechanism alignment | Use as the production-path anchor for native lookup-heavy transformer components |
+
+## Interpretation
+
+The paper should not start with "we prove a transformer." That lane is already
+crowded and would force comparisons the repo cannot yet win.
+
+The stronger claim is architectural:
+
+1. Transformer attention contains arithmetic and lookup-heavy nonlinear
+   structure that can be co-designed with a STARK backend.
+2. Fusing arithmetic and table membership avoids duplicated proof-system
+   plumbing that appears in separate source-plus-sidecar routes.
+3. The checked repo evidence already shows this saving across a bounded
+   profile family.
+4. The missing work is to strengthen the scaling controls, make accounting more
+   verifier-facing, and connect the bounded table policy to model-faithful
+   quantized attention.
+
+## Claim Boundary
+
+This matrix does not claim:
+
+- full LLM inference;
+- exact real-valued Softmax;
+- smallest proof among zkML systems;
+- public timing superiority;
+- production deployment;
+- complete literature coverage.
+
+## Sources
+
+- NANOZK: <https://arxiv.org/abs/2603.18046>
+- Jolt Atlas: <https://arxiv.org/abs/2602.17452>
+- zkLLM / zkAttn: <https://arxiv.org/abs/2404.16109>
+- DeepProve-1: <https://www.lagrange.dev/blog/deepprove-1>
+- EZKL docs: <https://docs.ezkl.xyz/>
+- RISC Zero proof system details: <https://dev.risczero.com/proof-system-in-detail.pdf>
+- stwo 2.2.0 crate docs: <https://docs.rs/crate/stwo/2.2.0>
+- S-two LogUp docs: <https://docs.starknet.io/learn/S-two-book/how-it-works/lookups>
+- S-two 2.0.0: <https://starkware.co/blog/s-two-2-0-0-prover-for-developers/>

--- a/scripts/tests/test_zkai_competitor_landscape_commitment_check.py
+++ b/scripts/tests/test_zkai_competitor_landscape_commitment_check.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "zkai_competitor_landscape_commitment_check.py"
+EVIDENCE_PATH = ROOT / "docs" / "engineering" / "evidence" / "zkai-competitor-landscape-2026-05.json"
+SPEC = importlib.util.spec_from_file_location("zkai_competitor_landscape_commitment_check", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load competitor landscape commitment checker from {SCRIPT_PATH}")
+CHECK = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECK)
+
+
+class ZkAiCompetitorLandscapeCommitmentCheckTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        with EVIDENCE_PATH.open("r", encoding="utf-8") as handle:
+            cls.payload = json.load(handle)
+
+    def fresh_payload(self) -> dict:
+        return copy.deepcopy(self.payload)
+
+    def test_checked_in_evidence_commitment_matches_systems(self) -> None:
+        self.assertEqual(
+            CHECK.check_path(EVIDENCE_PATH),
+            self.payload["systems_commitment"],
+        )
+
+    def test_rejects_stale_commitment_after_system_edit(self) -> None:
+        payload = self.fresh_payload()
+        payload["systems"][0]["name"] = "NANOZK drift"
+
+        with self.assertRaisesRegex(CHECK.CompetitorLandscapeCommitmentError, "systems commitment mismatch"):
+            CHECK.validate_payload(payload)
+
+    def test_rejects_malformed_commitment_fields(self) -> None:
+        payload = self.fresh_payload()
+        payload["systems_commitment_domain"] = ""
+        with self.assertRaisesRegex(CHECK.CompetitorLandscapeCommitmentError, "domain"):
+            CHECK.validate_payload(payload)
+
+        payload = self.fresh_payload()
+        payload["systems_commitment"] = "sha256:" + "00" * 32
+        with self.assertRaisesRegex(CHECK.CompetitorLandscapeCommitmentError, "blake2b-256"):
+            CHECK.validate_payload(payload)
+
+    def test_rejects_schema_and_domain_drift_after_recommit(self) -> None:
+        payload = self.fresh_payload()
+        payload["schema_version"] = True
+        with self.assertRaisesRegex(CHECK.CompetitorLandscapeCommitmentError, "schema_version"):
+            CHECK.validate_payload(payload)
+
+        payload = self.fresh_payload()
+        payload["schema"] = "zkai-competitor-landscape-v2"
+        with self.assertRaisesRegex(CHECK.CompetitorLandscapeCommitmentError, "schema"):
+            CHECK.validate_payload(payload)
+
+        payload = self.fresh_payload()
+        payload["systems_commitment_domain"] = "ptvm:zkai:competitor-landscape:systems:v2"
+        payload["systems_commitment"] = CHECK.systems_commitment(
+            payload["systems"],
+            payload["systems_commitment_domain"],
+        )
+        with self.assertRaisesRegex(CHECK.CompetitorLandscapeCommitmentError, "domain"):
+            CHECK.validate_payload(payload)
+
+    def test_rejects_symlink_evidence_path(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp_dir:
+            tmp = pathlib.Path(tmp_dir)
+            real = tmp / "real.json"
+            link = tmp / "link.json"
+            real.write_text(json.dumps(payload), encoding="utf-8")
+            link.symlink_to(real)
+
+            with self.assertRaisesRegex(CHECK.CompetitorLandscapeCommitmentError, "must not traverse symlinks"):
+                CHECK.check_path(link)
+            self.assertEqual(CHECK.main(["--evidence", str(link)]), 1)
+
+    def test_rejects_symlink_parent_path(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp_dir:
+            tmp = pathlib.Path(tmp_dir)
+            real_dir = tmp / "real"
+            real_dir.mkdir()
+            real = real_dir / "landscape.json"
+            link_dir = tmp / "linked"
+            real.write_text(json.dumps(payload), encoding="utf-8")
+            link_dir.symlink_to(real_dir, target_is_directory=True)
+
+            with self.assertRaisesRegex(CHECK.CompetitorLandscapeCommitmentError, "must not traverse symlinks"):
+                CHECK.check_path(link_dir / "landscape.json")
+
+    def test_main_returns_error_for_unreadable_or_invalid_payload(self) -> None:
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp_dir:
+            path = pathlib.Path(tmp_dir) / "bad.json"
+            path.write_bytes(b"\xff")
+            self.assertEqual(CHECK.main(["--evidence", str(path)]), 1)
+
+    def test_rejects_oversized_evidence_before_json_decode(self) -> None:
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp_dir:
+            path = pathlib.Path(tmp_dir) / "oversized.json"
+            path.write_text(" " * (CHECK.MAX_EVIDENCE_JSON_BYTES + 1), encoding="utf-8")
+            with self.assertRaisesRegex(CHECK.CompetitorLandscapeCommitmentError, "exceeds max size"):
+                CHECK.check_path(path)
+
+    def test_rejects_evidence_path_outside_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = pathlib.Path(tmp_dir) / "landscape.json"
+            path.write_text(json.dumps(self.fresh_payload()), encoding="utf-8")
+            self.assertEqual(CHECK.main(["--evidence", str(path)]), 1)
+
+    def test_cli_accepts_explicit_evidence_path(self) -> None:
+        payload = self.fresh_payload()
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp_dir:
+            path = pathlib.Path(tmp_dir) / "landscape.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            self.assertEqual(CHECK.main(["--evidence", str(path)]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/zkai_competitor_landscape_commitment_check.py
+++ b/scripts/zkai_competitor_landscape_commitment_check.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Verify the zkAI competitor landscape systems commitment."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import stat as stat_module
+import sys
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_EVIDENCE = ROOT / "docs" / "engineering" / "evidence" / "zkai-competitor-landscape-2026-05.json"
+MAX_EVIDENCE_JSON_BYTES = 1_048_576
+EXPECTED_SCHEMA_VERSION = 1
+EXPECTED_SCHEMA = "zkai-competitor-landscape-v1"
+EXPECTED_SYSTEMS_DOMAIN = "ptvm:zkai:competitor-landscape:systems:v1"
+
+
+class CompetitorLandscapeCommitmentError(ValueError):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def systems_commitment(systems: Any, domain: str) -> str:
+    digest = hashlib.blake2b(digest_size=32)
+    digest.update(domain.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(canonical_json_bytes(systems))
+    return f"blake2b-256:{digest.hexdigest()}"
+
+
+def _open_repo_regular_file(path: pathlib.Path) -> tuple[int, pathlib.Path]:
+    root = ROOT.resolve()
+    candidate = path if path.is_absolute() else ROOT / path
+    candidate = pathlib.Path(os.path.abspath(candidate))
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError as err:
+        raise CompetitorLandscapeCommitmentError(f"evidence path escapes repository: {path}") from err
+
+    current = root
+    pre_stat = None
+    try:
+        for part in relative.parts:
+            current = current / part
+            part_stat = current.lstat()
+            if stat_module.S_ISLNK(part_stat.st_mode):
+                raise CompetitorLandscapeCommitmentError(f"evidence path must not traverse symlinks: {path}")
+            pre_stat = part_stat
+        if pre_stat is None or not stat_module.S_ISREG(pre_stat.st_mode):
+            raise CompetitorLandscapeCommitmentError(f"evidence path is not a regular file: {path}")
+        fd = os.open(candidate, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            post_stat = os.fstat(fd)
+            if not stat_module.S_ISREG(post_stat.st_mode):
+                raise CompetitorLandscapeCommitmentError(f"evidence path is not a regular file: {path}")
+            if (post_stat.st_dev, post_stat.st_ino) != (pre_stat.st_dev, pre_stat.st_ino):
+                raise CompetitorLandscapeCommitmentError(f"evidence path changed while reading: {path}")
+            opened_fd = fd
+            fd = None
+            return opened_fd, candidate
+        finally:
+            if fd is not None:
+                os.close(fd)
+    except OSError as err:
+        raise CompetitorLandscapeCommitmentError(f"failed to read evidence path {path}: {err}") from err
+
+
+def load_payload(path: pathlib.Path) -> dict[str, Any]:
+    fd, _candidate = _open_repo_regular_file(path)
+    with os.fdopen(fd, "rb") as handle:
+        raw = handle.read(MAX_EVIDENCE_JSON_BYTES + 1)
+    if len(raw) > MAX_EVIDENCE_JSON_BYTES:
+        raise CompetitorLandscapeCommitmentError(
+            f"evidence JSON exceeds max size: got at least {len(raw)} bytes, limit {MAX_EVIDENCE_JSON_BYTES}"
+        )
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as err:
+        raise CompetitorLandscapeCommitmentError(f"invalid JSON in {path}: {err}") from err
+    if not isinstance(payload, dict):
+        raise CompetitorLandscapeCommitmentError("competitor landscape evidence must be a JSON object")
+    return payload
+
+
+def validate_payload(payload: dict[str, Any]) -> str:
+    schema_version = payload.get("schema_version")
+    if type(schema_version) is not int or schema_version != EXPECTED_SCHEMA_VERSION:
+        raise CompetitorLandscapeCommitmentError("schema_version drift")
+
+    schema = payload.get("schema")
+    if schema != EXPECTED_SCHEMA:
+        raise CompetitorLandscapeCommitmentError("schema drift")
+
+    domain = payload.get("systems_commitment_domain")
+    if domain != EXPECTED_SYSTEMS_DOMAIN:
+        raise CompetitorLandscapeCommitmentError("systems_commitment_domain drift")
+
+    stored = payload.get("systems_commitment")
+    if not isinstance(stored, str) or not stored.startswith("blake2b-256:"):
+        raise CompetitorLandscapeCommitmentError("systems_commitment must be a blake2b-256 commitment")
+    digest = stored.removeprefix("blake2b-256:")
+    if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+        raise CompetitorLandscapeCommitmentError("systems_commitment must contain a lowercase 32-byte hex digest")
+
+    systems = payload.get("systems")
+    if not isinstance(systems, list) or not systems:
+        raise CompetitorLandscapeCommitmentError("systems must be a non-empty list")
+
+    expected = systems_commitment(systems, domain)
+    if stored != expected:
+        raise CompetitorLandscapeCommitmentError(
+            f"systems commitment mismatch: stored {stored}, recomputed {expected}"
+        )
+    return expected
+
+
+def check_path(path: pathlib.Path) -> str:
+    return validate_payload(load_payload(path))
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--evidence",
+        type=pathlib.Path,
+        default=DEFAULT_EVIDENCE,
+        help="competitor landscape evidence JSON to validate",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        commitment = check_path(args.evidence)
+    except CompetitorLandscapeCommitmentError as err:
+        print(f"competitor landscape commitment check failed: {err}", file=sys.stderr)
+        return 1
+    print(f"competitor landscape systems commitment OK: {commitment}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a source-cited May 2026 zkML competitor landscape note.
- Add machine-readable JSON evidence with canonical system ids, `sources[]`, deterministic provenance, validation commands, and domain-separated `blake2b-256` `systems_commitment`.
- Add a checked-in fail-closed commitment checker that pins schema/domain, rejects symlink evidence paths and symlinked parents, bounds JSON reads, and catches stale commitment drift.
- Keep the claim boundary narrow: this repo competes on STARK-native fused proof architecture, not first/full/smallest zkML.

## Local validation
- `just gate-fast`
- `python3 -m json.tool docs/engineering/evidence/zkai-competitor-landscape-2026-05.json >/dev/null`
- `python3 scripts/zkai_competitor_landscape_commitment_check.py`
- `python3 scripts/research_issue_lint.py --repo-root .`
- `python3 -m unittest scripts.tests.test_research_issue_lint` (`15` tests)
- `python3 -m unittest scripts.tests.test_zkai_competitor_landscape_commitment_check` (`10` tests)
- `git diff --check`
- `just gate-no-nightly` passed all 14 local release-gate steps on head `7b345835`

## CI policy
- Do not use GitHub CI as the research loop. GitHub Actions remain manual-only; readiness is local validation plus Qodo/CodeRabbit review.
