### PR TITLE
Harden native attention MLP evidence writes

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -2,7 +2,7 @@
 
 Last refreshed: 2026-05-16
 Repository: `/Users/espejelomar/StarkNet/provable-transformer-vm`
-Mainline reference at refresh: `02870097`
+Mainline reference at refresh: `2cb41ca8`
 
 ## Immediate orientation
 

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -4,7 +4,7 @@ This is the tracked GitHub-safe mirror of the local `.codex` handoff notes.
 If you are in a local checkout, prefer `AGENTS.md`, `.codex/START_HERE.md`, and
 `.codex/HANDOFF.md` first. This file is the durable shared resume surface.
 
-**Mainline tip at last refresh:** `02870097` (matches
+**Mainline tip at last refresh:** `2cb41ca8` (matches
 `.codex/HANDOFF.md` “Mainline reference at refresh”; update both together).
 
 ## Read order for a fresh agent

--- a/scripts/tests/test_zkai_native_attention_mlp_single_proof_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_single_proof_gate.py
@@ -155,7 +155,10 @@ class NativeAttentionMlpSingleProofGateTests(unittest.TestCase):
             target = temp_dir / "target.json"
             link = temp_dir / "out.json"
             target.write_text("{}", encoding="utf-8")
-            link.symlink_to(target)
+            try:
+                link.symlink_to(target)
+            except OSError as err:
+                self.skipTest(f"symlink creation unavailable: {err}")
             with self.assertRaisesRegex(gate.NativeAttentionMlpSingleProofGateError, "symlink"):
                 gate.write_json(link, self.fresh_payload())
 
@@ -166,7 +169,10 @@ class NativeAttentionMlpSingleProofGateTests(unittest.TestCase):
             target = temp_dir / "target.tsv"
             link = temp_dir / "out.tsv"
             target.write_text("", encoding="utf-8")
-            link.symlink_to(target)
+            try:
+                link.symlink_to(target)
+            except OSError as err:
+                self.skipTest(f"symlink creation unavailable: {err}")
             with self.assertRaisesRegex(gate.NativeAttentionMlpSingleProofGateError, "symlink"):
                 gate.write_tsv(link, self.fresh_payload(), self.context)
 

--- a/scripts/tests/test_zkai_native_attention_mlp_single_proof_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_single_proof_gate.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -146,6 +147,40 @@ class NativeAttentionMlpSingleProofGateTests(unittest.TestCase):
             gate.validate_payload(loaded, context=self.context)
         finally:
             path.unlink(missing_ok=True)
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symlink support required")
+    def test_json_output_rejects_symlink(self) -> None:
+        with tempfile.TemporaryDirectory(dir=gate.EVIDENCE_DIR, prefix=".tmp-single-proof-json-symlink-") as tmp:
+            temp_dir = Path(tmp)
+            target = temp_dir / "target.json"
+            link = temp_dir / "out.json"
+            target.write_text("{}", encoding="utf-8")
+            link.symlink_to(target)
+            with self.assertRaisesRegex(gate.NativeAttentionMlpSingleProofGateError, "symlink"):
+                gate.write_json(link, self.fresh_payload())
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symlink support required")
+    def test_tsv_output_rejects_symlink(self) -> None:
+        with tempfile.TemporaryDirectory(dir=gate.EVIDENCE_DIR, prefix=".tmp-single-proof-tsv-symlink-") as tmp:
+            temp_dir = Path(tmp)
+            target = temp_dir / "target.tsv"
+            link = temp_dir / "out.tsv"
+            target.write_text("", encoding="utf-8")
+            link.symlink_to(target)
+            with self.assertRaisesRegex(gate.NativeAttentionMlpSingleProofGateError, "symlink"):
+                gate.write_tsv(link, self.fresh_payload(), self.context)
+
+    def test_json_output_path_escape_rejects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            outside = Path(tmp) / "single-proof.json"
+            with self.assertRaisesRegex(gate.NativeAttentionMlpSingleProofGateError, "escapes evidence directory"):
+                gate.write_json(outside, self.fresh_payload())
+
+    def test_tsv_output_path_escape_rejects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            outside = Path(tmp) / "single-proof.tsv"
+            with self.assertRaisesRegex(gate.NativeAttentionMlpSingleProofGateError, "escapes evidence directory"):
+                gate.write_tsv(outside, self.fresh_payload(), self.context)
 
 
 if __name__ == "__main__":

--- a/scripts/zkai_native_attention_mlp_single_proof_gate.py
+++ b/scripts/zkai_native_attention_mlp_single_proof_gate.py
@@ -555,11 +555,22 @@ def to_tsv(payload: dict[str, Any], context: dict[str, Any]) -> str:
 
 
 def write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    data = (json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n").encode("utf-8")
+    try:
+        route_gate.attribution_gate.write_bytes_atomic(path, data, "single proof JSON")
+    except route_gate.attribution_gate.MlpFusionAttributionError as err:
+        raise NativeAttentionMlpSingleProofGateError(str(err)) from err
 
 
 def write_tsv(path: pathlib.Path, payload: dict[str, Any], context: dict[str, Any]) -> None:
-    path.write_text(to_tsv(payload, context), encoding="utf-8")
+    try:
+        route_gate.attribution_gate.write_bytes_atomic(
+            path,
+            to_tsv(payload, context).encode("utf-8"),
+            "single proof TSV",
+        )
+    except route_gate.attribution_gate.MlpFusionAttributionError as err:
+        raise NativeAttentionMlpSingleProofGateError(str(err)) from err
 
 
 def main() -> int:
@@ -572,11 +583,9 @@ def main() -> int:
     payload = build_payload(context)
     validate_payload(payload, context=context)
     if args.write_json:
-        output = route_gate.attribution_gate.resolve_evidence_output_path(args.write_json, "single proof JSON")
-        write_json(output, payload)
+        write_json(args.write_json, payload)
     if args.write_tsv:
-        output = route_gate.attribution_gate.resolve_evidence_output_path(args.write_tsv, "single proof TSV")
-        write_tsv(output, payload, context)
+        write_tsv(args.write_tsv, payload, context)
     if not args.write_json and not args.write_tsv:
         print(json.dumps(payload, indent=2, sort_keys=True))
     return 0


### PR DESCRIPTION
## Summary
- replace direct JSON/TSV writes in the native attention+MLP single-proof gate with the shared atomic evidence writer
- add negative tests for symlink outputs and evidence-directory escape attempts
- refresh the repo handoff mainline pointer to the current main commit

## Why
This closes a concrete audit finding: the active single-proof evidence gate validated paths before writing, then used direct write_text calls. That left a narrow replacement/symlink window between validation and artifact publication. Generated evidence is treated as attacker-controlled, so this path should use the same atomic constrained writer as the newer route/frontier gates.

## Local validation
- python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_single_proof_gate
- python3 -m py_compile scripts/zkai_native_attention_mlp_single_proof_gate.py scripts/tests/test_zkai_native_attention_mlp_single_proof_gate.py
- python3 scripts/zkai_native_attention_mlp_single_proof_gate.py --write-json docs/engineering/evidence/zkai-native-attention-mlp-single-proof-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-attention-mlp-single-proof-2026-05.tsv
- python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_single_proof_gate scripts.tests.test_zkai_native_attention_mlp_single_proof_route_gate scripts.tests.test_zkai_d128_attention_mlp_boundary_frontier_gate scripts.tests.test_zkai_native_attention_mlp_lifting_ablation_gate scripts.tests.test_zkai_attention_derived_d128_mlp_fusion_attribution_gate
- python3 scripts/research_issue_lint.py --repo-root .
- python3 scripts/paper/paper_preflight.py --repo-root .
- git diff --check
- just gate-fast
- scripts/run_reference_verifier_suite.sh
- scripts/run_miri_suite.sh
- RUSTFLAGS='-Zub-checks=yes' cargo +nightly-2025-07-14 test --locked --features stwo-backend native_attention_mlp_single_proof --lib
- FUZZ_TIME_PER_TARGET=3 FUZZ_INPUT_TIMEOUT_SECONDS=3 FUZZ_WALL_CLOCK_GRACE_SECONDS=5 scripts/run_fuzz_smoke_suite.sh
- just gate

## Audit notes
- Semgrep via uvx was attempted but uvx hung during package setup before scanning; not counted as a pass.
- The full UB suite was started, but the complete suite is too expensive for this interactive loop. A targeted UB run over the active native attention+MLP single-proof module passed, including proof round-trip and tamper rejection.
- GitHub CI remains outside the readiness loop; this PR uses local validation plus Qodo/CodeRabbit/human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer output file handling: atomic UTF-8 writes (ensuring JSON newline), improved error handling, and stricter path validation.

* **Tests**
  * Added tests to verify rejection of symlinked or out-of-directory output paths.

* **Documentation**
  * Updated repository handoff documentation mainline tip.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->