### PR TITLE
Pin RMSNorm worst-label promotion policy

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -1646,8 +1646,8 @@ beat the `40,700` typed-byte two-proof frontier under the worst label in the
 checked inventory, not under one favorable transcript. The current best label is
 `40,836` typed bytes (`+136`, needing `137` bytes to beat the frontier), but the
 worst label is `42,100` typed bytes (`+1,400`, needing `1,401` bytes to beat the
-frontier). The policy gate rejects `17 / 17` promotion, metric, source,
-interpretation, non-claim, and payload-commitment drift cases. This is a
+frontier). The policy gate rejects `18 / 18` promotion, metric, inventory-byte,
+source, interpretation, non-claim, and payload-commitment drift cases. This is a
 NO-GO for frontier promotion and a GO for using worst-label inventory as the
 next opening-layout promotion rule; see
 `docs/engineering/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05-17.md`.

--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -1640,6 +1640,35 @@ RMSNorm-input label-sensitivity reproducibility metadata:
   `cargo +nightly-2025-07-14 test --locked --features stwo-backend rmsnorm_input_fused_label_probe --lib`;
   `cargo +nightly-2025-07-14 test --locked --features stwo-backend native_attention_mlp_single_proof --lib`.
 
+Latest RMSNorm-input label-policy gate: issue `#644` now has a checked
+multi-label promotion policy. A future RMSNorm-input opening-layout result must
+beat the `40,700` typed-byte two-proof frontier under the worst label in the
+checked inventory, not under one favorable transcript. The current best label is
+`40,836` typed bytes (`+136`, needing `137` bytes to beat the frontier), but the
+worst label is `42,100` typed bytes (`+1,400`, needing `1,401` bytes to beat the
+frontier). The policy gate rejects `17 / 17` promotion, metric, source,
+interpretation, non-claim, and payload-commitment drift cases. This is a
+NO-GO for frontier promotion and a GO for using worst-label inventory as the
+next opening-layout promotion rule; see
+`docs/engineering/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05-17.md`.
+
+RMSNorm-input label-policy reproducibility metadata:
+
+- Timing mode: proof-size accounting policy only; no new proof object and no
+  median-of-5 timing claim.
+- Source artifact:
+  `docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-sensitivity-2026-05.json`
+  with payload commitment
+  `blake2b-256:ca919cd12acdfb5783a1c017d0b64bdba62adae082c8cf503af739076720df2a`.
+- Evidence paths:
+  `docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json`
+  and
+  `docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv`.
+- Gate command:
+  `python3 scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv`.
+- Local policy tests:
+  `python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_rmsnorm_label_policy_gate`.
+
 Adapter opening-geometry budget reproducibility metadata:
 
 - Timing mode: proof-size accounting only; no proof regeneration, timing, or

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -121,8 +121,9 @@ This is the fast local entrypoint for a fresh agent working in this repository.
 115. `docs/engineering/zkai-native-attention-mlp-rmsnorm-input-fused-adapter-2026-05-17.md`
 116. `docs/engineering/zkai-native-attention-mlp-adapter-opening-geometry-budget-2026-05-17.md`
 117. `docs/engineering/zkai-native-attention-mlp-rmsnorm-label-sensitivity-2026-05-17.md`
-118. `docs/engineering/reproducibility.md`
-119. `git status --short --branch`
+118. `docs/engineering/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05-17.md`
+119. `docs/engineering/reproducibility.md`
+120. `git status --short --branch`
 
 ## What this repository is now
 
@@ -209,6 +210,13 @@ This repository currently has three live lanes.
      a no-go for frontier promotion and a requirement for a multi-label or
      query-inventory policy before any sub-kilobyte opening-layout claim; see
      `docs/engineering/zkai-native-attention-mlp-rmsnorm-label-sensitivity-2026-05-17.md`.
+   - The RMSNorm-input label-policy follow-up now pins that multi-label rule:
+     future opening-layout wins must beat the `40,700` typed-byte two-proof
+     frontier under the worst label in the checked inventory, not under one
+     favorable transcript. The current worst label is `42,100` typed bytes, so
+     the honest promotion target is a `1,401` typed-byte reduction, not the
+     `137` bytes suggested by the best single label; see
+     `docs/engineering/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05-17.md`.
    - The current attention-to-RMSNorm/MLP boundary is a checked NO-GO for one
      value-connected native proof object: the attention-derived d128 statement
      chain has `199,553` accounted rows (`1.010374x` the MLP fused surface),

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -398,6 +398,35 @@ RMSNorm-input label-sensitivity reproducibility metadata:
   `cargo +nightly-2025-07-14 test --locked --features stwo-backend rmsnorm_input_fused_label_probe --lib`;
   `cargo +nightly-2025-07-14 test --locked --features stwo-backend native_attention_mlp_single_proof --lib`.
 
+Latest RMSNorm-input label-policy gate: issue `#644` now has a checked
+multi-label promotion policy. A future RMSNorm-input opening-layout result must
+beat the `40,700` typed-byte two-proof frontier under the worst label in the
+checked inventory, not under one favorable transcript. The current best label is
+`40,836` typed bytes (`+136`, needing `137` bytes to beat the frontier), but the
+worst label is `42,100` typed bytes (`+1,400`, needing `1,401` bytes to beat the
+frontier). The policy gate rejects `17 / 17` promotion, metric, source,
+interpretation, non-claim, and payload-commitment drift cases. This is a
+NO-GO for frontier promotion and a GO for using worst-label inventory as the
+next opening-layout promotion rule; see
+`docs/engineering/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05-17.md`.
+
+RMSNorm-input label-policy reproducibility metadata:
+
+- Timing mode: proof-size accounting policy only; no new proof object and no
+  median-of-5 timing claim.
+- Source artifact:
+  `docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-sensitivity-2026-05.json`
+  with payload commitment
+  `blake2b-256:ca919cd12acdfb5783a1c017d0b64bdba62adae082c8cf503af739076720df2a`.
+- Evidence paths:
+  `docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json`
+  and
+  `docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv`.
+- Gate command:
+  `python3 scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv`.
+- Local policy tests:
+  `python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_rmsnorm_label_policy_gate`.
+
 Adapter opening-geometry budget reproducibility metadata:
 
 - Timing mode: proof-size accounting only; no proof regeneration, timing, or

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -404,8 +404,8 @@ beat the `40,700` typed-byte two-proof frontier under the worst label in the
 checked inventory, not under one favorable transcript. The current best label is
 `40,836` typed bytes (`+136`, needing `137` bytes to beat the frontier), but the
 worst label is `42,100` typed bytes (`+1,400`, needing `1,401` bytes to beat the
-frontier). The policy gate rejects `17 / 17` promotion, metric, source,
-interpretation, non-claim, and payload-commitment drift cases. This is a
+frontier). The policy gate rejects `18 / 18` promotion, metric, inventory-byte,
+source, interpretation, non-claim, and payload-commitment drift cases. This is a
 NO-GO for frontier promotion and a GO for using worst-label inventory as the
 next opening-layout promotion rule; see
 `docs/engineering/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05-17.md`.

--- a/docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json
+++ b/docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json
@@ -1,0 +1,215 @@
+{
+  "claim_boundary": "RMSNORM_INPUT_FUSED_OPENING_LAYOUT_CLAIMS_REQUIRE_A_MULTI_LABEL_INVENTORY;_CURRENT_INVENTORY_DOES_NOT_BEAT_THE_TWO_PROOF_FRONTIER",
+  "decision": "NO_GO_MULTI_LABEL_FRONTIER_PROMOTION",
+  "frontier": {
+    "compact_selector_typed_bytes": 40812,
+    "frontier_win_claimed": false,
+    "nanozk_reported_d128_block_proof_bytes": 6900,
+    "nanozk_win_claimed": false,
+    "nanozk_workload_matched": false,
+    "two_proof_frontier_typed_bytes": 40700
+  },
+  "interpretation": {
+    "human_read": "The best observed label is only 136 typed bytes above the two-proof frontier, but the worst label in the current RMSNorm-input inventory is 1,400 bytes above it. Under an honest worst-label policy the next route must remove 1,401 typed bytes, not 137, before a frontier promotion is allowed.",
+    "next_attack": "A future opening-layout variant must report the full label inventory and beat the two-proof frontier under the worst observed label. Single favorable labels are recorded as exploration only."
+  },
+  "issue": "https://github.com/omarespejel/provable-transformer-vm/issues/644",
+  "label_inventory": [
+    {
+      "name": "rmsnorm_input_fused",
+      "path_opening_bytes": 20512,
+      "typed_bytes": 41428,
+      "value_bytes": 20868,
+      "value_delta_vs_canonical": 0
+    },
+    {
+      "name": "label_probe_a",
+      "path_opening_bytes": 19920,
+      "typed_bytes": 40836,
+      "value_bytes": 20868,
+      "value_delta_vs_canonical": 0
+    },
+    {
+      "name": "label_probe_b",
+      "path_opening_bytes": 21184,
+      "typed_bytes": 42100,
+      "value_bytes": 20868,
+      "value_delta_vs_canonical": 0
+    }
+  ],
+  "mutation_result": {
+    "cases": [
+      {
+        "name": "frontier_overclaim",
+        "rejected": true
+      },
+      {
+        "name": "nanozk_overclaim",
+        "rejected": true
+      },
+      {
+        "name": "worst_label_typed_drift",
+        "rejected": true
+      },
+      {
+        "name": "worst_policy_reduction_drift",
+        "rejected": true
+      },
+      {
+        "name": "single_label_promoted",
+        "rejected": true
+      },
+      {
+        "name": "label_span_erased",
+        "rejected": true
+      },
+      {
+        "name": "candidate_missing_worst_label",
+        "rejected": true
+      },
+      {
+        "name": "source_digest_drift",
+        "rejected": true
+      },
+      {
+        "name": "source_commitment_drift",
+        "rejected": true
+      },
+      {
+        "name": "decision_drift",
+        "rejected": true
+      },
+      {
+        "name": "result_drift",
+        "rejected": true
+      },
+      {
+        "name": "claim_boundary_drift",
+        "rejected": true
+      },
+      {
+        "name": "non_claims_erased",
+        "rejected": true
+      },
+      {
+        "name": "validation_commands_erased",
+        "rejected": true
+      },
+      {
+        "name": "interpretation_drift",
+        "rejected": true
+      },
+      {
+        "name": "policy_extra_key",
+        "rejected": true
+      },
+      {
+        "name": "payload_commitment_drift",
+        "rejected": true
+      }
+    ],
+    "mutation_count": 17,
+    "rejected_count": 17
+  },
+  "non_claims": [
+    "not a two-proof frontier beat",
+    "not a proof-size win",
+    "not a NANOZK proof-size win",
+    "not a matched external zkML benchmark",
+    "not timing evidence",
+    "not a full transformer block proof",
+    "not production-ready zkML"
+  ],
+  "payload_commitment": "blake2b-256:7adbdfec5773bdd946ab2d745c2e449cd075269ff35587336d4d3f199d6ce4ac",
+  "policy_candidates": {
+    "canonical_label": {
+      "cherry_pick_risk": false,
+      "compact_promotable": false,
+      "delta_vs_compact_selector_bytes": 616,
+      "delta_vs_two_proof_frontier_bytes": 728,
+      "frontier_promotable": false,
+      "label_source": "rmsnorm_input_fused",
+      "name": "canonical_label",
+      "reduction_to_beat_compact_selector_bytes": 617,
+      "reduction_to_beat_frontier_bytes": 729,
+      "typed_bytes": 41428
+    },
+    "mean_two_label_probes": {
+      "cherry_pick_risk": true,
+      "compact_promotable": false,
+      "delta_vs_compact_selector_bytes": 656,
+      "delta_vs_two_proof_frontier_bytes": 768,
+      "frontier_promotable": false,
+      "label_source": "mean(label_probe_a,label_probe_b)",
+      "name": "mean_two_label_probes",
+      "reduction_to_beat_compact_selector_bytes": 657,
+      "reduction_to_beat_frontier_bytes": 769,
+      "typed_bytes": 41468
+    },
+    "single_best_label": {
+      "cherry_pick_risk": true,
+      "compact_promotable": false,
+      "delta_vs_compact_selector_bytes": 24,
+      "delta_vs_two_proof_frontier_bytes": 136,
+      "frontier_promotable": false,
+      "label_source": "label_probe_a",
+      "name": "single_best_label",
+      "reduction_to_beat_compact_selector_bytes": 25,
+      "reduction_to_beat_frontier_bytes": 137,
+      "typed_bytes": 40836
+    },
+    "worst_label_inventory": {
+      "cherry_pick_risk": false,
+      "compact_promotable": false,
+      "delta_vs_compact_selector_bytes": 1288,
+      "delta_vs_two_proof_frontier_bytes": 1400,
+      "frontier_promotable": false,
+      "label_source": "label_probe_b",
+      "name": "worst_label_inventory",
+      "reduction_to_beat_compact_selector_bytes": 1289,
+      "reduction_to_beat_frontier_bytes": 1401,
+      "typed_bytes": 42100
+    }
+  },
+  "promotion_policy": {
+    "multi_label_frontier_promotable": false,
+    "policy": "worst_label_inventory_must_beat_two_proof_frontier",
+    "required_reduction_to_beat_compact_selector_bytes": 1289,
+    "required_reduction_to_beat_frontier_bytes": 1401,
+    "single_label_cherry_pick_rejected": true,
+    "single_label_frontier_promotable": false
+  },
+  "result": "WORST_LABEL_INVENTORY_REQUIRES_1401_TYPED_BYTE_REDUCTION_BEFORE_PROMOTION",
+  "schema": "zkai-native-attention-mlp-rmsnorm-label-policy-gate-v1",
+  "source_artifacts": [
+    {
+      "name": "label_sensitivity_gate",
+      "path": "docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-sensitivity-2026-05.json",
+      "payload_commitment": "blake2b-256:ca919cd12acdfb5783a1c017d0b64bdba62adae082c8cf503af739076720df2a",
+      "sha256": "03777754ecf0a99f1ef7371cc038be99bd4471aeac3861ddf9a225697cf29f30"
+    }
+  ],
+  "summary": {
+    "best_observed_label": "label_probe_a",
+    "best_observed_label_delta_vs_frontier_bytes": 136,
+    "best_observed_label_typed_bytes": 40836,
+    "canonical_label_reduction_to_beat_frontier_bytes": 729,
+    "label_span_typed_bytes": 1264,
+    "mean_two_label_probes_reduction_to_beat_frontier_bytes": 769,
+    "single_best_label_reduction_to_beat_frontier_bytes": 137,
+    "value_delta_preserved_across_labels": true,
+    "worst_label_inventory": "label_probe_b",
+    "worst_label_inventory_delta_vs_frontier_bytes": 1400,
+    "worst_label_inventory_reduction_to_beat_compact_selector_bytes": 1289,
+    "worst_label_inventory_reduction_to_beat_frontier_bytes": 1401,
+    "worst_label_inventory_typed_bytes": 42100
+  },
+  "validation_commands": [
+    "python3 scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_rmsnorm_label_policy_gate",
+    "python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_rmsnorm_label_sensitivity_gate",
+    "git diff --check",
+    "just gate-fast",
+    "just gate"
+  ]
+}

--- a/docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json
+++ b/docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json
@@ -64,6 +64,10 @@
         "rejected": true
       },
       {
+        "name": "inventory_byte_drift",
+        "rejected": true
+      },
+      {
         "name": "candidate_missing_worst_label",
         "rejected": true
       },
@@ -108,8 +112,8 @@
         "rejected": true
       }
     ],
-    "mutation_count": 17,
-    "rejected_count": 17
+    "mutation_count": 18,
+    "rejected_count": 18
   },
   "non_claims": [
     "not a two-proof frontier beat",
@@ -120,7 +124,7 @@
     "not a full transformer block proof",
     "not production-ready zkML"
   ],
-  "payload_commitment": "blake2b-256:7adbdfec5773bdd946ab2d745c2e449cd075269ff35587336d4d3f199d6ce4ac",
+  "payload_commitment": "blake2b-256:ef71b343b14f57f07028247f3184a99bea46996c1d124c2cdb707b49c1304b1c",
   "policy_candidates": {
     "canonical_label": {
       "cherry_pick_risk": false,

--- a/docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv
@@ -1,0 +1,5 @@
+policy_candidate	typed_bytes	delta_vs_two_proof_frontier_bytes	reduction_to_beat_frontier_bytes	delta_vs_compact_selector_bytes	reduction_to_beat_compact_selector_bytes	frontier_promotable	cherry_pick_risk
+single_best_label	40836	136	137	24	25	false	true
+canonical_label	41428	728	729	616	617	false	false
+mean_two_label_probes	41468	768	769	656	657	false	true
+worst_label_inventory	42100	1400	1401	1288	1289	false	false

--- a/docs/engineering/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05-17.md
+++ b/docs/engineering/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05-17.md
@@ -1,0 +1,124 @@
+# zkAI Native Attention+MLP RMSNorm Label Policy - 2026-05-17
+
+Status: `NO_GO_MULTI_LABEL_FRONTIER_PROMOTION`.
+
+This gate follows the RMSNorm-input label-sensitivity result for issue `#644`.
+It does not build a new proof object. It defines the promotion rule needed
+before a future sub-kilobyte opening-layout improvement can be treated as a
+frontier result.
+
+## Result
+
+The previous label-sensitivity gate showed that label-only transcript movement
+can shift the same relation by `1,264` typed bytes. This policy gate turns that
+into a concrete rule:
+
+> A future RMSNorm-input opening-layout claim must beat the two-proof frontier
+> under the worst label in the checked label inventory, not under one favorable
+> label.
+
+Current numbers:
+
+| policy candidate | typed bytes | delta vs frontier | reduction to beat frontier | cherry-pick risk |
+| --- | ---: | ---: | ---: | --- |
+| single best label | `40,836` | `+136` | `137` | yes |
+| canonical label | `41,428` | `+728` | `729` | no |
+| mean of two label probes | `41,468` | `+768` | `769` | yes |
+| worst label inventory | `42,100` | `+1,400` | `1,401` | no |
+
+Human interpretation: the route is less close than the best single label makes
+it look. A cherry-picked view says the next route is `137` typed bytes away from
+the two-proof frontier. An honest worst-label policy says it is `1,401` typed
+bytes away.
+
+That is useful. It prevents us from promoting a transcript accident as a
+structural STARK-native proof-size win.
+
+## Policy
+
+The current promotion policy is:
+
+- report the full label inventory;
+- preserve the adapter equation and source binding inherited from the
+  RMSNorm-input fused route;
+- preserve direct value bytes across labels;
+- require the worst observed label to be below the `40,700` typed-byte
+  two-proof frontier;
+- reject NANOZK proof-size comparisons unless the workload and proof-object
+  class are matched.
+
+Under this policy the current inventory is a NO-GO:
+
+- best label: `40,836`, still `+136` above frontier;
+- worst label: `42,100`, `+1,400` above frontier;
+- required worst-label reduction to beat frontier: `1,401`;
+- required worst-label reduction to beat compact selector: `1,289`;
+- direct value delta across label probes: `0`.
+
+## Claim Boundary
+
+The checked claim is only:
+
+> Current RMSNorm-input label inventory does not support frontier promotion.
+> Future opening-layout wins must beat the frontier under a worst-label
+> inventory policy, because one favorable transcript label is not stable enough
+> evidence.
+
+Non-claims:
+
+- not a two-proof frontier beat;
+- not a proof-size win;
+- not a NANOZK proof-size win;
+- not a matched external zkML benchmark;
+- not timing evidence;
+- not a full transformer block proof;
+- not production-ready zkML.
+
+## Evidence
+
+- `docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json`
+- `docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv`
+- Source gate:
+  `docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-sensitivity-2026-05.json`
+- Gate script:
+  `scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py`
+- Tests:
+  `scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py`
+
+The policy gate rejects `17 / 17` mutation cases covering frontier overclaim,
+NANOZK overclaim, worst-label metric drift, promotion-policy drift,
+single-label promotion, label-span erasure, missing worst-label inventory,
+source digest drift, source commitment drift, decision/result/claim-boundary
+drift, non-claim erasure, validation-command erasure, interpretation drift,
+extra policy keys, and payload-commitment drift.
+
+## Reproduction
+
+```sh
+python3 scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv
+python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_rmsnorm_label_policy_gate
+python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_rmsnorm_label_sensitivity_gate
+git diff --check
+just gate-fast
+just gate
+```
+
+Recorded gate output:
+
+```json
+{"decision":"NO_GO_MULTI_LABEL_FRONTIER_PROMOTION","mutation_count":17,"mutations_rejected":17,"result":"WORST_LABEL_INVENTORY_REQUIRES_1401_TYPED_BYTE_REDUCTION_BEFORE_PROMOTION","worst_label_inventory_typed_bytes":42100,"worst_label_reduction_to_beat_frontier_bytes":1401}
+```
+
+## Next Attack
+
+The next structural opening-layout attempt should not optimize for the single
+best label. It should target the worst-label policy:
+
+- remove at least `1,401` typed bytes from the current worst-label inventory;
+- preserve `0` direct-value delta across labels;
+- keep the RMSNorm-input adapter equation and source binding;
+- report every checked label in the inventory;
+- only promote if the worst label beats the two-proof frontier.
+
+If a future route only wins under one favorable transcript label, record it as
+exploration and do not promote it.

--- a/docs/engineering/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05-17.md
+++ b/docs/engineering/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05-17.md
@@ -85,12 +85,12 @@ Non-claims:
 - Tests:
   `scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py`
 
-The policy gate rejects `17 / 17` mutation cases covering frontier overclaim,
+The policy gate rejects `18 / 18` mutation cases covering frontier overclaim,
 NANOZK overclaim, worst-label metric drift, promotion-policy drift,
-single-label promotion, label-span erasure, missing worst-label inventory,
-source digest drift, source commitment drift, decision/result/claim-boundary
-drift, non-claim erasure, validation-command erasure, interpretation drift,
-extra policy keys, and payload-commitment drift.
+single-label promotion, label-span erasure, inventory-byte drift, missing
+worst-label inventory, source digest drift, source commitment drift,
+decision/result/claim-boundary drift, non-claim erasure, validation-command
+erasure, interpretation drift, extra policy keys, and payload-commitment drift.
 
 ## Reproduction
 
@@ -106,7 +106,7 @@ just gate
 Recorded gate output:
 
 ```json
-{"decision":"NO_GO_MULTI_LABEL_FRONTIER_PROMOTION","mutation_count":17,"mutations_rejected":17,"result":"WORST_LABEL_INVENTORY_REQUIRES_1401_TYPED_BYTE_REDUCTION_BEFORE_PROMOTION","worst_label_inventory_typed_bytes":42100,"worst_label_reduction_to_beat_frontier_bytes":1401}
+{"decision":"NO_GO_MULTI_LABEL_FRONTIER_PROMOTION","mutation_count":18,"mutations_rejected":18,"result":"WORST_LABEL_INVENTORY_REQUIRES_1401_TYPED_BYTE_REDUCTION_BEFORE_PROMOTION","worst_label_inventory_typed_bytes":42100,"worst_label_reduction_to_beat_frontier_bytes":1401}
 ```
 
 ## Next Attack

--- a/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -4,6 +4,7 @@ import io
 import pathlib
 import tempfile
 import unittest
+from unittest import mock
 
 from scripts import zkai_native_attention_mlp_rmsnorm_label_policy_gate as gate
 
@@ -160,6 +161,35 @@ class RmsnormLabelPolicyGateTest(unittest.TestCase):
 
         with self.assertRaisesRegex(gate.LabelPolicyError, "duplicate output destination"):
             gate.write_outputs(payload, relative, absolute)
+
+    def test_write_outputs_stages_pair_before_replacing_targets(self) -> None:
+        payload = gate.build_payload()
+        json_path = gate.EVIDENCE_DIR / "rmsnorm-label-policy-atomic-json.tmp"
+        tsv_path = gate.EVIDENCE_DIR / "rmsnorm-label-policy-atomic-tsv.tmp"
+        original_writer = gate.sensitivity_gate.write_text_atomically
+        writes = []
+
+        try:
+            original_writer(json_path, "old-json\n")
+            original_writer(tsv_path, "old-tsv\n")
+
+            def fail_second_write(path: pathlib.Path, text: str) -> None:
+                writes.append(path)
+                if len(writes) == 2:
+                    raise gate.sensitivity_gate.RmsnormLabelSensitivityError("forced second write")
+                original_writer(path, text)
+
+            with mock.patch.object(
+                gate.sensitivity_gate, "write_text_atomically", side_effect=fail_second_write
+            ):
+                with self.assertRaisesRegex(gate.LabelPolicyError, "forced second write"):
+                    gate.write_outputs(payload, json_path, tsv_path)
+
+            self.assertEqual(json_path.read_text(), "old-json\n")
+            self.assertEqual(tsv_path.read_text(), "old-tsv\n")
+        finally:
+            json_path.unlink(missing_ok=True)
+            tsv_path.unlink(missing_ok=True)
 
     def test_write_outputs_rejects_outside_evidence_dir(self) -> None:
         payload = gate.build_payload()

--- a/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -191,6 +191,25 @@ class RmsnormLabelPolicyGateTest(unittest.TestCase):
             json_path.unlink(missing_ok=True)
             tsv_path.unlink(missing_ok=True)
 
+    def test_write_outputs_fsyncs_directory_after_pair_publish(self) -> None:
+        payload = gate.build_payload()
+        json_path = gate.EVIDENCE_DIR / "rmsnorm-label-policy-fsync-json.tmp"
+        tsv_path = gate.EVIDENCE_DIR / "rmsnorm-label-policy-fsync-tsv.tmp"
+
+        try:
+            with mock.patch.object(
+                gate.sensitivity_gate,
+                "fsync_dir_fd",
+                wraps=gate.sensitivity_gate.fsync_dir_fd,
+            ) as fsync_dir:
+                gate.write_outputs(payload, json_path, tsv_path)
+
+            self.assertTrue(fsync_dir.called)
+            self.assertEqual(json_path.parent, gate.EVIDENCE_DIR)
+        finally:
+            json_path.unlink(missing_ok=True)
+            tsv_path.unlink(missing_ok=True)
+
     def test_write_outputs_rejects_outside_evidence_dir(self) -> None:
         payload = gate.build_payload()
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -153,6 +153,14 @@ class RmsnormLabelPolicyGateTest(unittest.TestCase):
         with self.assertRaisesRegex(gate.LabelPolicyError, "duplicate output destination"):
             gate.write_outputs(payload, gate.JSON_OUT, gate.JSON_OUT)
 
+    def test_write_outputs_rejects_relative_absolute_duplicate_destinations(self) -> None:
+        payload = gate.build_payload()
+        relative = pathlib.Path("docs/engineering/evidence/rmsnorm-label-policy-collision.tmp")
+        absolute = gate.ROOT / relative
+
+        with self.assertRaisesRegex(gate.LabelPolicyError, "duplicate output destination"):
+            gate.write_outputs(payload, relative, absolute)
+
     def test_write_outputs_rejects_outside_evidence_dir(self) -> None:
         payload = gate.build_payload()
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -109,7 +109,9 @@ class RmsnormLabelPolicyGateTest(unittest.TestCase):
         mutated["label_inventory"][0]["typed_bytes"] += 1
         gate.refresh_payload_commitment(mutated)
 
-        with self.assertRaisesRegex(gate.LabelPolicyError, "inventory byte drift"):
+        with self.assertRaisesRegex(
+            gate.LabelPolicyError, "inventory byte drift: typed_bytes expected=41428 got=41429"
+        ):
             gate.validate_payload(mutated)
 
     def test_payload_commitment_rejects_drift(self) -> None:

--- a/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -95,6 +95,13 @@ class RmsnormLabelPolicyGateTest(unittest.TestCase):
         with self.assertRaisesRegex(gate.LabelPolicyError, "source artifact drift"):
             gate.validate_payload(mutated)
 
+    def test_source_artifact_path_is_posix_stable(self) -> None:
+        payload = gate.build_payload(include_mutations=False)
+        path = payload["source_artifacts"][0]["path"]
+
+        self.assertEqual(path, gate.LABEL_SENSITIVITY_RELATIVE_PATH)
+        self.assertNotIn("\\", path)
+
     def test_mutation_result_rejects_extra_keys(self) -> None:
         payload = gate.build_payload()
         mutated = copy.deepcopy(payload["mutation_result"])
@@ -139,6 +146,12 @@ class RmsnormLabelPolicyGateTest(unittest.TestCase):
 
         with self.assertRaisesRegex(gate.LabelPolicyError, "multi-label frontier"):
             gate.write_outputs(payload, gate.JSON_OUT, None)
+
+    def test_write_outputs_rejects_duplicate_destinations(self) -> None:
+        payload = gate.build_payload()
+
+        with self.assertRaisesRegex(gate.LabelPolicyError, "duplicate output destination"):
+            gate.write_outputs(payload, gate.JSON_OUT, gate.JSON_OUT)
 
     def test_write_outputs_rejects_outside_evidence_dir(self) -> None:
         payload = gate.build_payload()

--- a/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -1,0 +1,140 @@
+import copy
+import csv
+import io
+import pathlib
+import tempfile
+import unittest
+
+from scripts import zkai_native_attention_mlp_rmsnorm_label_policy_gate as gate
+
+
+class RmsnormLabelPolicyGateTest(unittest.TestCase):
+    def test_payload_pins_worst_label_policy(self) -> None:
+        payload = gate.build_payload()
+        summary = payload["summary"]
+
+        self.assertEqual(payload["decision"], gate.DECISION)
+        self.assertEqual(payload["result"], gate.RESULT)
+        self.assertEqual(summary["best_observed_label"], "label_probe_a")
+        self.assertEqual(summary["best_observed_label_typed_bytes"], 40_836)
+        self.assertEqual(summary["single_best_label_reduction_to_beat_frontier_bytes"], 137)
+        self.assertEqual(summary["canonical_label_reduction_to_beat_frontier_bytes"], 729)
+        self.assertEqual(summary["mean_two_label_probes_reduction_to_beat_frontier_bytes"], 769)
+        self.assertEqual(summary["worst_label_inventory"], "label_probe_b")
+        self.assertEqual(summary["worst_label_inventory_typed_bytes"], 42_100)
+        self.assertEqual(summary["worst_label_inventory_delta_vs_frontier_bytes"], 1_400)
+        self.assertEqual(summary["worst_label_inventory_reduction_to_beat_frontier_bytes"], 1_401)
+        self.assertEqual(summary["worst_label_inventory_reduction_to_beat_compact_selector_bytes"], 1_289)
+        self.assertEqual(summary["label_span_typed_bytes"], 1_264)
+        self.assertTrue(summary["value_delta_preserved_across_labels"])
+
+    def test_policy_candidates_show_cherry_pick_gap(self) -> None:
+        payload = gate.build_payload()
+        candidates = payload["policy_candidates"]
+
+        self.assertEqual(candidates["single_best_label"]["typed_bytes"], 40_836)
+        self.assertTrue(candidates["single_best_label"]["cherry_pick_risk"])
+        self.assertEqual(candidates["single_best_label"]["reduction_to_beat_frontier_bytes"], 137)
+        self.assertEqual(candidates["worst_label_inventory"]["typed_bytes"], 42_100)
+        self.assertFalse(candidates["worst_label_inventory"]["cherry_pick_risk"])
+        self.assertEqual(candidates["worst_label_inventory"]["reduction_to_beat_frontier_bytes"], 1_401)
+        self.assertFalse(candidates["worst_label_inventory"]["frontier_promotable"])
+
+    def test_label_inventory_preserves_value_bytes(self) -> None:
+        payload = gate.build_payload()
+        inventory = {item["name"]: item for item in payload["label_inventory"]}
+        canonical_value = inventory["rmsnorm_input_fused"]["value_bytes"]
+
+        for name in ("label_probe_a", "label_probe_b"):
+            with self.subTest(name=name):
+                self.assertEqual(inventory[name]["value_bytes"], canonical_value)
+                self.assertEqual(inventory[name]["value_delta_vs_canonical"], 0)
+
+    def test_mutations_are_rejected(self) -> None:
+        payload = gate.build_payload()
+        result = payload["mutation_result"]
+
+        self.assertEqual(result["mutation_count"], len(gate.EXPECTED_MUTATION_NAMES))
+        self.assertEqual(result["rejected_count"], len(gate.EXPECTED_MUTATION_NAMES))
+        self.assertEqual([case["name"] for case in result["cases"]], list(gate.EXPECTED_MUTATION_NAMES))
+        self.assertTrue(all(case["rejected"] for case in result["cases"]))
+
+    def test_frontier_overclaim_is_rejected(self) -> None:
+        payload = gate.build_payload(include_mutations=False)
+        mutated = copy.deepcopy(payload)
+        mutated["frontier"]["frontier_win_claimed"] = True
+        gate.refresh_payload_commitment(mutated)
+
+        with self.assertRaisesRegex(gate.LabelPolicyError, "frontier overclaim"):
+            gate.validate_payload(mutated)
+
+    def test_policy_reduction_drift_is_rejected(self) -> None:
+        payload = gate.build_payload(include_mutations=False)
+        mutated = copy.deepcopy(payload)
+        mutated["promotion_policy"]["required_reduction_to_beat_frontier_bytes"] = 137
+        gate.refresh_payload_commitment(mutated)
+
+        with self.assertRaisesRegex(gate.LabelPolicyError, "policy frontier reduction"):
+            gate.validate_payload(mutated)
+
+    def test_candidate_missing_worst_label_is_rejected(self) -> None:
+        payload = gate.build_payload(include_mutations=False)
+        mutated = copy.deepcopy(payload)
+        mutated["policy_candidates"].pop("worst_label_inventory")
+        gate.refresh_payload_commitment(mutated)
+
+        with self.assertRaisesRegex(gate.LabelPolicyError, "policy candidates key drift"):
+            gate.validate_payload(mutated)
+
+    def test_source_artifact_drift_is_rejected(self) -> None:
+        payload = gate.build_payload(include_mutations=False)
+        mutated = copy.deepcopy(payload)
+        mutated["source_artifacts"][0]["sha256"] = "00" * 32
+        gate.refresh_payload_commitment(mutated)
+
+        with self.assertRaisesRegex(gate.LabelPolicyError, "source artifact drift"):
+            gate.validate_payload(mutated)
+
+    def test_mutation_result_rejects_extra_keys(self) -> None:
+        payload = gate.build_payload()
+        mutated = copy.deepcopy(payload["mutation_result"])
+        mutated["unchecked"] = True
+
+        with self.assertRaisesRegex(gate.LabelPolicyError, "mutation result key drift"):
+            gate.validate_mutation_result(mutated)
+
+    def test_payload_commitment_rejects_drift(self) -> None:
+        payload = gate.build_payload(include_mutations=False)
+        mutated = copy.deepcopy(payload)
+        mutated["summary"]["label_span_typed_bytes"] = 0
+        gate.refresh_payload_commitment(mutated)
+
+        with self.assertRaisesRegex(gate.LabelPolicyError, "summary drift"):
+            gate.validate_payload(mutated)
+
+    def test_tsv_uses_policy_order(self) -> None:
+        payload = gate.build_payload()
+        text = gate.tsv_text(payload)
+        rows = list(csv.DictReader(io.StringIO(text), dialect="excel-tab"))
+
+        self.assertEqual([row["policy_candidate"] for row in rows], list(gate.POLICY_CANDIDATE_ORDER))
+        self.assertEqual(rows[-1]["policy_candidate"], "worst_label_inventory")
+        self.assertEqual(rows[-1]["reduction_to_beat_frontier_bytes"], "1401")
+
+    def test_write_outputs_rejects_invalid_payload(self) -> None:
+        payload = gate.build_payload()
+        payload["promotion_policy"]["multi_label_frontier_promotable"] = True
+        gate.refresh_payload_commitment(payload)
+
+        with self.assertRaisesRegex(gate.LabelPolicyError, "multi-label frontier"):
+            gate.write_outputs(payload, gate.JSON_OUT, None)
+
+    def test_write_outputs_rejects_outside_evidence_dir(self) -> None:
+        payload = gate.build_payload()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(gate.LabelPolicyError):
+                gate.write_outputs(payload, pathlib.Path(tmpdir) / "policy.json", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -103,6 +103,15 @@ class RmsnormLabelPolicyGateTest(unittest.TestCase):
         with self.assertRaisesRegex(gate.LabelPolicyError, "mutation result key drift"):
             gate.validate_mutation_result(mutated)
 
+    def test_inventory_byte_drift_is_rejected(self) -> None:
+        payload = gate.build_payload(include_mutations=False)
+        mutated = copy.deepcopy(payload)
+        mutated["label_inventory"][0]["typed_bytes"] += 1
+        gate.refresh_payload_commitment(mutated)
+
+        with self.assertRaisesRegex(gate.LabelPolicyError, "inventory byte drift"):
+            gate.validate_payload(mutated)
+
     def test_payload_commitment_rejects_drift(self) -> None:
         payload = gate.build_payload(include_mutations=False)
         mutated = copy.deepcopy(payload)
@@ -132,7 +141,7 @@ class RmsnormLabelPolicyGateTest(unittest.TestCase):
     def test_write_outputs_rejects_outside_evidence_dir(self) -> None:
         payload = gate.build_payload()
         with tempfile.TemporaryDirectory() as tmpdir:
-            with self.assertRaises(gate.LabelPolicyError):
+            with self.assertRaisesRegex(gate.LabelPolicyError, "evidence dir"):
                 gate.write_outputs(payload, pathlib.Path(tmpdir) / "policy.json", None)
 
 

--- a/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -205,7 +205,9 @@ class RmsnormLabelPolicyGateTest(unittest.TestCase):
                 gate.write_outputs(payload, json_path, tsv_path)
 
             self.assertGreaterEqual(fsync_dir.call_count, 3)
-            self.assertEqual(json_path.parent, gate.EVIDENCE_DIR)
+            self.assertTrue(
+                any(len(call.args) > 1 and call.args[1] == gate.EVIDENCE_DIR for call in fsync_dir.mock_calls)
+            )
         finally:
             json_path.unlink(missing_ok=True)
             tsv_path.unlink(missing_ok=True)

--- a/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -204,7 +204,7 @@ class RmsnormLabelPolicyGateTest(unittest.TestCase):
             ) as fsync_dir:
                 gate.write_outputs(payload, json_path, tsv_path)
 
-            self.assertTrue(fsync_dir.called)
+            self.assertGreaterEqual(fsync_dir.call_count, 3)
             self.assertEqual(json_path.parent, gate.EVIDENCE_DIR)
         finally:
             json_path.unlink(missing_ok=True)

--- a/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""Gate RMSNorm-input label-inventory promotion policy."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import hashlib
+import io
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import zkai_native_attention_mlp_rmsnorm_label_sensitivity_gate as sensitivity_gate
+
+
+EVIDENCE_DIR = ROOT / "docs" / "engineering" / "evidence"
+LABEL_SENSITIVITY_PATH = (
+    EVIDENCE_DIR / "zkai-native-attention-mlp-rmsnorm-label-sensitivity-2026-05.json"
+)
+JSON_OUT = EVIDENCE_DIR / "zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json"
+TSV_OUT = EVIDENCE_DIR / "zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv"
+
+SCHEMA = "zkai-native-attention-mlp-rmsnorm-label-policy-gate-v1"
+DECISION = "NO_GO_MULTI_LABEL_FRONTIER_PROMOTION"
+RESULT = "WORST_LABEL_INVENTORY_REQUIRES_1401_TYPED_BYTE_REDUCTION_BEFORE_PROMOTION"
+ISSUE = "https://github.com/omarespejel/provable-transformer-vm/issues/644"
+CLAIM_BOUNDARY = (
+    "RMSNORM_INPUT_FUSED_OPENING_LAYOUT_CLAIMS_REQUIRE_A_MULTI_LABEL_INVENTORY;"
+    "_CURRENT_INVENTORY_DOES_NOT_BEAT_THE_TWO_PROOF_FRONTIER"
+)
+PAYLOAD_DOMAIN = "ptvm:zkai:native-attention-mlp-rmsnorm-label-policy:v1"
+
+EXPECTED_LABEL_SENSITIVITY_SHA256 = (
+    "03777754ecf0a99f1ef7371cc038be99bd4471aeac3861ddf9a225697cf29f30"
+)
+EXPECTED_LABEL_SENSITIVITY_COMMITMENT = (
+    "blake2b-256:ca919cd12acdfb5783a1c017d0b64bdba62adae082c8cf503af739076720df2a"
+)
+
+TWO_PROOF_FRONTIER_TYPED_BYTES = 40_700
+COMPACT_SELECTOR_TYPED_BYTES = 40_812
+NANOZK_REPORTED_D128_BLOCK_PROOF_BYTES = 6_900
+LABEL_INVENTORY = ("rmsnorm_input_fused", "label_probe_a", "label_probe_b")
+POLICY_CANDIDATE_ORDER = (
+    "single_best_label",
+    "canonical_label",
+    "mean_two_label_probes",
+    "worst_label_inventory",
+)
+
+HUMAN_READ = (
+    "The best observed label is only 136 typed bytes above the two-proof frontier, "
+    "but the worst label in the current RMSNorm-input inventory is 1,400 bytes above it. "
+    "Under an honest worst-label policy the next route must remove 1,401 typed bytes, "
+    "not 137, before a frontier promotion is allowed."
+)
+NEXT_ATTACK = (
+    "A future opening-layout variant must report the full label inventory and beat the "
+    "two-proof frontier under the worst observed label. Single favorable labels are recorded "
+    "as exploration only."
+)
+INTERPRETATION = {
+    "human_read": HUMAN_READ,
+    "next_attack": NEXT_ATTACK,
+}
+
+NON_CLAIMS = (
+    "not a two-proof frontier beat",
+    "not a proof-size win",
+    "not a NANOZK proof-size win",
+    "not a matched external zkML benchmark",
+    "not timing evidence",
+    "not a full transformer block proof",
+    "not production-ready zkML",
+)
+
+VALIDATION_COMMANDS = (
+    "python3 scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py --write-json "
+    "docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json "
+    "--write-tsv docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv",
+    "python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_rmsnorm_label_policy_gate",
+    "python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_rmsnorm_label_sensitivity_gate",
+    "git diff --check",
+    "just gate-fast",
+    "just gate",
+)
+
+EXPECTED_MUTATION_NAMES = (
+    "frontier_overclaim",
+    "nanozk_overclaim",
+    "worst_label_typed_drift",
+    "worst_policy_reduction_drift",
+    "single_label_promoted",
+    "label_span_erased",
+    "candidate_missing_worst_label",
+    "source_digest_drift",
+    "source_commitment_drift",
+    "decision_drift",
+    "result_drift",
+    "claim_boundary_drift",
+    "non_claims_erased",
+    "validation_commands_erased",
+    "interpretation_drift",
+    "policy_extra_key",
+    "payload_commitment_drift",
+)
+
+TSV_COLUMNS = (
+    "policy_candidate",
+    "typed_bytes",
+    "delta_vs_two_proof_frontier_bytes",
+    "reduction_to_beat_frontier_bytes",
+    "delta_vs_compact_selector_bytes",
+    "reduction_to_beat_compact_selector_bytes",
+    "frontier_promotable",
+    "cherry_pick_risk",
+)
+
+
+class LabelPolicyError(ValueError):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode(
+            "utf-8"
+        )
+    except (TypeError, ValueError) as err:
+        raise LabelPolicyError(f"invalid JSON value: {err}") from err
+
+
+def payload_commitment(payload: dict[str, Any]) -> str:
+    material = {key: value for key, value in payload.items() if key != "payload_commitment"}
+    digest = hashlib.blake2b(digest_size=32)
+    digest.update(PAYLOAD_DOMAIN.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(canonical_json_bytes(material))
+    return "blake2b-256:" + digest.hexdigest()
+
+
+def refresh_payload_commitment(payload: dict[str, Any]) -> None:
+    payload["payload_commitment"] = payload_commitment(payload)
+
+
+def _dict(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise LabelPolicyError(f"{label} must be object")
+    return value
+
+
+def _list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise LabelPolicyError(f"{label} must be list")
+    return value
+
+
+def _int(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise LabelPolicyError(f"{label} must be integer")
+    return value
+
+
+def require_exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        details = []
+        if missing:
+            details.append(f"missing={missing}")
+        if extra:
+            details.append(f"extra={extra}")
+        raise LabelPolicyError(f"{label} key drift: {', '.join(details)}")
+
+
+def sha256_hex(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def reduction_to_beat(value: int, threshold: int) -> int:
+    return max(0, value - threshold + 1)
+
+
+def read_label_sensitivity_payload() -> tuple[dict[str, Any], bytes]:
+    try:
+        payload, raw = sensitivity_gate.read_json(LABEL_SENSITIVITY_PATH, "label sensitivity")
+        sensitivity_gate.validate_payload(payload)
+    except sensitivity_gate.RmsnormLabelSensitivityError as err:
+        raise LabelPolicyError(f"label sensitivity source invalid: {err}") from err
+    source_sha = sha256_hex(raw)
+    if source_sha != EXPECTED_LABEL_SENSITIVITY_SHA256:
+        raise LabelPolicyError("label sensitivity source digest drift")
+    if payload.get("payload_commitment") != EXPECTED_LABEL_SENSITIVITY_COMMITMENT:
+        raise LabelPolicyError("label sensitivity payload commitment drift")
+    return payload, raw
+
+
+def policy_candidate(name: str, typed_bytes: int, *, label_source: str, cherry_pick_risk: bool) -> dict[str, Any]:
+    return {
+        "name": name,
+        "label_source": label_source,
+        "typed_bytes": typed_bytes,
+        "delta_vs_two_proof_frontier_bytes": typed_bytes - TWO_PROOF_FRONTIER_TYPED_BYTES,
+        "reduction_to_beat_frontier_bytes": reduction_to_beat(
+            typed_bytes, TWO_PROOF_FRONTIER_TYPED_BYTES
+        ),
+        "delta_vs_compact_selector_bytes": typed_bytes - COMPACT_SELECTOR_TYPED_BYTES,
+        "reduction_to_beat_compact_selector_bytes": reduction_to_beat(
+            typed_bytes, COMPACT_SELECTOR_TYPED_BYTES
+        ),
+        "frontier_promotable": typed_bytes < TWO_PROOF_FRONTIER_TYPED_BYTES,
+        "compact_promotable": typed_bytes < COMPACT_SELECTOR_TYPED_BYTES,
+        "cherry_pick_risk": cherry_pick_risk,
+    }
+
+
+def build_payload(include_mutations: bool = True) -> dict[str, Any]:
+    source, raw = read_label_sensitivity_payload()
+    variants = _dict(source.get("variants"), "source variants")
+    inventory = []
+    for name in LABEL_INVENTORY:
+        variant = _dict(variants.get(name), f"source variant {name}")
+        inventory.append(
+            {
+                "name": name,
+                "typed_bytes": _int(variant.get("typed_bytes"), f"{name}.typed"),
+                "path_opening_bytes": _int(
+                    variant.get("path_opening_bytes"), f"{name}.path_opening"
+                ),
+                "value_bytes": _int(variant.get("value_bytes"), f"{name}.value"),
+                "value_delta_vs_canonical": _int(
+                    variant.get("value_delta_vs_canonical"), f"{name}.value_delta"
+                ),
+            }
+        )
+
+    canonical = next(item for item in inventory if item["name"] == "rmsnorm_input_fused")
+    probe_a = next(item for item in inventory if item["name"] == "label_probe_a")
+    probe_b = next(item for item in inventory if item["name"] == "label_probe_b")
+    best_label = min(inventory, key=lambda item: item["typed_bytes"])
+    worst_label = max(inventory, key=lambda item: item["typed_bytes"])
+    label_span = worst_label["typed_bytes"] - best_label["typed_bytes"]
+    mean_probe_typed = (probe_a["typed_bytes"] + probe_b["typed_bytes"]) // 2
+
+    candidates = {
+        "single_best_label": policy_candidate(
+            "single_best_label",
+            best_label["typed_bytes"],
+            label_source=best_label["name"],
+            cherry_pick_risk=True,
+        ),
+        "canonical_label": policy_candidate(
+            "canonical_label",
+            canonical["typed_bytes"],
+            label_source=canonical["name"],
+            cherry_pick_risk=False,
+        ),
+        "mean_two_label_probes": policy_candidate(
+            "mean_two_label_probes",
+            mean_probe_typed,
+            label_source="mean(label_probe_a,label_probe_b)",
+            cherry_pick_risk=True,
+        ),
+        "worst_label_inventory": policy_candidate(
+            "worst_label_inventory",
+            worst_label["typed_bytes"],
+            label_source=worst_label["name"],
+            cherry_pick_risk=False,
+        ),
+    }
+    worst_policy = candidates["worst_label_inventory"]
+    if worst_policy["reduction_to_beat_frontier_bytes"] != 1_401:
+        raise LabelPolicyError("worst-label frontier budget drift")
+    if any(item["value_delta_vs_canonical"] != 0 for item in inventory if item["name"] != "rmsnorm_input_fused"):
+        raise LabelPolicyError("label inventory changed direct value bytes")
+
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "decision": DECISION,
+        "result": RESULT,
+        "issue": ISSUE,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "source_artifacts": [
+            {
+                "name": "label_sensitivity_gate",
+                "path": str(LABEL_SENSITIVITY_PATH.relative_to(ROOT)),
+                "sha256": sha256_hex(raw),
+                "payload_commitment": source["payload_commitment"],
+            }
+        ],
+        "frontier": {
+            "two_proof_frontier_typed_bytes": TWO_PROOF_FRONTIER_TYPED_BYTES,
+            "compact_selector_typed_bytes": COMPACT_SELECTOR_TYPED_BYTES,
+            "nanozk_reported_d128_block_proof_bytes": NANOZK_REPORTED_D128_BLOCK_PROOF_BYTES,
+            "frontier_win_claimed": False,
+            "nanozk_win_claimed": False,
+            "nanozk_workload_matched": False,
+        },
+        "label_inventory": inventory,
+        "policy_candidates": candidates,
+        "promotion_policy": {
+            "policy": "worst_label_inventory_must_beat_two_proof_frontier",
+            "required_reduction_to_beat_frontier_bytes": worst_policy[
+                "reduction_to_beat_frontier_bytes"
+            ],
+            "required_reduction_to_beat_compact_selector_bytes": worst_policy[
+                "reduction_to_beat_compact_selector_bytes"
+            ],
+            "multi_label_frontier_promotable": False,
+            "single_label_frontier_promotable": False,
+            "single_label_cherry_pick_rejected": True,
+        },
+        "summary": {
+            "best_observed_label": best_label["name"],
+            "best_observed_label_typed_bytes": best_label["typed_bytes"],
+            "best_observed_label_delta_vs_frontier_bytes": best_label["typed_bytes"]
+            - TWO_PROOF_FRONTIER_TYPED_BYTES,
+            "single_best_label_reduction_to_beat_frontier_bytes": candidates[
+                "single_best_label"
+            ]["reduction_to_beat_frontier_bytes"],
+            "canonical_label_reduction_to_beat_frontier_bytes": candidates["canonical_label"][
+                "reduction_to_beat_frontier_bytes"
+            ],
+            "mean_two_label_probes_reduction_to_beat_frontier_bytes": candidates[
+                "mean_two_label_probes"
+            ]["reduction_to_beat_frontier_bytes"],
+            "worst_label_inventory": worst_label["name"],
+            "worst_label_inventory_typed_bytes": worst_label["typed_bytes"],
+            "worst_label_inventory_delta_vs_frontier_bytes": worst_label["typed_bytes"]
+            - TWO_PROOF_FRONTIER_TYPED_BYTES,
+            "worst_label_inventory_reduction_to_beat_frontier_bytes": worst_policy[
+                "reduction_to_beat_frontier_bytes"
+            ],
+            "worst_label_inventory_reduction_to_beat_compact_selector_bytes": worst_policy[
+                "reduction_to_beat_compact_selector_bytes"
+            ],
+            "label_span_typed_bytes": label_span,
+            "value_delta_preserved_across_labels": True,
+        },
+        "interpretation": dict(INTERPRETATION),
+        "non_claims": list(NON_CLAIMS),
+        "validation_commands": list(VALIDATION_COMMANDS),
+    }
+    refresh_payload_commitment(payload)
+    if include_mutations:
+        mutation_result = run_mutations(payload)
+        validate_mutation_result(mutation_result)
+        payload["mutation_result"] = mutation_result
+        refresh_payload_commitment(payload)
+    validate_payload(payload)
+    return payload
+
+
+def validate_mutation_result(mutation_result: dict[str, Any]) -> None:
+    require_exact_keys(mutation_result, {"cases", "mutation_count", "rejected_count"}, "mutation result")
+    cases = _list(mutation_result.get("cases"), "mutation cases")
+    if _int(mutation_result.get("mutation_count"), "mutation count") != len(EXPECTED_MUTATION_NAMES):
+        raise LabelPolicyError("mutation count drift")
+    if _int(mutation_result.get("rejected_count"), "rejected count") != len(EXPECTED_MUTATION_NAMES):
+        raise LabelPolicyError("mutation rejected count drift")
+    names = []
+    for index, case in enumerate(cases):
+        case_obj = _dict(case, f"mutation case {index}")
+        require_exact_keys(case_obj, {"name", "rejected"}, f"mutation case {index}")
+        name = case_obj.get("name")
+        if not isinstance(name, str):
+            raise LabelPolicyError("mutation case name drift")
+        names.append(name)
+        if case_obj.get("rejected") is not True:
+            raise LabelPolicyError(f"mutation not rejected: {name}")
+    if tuple(names) != EXPECTED_MUTATION_NAMES:
+        raise LabelPolicyError("mutation inventory drift")
+
+
+def validate_payload(payload: dict[str, Any]) -> None:
+    expected_top = {
+        "schema",
+        "decision",
+        "result",
+        "issue",
+        "claim_boundary",
+        "source_artifacts",
+        "frontier",
+        "label_inventory",
+        "policy_candidates",
+        "promotion_policy",
+        "summary",
+        "interpretation",
+        "non_claims",
+        "validation_commands",
+        "payload_commitment",
+    }
+    if "mutation_result" in payload:
+        expected_top.add("mutation_result")
+    require_exact_keys(payload, expected_top, "payload")
+    if payload.get("schema") != SCHEMA:
+        raise LabelPolicyError("schema drift")
+    if payload.get("decision") != DECISION:
+        raise LabelPolicyError("decision drift")
+    if payload.get("result") != RESULT:
+        raise LabelPolicyError("result drift")
+    if payload.get("issue") != ISSUE:
+        raise LabelPolicyError("issue drift")
+    if payload.get("claim_boundary") != CLAIM_BOUNDARY:
+        raise LabelPolicyError("claim boundary drift")
+
+    source_artifacts = _list(payload.get("source_artifacts"), "source artifacts")
+    expected_source = [
+        {
+            "name": "label_sensitivity_gate",
+            "path": str(LABEL_SENSITIVITY_PATH.relative_to(ROOT)),
+            "sha256": EXPECTED_LABEL_SENSITIVITY_SHA256,
+            "payload_commitment": EXPECTED_LABEL_SENSITIVITY_COMMITMENT,
+        }
+    ]
+    if source_artifacts != expected_source:
+        raise LabelPolicyError("source artifact drift")
+
+    frontier = _dict(payload.get("frontier"), "frontier")
+    expected_frontier = {
+        "two_proof_frontier_typed_bytes": TWO_PROOF_FRONTIER_TYPED_BYTES,
+        "compact_selector_typed_bytes": COMPACT_SELECTOR_TYPED_BYTES,
+        "nanozk_reported_d128_block_proof_bytes": NANOZK_REPORTED_D128_BLOCK_PROOF_BYTES,
+        "frontier_win_claimed": False,
+        "nanozk_win_claimed": False,
+        "nanozk_workload_matched": False,
+    }
+    if frontier.get("frontier_win_claimed") is not False:
+        raise LabelPolicyError("frontier overclaim")
+    if frontier.get("nanozk_win_claimed") is not False:
+        raise LabelPolicyError("NANOZK overclaim")
+    if frontier.get("nanozk_workload_matched") is not False:
+        raise LabelPolicyError("NANOZK workload drift")
+    if frontier != expected_frontier:
+        raise LabelPolicyError("frontier body drift")
+
+    inventory = _list(payload.get("label_inventory"), "label inventory")
+    if tuple(item.get("name") for item in inventory if isinstance(item, dict)) != LABEL_INVENTORY:
+        raise LabelPolicyError("label inventory order drift")
+    value_deltas = []
+    inventory_by_name = {}
+    for item in inventory:
+        label = _dict(item, "label inventory item")
+        require_exact_keys(
+            label,
+            {"name", "typed_bytes", "path_opening_bytes", "value_bytes", "value_delta_vs_canonical"},
+            "label inventory item",
+        )
+        name = label.get("name")
+        if name not in LABEL_INVENTORY:
+            raise LabelPolicyError("unknown label inventory item")
+        inventory_by_name[name] = label
+        value_deltas.append(_int(label.get("value_delta_vs_canonical"), f"{name}.value_delta"))
+    if any(delta != 0 for delta in value_deltas[1:]):
+        raise LabelPolicyError("label value delta drift")
+
+    candidates = _dict(payload.get("policy_candidates"), "policy candidates")
+    require_exact_keys(candidates, set(POLICY_CANDIDATE_ORDER), "policy candidates")
+    expected_candidate_values = {
+        "single_best_label": ("label_probe_a", 40_836, True),
+        "canonical_label": ("rmsnorm_input_fused", 41_428, False),
+        "mean_two_label_probes": ("mean(label_probe_a,label_probe_b)", 41_468, True),
+        "worst_label_inventory": ("label_probe_b", 42_100, False),
+    }
+    for name in POLICY_CANDIDATE_ORDER:
+        candidate = _dict(candidates.get(name), f"candidate {name}")
+        require_exact_keys(
+            candidate,
+            {
+                "name",
+                "label_source",
+                "typed_bytes",
+                "delta_vs_two_proof_frontier_bytes",
+                "reduction_to_beat_frontier_bytes",
+                "delta_vs_compact_selector_bytes",
+                "reduction_to_beat_compact_selector_bytes",
+                "frontier_promotable",
+                "compact_promotable",
+                "cherry_pick_risk",
+            },
+            f"candidate {name}",
+        )
+        label_source, typed, cherry_pick = expected_candidate_values[name]
+        if candidate.get("name") != name:
+            raise LabelPolicyError(f"{name} name drift")
+        if candidate.get("label_source") != label_source:
+            raise LabelPolicyError(f"{name} label source drift")
+        if _int(candidate.get("typed_bytes"), f"{name}.typed") != typed:
+            raise LabelPolicyError(f"{name} typed drift")
+        if candidate.get("cherry_pick_risk") is not cherry_pick:
+            raise LabelPolicyError(f"{name} cherry-pick drift")
+        if candidate.get("frontier_promotable") is not False:
+            raise LabelPolicyError(f"{name} frontier overclaim")
+        if candidate.get("compact_promotable") is not False:
+            raise LabelPolicyError(f"{name} compact overclaim")
+        if _int(candidate.get("delta_vs_two_proof_frontier_bytes"), f"{name}.frontier_delta") != (
+            typed - TWO_PROOF_FRONTIER_TYPED_BYTES
+        ):
+            raise LabelPolicyError(f"{name} frontier delta drift")
+        if _int(candidate.get("reduction_to_beat_frontier_bytes"), f"{name}.frontier_reduction") != (
+            reduction_to_beat(typed, TWO_PROOF_FRONTIER_TYPED_BYTES)
+        ):
+            raise LabelPolicyError(f"{name} frontier reduction drift")
+        if _int(candidate.get("delta_vs_compact_selector_bytes"), f"{name}.compact_delta") != (
+            typed - COMPACT_SELECTOR_TYPED_BYTES
+        ):
+            raise LabelPolicyError(f"{name} compact delta drift")
+        if _int(candidate.get("reduction_to_beat_compact_selector_bytes"), f"{name}.compact_reduction") != (
+            reduction_to_beat(typed, COMPACT_SELECTOR_TYPED_BYTES)
+        ):
+            raise LabelPolicyError(f"{name} compact reduction drift")
+
+    policy = _dict(payload.get("promotion_policy"), "promotion policy")
+    require_exact_keys(
+        policy,
+        {
+            "policy",
+            "required_reduction_to_beat_frontier_bytes",
+            "required_reduction_to_beat_compact_selector_bytes",
+            "multi_label_frontier_promotable",
+            "single_label_frontier_promotable",
+            "single_label_cherry_pick_rejected",
+        },
+        "promotion policy",
+    )
+    if policy.get("policy") != "worst_label_inventory_must_beat_two_proof_frontier":
+        raise LabelPolicyError("promotion policy drift")
+    if _int(policy.get("required_reduction_to_beat_frontier_bytes"), "policy frontier reduction") != 1_401:
+        raise LabelPolicyError("policy frontier reduction drift")
+    if _int(policy.get("required_reduction_to_beat_compact_selector_bytes"), "policy compact reduction") != 1_289:
+        raise LabelPolicyError("policy compact reduction drift")
+    if policy.get("multi_label_frontier_promotable") is not False:
+        raise LabelPolicyError("multi-label frontier overclaim")
+    if policy.get("single_label_frontier_promotable") is not False:
+        raise LabelPolicyError("single-label frontier overclaim")
+    if policy.get("single_label_cherry_pick_rejected") is not True:
+        raise LabelPolicyError("single-label cherry-pick guard erased")
+
+    summary = _dict(payload.get("summary"), "summary")
+    expected_summary = {
+        "best_observed_label": "label_probe_a",
+        "best_observed_label_typed_bytes": 40_836,
+        "best_observed_label_delta_vs_frontier_bytes": 136,
+        "single_best_label_reduction_to_beat_frontier_bytes": 137,
+        "canonical_label_reduction_to_beat_frontier_bytes": 729,
+        "mean_two_label_probes_reduction_to_beat_frontier_bytes": 769,
+        "worst_label_inventory": "label_probe_b",
+        "worst_label_inventory_typed_bytes": 42_100,
+        "worst_label_inventory_delta_vs_frontier_bytes": 1_400,
+        "worst_label_inventory_reduction_to_beat_frontier_bytes": 1_401,
+        "worst_label_inventory_reduction_to_beat_compact_selector_bytes": 1_289,
+        "label_span_typed_bytes": 1_264,
+        "value_delta_preserved_across_labels": True,
+    }
+    if summary != expected_summary:
+        raise LabelPolicyError("summary drift")
+    if _dict(payload.get("interpretation"), "interpretation") != INTERPRETATION:
+        raise LabelPolicyError("interpretation drift")
+    if _list(payload.get("non_claims"), "non_claims") != list(NON_CLAIMS):
+        raise LabelPolicyError("non-claims drift")
+    if _list(payload.get("validation_commands"), "validation_commands") != list(VALIDATION_COMMANDS):
+        raise LabelPolicyError("validation commands drift")
+    if "mutation_result" in payload:
+        validate_mutation_result(_dict(payload.get("mutation_result"), "mutation result"))
+    if payload.get("payload_commitment") != payload_commitment(payload):
+        raise LabelPolicyError("payload commitment drift")
+
+
+def run_mutations(payload: dict[str, Any]) -> dict[str, Any]:
+    mutations = (
+        ("frontier_overclaim", lambda p: p["frontier"].__setitem__("frontier_win_claimed", True)),
+        ("nanozk_overclaim", lambda p: p["frontier"].__setitem__("nanozk_win_claimed", True)),
+        ("worst_label_typed_drift", lambda p: p["summary"].__setitem__("worst_label_inventory_typed_bytes", 40_700)),
+        (
+            "worst_policy_reduction_drift",
+            lambda p: p["promotion_policy"].__setitem__("required_reduction_to_beat_frontier_bytes", 137),
+        ),
+        (
+            "single_label_promoted",
+            lambda p: p["promotion_policy"].__setitem__("single_label_frontier_promotable", True),
+        ),
+        ("label_span_erased", lambda p: p["summary"].__setitem__("label_span_typed_bytes", 0)),
+        ("candidate_missing_worst_label", lambda p: p["policy_candidates"].pop("worst_label_inventory")),
+        ("source_digest_drift", lambda p: p["source_artifacts"][0].__setitem__("sha256", "00" * 32)),
+        (
+            "source_commitment_drift",
+            lambda p: p["source_artifacts"][0].__setitem__("payload_commitment", "blake2b-256:" + "00" * 32),
+        ),
+        ("decision_drift", lambda p: p.__setitem__("decision", "GO_MULTI_LABEL_FRONTIER_PROMOTION")),
+        ("result_drift", lambda p: p.__setitem__("result", "LABEL_INVENTORY_BEATS_FRONTIER")),
+        ("claim_boundary_drift", lambda p: p.__setitem__("claim_boundary", "OVERCLAIMED")),
+        ("non_claims_erased", lambda p: p.__setitem__("non_claims", [])),
+        ("validation_commands_erased", lambda p: p.__setitem__("validation_commands", [])),
+        ("interpretation_drift", lambda p: p["interpretation"].__setitem__("human_read", "overclaimed")),
+        ("policy_extra_key", lambda p: p["promotion_policy"].__setitem__("unchecked", True)),
+        ("payload_commitment_drift", lambda p: p.__setitem__("payload_commitment", "blake2b-256:" + "00" * 32)),
+    )
+    if tuple(name for name, _ in mutations) != EXPECTED_MUTATION_NAMES:
+        raise LabelPolicyError("mutation definitions drift")
+    cases = []
+    for name, mutate in mutations:
+        mutated = copy.deepcopy(payload)
+        mutated.pop("mutation_result", None)
+        mutate(mutated)
+        if name != "payload_commitment_drift":
+            refresh_payload_commitment(mutated)
+        rejected = False
+        try:
+            validate_payload(mutated)
+        except LabelPolicyError:
+            rejected = True
+        cases.append({"name": name, "rejected": rejected})
+    return {
+        "mutation_count": len(cases),
+        "rejected_count": sum(1 for case in cases if case["rejected"]),
+        "cases": cases,
+    }
+
+
+def tsv_text(payload: dict[str, Any]) -> str:
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+    writer.writeheader()
+    for name in POLICY_CANDIDATE_ORDER:
+        candidate = payload["policy_candidates"][name]
+        writer.writerow(
+            {
+                "policy_candidate": name,
+                "typed_bytes": candidate["typed_bytes"],
+                "delta_vs_two_proof_frontier_bytes": candidate["delta_vs_two_proof_frontier_bytes"],
+                "reduction_to_beat_frontier_bytes": candidate["reduction_to_beat_frontier_bytes"],
+                "delta_vs_compact_selector_bytes": candidate["delta_vs_compact_selector_bytes"],
+                "reduction_to_beat_compact_selector_bytes": candidate[
+                    "reduction_to_beat_compact_selector_bytes"
+                ],
+                "frontier_promotable": str(candidate["frontier_promotable"]).lower(),
+                "cherry_pick_risk": str(candidate["cherry_pick_risk"]).lower(),
+            }
+        )
+    return output.getvalue()
+
+
+def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
+    validate_payload(payload)
+    try:
+        if json_path is not None:
+            sensitivity_gate.write_text_atomically(
+                json_path, json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            )
+        if tsv_path is not None:
+            sensitivity_gate.write_text_atomically(tsv_path, tsv_text(payload))
+    except sensitivity_gate.RmsnormLabelSensitivityError as err:
+        raise LabelPolicyError(f"failed to write output: {err}") from err
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write-json", type=pathlib.Path)
+    parser.add_argument("--write-tsv", type=pathlib.Path)
+    args = parser.parse_args()
+    payload = build_payload()
+    write_outputs(payload, args.write_json, args.write_tsv)
+    print(
+        json.dumps(
+            {
+                "decision": payload["decision"],
+                "result": payload["result"],
+                "worst_label_inventory_typed_bytes": payload["summary"][
+                    "worst_label_inventory_typed_bytes"
+                ],
+                "worst_label_reduction_to_beat_frontier_bytes": payload["summary"][
+                    "worst_label_inventory_reduction_to_beat_frontier_bytes"
+                ],
+                "mutation_count": payload["mutation_result"]["mutation_count"],
+                "mutations_rejected": payload["mutation_result"]["rejected_count"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -9,7 +9,9 @@ import csv
 import hashlib
 import io
 import json
+import os
 import pathlib
+import secrets
 import sys
 from typing import Any
 
@@ -691,19 +693,51 @@ def normalize_output_path(path: pathlib.Path) -> pathlib.Path:
         raise LabelPolicyError(f"failed to normalize output path: {err}") from err
 
 
+def staged_output_path(target: pathlib.Path, label: str) -> pathlib.Path:
+    return target.with_name(f".{target.name}.{os.getpid()}.{secrets.token_hex(8)}.{label}.stage")
+
+
+def write_output_pair_atomically(
+    json_target: pathlib.Path,
+    json_text: str,
+    tsv_target: pathlib.Path,
+    tsv_body: str,
+) -> None:
+    json_stage = staged_output_path(json_target, "json")
+    tsv_stage = staged_output_path(tsv_target, "tsv")
+    staged_paths = [json_stage, tsv_stage]
+    try:
+        sensitivity_gate.write_text_atomically(json_stage, json_text)
+        sensitivity_gate.write_text_atomically(tsv_stage, tsv_body)
+        os.replace(json_stage, json_target)
+        staged_paths.remove(json_stage)
+        os.replace(tsv_stage, tsv_target)
+        staged_paths.remove(tsv_stage)
+    except (OSError, sensitivity_gate.RmsnormLabelSensitivityError) as err:
+        for staged_path in staged_paths:
+            try:
+                staged_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise LabelPolicyError(f"failed to write output: {err}") from err
+
+
 def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
     validate_payload(payload)
     json_target = normalize_output_path(json_path) if json_path is not None else None
     tsv_target = normalize_output_path(tsv_path) if tsv_path is not None else None
     if json_target is not None and tsv_target is not None and json_target.resolve() == tsv_target.resolve():
         raise LabelPolicyError(f"duplicate output destination: {json_target}")
+    json_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    tsv_body = tsv_text(payload)
+    if json_target is not None and tsv_target is not None:
+        write_output_pair_atomically(json_target, json_text, tsv_target, tsv_body)
+        return
     try:
         if json_target is not None:
-            sensitivity_gate.write_text_atomically(
-                json_target, json.dumps(payload, indent=2, sort_keys=True) + "\n"
-            )
+            sensitivity_gate.write_text_atomically(json_target, json_text)
         if tsv_target is not None:
-            sensitivity_gate.write_text_atomically(tsv_target, tsv_text(payload))
+            sensitivity_gate.write_text_atomically(tsv_target, tsv_body)
     except sensitivity_gate.RmsnormLabelSensitivityError as err:
         raise LabelPolicyError(f"failed to write output: {err}") from err
 

--- a/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -713,13 +713,18 @@ def write_output_pair_atomically(
         staged_paths.remove(json_stage)
         os.replace(tsv_stage, tsv_target)
         staged_paths.remove(tsv_stage)
-        dir_fd: int | None = None
-        try:
-            dir_fd = sensitivity_gate.open_directory_fd(json_target.parent)
-            sensitivity_gate.fsync_dir_fd(dir_fd, json_target.parent)
-        finally:
-            if dir_fd is not None:
-                os.close(dir_fd)
+        fsynced_parents: list[pathlib.Path] = []
+        for parent in (json_target.parent, tsv_target.parent):
+            if parent in fsynced_parents:
+                continue
+            fsynced_parents.append(parent)
+            dir_fd: int | None = None
+            try:
+                dir_fd = sensitivity_gate.open_directory_fd(parent)
+                sensitivity_gate.fsync_dir_fd(dir_fd, parent)
+            finally:
+                if dir_fd is not None:
+                    os.close(dir_fd)
     except (OSError, sensitivity_gate.RmsnormLabelSensitivityError) as err:
         for staged_path in staged_paths:
             try:

--- a/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -55,6 +55,26 @@ POLICY_CANDIDATE_ORDER = (
     "mean_two_label_probes",
     "worst_label_inventory",
 )
+EXPECTED_LABEL_INVENTORY = {
+    "rmsnorm_input_fused": {
+        "typed_bytes": 41_428,
+        "path_opening_bytes": 20_512,
+        "value_bytes": 20_868,
+        "value_delta_vs_canonical": 0,
+    },
+    "label_probe_a": {
+        "typed_bytes": 40_836,
+        "path_opening_bytes": 19_920,
+        "value_bytes": 20_868,
+        "value_delta_vs_canonical": 0,
+    },
+    "label_probe_b": {
+        "typed_bytes": 42_100,
+        "path_opening_bytes": 21_184,
+        "value_bytes": 20_868,
+        "value_delta_vs_canonical": 0,
+    },
+}
 
 HUMAN_READ = (
     "The best observed label is only 136 typed bytes above the two-proof frontier, "
@@ -100,6 +120,7 @@ EXPECTED_MUTATION_NAMES = (
     "worst_policy_reduction_drift",
     "single_label_promoted",
     "label_span_erased",
+    "inventory_byte_drift",
     "candidate_missing_worst_label",
     "source_digest_drift",
     "source_commitment_drift",
@@ -460,6 +481,9 @@ def validate_payload(payload: dict[str, Any]) -> None:
             raise LabelPolicyError("unknown label inventory item")
         inventory_by_name[name] = label
         value_deltas.append(_int(label.get("value_delta_vs_canonical"), f"{name}.value_delta"))
+        for field, expected_value in EXPECTED_LABEL_INVENTORY[name].items():
+            if _int(label.get(field), f"{name}.{field}") != expected_value:
+                raise LabelPolicyError(f"{name} inventory byte drift")
     if any(delta != 0 for delta in value_deltas[1:]):
         raise LabelPolicyError("label value delta drift")
 
@@ -589,6 +613,7 @@ def run_mutations(payload: dict[str, Any]) -> dict[str, Any]:
             lambda p: p["promotion_policy"].__setitem__("single_label_frontier_promotable", True),
         ),
         ("label_span_erased", lambda p: p["summary"].__setitem__("label_span_typed_bytes", 0)),
+        ("inventory_byte_drift", lambda p: p["label_inventory"][0].__setitem__("typed_bytes", 41_429)),
         ("candidate_missing_worst_label", lambda p: p["policy_candidates"].pop("worst_label_inventory")),
         ("source_digest_drift", lambda p: p["source_artifacts"][0].__setitem__("sha256", "00" * 32)),
         (

--- a/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -25,6 +25,7 @@ EVIDENCE_DIR = ROOT / "docs" / "engineering" / "evidence"
 LABEL_SENSITIVITY_PATH = (
     EVIDENCE_DIR / "zkai-native-attention-mlp-rmsnorm-label-sensitivity-2026-05.json"
 )
+LABEL_SENSITIVITY_RELATIVE_PATH = LABEL_SENSITIVITY_PATH.relative_to(ROOT).as_posix()
 JSON_OUT = EVIDENCE_DIR / "zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json"
 TSV_OUT = EVIDENCE_DIR / "zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv"
 
@@ -313,7 +314,7 @@ def build_payload(include_mutations: bool = True) -> dict[str, Any]:
         "source_artifacts": [
             {
                 "name": "label_sensitivity_gate",
-                "path": str(LABEL_SENSITIVITY_PATH.relative_to(ROOT)),
+                "path": LABEL_SENSITIVITY_RELATIVE_PATH,
                 "sha256": sha256_hex(raw),
                 "payload_commitment": source["payload_commitment"],
             }
@@ -438,7 +439,7 @@ def validate_payload(payload: dict[str, Any]) -> None:
     expected_source = [
         {
             "name": "label_sensitivity_gate",
-            "path": str(LABEL_SENSITIVITY_PATH.relative_to(ROOT)),
+            "path": LABEL_SENSITIVITY_RELATIVE_PATH,
             "sha256": EXPECTED_LABEL_SENSITIVITY_SHA256,
             "payload_commitment": EXPECTED_LABEL_SENSITIVITY_COMMITMENT,
         }
@@ -685,6 +686,8 @@ def tsv_text(payload: dict[str, Any]) -> str:
 
 def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
     validate_payload(payload)
+    if json_path is not None and tsv_path is not None and json_path.resolve() == tsv_path.resolve():
+        raise LabelPolicyError(f"duplicate output destination: {json_path}")
     try:
         if json_path is not None:
             sensitivity_gate.write_text_atomically(

--- a/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -713,6 +713,13 @@ def write_output_pair_atomically(
         staged_paths.remove(json_stage)
         os.replace(tsv_stage, tsv_target)
         staged_paths.remove(tsv_stage)
+        dir_fd: int | None = None
+        try:
+            dir_fd = sensitivity_gate.open_directory_fd(json_target.parent)
+            sensitivity_gate.fsync_dir_fd(dir_fd, json_target.parent)
+        finally:
+            if dir_fd is not None:
+                os.close(dir_fd)
     except (OSError, sensitivity_gate.RmsnormLabelSensitivityError) as err:
         for staged_path in staged_paths:
             try:

--- a/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -684,17 +684,26 @@ def tsv_text(payload: dict[str, Any]) -> str:
     return output.getvalue()
 
 
+def normalize_output_path(path: pathlib.Path) -> pathlib.Path:
+    try:
+        return sensitivity_gate.require_output_path(path)
+    except sensitivity_gate.RmsnormLabelSensitivityError as err:
+        raise LabelPolicyError(f"failed to normalize output path: {err}") from err
+
+
 def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
     validate_payload(payload)
-    if json_path is not None and tsv_path is not None and json_path.resolve() == tsv_path.resolve():
-        raise LabelPolicyError(f"duplicate output destination: {json_path}")
+    json_target = normalize_output_path(json_path) if json_path is not None else None
+    tsv_target = normalize_output_path(tsv_path) if tsv_path is not None else None
+    if json_target is not None and tsv_target is not None and json_target.resolve() == tsv_target.resolve():
+        raise LabelPolicyError(f"duplicate output destination: {json_target}")
     try:
-        if json_path is not None:
+        if json_target is not None:
             sensitivity_gate.write_text_atomically(
-                json_path, json.dumps(payload, indent=2, sort_keys=True) + "\n"
+                json_target, json.dumps(payload, indent=2, sort_keys=True) + "\n"
             )
-        if tsv_path is not None:
-            sensitivity_gate.write_text_atomically(tsv_path, tsv_text(payload))
+        if tsv_target is not None:
+            sensitivity_gate.write_text_atomically(tsv_target, tsv_text(payload))
     except sensitivity_gate.RmsnormLabelSensitivityError as err:
         raise LabelPolicyError(f"failed to write output: {err}") from err
 

--- a/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
+++ b/scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py
@@ -482,8 +482,11 @@ def validate_payload(payload: dict[str, Any]) -> None:
         inventory_by_name[name] = label
         value_deltas.append(_int(label.get("value_delta_vs_canonical"), f"{name}.value_delta"))
         for field, expected_value in EXPECTED_LABEL_INVENTORY[name].items():
-            if _int(label.get(field), f"{name}.{field}") != expected_value:
-                raise LabelPolicyError(f"{name} inventory byte drift")
+            actual_value = _int(label.get(field), f"{name}.{field}")
+            if actual_value != expected_value:
+                raise LabelPolicyError(
+                    f"{name} inventory byte drift: {field} expected={expected_value} got={actual_value}"
+                )
     if any(delta != 0 for delta in value_deltas[1:]):
         raise LabelPolicyError("label value delta drift")
 
@@ -613,7 +616,13 @@ def run_mutations(payload: dict[str, Any]) -> dict[str, Any]:
             lambda p: p["promotion_policy"].__setitem__("single_label_frontier_promotable", True),
         ),
         ("label_span_erased", lambda p: p["summary"].__setitem__("label_span_typed_bytes", 0)),
-        ("inventory_byte_drift", lambda p: p["label_inventory"][0].__setitem__("typed_bytes", 41_429)),
+        (
+            "inventory_byte_drift",
+            lambda p: p["label_inventory"][0].__setitem__(
+                "typed_bytes",
+                EXPECTED_LABEL_INVENTORY["rmsnorm_input_fused"]["typed_bytes"] + 1,
+            ),
+        ),
         ("candidate_missing_worst_label", lambda p: p["policy_candidates"].pop("worst_label_inventory")),
         ("source_digest_drift", lambda p: p["source_artifacts"][0].__setitem__("sha256", "00" * 32)),
         (


### PR DESCRIPTION
## Summary

This PR adds the RMSNorm-input label-policy follow-up for issue #644.

It does not build a new proof object and it does not claim a proof-size win. It pins the promotion rule needed before a future RMSNorm-input opening-layout result can be treated as a frontier move: the route must beat the `40,700` typed-byte two-proof frontier under the worst label in the checked label inventory, not under one favorable transcript label.

## Result

Current policy candidates:

| candidate | typed bytes | delta vs frontier | reduction to beat frontier | cherry-pick risk |
| --- | ---: | ---: | ---: | --- |
| single best label | `40,836` | `+136` | `137` | yes |
| canonical label | `41,428` | `+728` | `729` | no |
| mean of two label probes | `41,468` | `+768` | `769` | yes |
| worst label inventory | `42,100` | `+1,400` | `1,401` | no |

Human meaning: a cherry-picked view says the route is only `137` typed bytes away from the frontier. The honest worst-label policy says it is `1,401` typed bytes away. That prevents us from promoting transcript-label variance as a structural proof-size result.

## Added

- `scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py`
- `scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py`
- JSON and TSV evidence under `docs/engineering/evidence/`
- Engineering note and handoff updates

## Mutation Guard

The policy gate now rejects `19 / 19` mutation cases covering frontier overclaim, NANOZK overclaim, worst-label metric drift, promotion-policy drift, single-label promotion, label-span erasure, direct inventory-byte drift, missing worst-label inventory, source digest drift, source commitment drift, decision/result/claim-boundary drift, non-claim erasure, validation-command erasure, interpretation drift, extra policy keys, and payload-commitment drift.

The second commit fixes CodeRabbit's valid hardening feedback by byte-for-byte pinning each published label-inventory row against the expected source metrics and by tightening the outside-evidence-dir negative test.

## Non-claims

- not a two-proof frontier beat
- not a proof-size win
- not a NANOZK proof-size win
- not a matched external zkML benchmark
- not timing evidence
- not a full transformer block proof
- not production-ready zkML

## Local Validation

No GitHub CI was used.

- `python3 scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-attention-mlp-rmsnorm-label-policy-2026-05.tsv`
- `python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_rmsnorm_label_policy_gate` (`19 / 19`)
- `python3 -m unittest scripts.tests.test_zkai_native_attention_mlp_rmsnorm_label_sensitivity_gate` (`24 / 24`)
- `python3 -m py_compile scripts/zkai_native_attention_mlp_rmsnorm_label_policy_gate.py scripts/tests/test_zkai_native_attention_mlp_rmsnorm_label_policy_gate.py`
- `git diff --check`
- `just gate-fast`
- `just gate` (`19 / 19`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added engineering docs describing a new RMSNorm-input multi-label frontier promotion gate, thresholds, evidence/artifact requirements, reproducibility commands, and promotion outcomes.

* **New Features**
  * Added a deterministic CLI to build, validate, and (optionally) publish gate payloads and reports.

* **Tests**
  * Added an extensive end-to-end test suite covering payload validation, mutation rejection cases, output writing behavior, and filesystem atomicity/fsync checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->