### PR TITLE
Add May 2026 competitor metric matrix

### DIFF
--- a/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json
+++ b/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json
@@ -1,0 +1,158 @@
+{
+  "claim_boundary": "SOURCE_BACKED_MAY2026_ZKML_COMPETITOR_MATRIX_WITH_LOCAL_STWO_ATTENTION_FUSION_AND_TRANSFORMER_BLOCK_TARGET_CONTEXT_NOT_A_MATCHED_PUBLIC_BENCHMARK_NOT_FULL_INFERENCE",
+  "decision": "GO_SOURCE_BACKED_COMPETITOR_MATRIX_NO_GO_MATCHED_BENCHMARK_CLAIMS",
+  "external_rows": [
+    {
+      "backend_family": "Halo2 IPA SNARK + lookups",
+      "comparison_status": "SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION",
+      "hardware": "Single Intel Xeon CPU @ 2.4GHz with 64GB RAM",
+      "model_or_dims": "GPT-2-scale block; d=768; dff=3072",
+      "proof_size_reported": "6.9 KB",
+      "prove_seconds": "6.3",
+      "setup_or_keygen_seconds": "37 per layer setup",
+      "source_locator": "Table 3 + Section 6.2",
+      "source_url": "https://arxiv.org/abs/2603.18046",
+      "system": "NANOZK",
+      "verify_seconds": "0.023",
+      "workload_label": "Transformer block proof",
+      "workload_scope": "Per-layer block proof"
+    },
+    {
+      "backend_family": "Halo2 IPA SNARK + lookups",
+      "comparison_status": "SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION",
+      "hardware": "Single Intel Xeon CPU @ 2.4GHz with 64GB RAM",
+      "model_or_dims": "GPT-2-Small; 12 layers",
+      "proof_size_reported": "NA",
+      "prove_seconds": "516",
+      "setup_or_keygen_seconds": "includes setup",
+      "source_locator": "Section 6.2",
+      "source_url": "https://arxiv.org/abs/2603.18046",
+      "system": "NANOZK",
+      "verify_seconds": "NA",
+      "workload_label": "GPT-2-Small full model",
+      "workload_scope": "Sequential 12-layer end-to-end"
+    },
+    {
+      "backend_family": "Lookup-centric sumcheck SNARK",
+      "comparison_status": "SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION",
+      "hardware": "NA",
+      "model_or_dims": "NanoGPT; ~0.25M params; 4 transformer layers",
+      "proof_size_reported": "NA",
+      "prove_seconds": "14",
+      "setup_or_keygen_seconds": "0.492 total keygen",
+      "source_locator": "Table 1",
+      "source_url": "https://arxiv.org/abs/2602.17452",
+      "system": "Jolt Atlas",
+      "verify_seconds": "0.517",
+      "workload_label": "NanoGPT proof",
+      "workload_scope": "End-to-end"
+    },
+    {
+      "backend_family": "Lookup-centric sumcheck SNARK",
+      "comparison_status": "SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION",
+      "hardware": "NA",
+      "model_or_dims": "GPT-2; 125M parameters",
+      "proof_size_reported": "NA",
+      "prove_seconds": "38",
+      "setup_or_keygen_seconds": "0.872 keygen",
+      "source_locator": "Table 3",
+      "source_url": "https://arxiv.org/abs/2602.17452",
+      "system": "Jolt Atlas",
+      "verify_seconds": "NA",
+      "workload_label": "GPT-2 proof",
+      "workload_scope": "End-to-end"
+    },
+    {
+      "backend_family": "Halo2-style zkML with lookups",
+      "comparison_status": "SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION",
+      "hardware": "NA",
+      "model_or_dims": "NanoGPT; ~0.25M params; 4 transformer layers",
+      "proof_size_reported": "NA",
+      "prove_seconds": "237",
+      "setup_or_keygen_seconds": "404 total keygen",
+      "source_locator": "Table 2",
+      "source_url": "https://arxiv.org/abs/2602.17452",
+      "system": "EZKL (reported by Jolt Atlas)",
+      "verify_seconds": "0.34",
+      "workload_label": "NanoGPT proof",
+      "workload_scope": "End-to-end"
+    }
+  ],
+  "interpretation": [
+    "NANOZK and Jolt Atlas are the relevant layerwise/end-to-end competitors for headline zkML metrics.",
+    "The local repo does not yet have a d128 layer proof to compare on proof size or verifier time.",
+    "The local competitive claim is currently architectural: STARK-native fusion saves duplicated opening/decommitment plumbing.",
+    "The next real block milestone is a parameterized d64 then d128 RMSNorm/SwiGLU/residual proof surface with the same statement bindings."
+  ],
+  "local_rows": [
+    {
+      "comparison_status": "LOCAL_MECHANISM_EVIDENCE_NOT_LAYERWISE_FULL_MODEL_BENCHMARK",
+      "local_status": "GO_BOUNDED_ARCHITECTURE_MECHANISM",
+      "metric": "matched route JSON proof-byte saving",
+      "support": "11 matched profiles; opening share 0.927722",
+      "surface": "Stwo attention/Softmax-table fusion",
+      "system": "provable-transformer-vm",
+      "unit": "bytes",
+      "value": 194097
+    },
+    {
+      "comparison_status": "LOCAL_RECEIPT_CHAIN_NOT_RECURSIVE_PROOF_COMPRESSION",
+      "local_status": "GO_STATEMENT_BOUND_RECEIPT_COMPOSITION",
+      "metric": "checked slice rows",
+      "support": "6 slices; 14 / 14 mutations rejected",
+      "surface": "d64 RMSNorm/SwiGLU/residual block receipt",
+      "system": "provable-transformer-vm",
+      "unit": "rows",
+      "value": 49600
+    },
+    {
+      "comparison_status": "TARGET_SPEC_ONLY_NOT_LOCAL_PROOF_RESULT",
+      "local_status": "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
+      "metric": "target estimated linear multiplications",
+      "support": "the d128 RMSNorm-SwiGLU-residual receipt target is pinned, but the repository does not contain a local d128 proof artifact, verifier handle, or relabeling suite",
+      "surface": "d128 RMSNorm/SwiGLU/residual comparator target",
+      "system": "provable-transformer-vm",
+      "unit": "linear_muls",
+      "value": 196608
+    }
+  ],
+  "non_claims": [
+    "not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero",
+    "not a local d128 proof result",
+    "not proof-size or verifier-time evidence for a local d128 transformer block",
+    "not full transformer inference",
+    "not exact real-valued Softmax",
+    "not production-ready"
+  ],
+  "payload_commitment": "sha256:33153867ba85c312a3218d945b46dd86a323b52fbbebdd4e284e898a6783c27f",
+  "schema": "zkai-may2026-competitor-metric-matrix-v1",
+  "source_artifacts": [
+    {
+      "kind": "published_zkml_numbers_tsv",
+      "path": "docs/paper/evidence/published-zkml-numbers-2026-04.tsv",
+      "sha256": "aa16aa98493ecf9f984d238875890c81b4525ebde21463b76010c92f6767390b"
+    },
+    {
+      "kind": "local_fusion_mechanism_json",
+      "path": "docs/engineering/evidence/zkai-attention-kv-stwo-fusion-mechanism-ablation-2026-05.json",
+      "sha256": "25f9d504967959465ec4feec5c6aa1c4e1adae5fd453933830858c3fe488fb97"
+    },
+    {
+      "kind": "local_d64_block_receipt_json",
+      "path": "docs/engineering/evidence/zkai-d64-block-receipt-composition-gate-2026-05.json",
+      "sha256": "a70c61a9724fb269d054f94f39f5b59e6cb7091c35782f6f53f94f3874e2ec13"
+    },
+    {
+      "kind": "local_d128_target_json",
+      "path": "docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json",
+      "sha256": "bf1b5cb0dc3471d5c7421f091b4f94f986e38f2ed80e91f325f26fc8080617a0"
+    }
+  ],
+  "validation_commands": [
+    "python3 scripts/zkai_may2026_competitor_metric_matrix_gate.py --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate",
+    "git diff --check",
+    "just gate-fast",
+    "just gate"
+  ]
+}

--- a/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv
+++ b/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv
@@ -1,0 +1,9 @@
+row_kind	system	surface_or_workload	prove_seconds	verify_seconds	proof_size_reported	local_metric	local_value	comparison_status
+external	NANOZK	Transformer block proof	6.3	0.023	6.9 KB			SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION
+external	NANOZK	GPT-2-Small full model	516	NA	NA			SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION
+external	Jolt Atlas	NanoGPT proof	14	0.517	NA			SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION
+external	Jolt Atlas	GPT-2 proof	38	NA	NA			SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION
+external	EZKL (reported by Jolt Atlas)	NanoGPT proof	237	0.34	NA			SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION
+local	provable-transformer-vm	Stwo attention/Softmax-table fusion				matched route JSON proof-byte saving	194097	LOCAL_MECHANISM_EVIDENCE_NOT_LAYERWISE_FULL_MODEL_BENCHMARK
+local	provable-transformer-vm	d64 RMSNorm/SwiGLU/residual block receipt				checked slice rows	49600	LOCAL_RECEIPT_CHAIN_NOT_RECURSIVE_PROOF_COMPRESSION
+local	provable-transformer-vm	d128 RMSNorm/SwiGLU/residual comparator target				target estimated linear multiplications	196608	TARGET_SPEC_ONLY_NOT_LOCAL_PROOF_RESULT

--- a/docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md
+++ b/docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md
@@ -39,7 +39,7 @@ checks the rows used for comparison:
 | NANOZK | GPT-2-Small full model | `516s` | `NA` | `NA` |
 | Jolt Atlas | NanoGPT proof | `14s` | `0.517s` | `NA` |
 | Jolt Atlas | GPT-2 proof | `38s` | `NA` | `NA` |
-| EZKL reported by Jolt Atlas | NanoGPT proof | `237s` | `0.34s` | `NA` |
+| EZKL (reported by Jolt Atlas) | NanoGPT proof | `237s` | `0.34s` | `NA` |
 
 These are source-backed context rows, not local reproductions.
 
@@ -49,7 +49,7 @@ These are source-backed context rows, not local reproductions.
 | --- | --- | ---: |
 | Stwo attention/Softmax-table fusion | `GO_BOUNDED_ARCHITECTURE_MECHANISM` | `194,097` matched JSON proof bytes saved |
 | d64 RMSNorm/SwiGLU/residual block receipt | `GO_STATEMENT_BOUND_RECEIPT_COMPOSITION` | `49,600` checked slice rows |
-| d128 RMSNorm/SwiGLU/residual target | `NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING` | `196,608` estimated linear multiplications |
+| d128 RMSNorm/SwiGLU/residual comparator target | `NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING` | `196,608` estimated linear multiplications |
 
 ## Interpretation
 

--- a/docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md
+++ b/docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md
@@ -33,13 +33,13 @@ The comparison posture is:
 The gate consumes `docs/paper/evidence/published-zkml-numbers-2026-04.tsv` and
 checks the rows used for comparison:
 
-| System | Workload | Prove | Verify | Proof size |
-| --- | ---: | ---: | ---: | ---: |
-| NANOZK | Transformer block proof | `6.3s` | `0.023s` | `6.9 KB` |
-| NANOZK | GPT-2-Small full model | `516s` | `NA` | `NA` |
-| Jolt Atlas | NanoGPT proof | `14s` | `0.517s` | `NA` |
-| Jolt Atlas | GPT-2 proof | `38s` | `NA` | `NA` |
-| EZKL (reported by Jolt Atlas) | NanoGPT proof | `237s` | `0.34s` | `NA` |
+| System | Workload | Prove | Verify | Proof size | Provenance |
+| --- | --- | ---: | ---: | ---: | --- |
+| NANOZK | Transformer block proof | `6.3s` | `0.023s` | `6.9 KB` | Halo2 IPA SNARK + lookups; arXiv `2603.18046`, Table 3 + Section 6.2; GPT-2-scale block `d=768`, `dff=3072`; single Intel Xeon CPU @ 2.4GHz with 64GB RAM; timing mode from source, wall/CPU split not reported; evidence path `docs/paper/evidence/published-zkml-numbers-2026-04.tsv`. |
+| NANOZK | GPT-2-Small full model | `516s` | `NA` | `NA` | Halo2 IPA SNARK + lookups; arXiv `2603.18046`, Section 6.2; GPT-2-Small, 12 sequential layers; includes setup; single Intel Xeon CPU @ 2.4GHz with 64GB RAM; verify/proof-size not reported by source; evidence path `docs/paper/evidence/published-zkml-numbers-2026-04.tsv`. |
+| Jolt Atlas | NanoGPT proof | `14s` | `0.517s` | `NA` | Lookup-centric sumcheck SNARK; arXiv `2602.17452`, Table 1; NanoGPT, about 0.25M params, 4 transformer layers; hardware not reported by source; proof size not reported by source; evidence path `docs/paper/evidence/published-zkml-numbers-2026-04.tsv`. |
+| Jolt Atlas | GPT-2 proof | `38s` | `NA` | `NA` | Lookup-centric sumcheck SNARK; arXiv `2602.17452`, Table 3; GPT-2, 125M parameters; hardware and verifier time not reported by source; proof size not reported by source; evidence path `docs/paper/evidence/published-zkml-numbers-2026-04.tsv`. |
+| EZKL (reported by Jolt Atlas) | NanoGPT proof | `237s` | `0.34s` | `NA` | Halo2-style zkML with lookups, reported by Jolt Atlas; arXiv `2602.17452`, Table 2; NanoGPT, about 0.25M params, 4 transformer layers; hardware not reported by source; proof size not reported by source; evidence path `docs/paper/evidence/published-zkml-numbers-2026-04.tsv`. |
 
 These are source-backed context rows, not local reproductions.
 

--- a/docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md
+++ b/docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md
@@ -1,0 +1,91 @@
+# zkAI May 2026 Competitor Metric Matrix - 2026-05-13
+
+## Question
+
+How should the repo compare itself against May 2026 zkML systems without
+pretending that the current local evidence is a matched public benchmark?
+
+## Decision
+
+GO for a source-backed comparison matrix. NO-GO for matched benchmark claims.
+
+The comparison posture is:
+
+> NANOZK, Jolt Atlas, and EZKL are the relevant public metric references for
+> layerwise or end-to-end zkML proving. This repository should compare against
+> them honestly, but its current strongest local result is architectural:
+> STARK-native attention/Softmax-table fusion saves duplicated opening and
+> decommitment plumbing.
+
+## Evidence
+
+- JSON:
+  `docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json`
+- TSV:
+  `docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv`
+- Gate:
+  `scripts/zkai_may2026_competitor_metric_matrix_gate.py`
+- Tests:
+  `scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py`
+
+## Source-Backed External Rows
+
+The gate consumes `docs/paper/evidence/published-zkml-numbers-2026-04.tsv` and
+checks the rows used for comparison:
+
+| System | Workload | Prove | Verify | Proof size |
+| --- | ---: | ---: | ---: | ---: |
+| NANOZK | Transformer block proof | `6.3s` | `0.023s` | `6.9 KB` |
+| NANOZK | GPT-2-Small full model | `516s` | `NA` | `NA` |
+| Jolt Atlas | NanoGPT proof | `14s` | `0.517s` | `NA` |
+| Jolt Atlas | GPT-2 proof | `38s` | `NA` | `NA` |
+| EZKL reported by Jolt Atlas | NanoGPT proof | `237s` | `0.34s` | `NA` |
+
+These are source-backed context rows, not local reproductions.
+
+## Local Rows
+
+| Local surface | Status | Metric |
+| --- | --- | ---: |
+| Stwo attention/Softmax-table fusion | `GO_BOUNDED_ARCHITECTURE_MECHANISM` | `194,097` matched JSON proof bytes saved |
+| d64 RMSNorm/SwiGLU/residual block receipt | `GO_STATEMENT_BOUND_RECEIPT_COMPOSITION` | `49,600` checked slice rows |
+| d128 RMSNorm/SwiGLU/residual target | `NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING` | `196,608` estimated linear multiplications |
+
+## Interpretation
+
+The repo should not claim that it beats NANOZK or Jolt Atlas on layer proof
+size or end-to-end proving time. It does not yet have the matched local d128
+proof artifact needed for that comparison.
+
+The sharper claim is that the STARK-native route exposes a different mechanism:
+attention arithmetic and lookup-heavy table membership can share proof-system
+opening structure when fused into one native proof object.
+
+The next block milestone is not another wrapper around the width-4 block. It is
+a parameterized d64 then d128 RMSNorm/SwiGLU/residual proof surface with the
+same statement bindings used by the d128 comparator target.
+
+## Non-Claims
+
+- Not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero.
+- Not a local d128 proof result.
+- Not proof-size or verifier-time evidence for a local d128 transformer block.
+- Not full transformer inference.
+- Not exact real-valued Softmax.
+- Not production-ready.
+
+## Validation
+
+```bash
+python3 scripts/zkai_may2026_competitor_metric_matrix_gate.py \
+  --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json \
+  --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv
+
+python3 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate
+
+git diff --check
+
+just gate-fast
+
+just gate
+```

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -319,6 +319,27 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         finally:
             path.unlink(missing_ok=True)
 
+    def test_load_tsv_rejects_duplicate_columns(self):
+        columns = list(gate.REQUIRED_PUBLISHED_COLUMNS)
+        duplicate_columns = columns + [columns[0]]
+        row = {column: "value" for column in columns}
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-duplicate-published-",
+            suffix=".tsv",
+            delete=False,
+        ) as handle:
+            path = pathlib.Path(handle.name)
+            handle.write("\t".join(duplicate_columns) + "\n")
+            handle.write("\t".join([row[column] for column in columns] + ["value"]) + "\n")
+        try:
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "TSV source has duplicate columns"):
+                gate.load_tsv(path)
+        finally:
+            path.unlink(missing_ok=True)
+
     def test_read_source_bytes_rejects_symlink_source(self):
         with tempfile.TemporaryDirectory(dir=gate.ENGINEERING_EVIDENCE) as tmp:
             real_path = pathlib.Path(tmp) / "real.json"

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -124,6 +124,13 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
             with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "repo-relative"):
                 gate.write_outputs(self.payload, pathlib.Path(tmp) / "out.json", gate.TSV_OUT.relative_to(gate.ROOT))
 
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "json and tsv output paths must differ"):
+            gate.write_outputs(
+                self.payload,
+                pathlib.Path("docs/engineering/evidence/competitor-case-collision.JSON"),
+                pathlib.Path("docs/engineering/evidence/competitor-case-collision.json"),
+            )
+
         with tempfile.NamedTemporaryFile(
             dir=gate.ENGINEERING_EVIDENCE,
             prefix="competitor-output-parent-",

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -162,10 +162,10 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         original_replace = gate.os.replace
         original_write_bytes = pathlib.Path.write_bytes
         try:
-            def fail_on_tsv(src, dst):
-                if pathlib.Path(dst) == tsv_path:
+            def fail_on_tsv(src, dst, *args, **kwargs):
+                if pathlib.Path(dst).name == tsv_path.name:
                     raise OSError("simulated second replace failure")
-                return original_replace(src, dst)
+                return original_replace(src, dst, *args, **kwargs)
 
             def fail_direct_write(_path, _contents):
                 raise AssertionError("rollback must restore through an atomic temp replace")
@@ -199,15 +199,15 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
             outside_target.write_text("outside-original", encoding="utf-8")
             original_replace = gate.os.replace
             try:
-                def swap_json_target_on_tsv(src, dst):
-                    if pathlib.Path(dst) == tsv_path:
+                def swap_json_target_on_tsv(src, dst, *args, **kwargs):
+                    if pathlib.Path(dst).name == tsv_path.name:
                         json_path.unlink(missing_ok=True)
                         try:
                             json_path.symlink_to(outside_target)
                         except OSError as err:
                             self.skipTest(f"symlink creation is unavailable: {err}")
                         raise OSError("simulated second replace failure after target swap")
-                    return original_replace(src, dst)
+                    return original_replace(src, dst, *args, **kwargs)
 
                 gate.os.replace = swap_json_target_on_tsv
                 with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "failed to roll back output path"):
@@ -219,6 +219,41 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
                 gate.os.replace = original_replace
                 json_path.unlink(missing_ok=True)
                 tsv_path.unlink(missing_ok=True)
+
+    def test_write_outputs_rejects_success_path_parent_symlink_swap(self):
+        with tempfile.TemporaryDirectory(dir=gate.ENGINEERING_EVIDENCE) as output_parent_name:
+            output_parent = pathlib.Path(output_parent_name)
+            backup_parent = output_parent.with_name(output_parent.name + "-backup")
+            json_path = output_parent / "out.json"
+            with tempfile.TemporaryDirectory() as outside_name:
+                outside_parent = pathlib.Path(outside_name)
+                original_replace = gate.os.replace
+                swapped = False
+                try:
+                    def swap_parent_on_first_replace(src, dst, *args, **kwargs):
+                        nonlocal swapped
+                        if not swapped and pathlib.Path(dst).name == json_path.name:
+                            swapped = True
+                            output_parent.rename(backup_parent)
+                            try:
+                                output_parent.symlink_to(outside_parent, target_is_directory=True)
+                            except OSError as err:
+                                self.skipTest(f"symlink creation is unavailable: {err}")
+                        return original_replace(src, dst, *args, **kwargs)
+
+                    gate.os.replace = swap_parent_on_first_replace
+                    with self.assertRaisesRegex(
+                        gate.CompetitorMetricMatrixError,
+                        "failed to write output path|failed to roll back output path",
+                    ):
+                        gate.write_outputs(self.payload, json_path.relative_to(gate.ROOT), None)
+                    self.assertFalse((outside_parent / json_path.name).exists())
+                finally:
+                    gate.os.replace = original_replace
+                    if output_parent.is_symlink():
+                        output_parent.unlink()
+                    if backup_parent.exists():
+                        backup_parent.rename(output_parent)
 
     def test_json_helpers_reject_non_finite_values(self):
         payload = copy.deepcopy(self.payload)

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -395,6 +395,26 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         finally:
             path.unlink(missing_ok=True)
 
+    def test_load_tsv_rejects_underwide_rows(self):
+        columns = list(gate.REQUIRED_PUBLISHED_COLUMNS)
+        row = {column: "value" for column in columns}
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-underwide-published-",
+            suffix=".tsv",
+            delete=False,
+        ) as handle:
+            path = pathlib.Path(handle.name)
+            handle.write("\t".join(columns) + "\n")
+            handle.write("\t".join(row[column] for column in columns[:-1]) + "\n")
+        try:
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "TSV source row 2 has missing cells"):
+                gate.load_tsv(path)
+        finally:
+            path.unlink(missing_ok=True)
+
     def test_read_source_bytes_rejects_symlink_source(self):
         with tempfile.TemporaryDirectory(dir=gate.ENGINEERING_EVIDENCE) as tmp:
             real_path = pathlib.Path(tmp) / "real.json"

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -1,0 +1,285 @@
+import copy
+import json
+import math
+import pathlib
+import tempfile
+import unittest
+
+from scripts import zkai_may2026_competitor_metric_matrix_gate as gate
+
+
+class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.payload_base = gate.build_payload()
+
+    def setUp(self) -> None:
+        self.payload = copy.deepcopy(self.payload_base)
+
+    def test_builds_source_backed_comparison_without_overclaiming(self):
+        payload = self.payload
+        gate.validate_payload(payload)
+
+        self.assertEqual(payload["schema"], gate.SCHEMA)
+        self.assertEqual(payload["decision"], gate.DECISION)
+        self.assertEqual(payload["claim_boundary"], gate.CLAIM_BOUNDARY)
+        self.assertEqual(len(payload["source_artifacts"]), 4)
+        self.assertEqual(len(payload["external_rows"]), 5)
+        self.assertEqual(len(payload["local_rows"]), 3)
+        self.assertIn("not a matched benchmark", payload["non_claims"][0])
+
+        external = {(row["system"], row["workload_label"]): row for row in payload["external_rows"]}
+        self.assertEqual(external[("NANOZK", "Transformer block proof")]["proof_size_reported"], "6.9 KB")
+        self.assertEqual(external[("NANOZK", "Transformer block proof")]["prove_seconds"], "6.3")
+        self.assertEqual(external[("Jolt Atlas", "GPT-2 proof")]["prove_seconds"], "38")
+        self.assertEqual(external[("EZKL (reported by Jolt Atlas)", "NanoGPT proof")]["prove_seconds"], "237")
+
+        local = {row["surface"]: row for row in payload["local_rows"]}
+        self.assertEqual(local["Stwo attention/Softmax-table fusion"]["value"], 194097)
+        self.assertEqual(local["d64 RMSNorm/SwiGLU/residual block receipt"]["value"], 49600)
+        self.assertEqual(local["d128 RMSNorm/SwiGLU/residual comparator target"]["value"], 196608)
+        self.assertEqual(
+            local["d128 RMSNorm/SwiGLU/residual comparator target"]["local_status"],
+            "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
+        )
+
+    def test_rejects_source_metric_drift(self):
+        payload = copy.deepcopy(self.payload)
+        payload["external_rows"][0]["prove_seconds"] = "0"
+        payload["payload_commitment"] = gate.payload_commitment(payload)
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "payload drift"):
+            gate.validate_payload(payload)
+
+    def test_rejects_local_overclaim_drift(self):
+        payload = copy.deepcopy(self.payload)
+        payload["local_rows"][2]["local_status"] = "GO_LOCAL_D128_PROOF"
+        payload["payload_commitment"] = gate.payload_commitment(payload)
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "payload drift"):
+            gate.validate_payload(payload)
+
+    def test_rejects_commitment_drift(self):
+        payload = copy.deepcopy(self.payload)
+        payload["payload_commitment"] = "sha256:" + "0" * 64
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "payload commitment drift"):
+            gate.validate_payload(payload)
+
+    def test_tsv_contains_external_and_local_rows(self):
+        tsv = gate.to_tsv(self.payload)
+        self.assertIn("external\tNANOZK\tTransformer block proof\t6.3\t0.023\t6.9 KB", tsv)
+        self.assertIn("local\tprovable-transformer-vm\tStwo attention/Softmax-table fusion", tsv)
+        self.assertIn("matched route JSON proof-byte saving\t194097", tsv)
+
+    def test_source_artifact_hashes_match_single_read_bytes(self):
+        payload = gate.build_payload_uncommitted()
+        source_by_path = {artifact["path"]: artifact for artifact in payload["source_artifacts"]}
+        for path in (gate.PUBLISHED_ZKML_NUMBERS, gate.FUSION_MECHANISM, gate.D64_BLOCK_RECEIPT, gate.D128_TARGET):
+            raw = gate.read_source_bytes(path, "test source")
+            artifact = source_by_path[str(path.relative_to(gate.ROOT))]
+            self.assertEqual(artifact["sha256"], gate.hashlib.sha256(raw).hexdigest())
+
+    def test_write_outputs_round_trip_and_rejects_outside_path(self):
+        with tempfile.NamedTemporaryFile(
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-matrix-test-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            json_path = pathlib.Path(handle.name)
+        json_path.unlink()
+        tsv_path = json_path.with_suffix(".tsv")
+        try:
+            gate.write_outputs(self.payload, json_path.relative_to(gate.ROOT), tsv_path.relative_to(gate.ROOT))
+            loaded = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertEqual(loaded, self.payload)
+            self.assertIn("row_kind", tsv_path.read_text(encoding="utf-8"))
+        finally:
+            json_path.unlink(missing_ok=True)
+            tsv_path.unlink(missing_ok=True)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "repo-relative"):
+                gate.write_outputs(self.payload, pathlib.Path(tmp) / "out.json", gate.TSV_OUT.relative_to(gate.ROOT))
+
+        with tempfile.NamedTemporaryFile(
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-output-parent-",
+            delete=False,
+        ) as handle:
+            parent_file = pathlib.Path(handle.name)
+        try:
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "failed to write output path"):
+                gate.write_outputs(
+                    self.payload,
+                    (parent_file / "out.json").relative_to(gate.ROOT),
+                    gate.TSV_OUT.relative_to(gate.ROOT),
+                )
+        finally:
+            parent_file.unlink(missing_ok=True)
+
+    def test_write_outputs_rolls_back_when_second_replace_fails(self):
+        with tempfile.NamedTemporaryFile(
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-transaction-json-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            json_path = pathlib.Path(handle.name)
+            handle.write(b"original-json")
+        tsv_path = json_path.with_suffix(".tsv")
+        tsv_path.unlink(missing_ok=True)
+
+        original_replace = gate.os.replace
+        original_write_bytes = pathlib.Path.write_bytes
+        try:
+            def fail_on_tsv(src, dst):
+                if pathlib.Path(dst) == tsv_path:
+                    raise OSError("simulated second replace failure")
+                return original_replace(src, dst)
+
+            def fail_direct_write(_path, _contents):
+                raise AssertionError("rollback must restore through an atomic temp replace")
+
+            gate.os.replace = fail_on_tsv
+            pathlib.Path.write_bytes = fail_direct_write
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "failed to write output path"):
+                gate.write_outputs(self.payload, json_path.relative_to(gate.ROOT), tsv_path.relative_to(gate.ROOT))
+            self.assertEqual(json_path.read_text(encoding="utf-8"), "original-json")
+            self.assertFalse(tsv_path.exists())
+        finally:
+            gate.os.replace = original_replace
+            pathlib.Path.write_bytes = original_write_bytes
+            json_path.unlink(missing_ok=True)
+            tsv_path.unlink(missing_ok=True)
+
+    def test_write_outputs_rollback_does_not_follow_swapped_symlink(self):
+        with tempfile.NamedTemporaryFile(
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-transaction-symlink-json-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            json_path = pathlib.Path(handle.name)
+            handle.write(b"original-json")
+        tsv_path = json_path.with_suffix(".tsv")
+        tsv_path.unlink(missing_ok=True)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            outside_target = pathlib.Path(tmp) / "outside-target.json"
+            outside_target.write_text("outside-original", encoding="utf-8")
+            original_replace = gate.os.replace
+            try:
+                def swap_json_target_on_tsv(src, dst):
+                    if pathlib.Path(dst) == tsv_path:
+                        json_path.unlink(missing_ok=True)
+                        try:
+                            json_path.symlink_to(outside_target)
+                        except OSError as err:
+                            self.skipTest(f"symlink creation is unavailable: {err}")
+                        raise OSError("simulated second replace failure after target swap")
+                    return original_replace(src, dst)
+
+                gate.os.replace = swap_json_target_on_tsv
+                with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "failed to write output path"):
+                    gate.write_outputs(self.payload, json_path.relative_to(gate.ROOT), tsv_path.relative_to(gate.ROOT))
+                self.assertEqual(outside_target.read_text(encoding="utf-8"), "outside-original")
+                self.assertTrue(json_path.is_symlink())
+                self.assertFalse(tsv_path.exists())
+            finally:
+                gate.os.replace = original_replace
+                json_path.unlink(missing_ok=True)
+                tsv_path.unlink(missing_ok=True)
+
+    def test_json_helpers_reject_non_finite_values(self):
+        payload = copy.deepcopy(self.payload)
+        payload["local_rows"][0]["value"] = math.nan
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "invalid JSON value"):
+            gate.canonical_json_bytes(payload)
+
+        payload = copy.deepcopy(self.payload)
+        payload["not_json_serializable"] = {1, 2, 3}
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "invalid JSON value"):
+            gate.canonical_json_bytes(payload)
+
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-non-finite-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            path = pathlib.Path(handle.name)
+            handle.write('{"value": Infinity}\n')
+        try:
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "non-finite JSON constant"):
+                gate.load_json(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_source_field_helpers_reject_wrong_types(self):
+        fusion = gate.load_json(gate.FUSION_MECHANISM)
+        fusion["route_matrix"]["fused_savings_bytes_total"] = "194097"
+        d64 = gate.load_json(gate.D64_BLOCK_RECEIPT)
+        d128 = gate.load_json(gate.D128_TARGET)
+
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion savings must be integer"):
+            gate._local_rows(fusion, d64, d128)
+
+        fusion = gate.load_json(gate.FUSION_MECHANISM)
+        fusion["section_delta"]["opening_bucket_savings_share"] = "0.927722"
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion opening share must be numeric"):
+            gate._local_rows(fusion, d64, d128)
+
+        fusion = gate.load_json(gate.FUSION_MECHANISM)
+        fusion["section_delta"]["opening_bucket_savings_share"] = math.inf
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion opening share must be finite"):
+            gate._local_rows(fusion, d64, d128)
+
+        fusion = gate.load_json(gate.FUSION_MECHANISM)
+        fusion["section_delta"]["opening_bucket_savings_share"] = 1.1
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion opening share must be between 0 and 1"):
+            gate._local_rows(fusion, d64, d128)
+
+        fusion = gate.load_json(gate.FUSION_MECHANISM)
+        fusion["route_matrix"]["fused_savings_bytes_total"] = 0
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion savings must be positive"):
+            gate._local_rows(fusion, d64, d128)
+
+        fusion = gate.load_json(gate.FUSION_MECHANISM)
+        d64 = gate.load_json(gate.D64_BLOCK_RECEIPT)
+        d64["summary"]["mutations_rejected"] = d64["summary"]["mutation_cases"] - 1
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "d64 mutation rejection summary drift"):
+            gate._local_rows(fusion, d64, d128)
+
+    def test_load_tsv_rejects_missing_required_columns(self):
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-bad-published-",
+            suffix=".tsv",
+            delete=False,
+        ) as handle:
+            path = pathlib.Path(handle.name)
+            handle.write("system\tworkload_label\nNANOZK\tTransformer block proof\n")
+        try:
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "TSV source missing columns"):
+                gate.load_tsv(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_read_source_bytes_rejects_symlink_source(self):
+        with tempfile.TemporaryDirectory(dir=gate.ENGINEERING_EVIDENCE) as tmp:
+            real_path = pathlib.Path(tmp) / "real.json"
+            real_path.write_text("{}", encoding="utf-8")
+            link_path = pathlib.Path(tmp) / "linked.json"
+            try:
+                link_path.symlink_to(real_path)
+            except OSError as err:
+                self.skipTest(f"symlink creation is unavailable: {err}")
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "symlinks"):
+                gate.read_source_bytes(link_path, "symlink test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -77,6 +77,22 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
             artifact = source_by_path[str(path.relative_to(gate.ROOT))]
             self.assertEqual(artifact["sha256"], gate.hashlib.sha256(raw).hexdigest())
 
+    def test_build_payload_reuses_precomputed_expected_payload(self):
+        original = gate.build_payload_uncommitted
+        calls = 0
+
+        def counted_build_payload_uncommitted():
+            nonlocal calls
+            calls += 1
+            return original()
+
+        try:
+            gate.build_payload_uncommitted = counted_build_payload_uncommitted
+            gate.build_payload()
+            self.assertEqual(calls, 1)
+        finally:
+            gate.build_payload_uncommitted = original
+
     def test_write_outputs_round_trip_and_rejects_outside_path(self):
         with tempfile.NamedTemporaryFile(
             dir=gate.ENGINEERING_EVIDENCE,
@@ -87,14 +103,22 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
             json_path = pathlib.Path(handle.name)
         json_path.unlink()
         tsv_path = json_path.with_suffix(".tsv")
+        only_json = json_path.with_name(json_path.stem + "-only.json")
+        implicit_tsv = only_json.with_suffix(".tsv")
         try:
             gate.write_outputs(self.payload, json_path.relative_to(gate.ROOT), tsv_path.relative_to(gate.ROOT))
             loaded = json.loads(json_path.read_text(encoding="utf-8"))
             self.assertEqual(loaded, self.payload)
             self.assertIn("row_kind", tsv_path.read_text(encoding="utf-8"))
+
+            gate.write_outputs(self.payload, only_json.relative_to(gate.ROOT), None)
+            self.assertTrue(only_json.exists())
+            self.assertFalse(implicit_tsv.exists())
         finally:
             json_path.unlink(missing_ok=True)
             tsv_path.unlink(missing_ok=True)
+            only_json.unlink(missing_ok=True)
+            implicit_tsv.unlink(missing_ok=True)
 
         with tempfile.TemporaryDirectory() as tmp:
             with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "repo-relative"):

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -210,7 +210,7 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
                     return original_replace(src, dst)
 
                 gate.os.replace = swap_json_target_on_tsv
-                with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "failed to write output path"):
+                with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "failed to roll back output path"):
                     gate.write_outputs(self.payload, json_path.relative_to(gate.ROOT), tsv_path.relative_to(gate.ROOT))
                 self.assertEqual(outside_target.read_text(encoding="utf-8"), "outside-original")
                 self.assertTrue(json_path.is_symlink())
@@ -295,6 +295,26 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
             handle.write("system\tworkload_label\nNANOZK\tTransformer block proof\n")
         try:
             with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "TSV source missing columns"):
+                gate.load_tsv(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_load_tsv_rejects_extra_required_columns(self):
+        columns = list(gate.REQUIRED_PUBLISHED_COLUMNS) + ["extra"]
+        row = {column: "value" for column in columns}
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-extra-published-",
+            suffix=".tsv",
+            delete=False,
+        ) as handle:
+            path = pathlib.Path(handle.name)
+            handle.write("\t".join(columns) + "\n")
+            handle.write("\t".join(row[column] for column in columns) + "\n")
+        try:
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "TSV source has extra columns"):
                 gate.load_tsv(path)
         finally:
             path.unlink(missing_ok=True)

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -340,6 +340,26 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         finally:
             path.unlink(missing_ok=True)
 
+    def test_load_tsv_rejects_overwide_rows(self):
+        columns = list(gate.REQUIRED_PUBLISHED_COLUMNS)
+        row = {column: "value" for column in columns}
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-overwide-published-",
+            suffix=".tsv",
+            delete=False,
+        ) as handle:
+            path = pathlib.Path(handle.name)
+            handle.write("\t".join(columns) + "\n")
+            handle.write("\t".join([row[column] for column in columns] + ["surplus"]) + "\n")
+        try:
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "TSV source row 2 has extra cells"):
+                gate.load_tsv(path)
+        finally:
+            path.unlink(missing_ok=True)
+
     def test_read_source_bytes_rejects_symlink_source(self):
         with tempfile.TemporaryDirectory(dir=gate.ENGINEERING_EVIDENCE) as tmp:
             real_path = pathlib.Path(tmp) / "real.json"

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -201,7 +201,11 @@ def _parse_tsv_bytes(path: pathlib.Path, raw: bytes) -> list[dict[str, str]]:
     except UnicodeDecodeError as err:
         raise CompetitorMetricMatrixError(f"failed to load TSV source {path}: {err}") from err
     reader = csv.DictReader(io.StringIO(text), delimiter="\t")
-    fieldnames = set(reader.fieldnames or [])
+    fieldname_list = reader.fieldnames or []
+    duplicate_fields = sorted({field for field in fieldname_list if fieldname_list.count(field) > 1})
+    if duplicate_fields:
+        raise CompetitorMetricMatrixError(f"TSV source has duplicate columns: {duplicate_fields}")
+    fieldnames = set(fieldname_list)
     missing = REQUIRED_PUBLISHED_COLUMNS - fieldnames
     if missing:
         raise CompetitorMetricMatrixError(f"TSV source missing columns: {sorted(missing)}")

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import csv
 import hashlib
 import io
@@ -378,7 +379,7 @@ def _local_rows(fusion: dict[str, Any], d64: dict[str, Any], d128: dict[str, Any
 
 def build_payload() -> dict[str, Any]:
     payload = build_payload_uncommitted()
-    expected = dict(payload)
+    expected = copy.deepcopy(payload)
     payload["payload_commitment"] = payload_commitment(payload)
     validate_payload(payload, expected=expected)
     return payload
@@ -526,7 +527,11 @@ def write_outputs(
     tsv_target = _assert_output_path(tsv_path, "tsv output path") if tsv_path is not None else None
     if json_target is None and tsv_target is None:
         raise CompetitorMetricMatrixError("at least one explicit output path is required")
-    if json_target is not None and tsv_target is not None and os.path.abspath(json_target) == os.path.abspath(tsv_target):
+    if (
+        json_target is not None
+        and tsv_target is not None
+        and os.path.abspath(json_target).casefold() == os.path.abspath(tsv_target).casefold()
+    ):
         raise CompetitorMetricMatrixError("json and tsv output paths must differ")
 
     outputs = []

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -83,6 +83,7 @@ EXPECTED_EXTERNAL_ROWS = {
 
 REQUIRED_PUBLISHED_COLUMNS = {
     "system",
+    "source_kind",
     "source_url",
     "source_locator",
     "backend_family",
@@ -94,6 +95,7 @@ REQUIRED_PUBLISHED_COLUMNS = {
     "proof_size_reported",
     "setup_or_keygen_seconds",
     "hardware",
+    "notes",
 }
 
 
@@ -199,9 +201,13 @@ def _parse_tsv_bytes(path: pathlib.Path, raw: bytes) -> list[dict[str, str]]:
     except UnicodeDecodeError as err:
         raise CompetitorMetricMatrixError(f"failed to load TSV source {path}: {err}") from err
     reader = csv.DictReader(io.StringIO(text), delimiter="\t")
-    missing = REQUIRED_PUBLISHED_COLUMNS - set(reader.fieldnames or [])
+    fieldnames = set(reader.fieldnames or [])
+    missing = REQUIRED_PUBLISHED_COLUMNS - fieldnames
     if missing:
         raise CompetitorMetricMatrixError(f"TSV source missing columns: {sorted(missing)}")
+    extra = fieldnames - REQUIRED_PUBLISHED_COLUMNS
+    if extra:
+        raise CompetitorMetricMatrixError(f"TSV source has extra columns: {sorted(extra)}")
     rows = list(reader)
     if not rows:
         raise CompetitorMetricMatrixError(f"TSV source must not be empty: {path}")
@@ -543,6 +549,7 @@ def write_outputs(
     replaced: list[pathlib.Path] = []
     original_bytes: dict[pathlib.Path, bytes | None] = {}
     write_error: OSError | None = None
+    rollback_errors: list[str] = []
 
     def write_temp(path: pathlib.Path, text: str) -> pathlib.Path:
         _assert_no_repo_symlink_components(path.parent, "output path")
@@ -599,14 +606,20 @@ def write_outputs(
                         path.unlink(missing_ok=True)
                     else:
                         rollback_replace(path, original)
-                except (CompetitorMetricMatrixError, OSError):
-                    pass
+                except (CompetitorMetricMatrixError, OSError) as err:
+                    rollback_errors.append(f"{path}: {err}")
         for tmp in temps:
             try:
                 tmp.unlink(missing_ok=True)
             except OSError as err:
                 if write_error is None:
                     raise CompetitorMetricMatrixError(f"failed to clean temporary output {tmp}: {err}") from err
+        if rollback_errors:
+            raise CompetitorMetricMatrixError(
+                "failed to roll back output path after write error: "
+                + "; ".join(rollback_errors)
+                + f"; original write error: {write_error}"
+            ) from write_error
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -216,6 +216,8 @@ def _parse_tsv_bytes(path: pathlib.Path, raw: bytes) -> list[dict[str, str]]:
     for index, row in enumerate(rows, start=2):
         if None in row:
             raise CompetitorMetricMatrixError(f"TSV source row {index} has extra cells")
+        if any(value is None for value in row.values()):
+            raise CompetitorMetricMatrixError(f"TSV source row {index} has missing cells")
     if not rows:
         raise CompetitorMetricMatrixError(f"TSV source must not be empty: {path}")
     return rows

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -213,6 +213,9 @@ def _parse_tsv_bytes(path: pathlib.Path, raw: bytes) -> list[dict[str, str]]:
     if extra:
         raise CompetitorMetricMatrixError(f"TSV source has extra columns: {sorted(extra)}")
     rows = list(reader)
+    for index, row in enumerate(rows, start=2):
+        if None in row:
+            raise CompetitorMetricMatrixError(f"TSV source row {index} has extra cells")
     if not rows:
         raise CompetitorMetricMatrixError(f"TSV source must not be empty: {path}")
     return rows

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -12,9 +12,9 @@ import json
 import math
 import os
 import pathlib
+import secrets
 import stat as stat_module
 import sys
-import tempfile
 from typing import Any
 
 
@@ -528,6 +528,44 @@ def _assert_no_repo_symlink_components(path: pathlib.Path, label: str) -> None:
             raise CompetitorMetricMatrixError(f"{label} must not include symlink components")
 
 
+def _directory_identity(path: pathlib.Path, label: str) -> tuple[int, int]:
+    try:
+        path_stat = path.lstat()
+    except OSError as err:
+        raise CompetitorMetricMatrixError(f"{label} parent directory is unavailable: {err}") from err
+    if stat_module.S_ISLNK(path_stat.st_mode) or not stat_module.S_ISDIR(path_stat.st_mode):
+        raise CompetitorMetricMatrixError(f"{label} parent must be a real directory")
+    return (path_stat.st_dev, path_stat.st_ino)
+
+
+def _assert_directory_identity(path: pathlib.Path, identity: tuple[int, int], label: str) -> None:
+    _assert_no_repo_symlink_components(path, label)
+    if _directory_identity(path, label) != identity:
+        raise CompetitorMetricMatrixError(f"{label} parent directory changed while writing")
+
+
+def _open_stable_directory(path: pathlib.Path, label: str) -> tuple[int, tuple[int, int]]:
+    _assert_no_repo_symlink_components(path, label)
+    path.mkdir(parents=True, exist_ok=True)
+    _assert_no_repo_symlink_components(path, label)
+    identity = _directory_identity(path, label)
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as err:
+        raise CompetitorMetricMatrixError(f"failed to open {label} parent directory: {err}") from err
+    try:
+        fd_stat = os.fstat(fd)
+        if not stat_module.S_ISDIR(fd_stat.st_mode):
+            raise CompetitorMetricMatrixError(f"{label} parent must be a real directory")
+        if (fd_stat.st_dev, fd_stat.st_ino) != identity:
+            raise CompetitorMetricMatrixError(f"{label} parent directory changed while opening")
+    except Exception:
+        os.close(fd)
+        raise
+    return fd, identity
+
+
 def write_outputs(
     payload: dict[str, Any],
     json_path: pathlib.Path | None,
@@ -552,55 +590,96 @@ def write_outputs(
         outputs.append((json_target, json_text))
     if tsv_target is not None:
         outputs.append((tsv_target, to_tsv(payload)))
-    temps: list[pathlib.Path] = []
+    temps: list[tuple[pathlib.Path, str, int, tuple[int, int]]] = []
     replaced: list[pathlib.Path] = []
     original_bytes: dict[pathlib.Path, bytes | None] = {}
-    write_error: OSError | None = None
+    write_error: Exception | None = None
     rollback_errors: list[str] = []
 
-    def write_temp(path: pathlib.Path, text: str) -> pathlib.Path:
-        _assert_no_repo_symlink_components(path.parent, "output path")
-        path.parent.mkdir(parents=True, exist_ok=True)
-        _assert_no_repo_symlink_components(path.parent, "output path")
-        if path.is_symlink():
-            raise CompetitorMetricMatrixError("output path must not include symlink components")
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
-            tmp_path = pathlib.Path(handle.name)
-            handle.write(text)
-            handle.flush()
-            os.fsync(handle.fileno())
-        return tmp_path
+    def write_temp(path: pathlib.Path, contents: bytes, label: str) -> tuple[pathlib.Path, str, int, tuple[int, int]]:
+        parent_fd, parent_identity = _open_stable_directory(path.parent, label)
+        temp_name: str | None = None
+        file_fd: int | None = None
+        try:
+            _assert_directory_identity(path.parent, parent_identity, label)
+            if path.is_symlink():
+                raise CompetitorMetricMatrixError(f"{label} must not include symlink components")
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+            for _ in range(100):
+                candidate = f".{path.name}.{secrets.token_hex(8)}.tmp"
+                try:
+                    file_fd = os.open(candidate, flags, 0o600, dir_fd=parent_fd)
+                    temp_name = candidate
+                    break
+                except FileExistsError:
+                    continue
+            if file_fd is None or temp_name is None:
+                raise CompetitorMetricMatrixError(f"failed to create unique temporary output for {label}")
+            with os.fdopen(file_fd, "wb") as handle:
+                file_fd = None
+                handle.write(contents)
+                handle.flush()
+                os.fsync(handle.fileno())
+            _assert_directory_identity(path.parent, parent_identity, label)
+            return (path.parent / temp_name, temp_name, parent_fd, parent_identity)
+        except Exception:
+            if file_fd is not None:
+                os.close(file_fd)
+            if temp_name is not None:
+                try:
+                    os.unlink(temp_name, dir_fd=parent_fd)
+                except FileNotFoundError:
+                    pass
+            os.close(parent_fd)
+            raise
 
-    def write_temp_bytes(path: pathlib.Path, contents: bytes) -> pathlib.Path:
-        _assert_no_repo_symlink_components(path.parent, "rollback output path")
-        path.parent.mkdir(parents=True, exist_ok=True)
-        _assert_no_repo_symlink_components(path.parent, "rollback output path")
+    def replace_temp(temp: tuple[pathlib.Path, str, int, tuple[int, int]], path: pathlib.Path, label: str) -> None:
+        _, temp_name, parent_fd, parent_identity = temp
+        _assert_directory_identity(path.parent, parent_identity, label)
         if path.is_symlink():
-            raise CompetitorMetricMatrixError("rollback output path must not include symlink components")
-        with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as handle:
-            tmp_path = pathlib.Path(handle.name)
-            handle.write(contents)
-            handle.flush()
-            os.fsync(handle.fileno())
-        return tmp_path
+            raise CompetitorMetricMatrixError(f"{label} must not include symlink components")
+        os.replace(temp_name, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        _assert_directory_identity(path.parent, parent_identity, label)
+
+    def cleanup_temp(temp: tuple[pathlib.Path, str, int, tuple[int, int]]) -> None:
+        _, temp_name, parent_fd, _ = temp
+        try:
+            os.unlink(temp_name, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
 
     def rollback_replace(path: pathlib.Path, contents: bytes) -> None:
         _assert_output_path(path.relative_to(ROOT), "rollback output path")
-        tmp = write_temp_bytes(path, contents)
+        tmp = write_temp(path, contents, "rollback output path")
         temps.append(tmp)
         _assert_output_path(path.relative_to(ROOT), "rollback output path")
-        os.replace(tmp, path)
+        replace_temp(tmp, path, "rollback output path")
+
+    def rollback_remove(path: pathlib.Path) -> None:
+        _assert_output_path(path.relative_to(ROOT), "rollback output path")
+        parent_fd, parent_identity = _open_stable_directory(path.parent, "rollback output path")
+        try:
+            _assert_directory_identity(path.parent, parent_identity, "rollback output path")
+            if path.is_symlink():
+                raise CompetitorMetricMatrixError("rollback output path must not include symlink components")
+            try:
+                os.unlink(path.name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            _assert_directory_identity(path.parent, parent_identity, "rollback output path")
+        finally:
+            os.close(parent_fd)
 
     try:
         try:
             for path, text in outputs:
                 original_bytes[path] = read_source_bytes(path, "existing output") if path.exists() else None
-                tmp = write_temp(path, text)
+                tmp = write_temp(path, text.encode("utf-8"), "output path")
                 temps.append(tmp)
             for tmp, (path, _) in zip(temps, outputs, strict=True):
-                os.replace(tmp, path)
+                replace_temp(tmp, path, "output path")
                 replaced.append(path)
-        except OSError as err:
+        except (CompetitorMetricMatrixError, OSError) as err:
             write_error = err
             raise CompetitorMetricMatrixError(f"failed to write output path: {err}") from err
     finally:
@@ -610,17 +689,19 @@ def write_outputs(
                 try:
                     _assert_output_path(path.relative_to(ROOT), "rollback output path")
                     if original is None:
-                        path.unlink(missing_ok=True)
+                        rollback_remove(path)
                     else:
                         rollback_replace(path, original)
                 except (CompetitorMetricMatrixError, OSError) as err:
                     rollback_errors.append(f"{path}: {err}")
         for tmp in temps:
             try:
-                tmp.unlink(missing_ok=True)
+                cleanup_temp(tmp)
             except OSError as err:
                 if write_error is None:
-                    raise CompetitorMetricMatrixError(f"failed to clean temporary output {tmp}: {err}") from err
+                    raise CompetitorMetricMatrixError(f"failed to clean temporary output {tmp[0]}: {err}") from err
+            finally:
+                os.close(tmp[2])
         if rollback_errors:
             raise CompetitorMetricMatrixError(
                 "failed to roll back output path after write error: "

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Build the May 2026 zkML competitor metric matrix without overclaiming."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+import os
+import pathlib
+import stat as stat_module
+import sys
+import tempfile
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+ENGINEERING_EVIDENCE = ROOT / "docs" / "engineering" / "evidence"
+PAPER_EVIDENCE = ROOT / "docs" / "paper" / "evidence"
+PUBLISHED_ZKML_NUMBERS = PAPER_EVIDENCE / "published-zkml-numbers-2026-04.tsv"
+FUSION_MECHANISM = ENGINEERING_EVIDENCE / "zkai-attention-kv-stwo-fusion-mechanism-ablation-2026-05.json"
+D64_BLOCK_RECEIPT = ENGINEERING_EVIDENCE / "zkai-d64-block-receipt-composition-gate-2026-05.json"
+D128_TARGET = ENGINEERING_EVIDENCE / "zkai-d128-layerwise-comparator-target-2026-05.json"
+JSON_OUT = ENGINEERING_EVIDENCE / "zkai-may2026-competitor-metric-matrix.json"
+TSV_OUT = ENGINEERING_EVIDENCE / "zkai-may2026-competitor-metric-matrix.tsv"
+
+SCHEMA = "zkai-may2026-competitor-metric-matrix-v1"
+DECISION = "GO_SOURCE_BACKED_COMPETITOR_MATRIX_NO_GO_MATCHED_BENCHMARK_CLAIMS"
+CLAIM_BOUNDARY = (
+    "SOURCE_BACKED_MAY2026_ZKML_COMPETITOR_MATRIX_WITH_LOCAL_STWO_ATTENTION_FUSION_AND_"
+    "TRANSFORMER_BLOCK_TARGET_CONTEXT_NOT_A_MATCHED_PUBLIC_BENCHMARK_NOT_FULL_INFERENCE"
+)
+MAX_SOURCE_BYTES = 16 * 1024 * 1024
+
+VALIDATION_COMMANDS = [
+    "python3 scripts/zkai_may2026_competitor_metric_matrix_gate.py --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate",
+    "git diff --check",
+    "just gate-fast",
+    "just gate",
+]
+
+NON_CLAIMS = [
+    "not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero",
+    "not a local d128 proof result",
+    "not proof-size or verifier-time evidence for a local d128 transformer block",
+    "not full transformer inference",
+    "not exact real-valued Softmax",
+    "not production-ready",
+]
+
+EXPECTED_EXTERNAL_ROWS = {
+    ("NANOZK", "Transformer block proof", "Per-layer block proof"): {
+        "prove_seconds": "6.3",
+        "verify_seconds": "0.023",
+        "proof_size_reported": "6.9 KB",
+    },
+    ("NANOZK", "GPT-2-Small full model", "Sequential 12-layer end-to-end"): {
+        "prove_seconds": "516",
+        "verify_seconds": "NA",
+        "proof_size_reported": "NA",
+    },
+    ("Jolt Atlas", "NanoGPT proof", "End-to-end"): {
+        "prove_seconds": "14",
+        "verify_seconds": "0.517",
+        "proof_size_reported": "NA",
+    },
+    ("Jolt Atlas", "GPT-2 proof", "End-to-end"): {
+        "prove_seconds": "38",
+        "verify_seconds": "NA",
+        "proof_size_reported": "NA",
+    },
+    ("EZKL (reported by Jolt Atlas)", "NanoGPT proof", "End-to-end"): {
+        "prove_seconds": "237",
+        "verify_seconds": "0.34",
+        "proof_size_reported": "NA",
+    },
+}
+
+REQUIRED_PUBLISHED_COLUMNS = {
+    "system",
+    "source_url",
+    "source_locator",
+    "backend_family",
+    "workload_label",
+    "workload_scope",
+    "model_or_dims",
+    "prove_seconds",
+    "verify_seconds",
+    "proof_size_reported",
+    "setup_or_keygen_seconds",
+    "hardware",
+}
+
+
+class CompetitorMetricMatrixError(ValueError):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as err:
+        raise CompetitorMetricMatrixError(f"invalid JSON value: {err}") from err
+
+
+def pretty_json(value: Any) -> str:
+    try:
+        return json.dumps(value, indent=2, sort_keys=True, allow_nan=False)
+    except (TypeError, ValueError) as err:
+        raise CompetitorMetricMatrixError(f"invalid JSON value: {err}") from err
+
+
+def payload_commitment(payload: dict[str, Any]) -> str:
+    material = {key: value for key, value in payload.items() if key != "payload_commitment"}
+    return "sha256:" + hashlib.sha256(canonical_json_bytes(material)).hexdigest()
+
+
+def read_source_bytes(path: pathlib.Path, label: str) -> bytes:
+    root = ROOT.resolve()
+    candidate = pathlib.Path(os.path.abspath(path if path.is_absolute() else ROOT / path))
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError as err:
+        raise CompetitorMetricMatrixError(f"source path must stay inside repository: {path}") from err
+
+    current = root
+    pre_stat = None
+    try:
+        for part in relative.parts:
+            current = current / part
+            part_stat = current.lstat()
+            if stat_module.S_ISLNK(part_stat.st_mode):
+                raise CompetitorMetricMatrixError(f"source path must not traverse symlinks: {path}")
+            pre_stat = part_stat
+        if pre_stat is None or not stat_module.S_ISREG(pre_stat.st_mode):
+            raise CompetitorMetricMatrixError(f"source path must be a repo file: {path}")
+        fd = os.open(candidate, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            post_stat = os.fstat(fd)
+            if not stat_module.S_ISREG(post_stat.st_mode):
+                raise CompetitorMetricMatrixError(f"source path must be a repo file: {path}")
+            if (post_stat.st_dev, post_stat.st_ino) != (pre_stat.st_dev, pre_stat.st_ino):
+                raise CompetitorMetricMatrixError(f"source path changed while reading: {path}")
+            with os.fdopen(fd, "rb") as handle:
+                fd = None
+                raw = handle.read(MAX_SOURCE_BYTES + 1)
+        finally:
+            if fd is not None:
+                os.close(fd)
+    except OSError as err:
+        raise CompetitorMetricMatrixError(f"failed to read {label} source {path}: {err}") from err
+    if len(raw) > MAX_SOURCE_BYTES:
+        raise CompetitorMetricMatrixError(
+            f"source exceeds max size: got at least {len(raw)} bytes, limit {MAX_SOURCE_BYTES}"
+        )
+    return raw
+
+
+def _source_from_bytes(path: pathlib.Path, kind: str, raw: bytes) -> dict[str, str]:
+    return {
+        "kind": kind,
+        "path": str(path.relative_to(ROOT)),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+    }
+
+
+def _parse_json_bytes(path: pathlib.Path, raw: bytes) -> dict[str, Any]:
+    try:
+        payload = json.loads(raw.decode("utf-8"), parse_constant=_reject_json_constant)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as err:
+        raise CompetitorMetricMatrixError(f"failed to load JSON source {path}: {err}") from err
+    if not isinstance(payload, dict):
+        raise CompetitorMetricMatrixError(f"JSON source must be object: {path}")
+    return payload
+
+
+def load_json(path: pathlib.Path) -> dict[str, Any]:
+    return _parse_json_bytes(path, read_source_bytes(path, "JSON"))
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant: {value}")
+
+
+def _parse_tsv_bytes(path: pathlib.Path, raw: bytes) -> list[dict[str, str]]:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as err:
+        raise CompetitorMetricMatrixError(f"failed to load TSV source {path}: {err}") from err
+    reader = csv.DictReader(io.StringIO(text), delimiter="\t")
+    missing = REQUIRED_PUBLISHED_COLUMNS - set(reader.fieldnames or [])
+    if missing:
+        raise CompetitorMetricMatrixError(f"TSV source missing columns: {sorted(missing)}")
+    rows = list(reader)
+    if not rows:
+        raise CompetitorMetricMatrixError(f"TSV source must not be empty: {path}")
+    return rows
+
+
+def load_tsv(path: pathlib.Path) -> list[dict[str, str]]:
+    return _parse_tsv_bytes(path, read_source_bytes(path, "TSV"))
+
+
+def _find_external_row(
+    rows: list[dict[str, str]], system: str, workload_label: str, workload_scope: str
+) -> dict[str, str]:
+    matches = [
+        row
+        for row in rows
+        if row.get("system") == system
+        and row.get("workload_label") == workload_label
+        and row.get("workload_scope") == workload_scope
+    ]
+    if len(matches) != 1:
+        raise CompetitorMetricMatrixError(
+            f"expected one published row for {system} / {workload_label} / {workload_scope}"
+        )
+    row = matches[0]
+    expected = EXPECTED_EXTERNAL_ROWS[(system, workload_label, workload_scope)]
+    for key, value in expected.items():
+        if row[key] != value:
+            raise CompetitorMetricMatrixError(f"published metric drift for {system} / {workload_label}: {key}")
+    return row
+
+
+def _tsv_cell(row: dict[str, str], key: str, label: str) -> str:
+    value = row.get(key)
+    if value is None:
+        raise CompetitorMetricMatrixError(f"{label} missing TSV column: {key}")
+    return value
+
+
+def _external_rows(published: list[dict[str, str]]) -> list[dict[str, Any]]:
+    selected = []
+    for system, workload, scope in EXPECTED_EXTERNAL_ROWS:
+        row = _find_external_row(published, system, workload, scope)
+        selected.append(
+            {
+                "system": _tsv_cell(row, "system", system),
+                "source_url": _tsv_cell(row, "source_url", system),
+                "source_locator": _tsv_cell(row, "source_locator", system),
+                "backend_family": _tsv_cell(row, "backend_family", system),
+                "workload_label": _tsv_cell(row, "workload_label", system),
+                "workload_scope": _tsv_cell(row, "workload_scope", system),
+                "model_or_dims": _tsv_cell(row, "model_or_dims", system),
+                "prove_seconds": _tsv_cell(row, "prove_seconds", system),
+                "verify_seconds": _tsv_cell(row, "verify_seconds", system),
+                "proof_size_reported": _tsv_cell(row, "proof_size_reported", system),
+                "setup_or_keygen_seconds": _tsv_cell(row, "setup_or_keygen_seconds", system),
+                "hardware": _tsv_cell(row, "hardware", system),
+                "comparison_status": "SOURCE_BACKED_CONTEXT_ONLY_NOT_LOCAL_REPRODUCTION",
+            }
+        )
+    return selected
+
+
+def _source_field(payload: dict[str, Any], path: tuple[str, ...], label: str) -> Any:
+    current: Any = payload
+    for part in path:
+        if not isinstance(current, dict) or part not in current:
+            raise CompetitorMetricMatrixError(f"{label} missing or malformed")
+        current = current[part]
+    return current
+
+
+def _integer_source_field(payload: dict[str, Any], path: tuple[str, ...], label: str) -> int:
+    value = _source_field(payload, path, label)
+    if type(value) is not int:
+        raise CompetitorMetricMatrixError(f"{label} must be integer")
+    return value
+
+
+def _numeric_source_field(payload: dict[str, Any], path: tuple[str, ...], label: str) -> float:
+    value = _source_field(payload, path, label)
+    if type(value) not in (int, float):
+        raise CompetitorMetricMatrixError(f"{label} must be numeric")
+    number = float(value)
+    if not math.isfinite(number):
+        raise CompetitorMetricMatrixError(f"{label} must be finite")
+    return number
+
+
+def _share_source_field(payload: dict[str, Any], path: tuple[str, ...], label: str) -> float:
+    number = _numeric_source_field(payload, path, label)
+    if number < 0.0 or number > 1.0:
+        raise CompetitorMetricMatrixError(f"{label} must be between 0 and 1")
+    return number
+
+
+def _string_source_field(payload: dict[str, Any], path: tuple[str, ...], label: str) -> str:
+    value = _source_field(payload, path, label)
+    if not isinstance(value, str):
+        raise CompetitorMetricMatrixError(f"{label} must be string")
+    return value
+
+
+def _local_rows(fusion: dict[str, Any], d64: dict[str, Any], d128: dict[str, Any]) -> list[dict[str, Any]]:
+    if _string_source_field(fusion, ("decision",), "fusion decision") != (
+        "GO_STARK_NATIVE_FUSION_MECHANISM_ABLATION_FOR_PAPER_ARCHITECTURE_CLAIM"
+    ):
+        raise CompetitorMetricMatrixError("fusion mechanism decision drift")
+    if _string_source_field(d64, ("decision",), "d64 decision") != "GO_D64_BLOCK_RECEIPT_COMPOSITION_GATE":
+        raise CompetitorMetricMatrixError("d64 block receipt decision drift")
+    if _string_source_field(d128, ("decision",), "d128 decision") != "NO_GO_D128_LAYERWISE_PROOF_ARTIFACT_MISSING":
+        raise CompetitorMetricMatrixError("d128 target decision drift")
+
+    fused_savings = _integer_source_field(fusion, ("route_matrix", "fused_savings_bytes_total"), "fusion savings")
+    matched_profiles = _integer_source_field(
+        fusion, ("route_matrix", "matched_profiles_checked"), "fusion matched profiles"
+    )
+    opening_share = _share_source_field(
+        fusion, ("section_delta", "opening_bucket_savings_share"), "fusion opening share"
+    )
+    total_checked_rows = _integer_source_field(d64, ("summary", "total_checked_rows"), "d64 total checked rows")
+    slice_count = _integer_source_field(d64, ("summary", "slice_count"), "d64 slice count")
+    mutations_rejected = _integer_source_field(d64, ("summary", "mutations_rejected"), "d64 mutations rejected")
+    mutation_cases = _integer_source_field(d64, ("summary", "mutation_cases"), "d64 mutation cases")
+    target_linear_muls = _integer_source_field(
+        d128, ("summary", "target_estimated_linear_muls"), "d128 target linear multiplications"
+    )
+    first_blocker = _string_source_field(d128, ("summary", "first_blocker"), "d128 first blocker")
+    if fused_savings <= 0:
+        raise CompetitorMetricMatrixError("fusion savings must be positive")
+    if matched_profiles <= 0:
+        raise CompetitorMetricMatrixError("fusion matched profiles must be positive")
+    if total_checked_rows <= 0:
+        raise CompetitorMetricMatrixError("d64 checked rows must be positive")
+    if slice_count <= 0:
+        raise CompetitorMetricMatrixError("d64 slice count must be positive")
+    if mutations_rejected != mutation_cases or mutation_cases <= 0:
+        raise CompetitorMetricMatrixError("d64 mutation rejection summary drift")
+    if target_linear_muls <= 0:
+        raise CompetitorMetricMatrixError("d128 target linear multiplications must be positive")
+
+    return [
+        {
+            "system": "provable-transformer-vm",
+            "surface": "Stwo attention/Softmax-table fusion",
+            "local_status": "GO_BOUNDED_ARCHITECTURE_MECHANISM",
+            "metric": "matched route JSON proof-byte saving",
+            "value": fused_savings,
+            "unit": "bytes",
+            "support": f"{matched_profiles} matched profiles; opening share {opening_share:.6f}",
+            "comparison_status": "LOCAL_MECHANISM_EVIDENCE_NOT_LAYERWISE_FULL_MODEL_BENCHMARK",
+        },
+        {
+            "system": "provable-transformer-vm",
+            "surface": "d64 RMSNorm/SwiGLU/residual block receipt",
+            "local_status": "GO_STATEMENT_BOUND_RECEIPT_COMPOSITION",
+            "metric": "checked slice rows",
+            "value": total_checked_rows,
+            "unit": "rows",
+            "support": f"{slice_count} slices; {mutations_rejected} / {mutation_cases} mutations rejected",
+            "comparison_status": "LOCAL_RECEIPT_CHAIN_NOT_RECURSIVE_PROOF_COMPRESSION",
+        },
+        {
+            "system": "provable-transformer-vm",
+            "surface": "d128 RMSNorm/SwiGLU/residual comparator target",
+            "local_status": "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
+            "metric": "target estimated linear multiplications",
+            "value": target_linear_muls,
+            "unit": "linear_muls",
+            "support": first_blocker,
+            "comparison_status": "TARGET_SPEC_ONLY_NOT_LOCAL_PROOF_RESULT",
+        },
+    ]
+
+
+def build_payload() -> dict[str, Any]:
+    payload = build_payload_uncommitted()
+    payload["payload_commitment"] = payload_commitment(payload)
+    validate_payload(payload)
+    return payload
+
+
+def validate_payload(payload: dict[str, Any]) -> None:
+    if not isinstance(payload, dict):
+        raise CompetitorMetricMatrixError("payload must be object")
+    expected = {key: value for key, value in build_payload_uncommitted().items() if key != "payload_commitment"}
+    candidate = {key: value for key, value in payload.items() if key != "payload_commitment"}
+    if candidate != expected:
+        if payload.get("schema") != SCHEMA:
+            raise CompetitorMetricMatrixError("schema drift")
+        if payload.get("decision") != DECISION:
+            raise CompetitorMetricMatrixError("decision drift")
+        if payload.get("claim_boundary") != CLAIM_BOUNDARY:
+            raise CompetitorMetricMatrixError("claim boundary drift")
+        if payload.get("non_claims") != NON_CLAIMS:
+            raise CompetitorMetricMatrixError("non_claims drift")
+        raise CompetitorMetricMatrixError("payload drift")
+    if payload.get("payload_commitment") != payload_commitment(payload):
+        raise CompetitorMetricMatrixError("payload commitment drift")
+
+
+def build_payload_uncommitted() -> dict[str, Any]:
+    published_raw = read_source_bytes(PUBLISHED_ZKML_NUMBERS, "published zkML TSV")
+    fusion_raw = read_source_bytes(FUSION_MECHANISM, "fusion mechanism JSON")
+    d64_raw = read_source_bytes(D64_BLOCK_RECEIPT, "d64 block receipt JSON")
+    d128_raw = read_source_bytes(D128_TARGET, "d128 target JSON")
+    published = _parse_tsv_bytes(PUBLISHED_ZKML_NUMBERS, published_raw)
+    fusion = _parse_json_bytes(FUSION_MECHANISM, fusion_raw)
+    d64 = _parse_json_bytes(D64_BLOCK_RECEIPT, d64_raw)
+    d128 = _parse_json_bytes(D128_TARGET, d128_raw)
+    return {
+        "schema": SCHEMA,
+        "decision": DECISION,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "source_artifacts": [
+            _source_from_bytes(PUBLISHED_ZKML_NUMBERS, "published_zkml_numbers_tsv", published_raw),
+            _source_from_bytes(FUSION_MECHANISM, "local_fusion_mechanism_json", fusion_raw),
+            _source_from_bytes(D64_BLOCK_RECEIPT, "local_d64_block_receipt_json", d64_raw),
+            _source_from_bytes(D128_TARGET, "local_d128_target_json", d128_raw),
+        ],
+        "external_rows": _external_rows(published),
+        "local_rows": _local_rows(fusion, d64, d128),
+        "interpretation": [
+            "NANOZK and Jolt Atlas are the relevant layerwise/end-to-end competitors for headline zkML metrics.",
+            "The local repo does not yet have a d128 layer proof to compare on proof size or verifier time.",
+            "The local competitive claim is currently architectural: STARK-native fusion saves duplicated opening/decommitment plumbing.",
+            "The next real block milestone is a parameterized d64 then d128 RMSNorm/SwiGLU/residual proof surface with the same statement bindings.",
+        ],
+        "non_claims": NON_CLAIMS,
+        "validation_commands": VALIDATION_COMMANDS,
+    }
+
+
+def to_tsv(payload: dict[str, Any]) -> str:
+    out = io.StringIO()
+    writer = csv.writer(out, delimiter="\t", lineterminator="\n")
+    writer.writerow(
+        [
+            "row_kind",
+            "system",
+            "surface_or_workload",
+            "prove_seconds",
+            "verify_seconds",
+            "proof_size_reported",
+            "local_metric",
+            "local_value",
+            "comparison_status",
+        ]
+    )
+    for row in payload["external_rows"]:
+        writer.writerow(
+            [
+                "external",
+                row["system"],
+                row["workload_label"],
+                row["prove_seconds"],
+                row["verify_seconds"],
+                row["proof_size_reported"],
+                "",
+                "",
+                row["comparison_status"],
+            ]
+        )
+    for row in payload["local_rows"]:
+        writer.writerow(
+            [
+                "local",
+                row["system"],
+                row["surface"],
+                "",
+                "",
+                "",
+                row["metric"],
+                row["value"],
+                row["comparison_status"],
+            ]
+        )
+    return out.getvalue()
+
+
+def _assert_output_path(path: pathlib.Path, label: str) -> pathlib.Path:
+    raw = str(path).replace("\\", "/")
+    relative = pathlib.PurePosixPath(raw)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise CompetitorMetricMatrixError(f"{label} must be repo-relative")
+    if pathlib.PurePosixPath(*relative.parts[:3]) != pathlib.PurePosixPath("docs/engineering/evidence"):
+        raise CompetitorMetricMatrixError(f"{label} must stay under docs/engineering/evidence")
+    full = ROOT.joinpath(*relative.parts)
+    _assert_no_repo_symlink_components(full.parent, label)
+    if full.is_symlink():
+        raise CompetitorMetricMatrixError(f"{label} must not include symlink components")
+    return full
+
+
+def _assert_no_repo_symlink_components(path: pathlib.Path, label: str) -> None:
+    root = ROOT
+    absolute = path if path.is_absolute() else ROOT / path
+    try:
+        relative = absolute.relative_to(ROOT)
+    except ValueError as err:
+        raise CompetitorMetricMatrixError(f"{label} must stay inside repository") from err
+    if ".." in relative.parts:
+        raise CompetitorMetricMatrixError(f"{label} must stay inside repository")
+    current = root
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink():
+            raise CompetitorMetricMatrixError(f"{label} must not include symlink components")
+
+
+def write_outputs(payload: dict[str, Any], json_path: pathlib.Path, tsv_path: pathlib.Path) -> None:
+    validate_payload(payload)
+    json_text = pretty_json(payload) + "\n"
+
+    json_target = _assert_output_path(json_path, "json output path")
+    tsv_target = _assert_output_path(tsv_path, "tsv output path")
+    if os.path.abspath(json_target) == os.path.abspath(tsv_target):
+        raise CompetitorMetricMatrixError("json and tsv output paths must differ")
+
+    outputs = [(json_target, json_text), (tsv_target, to_tsv(payload))]
+    temps: list[pathlib.Path] = []
+    replaced: list[pathlib.Path] = []
+    original_bytes: dict[pathlib.Path, bytes | None] = {}
+    write_error: OSError | None = None
+
+    def write_temp(path: pathlib.Path, text: str) -> pathlib.Path:
+        _assert_no_repo_symlink_components(path.parent, "output path")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _assert_no_repo_symlink_components(path.parent, "output path")
+        if path.is_symlink():
+            raise CompetitorMetricMatrixError("output path must not include symlink components")
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+            tmp_path = pathlib.Path(handle.name)
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return tmp_path
+
+    def write_temp_bytes(path: pathlib.Path, contents: bytes) -> pathlib.Path:
+        _assert_no_repo_symlink_components(path.parent, "rollback output path")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _assert_no_repo_symlink_components(path.parent, "rollback output path")
+        if path.is_symlink():
+            raise CompetitorMetricMatrixError("rollback output path must not include symlink components")
+        with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as handle:
+            tmp_path = pathlib.Path(handle.name)
+            handle.write(contents)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return tmp_path
+
+    def rollback_replace(path: pathlib.Path, contents: bytes) -> None:
+        _assert_output_path(path.relative_to(ROOT), "rollback output path")
+        tmp = write_temp_bytes(path, contents)
+        temps.append(tmp)
+        _assert_output_path(path.relative_to(ROOT), "rollback output path")
+        os.replace(tmp, path)
+
+    try:
+        try:
+            for path, text in outputs:
+                original_bytes[path] = read_source_bytes(path, "existing output") if path.exists() else None
+                tmp = write_temp(path, text)
+                temps.append(tmp)
+            for tmp, (path, _) in zip(temps, outputs, strict=True):
+                os.replace(tmp, path)
+                replaced.append(path)
+        except OSError as err:
+            write_error = err
+            raise CompetitorMetricMatrixError(f"failed to write output path: {err}") from err
+    finally:
+        if write_error is not None:
+            for path in reversed(replaced):
+                original = original_bytes.get(path)
+                try:
+                    _assert_output_path(path.relative_to(ROOT), "rollback output path")
+                    if original is None:
+                        path.unlink(missing_ok=True)
+                    else:
+                        rollback_replace(path, original)
+                except (CompetitorMetricMatrixError, OSError):
+                    pass
+        for tmp in temps:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError as err:
+                if write_error is None:
+                    raise CompetitorMetricMatrixError(f"failed to clean temporary output {tmp}: {err}") from err
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write-json", type=pathlib.Path, default=None)
+    parser.add_argument("--write-tsv", type=pathlib.Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        payload = build_payload()
+        if args.write_json or args.write_tsv:
+            write_outputs(payload, args.write_json or JSON_OUT.relative_to(ROOT), args.write_tsv or TSV_OUT.relative_to(ROOT))
+        else:
+            print(pretty_json(payload))
+    except CompetitorMetricMatrixError as err:
+        print(f"competitor metric matrix gate failed: {err}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -378,15 +378,18 @@ def _local_rows(fusion: dict[str, Any], d64: dict[str, Any], d128: dict[str, Any
 
 def build_payload() -> dict[str, Any]:
     payload = build_payload_uncommitted()
+    expected = dict(payload)
     payload["payload_commitment"] = payload_commitment(payload)
-    validate_payload(payload)
+    validate_payload(payload, expected=expected)
     return payload
 
 
-def validate_payload(payload: dict[str, Any]) -> None:
+def validate_payload(payload: dict[str, Any], *, expected: dict[str, Any] | None = None) -> None:
     if not isinstance(payload, dict):
         raise CompetitorMetricMatrixError("payload must be object")
-    expected = {key: value for key, value in build_payload_uncommitted().items() if key != "payload_commitment"}
+    if expected is None:
+        expected = build_payload_uncommitted()
+    expected = {key: value for key, value in expected.items() if key != "payload_commitment"}
     candidate = {key: value for key, value in payload.items() if key != "payload_commitment"}
     if candidate != expected:
         if payload.get("schema") != SCHEMA:
@@ -511,16 +514,26 @@ def _assert_no_repo_symlink_components(path: pathlib.Path, label: str) -> None:
             raise CompetitorMetricMatrixError(f"{label} must not include symlink components")
 
 
-def write_outputs(payload: dict[str, Any], json_path: pathlib.Path, tsv_path: pathlib.Path) -> None:
+def write_outputs(
+    payload: dict[str, Any],
+    json_path: pathlib.Path | None,
+    tsv_path: pathlib.Path | None,
+) -> None:
     validate_payload(payload)
     json_text = pretty_json(payload) + "\n"
 
-    json_target = _assert_output_path(json_path, "json output path")
-    tsv_target = _assert_output_path(tsv_path, "tsv output path")
-    if os.path.abspath(json_target) == os.path.abspath(tsv_target):
+    json_target = _assert_output_path(json_path, "json output path") if json_path is not None else None
+    tsv_target = _assert_output_path(tsv_path, "tsv output path") if tsv_path is not None else None
+    if json_target is None and tsv_target is None:
+        raise CompetitorMetricMatrixError("at least one explicit output path is required")
+    if json_target is not None and tsv_target is not None and os.path.abspath(json_target) == os.path.abspath(tsv_target):
         raise CompetitorMetricMatrixError("json and tsv output paths must differ")
 
-    outputs = [(json_target, json_text), (tsv_target, to_tsv(payload))]
+    outputs = []
+    if json_target is not None:
+        outputs.append((json_target, json_text))
+    if tsv_target is not None:
+        outputs.append((tsv_target, to_tsv(payload)))
     temps: list[pathlib.Path] = []
     replaced: list[pathlib.Path] = []
     original_bytes: dict[pathlib.Path, bytes | None] = {}
@@ -603,7 +616,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         payload = build_payload()
         if args.write_json or args.write_tsv:
-            write_outputs(payload, args.write_json or JSON_OUT.relative_to(ROOT), args.write_tsv or TSV_OUT.relative_to(ROOT))
+            write_outputs(payload, args.write_json, args.write_tsv)
         else:
             print(pretty_json(payload))
     except CompetitorMetricMatrixError as err:


### PR DESCRIPTION

## Summary
- add a source-backed May 2026 zkML competitor matrix for NANOZK, Jolt Atlas, and EZKL context rows
- add local comparison rows for Stwo attention/Softmax-table fusion, d64 block receipt composition, and the d128 no-go target
- add a gate and tests that keep the comparison honest: local rows are not treated as matched public benchmarks

## Evidence
- NANOZK d=768 transformer-block row: 6.3s prove, 0.023s verify, 6.9 KB proof, source-backed from published TSV
- Jolt Atlas NanoGPT/GPT-2 and EZKL NanoGPT rows are source-backed context only
- local Stwo fusion row carries 194,097 matched JSON proof bytes saved
- local d64 row carries 49,600 checked slice rows
- local d128 row remains NO-GO for missing local proof artifact

## Local validation
- `python3 scripts/zkai_may2026_competitor_metric_matrix_gate.py --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv`
- `python3 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate`
- `git diff --check`
- `just gate-fast`

## Hardening
- source artifacts are single-read and hash-bound
- non-finite JSON constants are rejected
- output writes are scoped under docs/engineering/evidence and rollback through atomic temp-file replace
- local comparison rows stay explicitly marked as context, target, or local mechanism evidence

## Non-claims
- not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero
- not a local d128 proof result
- not proof-size or verifier-time evidence for a local d128 transformer block
- not full transformer inference
- not exact real-valued Softmax
- not production-ready

GitHub Actions remain manual-only; this PR relies on local validation plus Qodo/CodeRabbit review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added engineering guidance defining the competitor metric matrix, evidence inputs, interpretation rules, explicit non-claims, and verification commands.

* **New Features**
  * Added a deterministic, source-backed competitor metric matrix generator with strict repo-confined input validation, commitment-based drift detection, deterministic TSV/JSON output, and atomic write/rollback behavior.

* **Tests**
  * Added comprehensive tests covering payload construction, drift rejection, source integrity, TSV/JSON round-trips, write rollback/symlink edge cases, and input validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/552)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->