### PR TITLE
Add package accounting to competitor matrix

### DIFF
--- a/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json
+++ b/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json
@@ -81,7 +81,8 @@
   "interpretation": [
     "NANOZK and Jolt Atlas are the relevant layerwise/end-to-end competitors for headline zkML metrics.",
     "The local repo does not yet have a d128 layer proof to compare on proof size or verifier time.",
-    "The local competitive claim is currently architectural: STARK-native fusion saves duplicated opening/decommitment plumbing.",
+    "The local competitive claim is architectural: STARK-native fusion saves duplicated opening/decommitment plumbing.",
+    "The executable package-accounting rows show a smaller verifier-facing package than the source statement chain, but they are external receipt accounting rather than native layer proof evidence.",
     "The next real block milestone is a parameterized d64 then d128 RMSNorm/SwiGLU/residual proof surface with the same statement bindings."
   ],
   "local_rows": [
@@ -114,17 +115,38 @@
       "system": "provable-transformer-vm",
       "unit": "linear_muls",
       "value": 196608
+    },
+    {
+      "comparison_status": "LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_NOT_MATCHED_LAYER_PROOF_BENCHMARK",
+      "local_status": "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF",
+      "metric": "compressed artifact plus proof plus public signals",
+      "support": "0.324945x source; saves 9872 bytes; 12 / 12 package mutations rejected; 40 receipt mutations rejected",
+      "surface": "attention-derived d128 executable package without VK",
+      "system": "provable-transformer-vm",
+      "unit": "bytes",
+      "value": 4752
+    },
+    {
+      "comparison_status": "LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_WITH_SETUP_NOT_MATCHED_LAYER_PROOF_BENCHMARK",
+      "local_status": "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF",
+      "metric": "compressed artifact plus proof plus public signals plus verification key",
+      "support": "0.725383x source; saves 4016 bytes; 17 public signals; VK counted as self-contained package",
+      "surface": "attention-derived d128 executable package with VK",
+      "system": "provable-transformer-vm",
+      "unit": "bytes",
+      "value": 10608
     }
   ],
   "non_claims": [
     "not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero",
     "not a local d128 proof result",
     "not proof-size or verifier-time evidence for a local d128 transformer block",
+    "not native proof-size evidence from the external package-accounting rows",
     "not full transformer inference",
     "not exact real-valued Softmax",
     "not production-ready"
   ],
-  "payload_commitment": "sha256:33153867ba85c312a3218d945b46dd86a323b52fbbebdd4e284e898a6783c27f",
+  "payload_commitment": "sha256:1f3102fded6ee40d98a4c7ba2759c8938786fe36845edf91e24d628bf27a3fb4",
   "schema": "zkai-may2026-competitor-metric-matrix-v1",
   "source_artifacts": [
     {
@@ -146,6 +168,11 @@
       "kind": "local_d128_target_json",
       "path": "docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json",
       "sha256": "bf1b5cb0dc3471d5c7421f091b4f94f986e38f2ed80e91f325f26fc8080617a0"
+    },
+    {
+      "kind": "local_one_block_package_accounting_json",
+      "path": "docs/engineering/evidence/zkai-one-block-executable-package-accounting-2026-05.json",
+      "sha256": "c7eae55c04fac6e1412752c07bfdf32deeb4e2059a51c3b279037905ce703277"
     }
   ],
   "validation_commands": [

--- a/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv
+++ b/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv
@@ -7,3 +7,5 @@ external	EZKL (reported by Jolt Atlas)	NanoGPT proof	237	0.34	NA			SOURCE_BACKED
 local	provable-transformer-vm	Stwo attention/Softmax-table fusion				matched route JSON proof-byte saving	194097	LOCAL_MECHANISM_EVIDENCE_NOT_LAYERWISE_FULL_MODEL_BENCHMARK
 local	provable-transformer-vm	d64 RMSNorm/SwiGLU/residual block receipt				checked slice rows	49600	LOCAL_RECEIPT_CHAIN_NOT_RECURSIVE_PROOF_COMPRESSION
 local	provable-transformer-vm	d128 RMSNorm/SwiGLU/residual comparator target				target estimated linear multiplications	196608	TARGET_SPEC_ONLY_NOT_LOCAL_PROOF_RESULT
+local	provable-transformer-vm	attention-derived d128 executable package without VK				compressed artifact plus proof plus public signals	4752	LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_NOT_MATCHED_LAYER_PROOF_BENCHMARK
+local	provable-transformer-vm	attention-derived d128 executable package with VK				compressed artifact plus proof plus public signals plus verification key	10608	LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_WITH_SETUP_NOT_MATCHED_LAYER_PROOF_BENCHMARK

--- a/docs/engineering/evidence/zkai-one-block-executable-package-accounting-2026-05.json
+++ b/docs/engineering/evidence/zkai-one-block-executable-package-accounting-2026-05.json
@@ -120,16 +120,16 @@
       "surface": "compressed artifact plus proof plus public signals plus verification key"
     }
   ],
-  "payload_commitment": "sha256:f4f879fac1dfe2807c1b52c4204acbb5023289dcde1911a2fbf10f981a68f247",
+  "payload_commitment": "sha256:327ccbc9bd6b46d507cd347e39e07eb6de6e58b2f5df24aab411ce066fe825ba",
   "result": "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_BLOCK_PROOF",
   "schema": "zkai-one-block-executable-package-accounting-v1",
   "source_artifacts": [
     {
       "decision": "GO_ONE_TRANSFORMER_BLOCK_SURFACE_NO_GO_MATCHED_LAYER_PROOF",
-      "file_sha256": "d287744e8dc8a8227fba110f47f86d5da7bac80353835dc1c2e054e20ec804e6",
+      "file_sha256": "e02fa957b2ca7d54056d564b53fd64bcdb5b94983dc1c7d59e4dc3c017436022",
       "kind": "one_block_scorecard_json",
       "path": "docs/engineering/evidence/zkai-one-transformer-block-surface-2026-05.json",
-      "payload_sha256": "22bbef36def7139aa7a9ccbca03f822a9ee2d070a99f258538f4c088cb1c3501",
+      "payload_sha256": "315729692adf873a6fab16882f03f8b349ee87b7a13d1030ffcc0660d1a48fc6",
       "schema": "zkai-one-transformer-block-surface-v1"
     },
     {

--- a/docs/engineering/evidence/zkai-one-transformer-block-surface-2026-05.json
+++ b/docs/engineering/evidence/zkai-one-transformer-block-surface-2026-05.json
@@ -105,7 +105,7 @@
     "not full autoregressive inference",
     "not production-ready"
   ],
-  "payload_commitment": "sha256:085b3fe4014e3b4c939389983b15d08b45abe34c5d71a6d25616953c0f80beba",
+  "payload_commitment": "sha256:7fad85e369c847672970fb2ed0f7d8ec8e36912b2817923d20f55ad7fd66d8f7",
   "schema": "zkai-one-transformer-block-surface-v1",
   "source_artifacts": [
     {
@@ -134,9 +134,9 @@
       "sha256": "0b2f311210c9102b758a1987441a0ef44044998636e6b7bf3ccd19e0558b60fc"
     },
     {
-      "kind": "source_backed_competitor_matrix_json",
-      "path": "docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json",
-      "sha256": "ed838fd9137d66fb2acbf72e3ac82fca4774a4d0f6d9b935a74674cfd671249d"
+      "kind": "published_zkml_numbers_tsv",
+      "path": "docs/paper/evidence/published-zkml-numbers-2026-04.tsv",
+      "sha256": "aa16aa98493ecf9f984d238875890c81b4525ebde21463b76010c92f6767390b"
     }
   ],
   "summary": {

--- a/docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md
+++ b/docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md
@@ -15,7 +15,8 @@ The comparison posture is:
 > layerwise or end-to-end zkML proving. This repository should compare against
 > them honestly, but its current strongest local result is architectural:
 > STARK-native attention/Softmax-table fusion saves duplicated opening and
-> decommitment plumbing.
+> decommitment plumbing, and the attention-derived one-block route now has
+> explicit external package accounting.
 
 ## Evidence
 
@@ -27,6 +28,18 @@ The comparison posture is:
   `scripts/zkai_may2026_competitor_metric_matrix_gate.py`
 - Tests:
   `scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py`
+
+## Dependency Discipline
+
+The evidence graph is intentionally acyclic:
+
+```text
+published zkML TSV -> one-block surface -> package accounting -> competitor matrix
+```
+
+The one-block surface reads the published zkML TSV directly for NANOZK context.
+The competitor matrix can therefore consume package accounting without feeding
+back into the surface that package accounting depends on.
 
 ## Source-Backed External Rows
 
@@ -50,6 +63,8 @@ These are source-backed context rows, not local reproductions.
 | Stwo attention/Softmax-table fusion | `GO_BOUNDED_ARCHITECTURE_MECHANISM` | `194,097` matched JSON proof bytes saved |
 | d64 RMSNorm/SwiGLU/residual block receipt | `GO_STATEMENT_BOUND_RECEIPT_COMPOSITION` | `49,600` checked slice rows |
 | d128 RMSNorm/SwiGLU/residual comparator target | `NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING` | `196,608` estimated linear multiplications |
+| attention-derived d128 executable package without VK | `GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF` | `4,752` bytes, `0.324945x` source |
+| attention-derived d128 executable package with VK | `GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF` | `10,608` bytes, `0.725383x` source |
 
 ## Interpretation
 
@@ -61,15 +76,25 @@ The sharper claim is that the STARK-native route exposes a different mechanism:
 attention arithmetic and lookup-heavy table membership can share proof-system
 opening structure when fused into one native proof object.
 
-The next block milestone is not another wrapper around the width-4 block. It is
-a parameterized d64 then d128 RMSNorm/SwiGLU/residual proof surface with the
-same statement bindings used by the d128 comparator target.
+The new package-accounting rows are useful because they make the attention-derived
+one-block statement route comparable as an artifact package:
+
+```text
+source statement chain: 14,624 bytes
+compressed transcript + proof + public signals: 4,752 bytes
+compressed transcript + proof + public signals + VK: 10,608 bytes
+```
+
+This is still not a native layer proof. The next block milestone is a
+parameterized d64 then d128 RMSNorm/SwiGLU/residual proof surface with the same
+statement bindings used by the d128 comparator target.
 
 ## Non-Claims
 
 - Not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero.
 - Not a local d128 proof result.
 - Not proof-size or verifier-time evidence for a local d128 transformer block.
+- Not native proof-size evidence from the external package-accounting rows.
 - Not full transformer inference.
 - Not exact real-valued Softmax.
 - Not production-ready.

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -23,9 +23,9 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         self.assertEqual(payload["schema"], gate.SCHEMA)
         self.assertEqual(payload["decision"], gate.DECISION)
         self.assertEqual(payload["claim_boundary"], gate.CLAIM_BOUNDARY)
-        self.assertEqual(len(payload["source_artifacts"]), 4)
+        self.assertEqual(len(payload["source_artifacts"]), 5)
         self.assertEqual(len(payload["external_rows"]), 5)
-        self.assertEqual(len(payload["local_rows"]), 3)
+        self.assertEqual(len(payload["local_rows"]), 5)
         self.assertIn("not a matched benchmark", payload["non_claims"][0])
 
         external = {(row["system"], row["workload_label"]): row for row in payload["external_rows"]}
@@ -38,9 +38,15 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         self.assertEqual(local["Stwo attention/Softmax-table fusion"]["value"], 194097)
         self.assertEqual(local["d64 RMSNorm/SwiGLU/residual block receipt"]["value"], 49600)
         self.assertEqual(local["d128 RMSNorm/SwiGLU/residual comparator target"]["value"], 196608)
+        self.assertEqual(local["attention-derived d128 executable package without VK"]["value"], 4752)
+        self.assertEqual(local["attention-derived d128 executable package with VK"]["value"], 10608)
         self.assertEqual(
             local["d128 RMSNorm/SwiGLU/residual comparator target"]["local_status"],
             "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
+        )
+        self.assertEqual(
+            local["attention-derived d128 executable package without VK"]["local_status"],
+            "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF",
         )
 
     def test_rejects_source_metric_drift(self):
@@ -68,11 +74,19 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         self.assertIn("external\tNANOZK\tTransformer block proof\t6.3\t0.023\t6.9 KB", tsv)
         self.assertIn("local\tprovable-transformer-vm\tStwo attention/Softmax-table fusion", tsv)
         self.assertIn("matched route JSON proof-byte saving\t194097", tsv)
+        self.assertIn("attention-derived d128 executable package without VK", tsv)
+        self.assertIn("compressed artifact plus proof plus public signals\t4752", tsv)
 
     def test_source_artifact_hashes_match_single_read_bytes(self):
         payload = gate.build_payload_uncommitted()
         source_by_path = {artifact["path"]: artifact for artifact in payload["source_artifacts"]}
-        for path in (gate.PUBLISHED_ZKML_NUMBERS, gate.FUSION_MECHANISM, gate.D64_BLOCK_RECEIPT, gate.D128_TARGET):
+        for path in (
+            gate.PUBLISHED_ZKML_NUMBERS,
+            gate.FUSION_MECHANISM,
+            gate.D64_BLOCK_RECEIPT,
+            gate.D128_TARGET,
+            gate.PACKAGE_ACCOUNTING,
+        ):
             raw = gate.read_source_bytes(path, "test source")
             artifact = source_by_path[str(path.relative_to(gate.ROOT))]
             self.assertEqual(artifact["sha256"], gate.hashlib.sha256(raw).hexdigest())
@@ -282,40 +296,68 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         finally:
             path.unlink(missing_ok=True)
 
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="competitor-duplicate-json-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            path = pathlib.Path(handle.name)
+            handle.write('{"value": 1, "value": 2}\n')
+        try:
+            with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "duplicate JSON key"):
+                gate.load_json(path)
+        finally:
+            path.unlink(missing_ok=True)
+
     def test_source_field_helpers_reject_wrong_types(self):
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         fusion["route_matrix"]["fused_savings_bytes_total"] = "194097"
         d64 = gate.load_json(gate.D64_BLOCK_RECEIPT)
         d128 = gate.load_json(gate.D128_TARGET)
+        package = gate.load_json(gate.PACKAGE_ACCOUNTING)
 
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion savings must be integer"):
-            gate._local_rows(fusion, d64, d128)
+            gate._local_rows(fusion, d64, d128, package)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         fusion["section_delta"]["opening_bucket_savings_share"] = "0.927722"
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion opening share must be numeric"):
-            gate._local_rows(fusion, d64, d128)
+            gate._local_rows(fusion, d64, d128, package)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         fusion["section_delta"]["opening_bucket_savings_share"] = math.inf
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion opening share must be finite"):
-            gate._local_rows(fusion, d64, d128)
+            gate._local_rows(fusion, d64, d128, package)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         fusion["section_delta"]["opening_bucket_savings_share"] = 1.1
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion opening share must be between 0 and 1"):
-            gate._local_rows(fusion, d64, d128)
+            gate._local_rows(fusion, d64, d128, package)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         fusion["route_matrix"]["fused_savings_bytes_total"] = 0
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion savings must be positive"):
-            gate._local_rows(fusion, d64, d128)
+            gate._local_rows(fusion, d64, d128, package)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         d64 = gate.load_json(gate.D64_BLOCK_RECEIPT)
         d64["summary"]["mutations_rejected"] = d64["summary"]["mutation_cases"] - 1
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "d64 mutation rejection summary drift"):
-            gate._local_rows(fusion, d64, d128)
+            gate._local_rows(fusion, d64, d128, package)
+
+        d64 = gate.load_json(gate.D64_BLOCK_RECEIPT)
+        package = gate.load_json(gate.PACKAGE_ACCOUNTING)
+        package["summary"]["package_without_vk_bytes"] = 1
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "package without VK bytes drift"):
+            gate._local_rows(fusion, d64, d128, package)
+
+        package = gate.load_json(gate.PACKAGE_ACCOUNTING)
+        package["all_mutations_rejected"] = False
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "package accounting mutations"):
+            gate._local_rows(fusion, d64, d128, package)
 
     def test_load_tsv_rejects_missing_required_columns(self):
         with tempfile.NamedTemporaryFile(

--- a/scripts/tests/test_zkai_one_transformer_block_surface_gate.py
+++ b/scripts/tests/test_zkai_one_transformer_block_surface_gate.py
@@ -86,21 +86,21 @@ class OneTransformerBlockSurfaceGateTests(unittest.TestCase):
         d128 = gate.load_json(gate.D128_BLOCK_RECEIPT)
         attention_derived = gate.load_json(gate.ATTENTION_DERIVED_D128_CHAIN)
         attention_derived_snark = gate.load_json(gate.ATTENTION_DERIVED_D128_SNARK_RECEIPT)
-        matrix = gate.load_json(gate.COMPETITOR_MATRIX)
+        published_rows = gate.load_tsv(gate.PUBLISHED_ZKML_NUMBERS)
 
         fusion["route_matrix"]["fused_savings_bytes_total"] = 0
         with self.assertRaisesRegex(gate.OneTransformerBlockSurfaceError, "fusion metrics must be positive"):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         d128["summary"]["mutations_rejected"] = d128["summary"]["mutation_cases"] - 1
         with self.assertRaisesRegex(gate.OneTransformerBlockSurfaceError, "d128 mutation rejection count drift"):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
         d128 = gate.load_json(gate.D128_BLOCK_RECEIPT)
         attention_derived["summary"]["edge_count"] = 10
         with self.assertRaisesRegex(gate.OneTransformerBlockSurfaceError, "attention-derived d128 chain edge count drift"):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
         attention_derived = gate.load_json(gate.ATTENTION_DERIVED_D128_CHAIN)
         attention_derived["summary"].pop("block_statement_commitment")
@@ -108,7 +108,7 @@ class OneTransformerBlockSurfaceGateTests(unittest.TestCase):
             gate.OneTransformerBlockSurfaceError,
             "attention-derived d128 chain summary block statement commitment",
         ):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
         attention_derived = gate.load_json(gate.ATTENTION_DERIVED_D128_CHAIN)
         attention_derived["summary"]["block_statement_commitment"] = "blake2b-256:" + "00" * 32
@@ -116,7 +116,7 @@ class OneTransformerBlockSurfaceGateTests(unittest.TestCase):
             gate.OneTransformerBlockSurfaceError,
             "attention-derived d128 chain summary commitment drift",
         ):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
         attention_derived = gate.load_json(gate.ATTENTION_DERIVED_D128_CHAIN)
         attention_derived_snark["receipt_metrics"]["proof_size_bytes"] = 1
@@ -124,7 +124,7 @@ class OneTransformerBlockSurfaceGateTests(unittest.TestCase):
             gate.OneTransformerBlockSurfaceError,
             "attention-derived d128 SNARK receipt metric drift: proof_size_bytes",
         ):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
         attention_derived_snark = gate.load_json(gate.ATTENTION_DERIVED_D128_SNARK_RECEIPT)
         attention_derived_snark["source_route_metrics"]["source_relation_rows"] = 1
@@ -132,7 +132,7 @@ class OneTransformerBlockSurfaceGateTests(unittest.TestCase):
             gate.OneTransformerBlockSurfaceError,
             "attention-derived d128 SNARK source relation rows mismatch",
         ):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
         attention_derived_snark = gate.load_json(gate.ATTENTION_DERIVED_D128_SNARK_RECEIPT)
         attention_derived_snark["source_route_metrics"].pop("compressed_to_source_ratio")
@@ -140,7 +140,7 @@ class OneTransformerBlockSurfaceGateTests(unittest.TestCase):
             gate.OneTransformerBlockSurfaceError,
             "attention-derived d128 SNARK compressed/source ratio",
         ):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
         attention_derived_snark = gate.load_json(gate.ATTENTION_DERIVED_D128_SNARK_RECEIPT)
         attention_derived_snark["source_route_metrics"]["compressed_to_source_ratio"] = 1.0
@@ -148,32 +148,32 @@ class OneTransformerBlockSurfaceGateTests(unittest.TestCase):
             gate.OneTransformerBlockSurfaceError,
             "attention-derived d128 SNARK compressed/source ratio drift",
         ):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
         attention_derived = gate.load_json(gate.ATTENTION_DERIVED_D128_CHAIN)
         attention_derived_snark = gate.load_json(gate.ATTENTION_DERIVED_D128_SNARK_RECEIPT)
         nanozk_block_row = next(
             row
-            for row in matrix["external_rows"]
+            for row in published_rows
             if row.get("system") == "NANOZK"
             and row.get("workload_label") == "Transformer block proof"
             and row.get("workload_scope") == "Per-layer block proof"
         )
         nanozk_block_row["proof_size_reported"] = "1 byte"
         with self.assertRaisesRegex(gate.OneTransformerBlockSurfaceError, "NANOZK row drift"):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
-        matrix = gate.load_json(gate.COMPETITOR_MATRIX)
+        published_rows = gate.load_tsv(gate.PUBLISHED_ZKML_NUMBERS)
         nanozk_block_row = next(
             row
-            for row in matrix["external_rows"]
+            for row in published_rows
             if row.get("system") == "NANOZK"
             and row.get("workload_label") == "Transformer block proof"
             and row.get("workload_scope") == "Per-layer block proof"
         )
         nanozk_block_row.pop("model_or_dims", None)
         with self.assertRaisesRegex(gate.OneTransformerBlockSurfaceError, "NANOZK row drift: model_or_dims"):
-            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+            gate._component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
 
     def test_tsv_contains_component_rows(self):
         tsv = gate.to_tsv(self.payload)
@@ -270,6 +270,39 @@ class OneTransformerBlockSurfaceGateTests(unittest.TestCase):
         try:
             with self.assertRaisesRegex(gate.OneTransformerBlockSurfaceError, "non-finite JSON constant"):
                 gate.load_json(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="one-block-duplicate-json-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            path = pathlib.Path(handle.name)
+            handle.write('{"value": 1, "value": 2}\n')
+        try:
+            with self.assertRaisesRegex(gate.OneTransformerBlockSurfaceError, "duplicate JSON key"):
+                gate.load_json(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_load_tsv_rejects_duplicate_columns(self):
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=gate.ENGINEERING_EVIDENCE,
+            prefix="one-block-duplicate-tsv-",
+            suffix=".tsv",
+            delete=False,
+        ) as handle:
+            path = pathlib.Path(handle.name)
+            handle.write("system\tsystem\nNANOZK\tNANOZK\n")
+        try:
+            with self.assertRaisesRegex(gate.OneTransformerBlockSurfaceError, "duplicate columns"):
+                gate.load_tsv(path)
         finally:
             path.unlink(missing_ok=True)
 

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -25,6 +25,7 @@ PUBLISHED_ZKML_NUMBERS = PAPER_EVIDENCE / "published-zkml-numbers-2026-04.tsv"
 FUSION_MECHANISM = ENGINEERING_EVIDENCE / "zkai-attention-kv-stwo-fusion-mechanism-ablation-2026-05.json"
 D64_BLOCK_RECEIPT = ENGINEERING_EVIDENCE / "zkai-d64-block-receipt-composition-gate-2026-05.json"
 D128_TARGET = ENGINEERING_EVIDENCE / "zkai-d128-layerwise-comparator-target-2026-05.json"
+PACKAGE_ACCOUNTING = ENGINEERING_EVIDENCE / "zkai-one-block-executable-package-accounting-2026-05.json"
 JSON_OUT = ENGINEERING_EVIDENCE / "zkai-may2026-competitor-metric-matrix.json"
 TSV_OUT = ENGINEERING_EVIDENCE / "zkai-may2026-competitor-metric-matrix.tsv"
 
@@ -48,10 +49,22 @@ NON_CLAIMS = [
     "not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero",
     "not a local d128 proof result",
     "not proof-size or verifier-time evidence for a local d128 transformer block",
+    "not native proof-size evidence from the external package-accounting rows",
     "not full transformer inference",
     "not exact real-valued Softmax",
     "not production-ready",
 ]
+
+EXPECTED_PACKAGE_SOURCE_BYTES = 14_624
+EXPECTED_PACKAGE_WITHOUT_VK_BYTES = 4_752
+EXPECTED_PACKAGE_WITHOUT_VK_RATIO = 0.324945
+EXPECTED_PACKAGE_WITHOUT_VK_SAVING_BYTES = 9_872
+EXPECTED_PACKAGE_WITH_VK_BYTES = 10_608
+EXPECTED_PACKAGE_WITH_VK_RATIO = 0.725383
+EXPECTED_PACKAGE_WITH_VK_SAVING_BYTES = 4_016
+EXPECTED_PACKAGE_MUTATIONS = 12
+EXPECTED_PACKAGE_RECEIPT_MUTATIONS = 40
+EXPECTED_PACKAGE_PUBLIC_SIGNAL_COUNT = 17
 
 EXPECTED_EXTERNAL_ROWS = {
     ("NANOZK", "Transformer block proof", "Per-layer block proof"): {
@@ -179,7 +192,11 @@ def _source_from_bytes(path: pathlib.Path, kind: str, raw: bytes) -> dict[str, s
 
 def _parse_json_bytes(path: pathlib.Path, raw: bytes) -> dict[str, Any]:
     try:
-        payload = json.loads(raw.decode("utf-8"), parse_constant=_reject_json_constant)
+        payload = json.loads(
+            raw.decode("utf-8"),
+            parse_constant=_reject_json_constant,
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
     except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as err:
         raise CompetitorMetricMatrixError(f"failed to load JSON source {path}: {err}") from err
     if not isinstance(payload, dict):
@@ -193,6 +210,15 @@ def load_json(path: pathlib.Path) -> dict[str, Any]:
 
 def _reject_json_constant(value: str) -> None:
     raise ValueError(f"non-finite JSON constant: {value}")
+
+
+def _reject_duplicate_json_keys(items: list[tuple[str, Any]]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for key, value in items:
+        if key in payload:
+            raise ValueError(f"duplicate JSON key: {key}")
+        payload[key] = value
+    return payload
 
 
 def _parse_tsv_bytes(path: pathlib.Path, raw: bytes) -> list[dict[str, str]]:
@@ -313,6 +339,13 @@ def _share_source_field(payload: dict[str, Any], path: tuple[str, ...], label: s
     return number
 
 
+def _bool_source_field(payload: dict[str, Any], path: tuple[str, ...], label: str) -> bool:
+    value = _source_field(payload, path, label)
+    if type(value) is not bool:
+        raise CompetitorMetricMatrixError(f"{label} must be boolean")
+    return value
+
+
 def _string_source_field(payload: dict[str, Any], path: tuple[str, ...], label: str) -> str:
     value = _source_field(payload, path, label)
     if not isinstance(value, str):
@@ -320,7 +353,12 @@ def _string_source_field(payload: dict[str, Any], path: tuple[str, ...], label: 
     return value
 
 
-def _local_rows(fusion: dict[str, Any], d64: dict[str, Any], d128: dict[str, Any]) -> list[dict[str, Any]]:
+def _local_rows(
+    fusion: dict[str, Any],
+    d64: dict[str, Any],
+    d128: dict[str, Any],
+    package: dict[str, Any],
+) -> list[dict[str, Any]]:
     if _string_source_field(fusion, ("decision",), "fusion decision") != (
         "GO_STARK_NATIVE_FUSION_MECHANISM_ABLATION_FOR_PAPER_ARCHITECTURE_CLAIM"
     ):
@@ -329,6 +367,23 @@ def _local_rows(fusion: dict[str, Any], d64: dict[str, Any], d128: dict[str, Any
         raise CompetitorMetricMatrixError("d64 block receipt decision drift")
     if _string_source_field(d128, ("decision",), "d128 decision") != "NO_GO_D128_LAYERWISE_PROOF_ARTIFACT_MISSING":
         raise CompetitorMetricMatrixError("d128 target decision drift")
+    if (
+        _string_source_field(package, ("schema",), "package accounting schema")
+        != "zkai-one-block-executable-package-accounting-v1"
+    ):
+        raise CompetitorMetricMatrixError("package accounting schema drift")
+    if (
+        _string_source_field(package, ("decision",), "package accounting decision")
+        != "GO_ONE_BLOCK_EXECUTABLE_PACKAGE_ACCOUNTING_NO_GO_NATIVE_PROOF_SIZE"
+    ):
+        raise CompetitorMetricMatrixError("package accounting decision drift")
+    if (
+        _string_source_field(package, ("result",), "package accounting result")
+        != "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_BLOCK_PROOF"
+    ):
+        raise CompetitorMetricMatrixError("package accounting result drift")
+    if not _bool_source_field(package, ("all_mutations_rejected",), "package accounting all mutations rejected"):
+        raise CompetitorMetricMatrixError("package accounting mutations must all reject")
 
     fused_savings = _integer_source_field(fusion, ("route_matrix", "fused_savings_bytes_total"), "fusion savings")
     matched_profiles = _integer_source_field(
@@ -345,6 +400,32 @@ def _local_rows(fusion: dict[str, Any], d64: dict[str, Any], d128: dict[str, Any
         d128, ("summary", "target_estimated_linear_muls"), "d128 target linear multiplications"
     )
     first_blocker = _string_source_field(d128, ("summary", "first_blocker"), "d128 first blocker")
+    package_source_bytes = _integer_source_field(
+        package, ("summary", "source_statement_chain_bytes"), "package source bytes"
+    )
+    package_without_vk_bytes = _integer_source_field(
+        package, ("summary", "package_without_vk_bytes"), "package without VK bytes"
+    )
+    package_without_vk_ratio = _share_source_field(
+        package, ("summary", "package_without_vk_ratio_vs_source"), "package without VK ratio"
+    )
+    package_without_vk_saving = _integer_source_field(
+        package, ("summary", "package_without_vk_saving_bytes"), "package without VK saving"
+    )
+    package_with_vk_bytes = _integer_source_field(package, ("summary", "package_with_vk_bytes"), "package with VK bytes")
+    package_with_vk_ratio = _share_source_field(
+        package, ("summary", "package_with_vk_ratio_vs_source"), "package with VK ratio"
+    )
+    package_with_vk_saving = _integer_source_field(
+        package, ("summary", "package_with_vk_saving_bytes"), "package with VK saving"
+    )
+    package_cases = _integer_source_field(package, ("case_count",), "package mutation cases")
+    package_receipt_mutations = _integer_source_field(
+        package, ("summary", "receipt_mutations_rejected"), "package receipt mutations"
+    )
+    package_public_signals = _integer_source_field(
+        package, ("summary", "receipt_public_signal_count"), "package public signals"
+    )
     if fused_savings <= 0:
         raise CompetitorMetricMatrixError("fusion savings must be positive")
     if matched_profiles <= 0:
@@ -357,6 +438,21 @@ def _local_rows(fusion: dict[str, Any], d64: dict[str, Any], d128: dict[str, Any
         raise CompetitorMetricMatrixError("d64 mutation rejection summary drift")
     if target_linear_muls <= 0:
         raise CompetitorMetricMatrixError("d128 target linear multiplications must be positive")
+    expected_package_values = {
+        "package source bytes": (package_source_bytes, EXPECTED_PACKAGE_SOURCE_BYTES),
+        "package without VK bytes": (package_without_vk_bytes, EXPECTED_PACKAGE_WITHOUT_VK_BYTES),
+        "package without VK ratio": (package_without_vk_ratio, EXPECTED_PACKAGE_WITHOUT_VK_RATIO),
+        "package without VK saving": (package_without_vk_saving, EXPECTED_PACKAGE_WITHOUT_VK_SAVING_BYTES),
+        "package with VK bytes": (package_with_vk_bytes, EXPECTED_PACKAGE_WITH_VK_BYTES),
+        "package with VK ratio": (package_with_vk_ratio, EXPECTED_PACKAGE_WITH_VK_RATIO),
+        "package with VK saving": (package_with_vk_saving, EXPECTED_PACKAGE_WITH_VK_SAVING_BYTES),
+        "package mutation cases": (package_cases, EXPECTED_PACKAGE_MUTATIONS),
+        "package receipt mutations": (package_receipt_mutations, EXPECTED_PACKAGE_RECEIPT_MUTATIONS),
+        "package public signals": (package_public_signals, EXPECTED_PACKAGE_PUBLIC_SIGNAL_COUNT),
+    }
+    for label, (actual, expected) in expected_package_values.items():
+        if actual != expected:
+            raise CompetitorMetricMatrixError(f"{label} drift")
 
     return [
         {
@@ -388,6 +484,33 @@ def _local_rows(fusion: dict[str, Any], d64: dict[str, Any], d128: dict[str, Any
             "unit": "linear_muls",
             "support": first_blocker,
             "comparison_status": "TARGET_SPEC_ONLY_NOT_LOCAL_PROOF_RESULT",
+        },
+        {
+            "system": "provable-transformer-vm",
+            "surface": "attention-derived d128 executable package without VK",
+            "local_status": "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF",
+            "metric": "compressed artifact plus proof plus public signals",
+            "value": package_without_vk_bytes,
+            "unit": "bytes",
+            "support": (
+                f"{package_without_vk_ratio:.6f}x source; saves {package_without_vk_saving} bytes; "
+                f"{package_cases} / {package_cases} package mutations rejected; "
+                f"{package_receipt_mutations} receipt mutations rejected"
+            ),
+            "comparison_status": "LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_NOT_MATCHED_LAYER_PROOF_BENCHMARK",
+        },
+        {
+            "system": "provable-transformer-vm",
+            "surface": "attention-derived d128 executable package with VK",
+            "local_status": "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF",
+            "metric": "compressed artifact plus proof plus public signals plus verification key",
+            "value": package_with_vk_bytes,
+            "unit": "bytes",
+            "support": (
+                f"{package_with_vk_ratio:.6f}x source; saves {package_with_vk_saving} bytes; "
+                f"{package_public_signals} public signals; VK counted as self-contained package"
+            ),
+            "comparison_status": "LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_WITH_SETUP_NOT_MATCHED_LAYER_PROOF_BENCHMARK",
         },
     ]
 
@@ -426,10 +549,12 @@ def build_payload_uncommitted() -> dict[str, Any]:
     fusion_raw = read_source_bytes(FUSION_MECHANISM, "fusion mechanism JSON")
     d64_raw = read_source_bytes(D64_BLOCK_RECEIPT, "d64 block receipt JSON")
     d128_raw = read_source_bytes(D128_TARGET, "d128 target JSON")
+    package_raw = read_source_bytes(PACKAGE_ACCOUNTING, "one-block package accounting JSON")
     published = _parse_tsv_bytes(PUBLISHED_ZKML_NUMBERS, published_raw)
     fusion = _parse_json_bytes(FUSION_MECHANISM, fusion_raw)
     d64 = _parse_json_bytes(D64_BLOCK_RECEIPT, d64_raw)
     d128 = _parse_json_bytes(D128_TARGET, d128_raw)
+    package = _parse_json_bytes(PACKAGE_ACCOUNTING, package_raw)
     return {
         "schema": SCHEMA,
         "decision": DECISION,
@@ -439,13 +564,15 @@ def build_payload_uncommitted() -> dict[str, Any]:
             _source_from_bytes(FUSION_MECHANISM, "local_fusion_mechanism_json", fusion_raw),
             _source_from_bytes(D64_BLOCK_RECEIPT, "local_d64_block_receipt_json", d64_raw),
             _source_from_bytes(D128_TARGET, "local_d128_target_json", d128_raw),
+            _source_from_bytes(PACKAGE_ACCOUNTING, "local_one_block_package_accounting_json", package_raw),
         ],
         "external_rows": _external_rows(published),
-        "local_rows": _local_rows(fusion, d64, d128),
+        "local_rows": _local_rows(fusion, d64, d128, package),
         "interpretation": [
             "NANOZK and Jolt Atlas are the relevant layerwise/end-to-end competitors for headline zkML metrics.",
             "The local repo does not yet have a d128 layer proof to compare on proof size or verifier time.",
-            "The local competitive claim is currently architectural: STARK-native fusion saves duplicated opening/decommitment plumbing.",
+            "The local competitive claim is architectural: STARK-native fusion saves duplicated opening/decommitment plumbing.",
+            "The executable package-accounting rows show a smaller verifier-facing package than the source statement chain, but they are external receipt accounting rather than native layer proof evidence.",
             "The next real block milestone is a parameterized d64 then d128 RMSNorm/SwiGLU/residual proof surface with the same statement bindings.",
         ],
         "non_claims": NON_CLAIMS,

--- a/scripts/zkai_one_transformer_block_surface_gate.py
+++ b/scripts/zkai_one_transformer_block_surface_gate.py
@@ -19,6 +19,7 @@ from typing import Any
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 ENGINEERING_EVIDENCE = ROOT / "docs" / "engineering" / "evidence"
+PAPER_EVIDENCE = ROOT / "docs" / "paper" / "evidence"
 JSON_OUT = ENGINEERING_EVIDENCE / "zkai-one-transformer-block-surface-2026-05.json"
 TSV_OUT = ENGINEERING_EVIDENCE / "zkai-one-transformer-block-surface-2026-05.tsv"
 
@@ -31,7 +32,7 @@ ATTENTION_DERIVED_D128_CHAIN = (
 ATTENTION_DERIVED_D128_SNARK_RECEIPT = (
     ENGINEERING_EVIDENCE / "zkai-attention-derived-d128-snark-statement-receipt-2026-05.json"
 )
-COMPETITOR_MATRIX = ENGINEERING_EVIDENCE / "zkai-may2026-competitor-metric-matrix.json"
+PUBLISHED_ZKML_NUMBERS = PAPER_EVIDENCE / "published-zkml-numbers-2026-04.tsv"
 EXPECTED_ATTENTION_DERIVED_D128_BLOCK_STATEMENT_COMMITMENT = (
     "blake2b-256:5954b84283b2880c878c70ed533935925de1e14026126a406ad04f66c7ce14a5"
 )
@@ -104,6 +105,15 @@ def _reject_json_constant(value: str) -> None:
     raise ValueError(f"non-finite JSON constant: {value}")
 
 
+def _reject_duplicate_json_keys(items: list[tuple[str, Any]]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for key, value in items:
+        if key in payload:
+            raise ValueError(f"duplicate JSON key: {key}")
+        payload[key] = value
+    return payload
+
+
 def read_source_bytes(path: pathlib.Path, label: str) -> bytes:
     root = ROOT.resolve()
     candidate = pathlib.Path(os.path.abspath(path if path.is_absolute() else ROOT / path))
@@ -155,7 +165,11 @@ def _source_from_bytes(path: pathlib.Path, kind: str, raw: bytes) -> dict[str, s
 
 def _parse_json_bytes(path: pathlib.Path, raw: bytes) -> dict[str, Any]:
     try:
-        payload = json.loads(raw.decode("utf-8"), parse_constant=_reject_json_constant)
+        payload = json.loads(
+            raw.decode("utf-8"),
+            parse_constant=_reject_json_constant,
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
     except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as err:
         raise OneTransformerBlockSurfaceError(f"failed to load JSON source {path}: {err}") from err
     if not isinstance(payload, dict):
@@ -163,19 +177,38 @@ def _parse_json_bytes(path: pathlib.Path, raw: bytes) -> dict[str, Any]:
     return payload
 
 
+def _parse_tsv_bytes(path: pathlib.Path, raw: bytes) -> list[dict[str, str]]:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as err:
+        raise OneTransformerBlockSurfaceError(f"failed to load TSV source {path}: {err}") from err
+    reader = csv.DictReader(io.StringIO(text), delimiter="\t")
+    fieldname_list = reader.fieldnames or []
+    duplicate_fields = sorted({field for field in fieldname_list if fieldname_list.count(field) > 1})
+    if duplicate_fields:
+        raise OneTransformerBlockSurfaceError(f"TSV source has duplicate columns: {duplicate_fields}")
+    rows = list(reader)
+    if not rows:
+        raise OneTransformerBlockSurfaceError(f"TSV source must not be empty: {path}")
+    for index, row in enumerate(rows, start=2):
+        if None in row:
+            raise OneTransformerBlockSurfaceError(f"TSV source row {index} has extra cells")
+        if any(value is None for value in row.values()):
+            raise OneTransformerBlockSurfaceError(f"TSV source row {index} has missing cells")
+    return rows
+
+
 def load_json(path: pathlib.Path) -> dict[str, Any]:
     return _parse_json_bytes(path, read_source_bytes(path, "JSON"))
+
+
+def load_tsv(path: pathlib.Path) -> list[dict[str, str]]:
+    return _parse_tsv_bytes(path, read_source_bytes(path, "TSV"))
 
 
 def _dict(value: Any, field: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise OneTransformerBlockSurfaceError(f"{field} must be object")
-    return value
-
-
-def _list(value: Any, field: str) -> list[Any]:
-    if not isinstance(value, list):
-        raise OneTransformerBlockSurfaceError(f"{field} must be list")
     return value
 
 
@@ -209,15 +242,7 @@ def _float_field(payload: dict[str, Any], path: tuple[str, ...], label: str) -> 
     return value_float
 
 
-def _nanozk_block_row(matrix: dict[str, Any]) -> dict[str, Any]:
-    if _string_field(matrix, ("schema",), "competitor matrix schema") != "zkai-may2026-competitor-metric-matrix-v1":
-        raise OneTransformerBlockSurfaceError("competitor matrix schema drift")
-    if (
-        _string_field(matrix, ("decision",), "competitor matrix decision")
-        != "GO_SOURCE_BACKED_COMPETITOR_MATRIX_NO_GO_MATCHED_BENCHMARK_CLAIMS"
-    ):
-        raise OneTransformerBlockSurfaceError("competitor matrix decision drift")
-    rows = _list(matrix.get("external_rows"), "competitor matrix external_rows")
+def _nanozk_block_row(rows: list[dict[str, str]]) -> dict[str, str]:
     matches = [
         row
         for row in rows
@@ -394,7 +419,7 @@ def _component_rows(
     d128: dict[str, Any],
     attention_derived_d128: dict[str, Any],
     attention_derived_d128_snark: dict[str, Any],
-    matrix: dict[str, Any],
+    published_rows: list[dict[str, str]],
 ) -> list[dict[str, Any]]:
     if _string_field(fusion, ("schema",), "fusion schema") != "zkai-attention-kv-stwo-fusion-mechanism-ablation-v1":
         raise OneTransformerBlockSurfaceError("fusion schema drift")
@@ -412,7 +437,7 @@ def _component_rows(
         attention_derived_d128_snark,
         attention_derived_summary,
     )
-    nanozk = _nanozk_block_row(matrix)
+    nanozk = _nanozk_block_row(published_rows)
     receipt_metrics = snark_summary["receipt_metrics"]
 
     fused_savings = _int_field(fusion, ("route_matrix", "fused_savings_bytes_total"), "fusion savings")
@@ -504,14 +529,14 @@ def build_payload_uncommitted() -> dict[str, Any]:
         ATTENTION_DERIVED_D128_SNARK_RECEIPT,
         "attention-derived d128 SNARK receipt JSON",
     )
-    matrix_raw = read_source_bytes(COMPETITOR_MATRIX, "competitor matrix JSON")
+    published_raw = read_source_bytes(PUBLISHED_ZKML_NUMBERS, "published zkML TSV")
     fusion = _parse_json_bytes(FUSION_MECHANISM, fusion_raw)
     d64 = _parse_json_bytes(D64_BLOCK_RECEIPT, d64_raw)
     d128 = _parse_json_bytes(D128_BLOCK_RECEIPT, d128_raw)
     attention_derived = _parse_json_bytes(ATTENTION_DERIVED_D128_CHAIN, attention_derived_raw)
     attention_derived_snark = _parse_json_bytes(ATTENTION_DERIVED_D128_SNARK_RECEIPT, attention_derived_snark_raw)
-    matrix = _parse_json_bytes(COMPETITOR_MATRIX, matrix_raw)
-    component_rows = _component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, matrix)
+    published_rows = _parse_tsv_bytes(PUBLISHED_ZKML_NUMBERS, published_raw)
+    component_rows = _component_rows(fusion, d64, d128, attention_derived, attention_derived_snark, published_rows)
     d64_row = next(row for row in component_rows if row["surface"].startswith("d64 "))
     d128_row = next(row for row in component_rows if row["surface"].startswith("d128 "))
     attention_derived_row = next(
@@ -544,7 +569,7 @@ def build_payload_uncommitted() -> dict[str, Any]:
                 "local_attention_derived_d128_snark_statement_receipt_json",
                 attention_derived_snark_raw,
             ),
-            _source_from_bytes(COMPETITOR_MATRIX, "source_backed_competitor_matrix_json", matrix_raw),
+            _source_from_bytes(PUBLISHED_ZKML_NUMBERS, "published_zkml_numbers_tsv", published_raw),
         ],
         "component_rows": component_rows,
         "block_component_map": [


### PR DESCRIPTION
## Summary
- decouple the one-block surface gate from the competitor matrix by reading the published zkML TSV directly
- add the one-block executable package accounting artifact as two local competitor-matrix rows
- harden touched JSON readers against duplicate keys and add targeted drift tests

## Results
- local rows: 3 -> 5
- source artifacts: 4 -> 5
- external rows remain 5
- evidence DAG: published zkML TSV -> one-block surface -> package accounting -> competitor matrix
- package without VK: 4,752 bytes, 0.324945x source, saves 9,872 bytes
- package with VK: 10,608 bytes, 0.725383x source, saves 4,016 bytes
- package mutation rejection: 12 / 12 package mutations plus 40 upstream receipt mutations

## Non-claims
- not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero
- not native d128 proof-size evidence
- not a local d128 layer proof
- not prover/verifier timing evidence
- not full transformer inference or exact real-valued Softmax

## Local validation
- `python3 scripts/zkai_one_transformer_block_surface_gate.py --write-json docs/engineering/evidence/zkai-one-transformer-block-surface-2026-05.json --write-tsv docs/engineering/evidence/zkai-one-transformer-block-surface-2026-05.tsv`
- `python3 scripts/zkai_one_block_executable_package_accounting_gate.py --write-json docs/engineering/evidence/zkai-one-block-executable-package-accounting-2026-05.json --write-tsv docs/engineering/evidence/zkai-one-block-executable-package-accounting-2026-05.tsv`
- `python3 scripts/zkai_may2026_competitor_metric_matrix_gate.py --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv`
- `python3 -m py_compile scripts/zkai_one_transformer_block_surface_gate.py scripts/tests/test_zkai_one_transformer_block_surface_gate.py scripts/zkai_one_block_executable_package_accounting_gate.py scripts/tests/test_zkai_one_block_executable_package_accounting_gate.py scripts/zkai_may2026_competitor_metric_matrix_gate.py scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py`
- `python3 -m unittest scripts.tests.test_zkai_one_transformer_block_surface_gate scripts.tests.test_zkai_one_block_executable_package_accounting_gate scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate` -> 39 tests OK
- `git diff --check`
- `just gate-fast`
- `just gate` -> local release gate passed: 14 / 14 steps OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package accounting metrics (with and without verification key) to the competitor metric matrix.

* **Bug Fixes**
  * Enhanced data validation to reject duplicate JSON keys and duplicate column headers in input files.

* **Documentation**
  * Updated metric matrix documentation with expanded comparison framework and dependency discipline section.

* **Tests**
  * Extended test coverage for data validation and duplicate detection across multiple verification gates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/568)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->