### PR TITLE
Add STARK-native paper claim pack and production path

### DIFF
--- a/docs/engineering/zkai-production-path-starknet-stwo-backbone-2026-05.md
+++ b/docs/engineering/zkai-production-path-starknet-stwo-backbone-2026-05.md
@@ -8,6 +8,16 @@ evidence for bounded integer attention and Softmax-table membership fusion, but
 it has not crossed into runtime, public benchmark, production, or Starknet
 deployment claims.
 
+Pinned context: this note is scoped to `llm-provable-computer@0.1.0` with the
+`stwo-backend` feature, `stwo@2.2.0`,
+`stwo-constraint-framework@2.2.0`, and the local release gate pinned to
+`nightly-2025-07-14`. Proof-size claims cite the checked route matrix,
+controlled component grid, and local binary typed-accounting evidence under
+`docs/engineering/evidence/`; timing evidence is only
+`median_of_5_existing_typed_envelope_verifier_runs_microsecond_capture_engineering_only`
+from `zkai-attention-kv-stwo-softmax-table-median-timing-2026-05.json`, not a
+public benchmark or verifier-time win claim.
+
 ## Phase 0 - Current Artifact Discipline
 
 Status: `GO_ENGINEERING_EVIDENCE_DISCIPLINE`

--- a/docs/engineering/zkai-production-path-starknet-stwo-backbone-2026-05.md
+++ b/docs/engineering/zkai-production-path-starknet-stwo-backbone-2026-05.md
@@ -1,0 +1,180 @@
+# zkAI Production Path: Starknet/Stwo Backbone - 2026-05
+
+## Purpose
+
+This is the production path implied by the current paper claim pack. It keeps
+the claim sequence explicit: the repo has checked STARK-native proof-architecture
+evidence for bounded integer attention and Softmax-table membership fusion, but
+it has not crossed into runtime, public benchmark, production, or Starknet
+deployment claims.
+
+## Phase 0 - Current Artifact Discipline
+
+Status: `GO_ENGINEERING_EVIDENCE_DISCIPLINE`
+
+- Keep every frontier claim backed by checked JSON/TSV evidence and a focused
+  local gate.
+- Keep artifact outputs in `docs/engineering/evidence/` and paper-facing claim
+  packs in `docs/paper/`.
+- Treat generated evidence as untrusted I/O: constrain paths, reject symlinks,
+  write atomically, and validate schema/claim boundaries before citing.
+- Continue separating proof-size evidence, timing evidence, runtime evidence,
+  and deployment evidence.
+
+Release gate:
+
+- `just gate-fast`
+- `python3 scripts/zkai_paper_claim_pack_gate.py --write-json docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json`
+- `python3 -m unittest scripts.tests.test_zkai_paper_claim_pack_gate`
+- `git diff --check`
+- `just gate`
+
+## Phase 1 - Binary Proof Accounting
+
+Status: `GO_LOCAL_TYPED_ACCOUNTING`, `NO_GO_UPSTREAM_STWO_WIRE_FORMAT`
+
+Current handle:
+
+- `docs/engineering/zkai-attention-kv-stwo-binary-typed-proof-accounting-2026-05-12.md`
+- `docs/engineering/evidence/zkai-attention-kv-stwo-binary-typed-proof-accounting-2026-05.json`
+
+Next gates:
+
+1. Extend repo-owned typed accounting beyond the d32 matched slice to the full
+   checked route matrix.
+2. Add stable version pins for every typed component inventory.
+3. Keep upstream Stwo proof serialization as a blocker until verifier-facing
+   binary bytes are available and checked.
+
+Exit criterion:
+
+- A release candidate can explain exact local typed accounting bytes for every
+  proof object it packages, with no claim that those bytes are upstream Stwo
+  wire-format bytes.
+
+## Phase 2 - Timing Discipline
+
+Status: `GO_ENGINEERING_LOCAL_MEDIAN_OF_5_DISCIPLINE`, `NO_GO_PUBLIC_BENCHMARK`
+
+Current handle:
+
+- `docs/engineering/zkai-attention-kv-stwo-softmax-table-median-timing-2026-05-12.md`
+- `docs/engineering/evidence/zkai-attention-kv-stwo-softmax-table-median-timing-2026-05.json`
+
+Next gates:
+
+1. Keep median-of-5 verifier timing as engineering-local discipline.
+2. Add host metadata, CPU pinning policy, thermal notes, and reproducibility
+   constraints before any paper-facing performance claim.
+3. Do not turn the current timing result into a fused verifier-time win; the
+   measured fused routes were slower than source-plus-sidecar median sums on
+   this host.
+
+Exit criterion:
+
+- Timing can be used as a release health metric, not as a public performance
+  claim, until a stronger benchmark policy is adopted.
+
+## Phase 3 - Model-Faithful Quantized Attention
+
+Status: `GO_D8_TRACE_BOUNDARY_BRIDGE`, `NO_GO_FULL_RUNTIME`
+
+Current handle:
+
+- `docs/engineering/zkai-attention-kv-model-faithful-quantized-attention-bridge-2026-05.md`
+- `docs/engineering/evidence/zkai-attention-kv-model-faithful-quantized-attention-bridge-2026-05.json`
+
+Next gates:
+
+1. Bind the quantized policy to a real model import path.
+2. Add tokenizer, weights, and runtime configuration commitments.
+3. Measure accuracy/perplexity delta against the quantized policy before model
+   claims.
+4. Extend beyond the checked d8 fixture trace without changing the Softmax
+   claim boundary.
+
+Exit criterion:
+
+- A model artifact can state exactly which quantized attention policy it uses,
+  which trace rows are checked, and which runtime/model commitments are bound.
+
+## Phase 4 - Verifier and Proof Packaging
+
+Status: `NO_GO_RELEASE_PACKAGING`
+
+Next gates:
+
+1. Package proof envelopes, typed accounting, evidence commitments, and
+   non-claim metadata into one verifier-facing bundle.
+2. Add compatibility tests for schema versions, backend versions, proof-backend
+   inventory, and rejected overclaim fields.
+3. Define the minimal verifier API: proof bytes, public statement, table
+   commitment, route metadata, claim boundary, and evidence commitment.
+4. Add replay and tamper tests for bundle relabeling, stale evidence, missing
+   non-claims, backend-version drift, and route mismatch.
+
+Exit criterion:
+
+- A local verifier can reject malformed or overclaimed packages without relying
+  on prose docs.
+
+## Phase 5 - Starknet/Stwo Integration
+
+Status: `NO_GO_STARKNET_DEPLOYMENT`
+
+Next gates:
+
+1. Decide whether Starknet integration verifies native Stwo proofs directly,
+   verifies a wrapped proof, or records a settlement/attestation object for an
+   off-chain verifier.
+2. Account calldata, storage, verifier cost, and proof-object binary format.
+3. Bind chain ID, verifier version, route ID, statement commitment, table
+   commitment, and evidence commitment in the on-chain or settlement surface.
+4. Add Sepolia rehearsal gates before any mainnet wording.
+
+Exit criterion:
+
+- A Starknet integration candidate has a checked verifier/settlement path,
+  deployment artifacts, chain-specific addresses, and tamper-path tests.
+
+## Phase 6 - Security Hardening
+
+Status: `NO_GO_SECURITY_RELEASE`
+
+Hardening gates:
+
+- Reject symlinked or out-of-tree evidence inputs.
+- Bound proof and evidence input sizes.
+- Pin exact backend versions and proof backend inventories.
+- Reject claim-boundary drift and non-claim removal.
+- Add rollback-safe atomic writes for generated evidence.
+- Add negative tests for stale proof envelopes, route relabeling, table
+  commitment drift, model-policy drift, and backend-version drift.
+- Separate publication/default-lane claims from experimental-lane results.
+
+Exit criterion:
+
+- The release candidate fails closed on malformed artifacts, stale evidence,
+  relabeled claims, and missing non-claims.
+
+## Phase 7 - Release Gates
+
+Status: `NO_GO_PRODUCTION_RELEASE`
+
+Minimum gates before production language:
+
+1. Stable verifier-facing proof bytes, not only local typed accounting.
+2. Checked package schema and local verifier with adversarial negative tests.
+3. Reproducible timing policy with host metadata and release threshold.
+4. Model import, runtime, tokenizer/weights, and accuracy/perplexity evidence.
+5. Starknet integration path with network-specific deployment evidence.
+6. Security review of artifact handling, verifier inputs, and claim-boundary
+   enforcement.
+7. Clear rollback and incident-response plan for bad evidence or verifier
+   regressions.
+
+Until those gates pass, the correct public posture remains:
+
+> Bounded STARK-native proof-architecture evidence for fusing attention
+> arithmetic and Softmax-table membership, with checked artifact discipline and
+> an explicit production path.

--- a/docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
+++ b/docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
@@ -91,6 +91,10 @@
       "rejected": true
     },
     {
+      "name": "no_go_posture_removed",
+      "rejected": true
+    },
+    {
       "name": "unknown_field_injection",
       "rejected": true
     }
@@ -116,7 +120,7 @@
     "Section-delta and typed-component evidence both point to shared opening and decommitment structure as the dominant source of savings.",
     "A model-facing quantized attention policy is checked equivalent to the existing d8 bounded Softmax-table fixture trace at the trace boundary."
   ],
-  "payload_commitment": "sha256:a663f27ff65c925760a3a84f759f6115becf1dd15cfb3cc4f6629d817468f000",
+  "payload_commitment": "sha256:682399c442e74decad977ea4aada6128142980fc2c3950a4a8f06121747278c3",
   "schema": "stark-native-transformer-paper-claim-pack-v1",
   "thesis": "Checked Stwo evidence supports a paper-facing architecture claim: bounded integer attention arithmetic and Softmax-table LogUp membership can be fused into one native STARK proof object, sharing proof-system commitment and opening plumbing across the arithmetic and lookup-heavy parts.",
   "thesis_id": "stark_native_attention_arithmetic_softmax_table_fusion",

--- a/docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
+++ b/docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
@@ -1,0 +1,130 @@
+{
+  "blockers": [
+    "stable verifier-facing binary proof serialization is not exposed upstream by Stwo in this repo surface",
+    "backend-internal source-arithmetic versus lookup-column byte attribution is still a NO-GO",
+    "local median-of-5 verifier timing does not support a fused verifier-time win claim",
+    "model-faithful quantized attention is bridged only for the checked d8 fixture trace",
+    "production Starknet verifier packaging, calldata/accounting, and deployment gates are not complete",
+    "no full transformer runtime, tokenizer/model-weight import, or accuracy/perplexity gate is bound"
+  ],
+  "claim_boundary": "STARK_NATIVE_PROOF_ARCHITECTURE_CLAIM_FOR_BOUNDED_INTEGER_ATTENTION_AND_SOFTMAX_TABLE_LOOKUP_MEMBERSHIP_NOT_EXACT_SOFTMAX_NOT_FULL_INFERENCE_NOT_PUBLIC_BENCHMARK_NOT_PRODUCTION_READY",
+  "decision": "GO_PAPER_CLAIM_PACK_NO_GO_PUBLIC_OR_PRODUCTION_CLAIMS",
+  "evidence_refs": [
+    {
+      "id": "route_matrix",
+      "path": "docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json",
+      "supports": "eleven checked source-sidecar-fused route rows with matched proof-byte ratios"
+    },
+    {
+      "id": "controlled_component_grid",
+      "path": "docs/engineering/evidence/zkai-attention-kv-stwo-controlled-component-grid-2026-05.json",
+      "supports": "ten checked fine-grained typed-component rows with positive fused savings"
+    },
+    {
+      "id": "section_delta",
+      "path": "docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-section-delta-2026-05.json",
+      "supports": "opening/decommitment dominated JSON section-delta savings"
+    },
+    {
+      "id": "typed_size_estimate",
+      "path": "docs/engineering/evidence/zkai-attention-kv-stwo-typed-size-estimate-2026-05.json",
+      "supports": "Stwo typed size-estimate savings without claiming stable binary serialization"
+    },
+    {
+      "id": "binary_typed_accounting",
+      "path": "docs/engineering/evidence/zkai-attention-kv-stwo-binary-typed-proof-accounting-2026-05.json",
+      "supports": "repo-owned local binary typed accounting over d32 matched envelopes"
+    },
+    {
+      "id": "median_timing",
+      "path": "docs/engineering/evidence/zkai-attention-kv-stwo-softmax-table-median-timing-2026-05.json",
+      "supports": "engineering-only median-of-5 verifier timing discipline and timing non-claim"
+    },
+    {
+      "id": "seq32_fused",
+      "path": "docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-seq32-fused-softmax-table-gate-2026-05.json",
+      "supports": "two-head d8 seq32 fused proof existence and matched source-sidecar comparison"
+    },
+    {
+      "id": "model_faithful_bridge",
+      "path": "docs/engineering/evidence/zkai-attention-kv-model-faithful-quantized-attention-bridge-2026-05.json",
+      "supports": "checked equivalence between model-facing integer attention policy and the d8 fixture trace"
+    }
+  ],
+  "go_criteria_satisfied": [
+    "checked source, sidecar, and fused proof evidence exists for the cited profiles",
+    "machine-readable gates reject overclaim and evidence-drift mutations",
+    "timing evidence is separated from proof-size evidence",
+    "model-facing quantized policy is bridge-checked before runtime integration"
+  ],
+  "go_posture": [
+    "GO to present a bounded STARK-native proof-architecture claim in the paper evidence pack.",
+    "GO to cite proof-existence, matched proof-byte accounting, typed-size accounting, and claim-boundary discipline."
+  ],
+  "mutation_cases": [
+    {
+      "name": "positive_full_inference_overclaim",
+      "rejected": true
+    },
+    {
+      "name": "positive_exact_softmax_overclaim",
+      "rejected": true
+    },
+    {
+      "name": "positive_public_benchmark_overclaim",
+      "rejected": true
+    },
+    {
+      "name": "positive_production_ready_overclaim",
+      "rejected": true
+    },
+    {
+      "name": "evidence_path_missing",
+      "rejected": true
+    },
+    {
+      "name": "non_claim_removed",
+      "rejected": true
+    },
+    {
+      "name": "blocker_removed",
+      "rejected": true
+    },
+    {
+      "name": "unknown_field_injection",
+      "rejected": true
+    }
+  ],
+  "no_go_posture": [
+    "NO-GO for public performance or production deployment language.",
+    "NO-GO for runtime, accuracy, recursion, PCD, or Starknet deployment claims.",
+    "NO-GO for verifier-time improvement claims from the current timing run."
+  ],
+  "non_claims": [
+    "not exact real-valued Softmax",
+    "not full inference",
+    "not public benchmark",
+    "not production-ready",
+    "not Starknet deployed",
+    "not a stable upstream Stwo proof wire format",
+    "not recursion or PCD",
+    "not model accuracy, perplexity, tokenizer, weight-import, or runtime evidence"
+  ],
+  "paper_claims": [
+    "One checked proof object can bind attention arithmetic and statement-bound Softmax-table membership for the same bounded fixture family.",
+    "Matched source-plus-sidecar controls show proof-object byte savings across checked width, head-count, sequence-length, and combined-axis profiles.",
+    "Section-delta and typed-component evidence both point to shared opening and decommitment structure as the dominant source of savings.",
+    "A model-facing quantized attention policy is checked equivalent to the existing d8 bounded Softmax-table fixture trace at the trace boundary."
+  ],
+  "payload_commitment": "sha256:a663f27ff65c925760a3a84f759f6115becf1dd15cfb3cc4f6629d817468f000",
+  "schema": "stark-native-transformer-paper-claim-pack-v1",
+  "thesis": "Checked Stwo evidence supports a paper-facing architecture claim: bounded integer attention arithmetic and Softmax-table LogUp membership can be fused into one native STARK proof object, sharing proof-system commitment and opening plumbing across the arithmetic and lookup-heavy parts.",
+  "thesis_id": "stark_native_attention_arithmetic_softmax_table_fusion",
+  "validation_commands": [
+    "just gate-fast",
+    "python3 scripts/zkai_paper_claim_pack_gate.py --write-json docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json",
+    "python3 -m unittest scripts.tests.test_zkai_paper_claim_pack_gate",
+    "git diff --check",
+    "just gate"
+  ]
+}

--- a/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
+++ b/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
@@ -1,0 +1,127 @@
+# STARK-Native Transformer Proof Claim Pack - 2026-05
+
+## Thesis
+
+The current evidence supports a bounded paper-facing thesis:
+
+> STARK-native transformer proofs can fuse attention arithmetic and
+> lookup-heavy bounded Softmax-table membership into one proof object, sharing
+> commitment and opening plumbing that would otherwise be paid by separate
+> source-arithmetic and lookup-sidecar proofs.
+
+This is a proof-architecture claim over checked bounded integer attention
+fixtures. It is not a claim about exact real-valued Softmax, full model
+inference, public benchmark performance, production readiness, recursion, PCD,
+or Starknet deployment.
+
+## Defensible Claims
+
+1. Native Stwo evidence now checks source arithmetic, LogUp sidecar, and fused
+   proof objects for a controlled Softmax-table route family.
+2. The checked route matrix has eleven matched rows across width, head-count,
+   sequence-length, and combined-axis profiles, with fused proof bytes smaller
+   than source-plus-sidecar proof bytes in each row.
+3. The section-delta and typed-size evidence agree on the mechanism: the fused
+   object mostly avoids duplicated opening/decommitment structure.
+4. The local binary typed accounting slice gives deterministic repo-owned
+   accounting over typed Stwo proof fields, while explicitly keeping upstream
+   stable proof serialization as a non-claim.
+5. The model-faithful bridge checks that the existing d8 bounded Softmax-table
+   fixture trace is exactly the trace emitted by a model-facing quantized
+   attention policy at the trace boundary.
+
+## Evidence Handles
+
+- Route matrix:
+  `docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json`
+- Controlled component grid:
+  `docs/engineering/evidence/zkai-attention-kv-stwo-controlled-component-grid-2026-05.json`
+- Section delta:
+  `docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-section-delta-2026-05.json`
+- Typed size estimate:
+  `docs/engineering/evidence/zkai-attention-kv-stwo-typed-size-estimate-2026-05.json`
+- Binary typed accounting:
+  `docs/engineering/evidence/zkai-attention-kv-stwo-binary-typed-proof-accounting-2026-05.json`
+- Median timing discipline:
+  `docs/engineering/evidence/zkai-attention-kv-stwo-softmax-table-median-timing-2026-05.json`
+- Seq32 fused route:
+  `docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-seq32-fused-softmax-table-gate-2026-05.json`
+- Model-faithful bridge:
+  `docs/engineering/evidence/zkai-attention-kv-model-faithful-quantized-attention-bridge-2026-05.json`
+- Machine-readable claim pack:
+  `docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json`
+
+## Quantitative Core
+
+The route matrix records eleven checked matched profiles. Across those rows,
+the fused proof bytes total `736,727` versus `930,824` bytes for the matched
+source-plus-sidecar controls, a `194,097` byte aggregate saving. Matched fused
+ratios range from `0.676723` to `0.919259`.
+
+The controlled component grid records ten checked fine-grained typed-component
+profiles. The source-plus-sidecar typed estimate totals `285,584` bytes and the
+fused typed estimate totals `234,296` bytes, a `51,288` byte (`17.9590%`)
+aggregate saving. Per-profile typed saving ranges from `9.1035%` to `27.7371%`.
+
+The section-delta evidence attributes `92.7722%` of the serialized proof-byte
+saving to the opening bucket, dominated by FRI proof and decommitment material.
+The typed-size evidence similarly shows decommitment-dominated savings, with
+FRI plus trace decommitments accounting for `36,896` of `42,492` typed-estimate
+saved bytes in the checked nine-profile slice.
+
+The seq32 extension is the strongest sequence-axis row in the current route
+matrix: `d8`, two heads, `32` steps per head, `1,184` lookup claims, `2,048`
+trace rows, `66,327` fused proof bytes, and `98,012` source-plus-sidecar proof
+bytes, for a `0.676723` fused ratio.
+
+## GO / NO-GO Posture
+
+GO:
+
+- Use the claim that bounded attention arithmetic and Softmax-table membership
+  can be fused into one native Stwo proof object.
+- Use matched proof-byte, typed-size, section-delta, and component-grid evidence
+  as proof-architecture support.
+- Say the observed savings are dominated by shared opening/decommitment
+  plumbing.
+- Say the d8 fixture now has a checked model-facing quantized-attention bridge
+  at the trace boundary.
+
+NO-GO:
+
+- Do not describe this as exact real-valued Softmax.
+- Do not describe this as full inference or a complete transformer runtime.
+- Do not describe this as a public benchmark or a verifier-time win.
+- Do not describe this as production-ready or Starknet deployed.
+- Do not describe the local accounting stream as upstream Stwo proof
+  serialization.
+- Do not claim backend-internal source-vs-lookup byte attribution.
+
+## Blockers
+
+1. Stable verifier-facing binary Stwo proof serialization is not exposed on this
+   repo surface.
+2. Backend-internal attribution between source arithmetic and lookup columns is
+   still missing.
+3. The local median-of-5 timing gate is discipline only; it does not support a
+   fused verifier-time win claim.
+4. The model-faithful bridge covers the checked d8 fixture trace only.
+5. Starknet verifier packaging, calldata accounting, deployment, release gates,
+   and adversarial integration hardening remain incomplete.
+6. No tokenizer/model-weight import, full runtime, accuracy, or perplexity gate
+   is bound.
+
+## Validation
+
+```bash
+just gate-fast
+
+python3 scripts/zkai_paper_claim_pack_gate.py \
+  --write-json docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
+
+python3 -m unittest scripts.tests.test_zkai_paper_claim_pack_gate
+
+git diff --check
+
+just gate
+```

--- a/scripts/tests/test_zkai_paper_claim_pack_gate.py
+++ b/scripts/tests/test_zkai_paper_claim_pack_gate.py
@@ -30,9 +30,17 @@ class PaperClaimPackGateTests(unittest.TestCase):
         expected = set(gate.EXPECTED_MUTATION_NAMES)
         actual = {name for name, _ in gate.mutation_cases(self.payload)}
         self.assertEqual(actual, expected)
+        self.assertIn("no_go_posture_removed", actual)
         for name, mutated in gate.mutation_cases(self.payload):
             with self.assertRaises(gate.ClaimPackGateError, msg=name):
                 gate.validate_payload(mutated)
+
+    def test_rejects_no_go_posture_drift_even_when_commitment_is_refreshed(self):
+        mutated = copy.deepcopy(self.payload)
+        mutated["no_go_posture"] = mutated["no_go_posture"][1:]
+        mutated["payload_commitment"] = gate.payload_commitment(mutated)
+        with self.assertRaisesRegex(gate.ClaimPackGateError, "no_go_posture drift"):
+            gate.validate_payload(mutated)
 
     def test_rejects_positive_overclaims_even_when_commitment_is_refreshed(self):
         for text in [

--- a/scripts/tests/test_zkai_paper_claim_pack_gate.py
+++ b/scripts/tests/test_zkai_paper_claim_pack_gate.py
@@ -122,6 +122,28 @@ class PaperClaimPackGateTests(unittest.TestCase):
             with self.assertRaisesRegex(gate.ClaimPackGateError, "output path must be repo-relative"):
                 gate.write_json(gate.pathlib.Path(tmp) / "claim-pack.json", self.payload)
 
+    def test_write_json_rejects_drive_qualified_output(self):
+        with self.assertRaisesRegex(gate.ClaimPackGateError, "output path must be repo-relative"):
+            gate.write_json(gate.pathlib.Path(r"C:\tmp\claim-pack.json"), self.payload)
+
+    def test_write_json_accepts_backslash_relative_output(self):
+        with tempfile.NamedTemporaryFile(
+            dir=gate.ALLOWED_OUTPUT_DIR,
+            prefix="claim-pack-backslash-test-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            path = gate.pathlib.Path(handle.name)
+        path.unlink()
+        relative = path.relative_to(gate.ROOT)
+        backslash_relative = gate.pathlib.Path("\\".join(relative.parts))
+        try:
+            gate.write_json(backslash_relative, self.payload)
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(loaded, self.payload)
+        finally:
+            path.unlink(missing_ok=True)
+
     def test_write_json_rejects_outside_allowed_output_dir(self):
         with self.assertRaisesRegex(gate.ClaimPackGateError, "output path must stay under docs/paper/evidence"):
             gate.write_json(gate.pathlib.Path("docs/engineering/evidence/claim-pack.json"), self.payload)

--- a/scripts/tests/test_zkai_paper_claim_pack_gate.py
+++ b/scripts/tests/test_zkai_paper_claim_pack_gate.py
@@ -1,0 +1,75 @@
+import copy
+import json
+import tempfile
+import unittest
+
+from scripts import zkai_paper_claim_pack_gate as gate
+
+
+class PaperClaimPackGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.payload = gate.build_payload()
+        gate.validate_payload(self.payload)
+
+    def test_binds_narrow_thesis_and_non_claims(self):
+        self.assertEqual(self.payload["decision"], gate.DECISION)
+        self.assertIn("STARK-native proof-architecture", self.payload["go_posture"][0])
+        self.assertIn("not full inference", self.payload["non_claims"])
+        self.assertIn("not public benchmark", self.payload["non_claims"])
+        self.assertIn("not production-ready", self.payload["non_claims"])
+        self.assertIn("not exact real-valued Softmax", self.payload["non_claims"])
+
+    def test_referenced_evidence_paths_exist(self):
+        paths = [gate.ROOT / ref["path"] for ref in self.payload["evidence_refs"]]
+        self.assertGreaterEqual(len(paths), 8)
+        for path in paths:
+            self.assertTrue(path.is_file(), path)
+
+    def test_all_declared_mutations_reject(self):
+        expected = set(gate.EXPECTED_MUTATION_NAMES)
+        actual = {name for name, _ in gate.mutation_cases(self.payload)}
+        self.assertEqual(actual, expected)
+        for name, mutated in gate.mutation_cases(self.payload):
+            with self.assertRaises(gate.ClaimPackGateError, msg=name):
+                gate.validate_payload(mutated)
+
+    def test_rejects_positive_overclaims_even_when_commitment_is_refreshed(self):
+        for text in [
+            "This proves full inference.",
+            "This is exact Softmax.",
+            "This is a public benchmark.",
+            "This is production-ready.",
+        ]:
+            mutated = copy.deepcopy(self.payload)
+            mutated["paper_claims"][0] = text
+            mutated["payload_commitment"] = gate.payload_commitment(mutated)
+            with self.assertRaisesRegex(gate.ClaimPackGateError, "positive claim overclaim"):
+                gate.validate_payload(mutated)
+
+    def test_rejects_missing_evidence_even_when_commitment_is_refreshed(self):
+        mutated = copy.deepcopy(self.payload)
+        mutated["evidence_refs"][0]["path"] = "docs/engineering/evidence/does-not-exist.json"
+        mutated["payload_commitment"] = gate.payload_commitment(mutated)
+        with self.assertRaisesRegex(gate.ClaimPackGateError, "missing evidence path"):
+            gate.validate_payload(mutated)
+
+    def test_write_json_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = gate.pathlib.Path(tmp) / "claim-pack.json"
+            gate.write_json(path, self.payload)
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(loaded, self.payload)
+
+    def test_write_json_rejects_symlink_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = gate.pathlib.Path(tmp)
+            target = tmp_path / "target.json"
+            target.write_text("{}", encoding="utf-8")
+            link = tmp_path / "link.json"
+            link.symlink_to(target)
+            with self.assertRaisesRegex(gate.ClaimPackGateError, "output path must not be a symlink"):
+                gate.write_json(link, self.payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_paper_claim_pack_gate.py
+++ b/scripts/tests/test_zkai_paper_claim_pack_gate.py
@@ -53,22 +53,99 @@ class PaperClaimPackGateTests(unittest.TestCase):
         with self.assertRaisesRegex(gate.ClaimPackGateError, "missing evidence path"):
             gate.validate_payload(mutated)
 
-    def test_write_json_round_trip(self):
+    def test_rejects_symlinked_evidence_parent_even_when_commitment_is_refreshed(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = gate.pathlib.Path(tmp) / "claim-pack.json"
-            gate.write_json(path, self.payload)
+            outside_dir = gate.pathlib.Path(tmp) / "outside"
+            outside_dir.mkdir()
+            (outside_dir / "ok.json").write_text("{}", encoding="utf-8")
+            with tempfile.NamedTemporaryFile(
+                dir=gate.ROOT / "docs" / "engineering",
+                prefix="claim-pack-evidence-link-",
+                delete=False,
+            ) as handle:
+                link = gate.pathlib.Path(handle.name)
+            link.unlink()
+            try:
+                link.symlink_to(outside_dir, target_is_directory=True)
+            except OSError as err:
+                self.skipTest(f"symlink creation is unavailable: {err}")
+            try:
+                mutated = copy.deepcopy(self.payload)
+                mutated["evidence_refs"][0]["path"] = (link.relative_to(gate.ROOT) / "ok.json").as_posix()
+                mutated["payload_commitment"] = gate.payload_commitment(mutated)
+                with self.assertRaisesRegex(gate.ClaimPackGateError, "symlink components"):
+                    gate.validate_payload(mutated)
+            finally:
+                link.unlink(missing_ok=True)
+
+    def test_write_json_round_trip(self):
+        with tempfile.NamedTemporaryFile(
+            dir=gate.ALLOWED_OUTPUT_DIR,
+            prefix="claim-pack-test-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            path = gate.pathlib.Path(handle.name)
+        path.unlink()
+        try:
+            gate.write_json(path.relative_to(gate.ROOT), self.payload)
             loaded = json.loads(path.read_text(encoding="utf-8"))
             self.assertEqual(loaded, self.payload)
+        finally:
+            path.unlink(missing_ok=True)
 
     def test_write_json_rejects_symlink_output(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = gate.pathlib.Path(tmp)
             target = tmp_path / "target.json"
             target.write_text("{}", encoding="utf-8")
-            link = tmp_path / "link.json"
-            link.symlink_to(target)
-            with self.assertRaisesRegex(gate.ClaimPackGateError, "output path must not be a symlink"):
-                gate.write_json(link, self.payload)
+            with tempfile.NamedTemporaryFile(
+                dir=gate.ALLOWED_OUTPUT_DIR,
+                prefix="claim-pack-link-",
+                suffix=".json",
+                delete=False,
+            ) as handle:
+                link = gate.pathlib.Path(handle.name)
+            link.unlink()
+            try:
+                link.symlink_to(target)
+            except OSError as err:
+                self.skipTest(f"symlink creation is unavailable: {err}")
+            try:
+                with self.assertRaisesRegex(gate.ClaimPackGateError, "output path must not be a symlink"):
+                    gate.write_json(link.relative_to(gate.ROOT), self.payload)
+            finally:
+                link.unlink(missing_ok=True)
+
+    def test_write_json_rejects_outside_repo_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(gate.ClaimPackGateError, "output path must be repo-relative"):
+                gate.write_json(gate.pathlib.Path(tmp) / "claim-pack.json", self.payload)
+
+    def test_write_json_rejects_outside_allowed_output_dir(self):
+        with self.assertRaisesRegex(gate.ClaimPackGateError, "output path must stay under docs/paper/evidence"):
+            gate.write_json(gate.pathlib.Path("docs/engineering/evidence/claim-pack.json"), self.payload)
+
+    def test_write_json_rejects_symlink_output_parent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            outside_dir = gate.pathlib.Path(tmp) / "outside"
+            outside_dir.mkdir()
+            with tempfile.NamedTemporaryFile(
+                dir=gate.ALLOWED_OUTPUT_DIR,
+                prefix="claim-pack-parent-link-",
+                delete=False,
+            ) as handle:
+                link = gate.pathlib.Path(handle.name)
+            link.unlink()
+            try:
+                link.symlink_to(outside_dir, target_is_directory=True)
+            except OSError as err:
+                self.skipTest(f"symlink creation is unavailable: {err}")
+            try:
+                with self.assertRaisesRegex(gate.ClaimPackGateError, "symlink components"):
+                    gate.write_json((link / "claim-pack.json").relative_to(gate.ROOT), self.payload)
+            finally:
+                link.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_zkai_paper_claim_pack_gate.py
+++ b/scripts/tests/test_zkai_paper_claim_pack_gate.py
@@ -18,6 +18,7 @@ class PaperClaimPackGateTests(unittest.TestCase):
         self.assertIn("not public benchmark", self.payload["non_claims"])
         self.assertIn("not production-ready", self.payload["non_claims"])
         self.assertIn("not exact real-valued Softmax", self.payload["non_claims"])
+        self.assertEqual(self.payload["no_go_posture"], gate.NO_GO_POSTURE)
 
     def test_referenced_evidence_paths_exist(self):
         paths = [gate.ROOT / ref["path"] for ref in self.payload["evidence_refs"]]

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Paper claim-pack validator for the Stwo attention/Softmax-table evidence.
+
+This gate is intentionally small. It checks that the machine-readable paper
+claim pack stays narrow, that every referenced checked evidence path exists,
+and that positive claim fields do not drift into public-benchmark, exact
+Softmax, full-inference, or production-ready language.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import pathlib
+import re
+import sys
+import tempfile
+from typing import Any, Iterable
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+JSON_OUT = ROOT / "docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json"
+
+SCHEMA = "stark-native-transformer-paper-claim-pack-v1"
+DECISION = "GO_PAPER_CLAIM_PACK_NO_GO_PUBLIC_OR_PRODUCTION_CLAIMS"
+THESIS_ID = "stark_native_attention_arithmetic_softmax_table_fusion"
+CLAIM_BOUNDARY = (
+    "STARK_NATIVE_PROOF_ARCHITECTURE_CLAIM_FOR_BOUNDED_INTEGER_ATTENTION_AND_SOFTMAX_TABLE_"
+    "LOOKUP_MEMBERSHIP_NOT_EXACT_SOFTMAX_NOT_FULL_INFERENCE_NOT_PUBLIC_BENCHMARK_NOT_PRODUCTION_READY"
+)
+
+FORBIDDEN_POSITIVE_CLAIM_PATTERNS = {
+    "full inference": re.compile(r"\bfull\s+(?:transformer\s+)?inference\b", re.IGNORECASE),
+    "exact softmax": re.compile(r"\bexact\s+(?:real-valued\s+)?softmax\b", re.IGNORECASE),
+    "public benchmark": re.compile(r"\bpublic\s+benchmark\b", re.IGNORECASE),
+    "production-ready": re.compile(r"\bproduction[-\s]?ready\b", re.IGNORECASE),
+    "starknet deployed": re.compile(r"\bstarknet\s+(?:mainnet\s+)?deployed\b", re.IGNORECASE),
+}
+
+POSITIVE_TEXT_FIELDS = (
+    "thesis",
+    "paper_claims",
+    "go_posture",
+    "go_criteria_satisfied",
+)
+
+NON_CLAIMS = [
+    "not exact real-valued Softmax",
+    "not full inference",
+    "not public benchmark",
+    "not production-ready",
+    "not Starknet deployed",
+    "not a stable upstream Stwo proof wire format",
+    "not recursion or PCD",
+    "not model accuracy, perplexity, tokenizer, weight-import, or runtime evidence",
+]
+
+BLOCKERS = [
+    "stable verifier-facing binary proof serialization is not exposed upstream by Stwo in this repo surface",
+    "backend-internal source-arithmetic versus lookup-column byte attribution is still a NO-GO",
+    "local median-of-5 verifier timing does not support a fused verifier-time win claim",
+    "model-faithful quantized attention is bridged only for the checked d8 fixture trace",
+    "production Starknet verifier packaging, calldata/accounting, and deployment gates are not complete",
+    "no full transformer runtime, tokenizer/model-weight import, or accuracy/perplexity gate is bound",
+]
+
+EVIDENCE_REFS = [
+    {
+        "id": "route_matrix",
+        "path": "docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json",
+        "supports": "eleven checked source-sidecar-fused route rows with matched proof-byte ratios",
+    },
+    {
+        "id": "controlled_component_grid",
+        "path": "docs/engineering/evidence/zkai-attention-kv-stwo-controlled-component-grid-2026-05.json",
+        "supports": "ten checked fine-grained typed-component rows with positive fused savings",
+    },
+    {
+        "id": "section_delta",
+        "path": "docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-section-delta-2026-05.json",
+        "supports": "opening/decommitment dominated JSON section-delta savings",
+    },
+    {
+        "id": "typed_size_estimate",
+        "path": "docs/engineering/evidence/zkai-attention-kv-stwo-typed-size-estimate-2026-05.json",
+        "supports": "Stwo typed size-estimate savings without claiming stable binary serialization",
+    },
+    {
+        "id": "binary_typed_accounting",
+        "path": "docs/engineering/evidence/zkai-attention-kv-stwo-binary-typed-proof-accounting-2026-05.json",
+        "supports": "repo-owned local binary typed accounting over d32 matched envelopes",
+    },
+    {
+        "id": "median_timing",
+        "path": "docs/engineering/evidence/zkai-attention-kv-stwo-softmax-table-median-timing-2026-05.json",
+        "supports": "engineering-only median-of-5 verifier timing discipline and timing non-claim",
+    },
+    {
+        "id": "seq32_fused",
+        "path": "docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-seq32-fused-softmax-table-gate-2026-05.json",
+        "supports": "two-head d8 seq32 fused proof existence and matched source-sidecar comparison",
+    },
+    {
+        "id": "model_faithful_bridge",
+        "path": "docs/engineering/evidence/zkai-attention-kv-model-faithful-quantized-attention-bridge-2026-05.json",
+        "supports": "checked equivalence between model-facing integer attention policy and the d8 fixture trace",
+    },
+]
+
+EXPECTED_KEYS = {
+    "schema",
+    "decision",
+    "thesis_id",
+    "claim_boundary",
+    "thesis",
+    "paper_claims",
+    "evidence_refs",
+    "go_posture",
+    "go_criteria_satisfied",
+    "no_go_posture",
+    "non_claims",
+    "blockers",
+    "validation_commands",
+    "mutation_cases",
+    "payload_commitment",
+}
+
+EXPECTED_MUTATION_NAMES = (
+    "positive_full_inference_overclaim",
+    "positive_exact_softmax_overclaim",
+    "positive_public_benchmark_overclaim",
+    "positive_production_ready_overclaim",
+    "evidence_path_missing",
+    "non_claim_removed",
+    "blocker_removed",
+    "unknown_field_injection",
+)
+
+
+class ClaimPackGateError(ValueError):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def payload_commitment(payload: dict[str, Any]) -> str:
+    material = {key: value for key, value in payload.items() if key != "payload_commitment"}
+    return "sha256:" + hashlib.sha256(canonical_json_bytes(material)).hexdigest()
+
+
+def _flatten_strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            yield from _flatten_strings(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _flatten_strings(item)
+
+
+def _assert_no_positive_overclaims(payload: dict[str, Any]) -> None:
+    for field in POSITIVE_TEXT_FIELDS:
+        for text in _flatten_strings(payload.get(field)):
+            for label, pattern in FORBIDDEN_POSITIVE_CLAIM_PATTERNS.items():
+                if pattern.search(text):
+                    raise ClaimPackGateError(f"positive claim overclaim: {label} in {field}")
+
+
+def _assert_evidence_paths_exist(payload: dict[str, Any]) -> None:
+    refs = payload.get("evidence_refs")
+    if not isinstance(refs, list) or not refs:
+        raise ClaimPackGateError("evidence_refs must be a non-empty list")
+    for index, ref in enumerate(refs):
+        if not isinstance(ref, dict):
+            raise ClaimPackGateError(f"evidence_refs[{index}] must be an object")
+        path = ref.get("path")
+        if not isinstance(path, str) or path.startswith("/") or ".." in pathlib.PurePosixPath(path).parts:
+            raise ClaimPackGateError(f"evidence_refs[{index}].path must be repo-relative")
+        full_path = ROOT / path
+        if full_path.is_symlink():
+            raise ClaimPackGateError(f"evidence_refs[{index}].path must not be a symlink")
+        if not full_path.is_file():
+            raise ClaimPackGateError(f"missing evidence path: {path}")
+
+
+def _assert_exact_list(value: Any, expected: list[str], label: str) -> None:
+    if value != expected:
+        raise ClaimPackGateError(f"{label} drift")
+
+
+def validate_payload(payload: dict[str, Any]) -> None:
+    if set(payload) != EXPECTED_KEYS:
+        raise ClaimPackGateError("unknown or missing claim-pack field")
+    if payload["schema"] != SCHEMA:
+        raise ClaimPackGateError("schema drift")
+    if payload["decision"] != DECISION:
+        raise ClaimPackGateError("decision drift")
+    if payload["thesis_id"] != THESIS_ID:
+        raise ClaimPackGateError("thesis id drift")
+    if payload["claim_boundary"] != CLAIM_BOUNDARY:
+        raise ClaimPackGateError("claim boundary drift")
+    _assert_no_positive_overclaims(payload)
+    _assert_exact_list(payload["non_claims"], NON_CLAIMS, "non_claims")
+    _assert_exact_list(payload["blockers"], BLOCKERS, "blockers")
+    _assert_evidence_paths_exist(payload)
+    mutation_cases = payload.get("mutation_cases")
+    if not isinstance(mutation_cases, list) or len(mutation_cases) != len(EXPECTED_MUTATION_NAMES):
+        raise ClaimPackGateError("mutation case count drift")
+    for index, (case, expected_name) in enumerate(zip(mutation_cases, EXPECTED_MUTATION_NAMES, strict=True)):
+        if case != {"name": expected_name, "rejected": True}:
+            raise ClaimPackGateError(f"mutation case drift at {index}")
+    if payload["payload_commitment"] != payload_commitment(payload):
+        raise ClaimPackGateError("payload commitment drift")
+
+
+def build_payload() -> dict[str, Any]:
+    payload = {
+        "schema": SCHEMA,
+        "decision": DECISION,
+        "thesis_id": THESIS_ID,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "thesis": (
+            "Checked Stwo evidence supports a paper-facing architecture claim: bounded integer attention "
+            "arithmetic and Softmax-table LogUp membership can be fused into one native STARK proof object, "
+            "sharing proof-system commitment and opening plumbing across the arithmetic and lookup-heavy parts."
+        ),
+        "paper_claims": [
+            (
+                "One checked proof object can bind attention arithmetic and statement-bound Softmax-table "
+                "membership for the same bounded fixture family."
+            ),
+            (
+                "Matched source-plus-sidecar controls show proof-object byte savings across checked width, "
+                "head-count, sequence-length, and combined-axis profiles."
+            ),
+            (
+                "Section-delta and typed-component evidence both point to shared opening and decommitment "
+                "structure as the dominant source of savings."
+            ),
+            (
+                "A model-facing quantized attention policy is checked equivalent to the existing d8 bounded "
+                "Softmax-table fixture trace at the trace boundary."
+            ),
+        ],
+        "evidence_refs": list(EVIDENCE_REFS),
+        "go_posture": [
+            "GO to present a bounded STARK-native proof-architecture claim in the paper evidence pack.",
+            "GO to cite proof-existence, matched proof-byte accounting, typed-size accounting, and claim-boundary discipline.",
+        ],
+        "go_criteria_satisfied": [
+            "checked source, sidecar, and fused proof evidence exists for the cited profiles",
+            "machine-readable gates reject overclaim and evidence-drift mutations",
+            "timing evidence is separated from proof-size evidence",
+            "model-facing quantized policy is bridge-checked before runtime integration",
+        ],
+        "no_go_posture": [
+            "NO-GO for public performance or production deployment language.",
+            "NO-GO for runtime, accuracy, recursion, PCD, or Starknet deployment claims.",
+            "NO-GO for verifier-time improvement claims from the current timing run.",
+        ],
+        "non_claims": list(NON_CLAIMS),
+        "blockers": list(BLOCKERS),
+        "validation_commands": [
+            "just gate-fast",
+            "python3 scripts/zkai_paper_claim_pack_gate.py --write-json docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json",
+            "python3 -m unittest scripts.tests.test_zkai_paper_claim_pack_gate",
+            "git diff --check",
+            "just gate",
+        ],
+        "mutation_cases": [{"name": name, "rejected": True} for name in EXPECTED_MUTATION_NAMES],
+    }
+    payload["payload_commitment"] = payload_commitment(payload)
+    return payload
+
+
+def mutation_cases(payload: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    cases: list[tuple[str, dict[str, Any]]] = []
+
+    mutated = copy.deepcopy(payload)
+    mutated["paper_claims"][0] = "This proves full inference."
+    cases.append(("positive_full_inference_overclaim", mutated))
+
+    mutated = copy.deepcopy(payload)
+    mutated["paper_claims"][0] = "This proves exact Softmax."
+    cases.append(("positive_exact_softmax_overclaim", mutated))
+
+    mutated = copy.deepcopy(payload)
+    mutated["go_posture"][0] = "GO for public benchmark publication."
+    cases.append(("positive_public_benchmark_overclaim", mutated))
+
+    mutated = copy.deepcopy(payload)
+    mutated["paper_claims"][0] = "This is production-ready."
+    cases.append(("positive_production_ready_overclaim", mutated))
+
+    mutated = copy.deepcopy(payload)
+    mutated["evidence_refs"][0]["path"] = "docs/engineering/evidence/missing-claim-pack-evidence.json"
+    cases.append(("evidence_path_missing", mutated))
+
+    mutated = copy.deepcopy(payload)
+    mutated["non_claims"] = mutated["non_claims"][1:]
+    cases.append(("non_claim_removed", mutated))
+
+    mutated = copy.deepcopy(payload)
+    mutated["blockers"] = mutated["blockers"][1:]
+    cases.append(("blocker_removed", mutated))
+
+    mutated = copy.deepcopy(payload)
+    mutated["unexpected"] = "claim smuggling"
+    cases.append(("unknown_field_injection", mutated))
+
+    return cases
+
+
+def write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    validate_payload(payload)
+    if path.exists() and path.is_symlink():
+        raise ClaimPackGateError("output path must not be a symlink")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.parent.is_symlink():
+        raise ClaimPackGateError("output parent must not be a symlink")
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+        tmp_path = pathlib.Path(handle.name)
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    tmp_path.replace(path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write-json", type=pathlib.Path, default=None)
+    args = parser.parse_args(argv)
+
+    payload = build_payload()
+    validate_payload(payload)
+    for expected_name, mutated in mutation_cases(payload):
+        try:
+            validate_payload(mutated)
+        except ClaimPackGateError:
+            continue
+        raise ClaimPackGateError(f"mutation did not reject: {expected_name}")
+
+    if args.write_json:
+        write_json(args.write_json, payload)
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -21,6 +21,8 @@ from typing import Any, Iterable
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 JSON_OUT = ROOT / "docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json"
+ALLOWED_OUTPUT_DIR = ROOT / "docs" / "paper" / "evidence"
+ALLOWED_OUTPUT_PREFIX = pathlib.PurePosixPath("docs/paper/evidence")
 
 SCHEMA = "stark-native-transformer-paper-claim-pack-v1"
 DECISION = "GO_PAPER_CLAIM_PACK_NO_GO_PUBLIC_OR_PRODUCTION_CLAIMS"
@@ -170,6 +172,36 @@ def _assert_no_positive_overclaims(payload: dict[str, Any]) -> None:
                     raise ClaimPackGateError(f"positive claim overclaim: {label} in {field}")
 
 
+def _repo_relative_path(value: str | pathlib.Path, label: str) -> pathlib.PurePosixPath:
+    path = pathlib.PurePosixPath(str(value))
+    if path.is_absolute() or ".." in path.parts:
+        raise ClaimPackGateError(f"{label} must be repo-relative")
+    return path
+
+
+def _full_repo_path(relative_path: pathlib.PurePosixPath) -> pathlib.Path:
+    return ROOT.joinpath(*relative_path.parts)
+
+
+def _assert_repo_contained(full_path: pathlib.Path, label: str) -> None:
+    try:
+        full_path.resolve(strict=True).relative_to(ROOT.resolve(strict=True))
+    except (FileNotFoundError, ValueError) as err:
+        raise ClaimPackGateError(f"{label} must stay within repo") from err
+
+
+def _assert_no_repo_symlink_components(full_path: pathlib.Path, label: str) -> None:
+    try:
+        relative_parts = full_path.relative_to(ROOT).parts
+    except ValueError as err:
+        raise ClaimPackGateError(f"{label} must stay within repo") from err
+    current = ROOT
+    for part in relative_parts:
+        current = current / part
+        if current.is_symlink():
+            raise ClaimPackGateError(f"{label} must not include symlink components")
+
+
 def _assert_evidence_paths_exist(payload: dict[str, Any]) -> None:
     refs = payload.get("evidence_refs")
     if not isinstance(refs, list) or not refs:
@@ -178,13 +210,13 @@ def _assert_evidence_paths_exist(payload: dict[str, Any]) -> None:
         if not isinstance(ref, dict):
             raise ClaimPackGateError(f"evidence_refs[{index}] must be an object")
         path = ref.get("path")
-        if not isinstance(path, str) or path.startswith("/") or ".." in pathlib.PurePosixPath(path).parts:
+        if not isinstance(path, str):
             raise ClaimPackGateError(f"evidence_refs[{index}].path must be repo-relative")
-        full_path = ROOT / path
-        if full_path.is_symlink():
-            raise ClaimPackGateError(f"evidence_refs[{index}].path must not be a symlink")
+        full_path = _full_repo_path(_repo_relative_path(path, f"evidence_refs[{index}].path"))
+        _assert_no_repo_symlink_components(full_path, f"evidence_refs[{index}].path")
         if not full_path.is_file():
             raise ClaimPackGateError(f"missing evidence path: {path}")
+        _assert_repo_contained(full_path, f"evidence_refs[{index}].path")
 
 
 def _assert_exact_list(value: Any, expected: list[str], label: str) -> None:
@@ -317,15 +349,26 @@ def mutation_cases(payload: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
 
 def write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
     validate_payload(payload)
-    if path.exists() and path.is_symlink():
+    relative_path = _repo_relative_path(path, "output path")
+    if relative_path.parts[: len(ALLOWED_OUTPUT_PREFIX.parts)] != ALLOWED_OUTPUT_PREFIX.parts:
+        raise ClaimPackGateError("output path must stay under docs/paper/evidence")
+    path = _full_repo_path(relative_path)
+    if path.is_symlink():
         raise ClaimPackGateError("output path must not be a symlink")
+    _assert_no_repo_symlink_components(path.parent, "output parent hierarchy")
     path.parent.mkdir(parents=True, exist_ok=True)
-    if path.parent.is_symlink():
-        raise ClaimPackGateError("output parent must not be a symlink")
+    _assert_no_repo_symlink_components(path.parent, "output parent hierarchy")
+    try:
+        path.parent.resolve(strict=True).relative_to(ALLOWED_OUTPUT_DIR.resolve(strict=True))
+    except ValueError as err:
+        raise ClaimPackGateError("output path must stay under docs/paper/evidence") from err
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
         tmp_path = pathlib.Path(handle.name)
         json.dump(payload, handle, indent=2, sort_keys=True)
         handle.write("\n")
+    if path.is_symlink():
+        tmp_path.unlink(missing_ok=True)
+        raise ClaimPackGateError("output path must not be a symlink")
     tmp_path.replace(path)
 
 

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -67,6 +67,12 @@ BLOCKERS = [
     "no full transformer runtime, tokenizer/model-weight import, or accuracy/perplexity gate is bound",
 ]
 
+NO_GO_POSTURE = [
+    "NO-GO for public performance or production deployment language.",
+    "NO-GO for runtime, accuracy, recursion, PCD, or Starknet deployment claims.",
+    "NO-GO for verifier-time improvement claims from the current timing run.",
+]
+
 EVIDENCE_REFS = [
     {
         "id": "route_matrix",
@@ -136,6 +142,7 @@ EXPECTED_MUTATION_NAMES = (
     "evidence_path_missing",
     "non_claim_removed",
     "blocker_removed",
+    "no_go_posture_removed",
     "unknown_field_injection",
 )
 
@@ -239,6 +246,7 @@ def validate_payload(payload: dict[str, Any]) -> None:
     if payload["claim_boundary"] != CLAIM_BOUNDARY:
         raise ClaimPackGateError("claim boundary drift")
     _assert_no_positive_overclaims(payload)
+    _assert_exact_list(payload["no_go_posture"], NO_GO_POSTURE, "no_go_posture")
     _assert_exact_list(payload["non_claims"], NON_CLAIMS, "non_claims")
     _assert_exact_list(payload["blockers"], BLOCKERS, "blockers")
     _assert_evidence_paths_exist(payload)
@@ -292,11 +300,7 @@ def build_payload() -> dict[str, Any]:
             "timing evidence is separated from proof-size evidence",
             "model-facing quantized policy is bridge-checked before runtime integration",
         ],
-        "no_go_posture": [
-            "NO-GO for public performance or production deployment language.",
-            "NO-GO for runtime, accuracy, recursion, PCD, or Starknet deployment claims.",
-            "NO-GO for verifier-time improvement claims from the current timing run.",
-        ],
+        "no_go_posture": list(NO_GO_POSTURE),
         "non_claims": list(NON_CLAIMS),
         "blockers": list(BLOCKERS),
         "validation_commands": [
@@ -342,6 +346,10 @@ def mutation_cases(payload: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
     mutated = copy.deepcopy(payload)
     mutated["blockers"] = mutated["blockers"][1:]
     cases.append(("blocker_removed", mutated))
+
+    mutated = copy.deepcopy(payload)
+    mutated["no_go_posture"] = mutated["no_go_posture"][1:]
+    cases.append(("no_go_posture_removed", mutated))
 
     mutated = copy.deepcopy(payload)
     mutated["unexpected"] = "claim smuggling"

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -173,7 +173,10 @@ def _assert_no_positive_overclaims(payload: dict[str, Any]) -> None:
 
 
 def _repo_relative_path(value: str | pathlib.Path, label: str) -> pathlib.PurePosixPath:
-    path = pathlib.PurePosixPath(str(value))
+    raw_path = str(value).replace("\\", "/")
+    if re.match(r"^[A-Za-z]:", raw_path):
+        raise ClaimPackGateError(f"{label} must be repo-relative")
+    path = pathlib.PurePosixPath(raw_path)
     if path.is_absolute() or ".." in path.parts:
         raise ClaimPackGateError(f"{label} must be repo-relative")
     return path


### PR DESCRIPTION
## Summary
- add a paper-facing STARK-native transformer proof claim pack with bounded thesis, GO/NO-GO posture, blockers, and machine-readable evidence
- add a Starknet/Stwo production-path note that sequences binary accounting, timing, model-faithful attention, verifier packaging, and hardening work
- add a local gate that validates required evidence, non-claims, mutation coverage, and claim-boundary discipline

## Evidence
- docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
- docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
- docs/engineering/zkai-production-path-starknet-stwo-backbone-2026-05.md

## Local validation
- just gate-fast
- python3 scripts/zkai_paper_claim_pack_gate.py --write-json docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
- python3 -m unittest scripts.tests.test_zkai_paper_claim_pack_gate
- git diff --check
- just gate

## Non-claims
- not full LLM inference
- not exact real-valued Softmax
- not verifier-time improvement
- not recursion or PCD
- not production readiness
- not accuracy or perplexity evidence
- not a claim of beating all zkML systems

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a staged engineering production roadmap with phased release gates, timing, security hardening, and success/exit criteria.
  * Added a technical claim-pack paper describing a STARK-native transformer proof, bounded claims, evidence requirements, GO/NO‑GO criteria, and validation instructions.

* **Tests**
  * Added a comprehensive end-to-end test suite validating claim-pack payloads, negative/mutation cases, and output path safety.

* **Chores**
  * Added a CLI gate to build, validate, and optionally write verified claim-pack JSON payloads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/550)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->