### PR TITLE
Gate deterministic adjacent label policy

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -2369,6 +2369,47 @@ Seq32 adjacent label-policy reproducibility metadata:
   `just gate-fast`;
   `just gate`.
 
+Latest deterministic adjacent label-policy gate: the follow-up policy gate
+turns the adjacent-label result into a stricter supported-label rule without
+promoting the whole inventory. The full adjacent inventory remains a NO-GO
+because the fixed adjacent label is `42,156` typed bytes (`+88` versus the
+`42,068` champion) and adds `592` path-opening typed bytes. The deterministic
+supported-label policy rejects that inflating label and keeps the two checked
+labels whose worst case is probe A at `40,332` typed bytes, saving `1,736`
+typed bytes (`4.1267%`) versus the champion; probe B is `37,532` typed bytes,
+saving `4,536` typed bytes (`10.7825%`). Direct value bytes stay fixed at
+`20,924`, so the mechanism remains transcript/opening material, not changed
+arithmetic. This is not a final generator-backed label policy, not robust to
+unseen labels, not a matched external benchmark, and not a NANOZK proof-size
+win. See
+`docs/engineering/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05-19.md`.
+
+Seq32 deterministic adjacent label-policy reproducibility metadata:
+
+- Source policy path:
+  `docs/engineering/evidence/zkai-native-seq32-attention-mlp-rmsnorm-adjacent-label-policy-2026-05.json`.
+- Source policy SHA-256:
+  `b85b9001dc0e9387b4cc2fc49302c9d7bbe7e9ff8d8f6c9b31c394a21b14b9d1`.
+- Source policy payload commitment:
+  `blake2b-256:f2bcfec2552cc89befcb489271b357063cf13ea302fb91732cb416249ea427a2`.
+- Gate schema:
+  `zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-gate-v1`.
+- Decision:
+  `GO_SUPPORTED_ADJACENT_LABEL_POLICY_BEATS_CURRENT_CHAMPION`.
+- Evidence paths:
+  `docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json`
+  and
+  `docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv`.
+- Local validation commands:
+  `python3.10 scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv`;
+  `python3.10 -m py_compile scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py`;
+  `python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate`;
+  `python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_adjacent_label_policy_gate`;
+  `cargo +nightly-2025-07-14 test --locked --features stwo-backend rmsnorm_input_adjacent_label --lib`;
+  `git diff --check`;
+  `just gate-fast`;
+  `just gate`.
+
 ## Resume protocol
 
 1. Read `AGENTS.md`.

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -2275,18 +2275,19 @@ Seq32 adjacent label-policy reproducibility metadata:
   `just gate-fast`;
   `just gate`.
 
-Latest deterministic adjacent label-policy gate: the supported-label follow-up
-keeps the adjacent-label result honest. The full adjacent inventory is still a
-NO-GO because the fixed adjacent label is `42,156` typed bytes (`+88` versus
-the `42,068` champion) and adds `592` path-opening typed bytes. The
-deterministic supported-label policy rejects that inflating label and keeps
-the two checked labels whose worst case is probe A at `40,332` typed bytes,
-saving `1,736` typed bytes (`4.1267%`) versus the champion; probe B is
-`37,532` typed bytes, saving `4,536` typed bytes (`10.7825%`). Direct value
-bytes stay fixed at `20,924`, so the mechanism remains transcript/opening
-material, not changed arithmetic. This is not a final generator-backed label
-policy, not robust to unseen labels, not a matched external benchmark, and not
-a NANOZK proof-size win. See
+Latest deterministic adjacent label-policy gate: the follow-up policy gate
+turns the adjacent-label result into a stricter supported-label rule without
+promoting the whole inventory. The full adjacent inventory remains a NO-GO
+because the fixed adjacent label is `42,156` typed bytes (`+88` versus the
+`42,068` champion) and adds `592` path-opening typed bytes. The deterministic
+supported-label policy rejects that inflating label and keeps the two checked
+labels whose worst case is probe A at `40,332` typed bytes, saving `1,736`
+typed bytes (`4.1267%`) versus the champion; probe B is `37,532` typed bytes,
+saving `4,536` typed bytes (`10.7825%`). Direct value bytes stay fixed at
+`20,924`, so the mechanism remains transcript/opening material, not changed
+arithmetic. This is not a final generator-backed label policy, not robust to
+unseen labels, not a matched external benchmark, and not a NANOZK proof-size
+win. See
 `docs/engineering/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05-19.md`.
 
 Seq32 deterministic adjacent label-policy reproducibility metadata:

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -2275,6 +2275,46 @@ Seq32 adjacent label-policy reproducibility metadata:
   `just gate-fast`;
   `just gate`.
 
+Latest deterministic adjacent label-policy gate: the supported-label follow-up
+keeps the adjacent-label result honest. The full adjacent inventory is still a
+NO-GO because the fixed adjacent label is `42,156` typed bytes (`+88` versus
+the `42,068` champion) and adds `592` path-opening typed bytes. The
+deterministic supported-label policy rejects that inflating label and keeps
+the two checked labels whose worst case is probe A at `40,332` typed bytes,
+saving `1,736` typed bytes (`4.1267%`) versus the champion; probe B is
+`37,532` typed bytes, saving `4,536` typed bytes (`10.7825%`). Direct value
+bytes stay fixed at `20,924`, so the mechanism remains transcript/opening
+material, not changed arithmetic. This is not a final generator-backed label
+policy, not robust to unseen labels, not a matched external benchmark, and not
+a NANOZK proof-size win. See
+`docs/engineering/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05-19.md`.
+
+Seq32 deterministic adjacent label-policy reproducibility metadata:
+
+- Source policy path:
+  `docs/engineering/evidence/zkai-native-seq32-attention-mlp-rmsnorm-adjacent-label-policy-2026-05.json`.
+- Source policy SHA-256:
+  `b85b9001dc0e9387b4cc2fc49302c9d7bbe7e9ff8d8f6c9b31c394a21b14b9d1`.
+- Source policy payload commitment:
+  `blake2b-256:f2bcfec2552cc89befcb489271b357063cf13ea302fb91732cb416249ea427a2`.
+- Gate schema:
+  `zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-gate-v1`.
+- Decision:
+  `GO_SUPPORTED_ADJACENT_LABEL_POLICY_BEATS_CURRENT_CHAMPION`.
+- Evidence paths:
+  `docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json`
+  and
+  `docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv`.
+- Local validation commands:
+  `python3.10 scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv`;
+  `python3.10 -m py_compile scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py`;
+  `python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate`;
+  `python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_adjacent_label_policy_gate`;
+  `cargo +nightly-2025-07-14 test --locked --features stwo-backend rmsnorm_input_adjacent_label --lib`;
+  `git diff --check`;
+  `just gate-fast`;
+  `just gate`.
+
 1. Treat `rmsnorm_mlp_fused` as the current positive MLP-side fusion result:
    the native fused proof saves `32,144` local typed bytes (`56.4167%`) versus
    separate RMSNorm, bridge, gate/value, activation, down-projection, and

--- a/docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json
+++ b/docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json
@@ -191,6 +191,26 @@
         "rejected": true
       },
       {
+        "error": "label inventory drift",
+        "name": "label_adapter_mode_drift",
+        "rejected": true
+      },
+      {
+        "error": "label inventory drift",
+        "name": "label_proof_json_drift",
+        "rejected": true
+      },
+      {
+        "error": "label inventory drift",
+        "name": "label_status_reason_drift",
+        "rejected": true
+      },
+      {
+        "error": "label inventory drift",
+        "name": "champion_value_drift",
+        "rejected": true
+      },
+      {
         "error": "payload commitment drift",
         "name": "payload_commitment_drift",
         "rejected": true
@@ -214,9 +234,13 @@
       "final_policy_overclaim",
       "unknown_policy_field",
       "label_inventory_order_drift",
+      "label_adapter_mode_drift",
+      "label_proof_json_drift",
+      "label_status_reason_drift",
+      "champion_value_drift",
       "payload_commitment_drift"
     ],
-    "mutations_rejected": 18
+    "mutations_rejected": 22
   },
   "non_claims": [
     "not a final production label-selection policy",
@@ -229,7 +253,7 @@
     "not timing evidence",
     "not production-ready zkML"
   ],
-  "payload_commitment": "blake2b-256:e7238aad6226916d0a0c56234cda57b9c5d277ecbf8d034b434a3efbf67f628b",
+  "payload_commitment": "blake2b-256:cb60558f8b274ffa44d51de3367a34759b408b5c1dd3427583d3031ef9017fdd",
   "policy_summary": {
     "adjacent_value_bytes": 20924,
     "best_supported_label_id": "adjacent_label_probe_b",

--- a/docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json
+++ b/docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json
@@ -1,0 +1,275 @@
+{
+  "claim_boundary": "DETERMINISTIC_POLICY_OVER_EXISTING_SEQ32_ADJACENT_LABEL_INVENTORY;REJECTS_FIXED_LABEL_PATH_OPENING_INFLATION;NOT_A_FINAL_LABEL_GENERATOR_NOT_A_NANOZK_WIN",
+  "decision": "GO_SUPPORTED_ADJACENT_LABEL_POLICY_BEATS_CURRENT_CHAMPION",
+  "deterministic_policy": {
+    "best_supported_label_id": "adjacent_label_probe_b",
+    "best_supported_saving_typed_bytes": 4536,
+    "best_supported_typed_bytes": 37532,
+    "name": "reject_path_opening_inflation_v1",
+    "rejected_label_count": 1,
+    "rejected_label_ids": [
+      "fixed_adjacent_layout"
+    ],
+    "rejection_criteria": [
+      "path_opening_bytes are greater than or equal to the current champion",
+      "typed_bytes are greater than or equal to the current champion",
+      "direct value bytes drift from the adjacent label inventory"
+    ],
+    "support_criteria": [
+      "adapter_mode is an adjacent label probe",
+      "direct value bytes equal 20924",
+      "path_opening_bytes are below the current champion",
+      "typed_bytes are below the current champion",
+      "source envelope and accounting are pinned by digest and payload commitment"
+    ],
+    "supported_label_count": 2,
+    "supported_label_ids": [
+      "adjacent_label_probe_a",
+      "adjacent_label_probe_b"
+    ],
+    "supported_labels_promotable_vs_current_champion": true,
+    "worst_supported_label_id": "adjacent_label_probe_a",
+    "worst_supported_saving_share": "0.041267",
+    "worst_supported_saving_typed_bytes": 1736,
+    "worst_supported_typed_bytes": 40332
+  },
+  "full_inventory_policy": {
+    "delta_vs_current_champion_typed_bytes": 88,
+    "full_inventory_label_ids": [
+      "fixed_adjacent_layout",
+      "adjacent_label_probe_a",
+      "adjacent_label_probe_b"
+    ],
+    "full_inventory_promotable_vs_current_champion": false,
+    "name": "full_adjacent_inventory_worst_label_v1",
+    "reason": "the fixed adjacent label inflates path-opening material and misses the champion by 88 typed bytes",
+    "worst_full_inventory_label_id": "fixed_adjacent_layout",
+    "worst_full_inventory_typed_bytes": 42156
+  },
+  "interpretation": {
+    "human_read": "The full adjacent label inventory is not promotable because the fixed adjacent label is 88 typed bytes above the current champion. The deterministic supported-label policy rejects that path-opening-inflating label and keeps the two checked labels whose worst case saves 1,736 typed bytes.",
+    "mechanism_read": "The policy is not changing arithmetic. Direct value bytes stay fixed at 20,924; the policy only rejects labels whose path-opening material grows beyond the current champion.",
+    "next_experiment": "Turn this policy into a generator-backed label inventory, then test whether unseen labels still keep the worst supported proof below 42,068 typed bytes."
+  },
+  "issue_hint": "seq32-deterministic-adjacent-label-policy",
+  "label_inventory": [
+    {
+      "adapter_mode": "duplicate_base_preprocessed_v1",
+      "path_opening_bytes": 20592,
+      "path_opening_delta_vs_champion": 0,
+      "policy_status": "comparison_champion",
+      "proof_json_bytes": 121996,
+      "status_reason": "baseline for typed/path-opening deltas",
+      "typed_bytes": 42068,
+      "typed_delta_vs_champion": 0,
+      "value_bytes": 21428,
+      "variant_id": "current_duplicate_base"
+    },
+    {
+      "adapter_mode": "rmsnorm_input_fused_adjacent_fixed_v1",
+      "path_opening_bytes": 21184,
+      "path_opening_delta_vs_champion": 592,
+      "policy_status": "rejected_inflating_label",
+      "proof_json_bytes": 122688,
+      "status_reason": "path-opening bytes are not below the current champion",
+      "typed_bytes": 42156,
+      "typed_delta_vs_champion": 88,
+      "value_bytes": 20924,
+      "variant_id": "fixed_adjacent_layout"
+    },
+    {
+      "adapter_mode": "rmsnorm_input_fused_adjacent_label_probe_a_v1",
+      "path_opening_bytes": 19360,
+      "path_opening_delta_vs_champion": -1232,
+      "policy_status": "supported_label",
+      "proof_json_bytes": 116321,
+      "status_reason": "value bytes stable and path-opening/typed bytes beat the current champion",
+      "typed_bytes": 40332,
+      "typed_delta_vs_champion": -1736,
+      "value_bytes": 20924,
+      "variant_id": "adjacent_label_probe_a"
+    },
+    {
+      "adapter_mode": "rmsnorm_input_fused_adjacent_label_probe_b_v1",
+      "path_opening_bytes": 16560,
+      "path_opening_delta_vs_champion": -4032,
+      "policy_status": "supported_label",
+      "proof_json_bytes": 106317,
+      "status_reason": "value bytes stable and path-opening/typed bytes beat the current champion",
+      "typed_bytes": 37532,
+      "typed_delta_vs_champion": -4536,
+      "value_bytes": 20924,
+      "variant_id": "adjacent_label_probe_b"
+    }
+  ],
+  "mutation_result": {
+    "all_mutations_rejected": true,
+    "cases": [
+      {
+        "error": "decision drift",
+        "name": "decision_drift",
+        "rejected": true
+      },
+      {
+        "error": "result drift",
+        "name": "result_drift",
+        "rejected": true
+      },
+      {
+        "error": "full inventory overclaim",
+        "name": "full_inventory_overclaim",
+        "rejected": true
+      },
+      {
+        "error": "label inventory drift",
+        "name": "fixed_label_supported",
+        "rejected": true
+      },
+      {
+        "error": "label inventory drift",
+        "name": "probe_a_rejected",
+        "rejected": true
+      },
+      {
+        "error": "deterministic policy drift",
+        "name": "worst_supported_typed_drift",
+        "rejected": true
+      },
+      {
+        "error": "policy summary drift",
+        "name": "worst_supported_saving_erased",
+        "rejected": true
+      },
+      {
+        "error": "deterministic policy drift",
+        "name": "support_criteria_erased",
+        "rejected": true
+      },
+      {
+        "error": "policy summary drift",
+        "name": "value_stability_erased",
+        "rejected": true
+      },
+      {
+        "error": "source artifact drift",
+        "name": "source_digest_drift",
+        "rejected": true
+      },
+      {
+        "error": "source artifact drift",
+        "name": "source_commitment_drift",
+        "rejected": true
+      },
+      {
+        "error": "validation command drift",
+        "name": "validation_command_drift",
+        "rejected": true
+      },
+      {
+        "error": "non_claims drift",
+        "name": "removed_non_claim",
+        "rejected": true
+      },
+      {
+        "error": "claim_boundary drift",
+        "name": "nanozk_overclaim",
+        "rejected": true
+      },
+      {
+        "error": "non_claims drift",
+        "name": "final_policy_overclaim",
+        "rejected": true
+      },
+      {
+        "error": "deterministic policy field drift: unexpected unchecked",
+        "name": "unknown_policy_field",
+        "rejected": true
+      },
+      {
+        "error": "label inventory order drift",
+        "name": "label_inventory_order_drift",
+        "rejected": true
+      },
+      {
+        "error": "payload commitment drift",
+        "name": "payload_commitment_drift",
+        "rejected": true
+      }
+    ],
+    "mutation_names": [
+      "decision_drift",
+      "result_drift",
+      "full_inventory_overclaim",
+      "fixed_label_supported",
+      "probe_a_rejected",
+      "worst_supported_typed_drift",
+      "worst_supported_saving_erased",
+      "support_criteria_erased",
+      "value_stability_erased",
+      "source_digest_drift",
+      "source_commitment_drift",
+      "validation_command_drift",
+      "removed_non_claim",
+      "nanozk_overclaim",
+      "final_policy_overclaim",
+      "unknown_policy_field",
+      "label_inventory_order_drift",
+      "payload_commitment_drift"
+    ],
+    "mutations_rejected": 18
+  },
+  "non_claims": [
+    "not a final production label-selection policy",
+    "not a generator-backed label inventory",
+    "not robust to unseen labels",
+    "not a NANOZK proof-size win",
+    "not a matched external zkML benchmark",
+    "not a full transformer block proof",
+    "not exact real-valued Softmax",
+    "not timing evidence",
+    "not production-ready zkML"
+  ],
+  "payload_commitment": "blake2b-256:e7238aad6226916d0a0c56234cda57b9c5d277ecbf8d034b434a3efbf67f628b",
+  "policy_summary": {
+    "adjacent_value_bytes": 20924,
+    "best_supported_label_id": "adjacent_label_probe_b",
+    "best_supported_saving_typed_bytes": 4536,
+    "best_supported_typed_bytes": 37532,
+    "current_champion_json_bytes": 121996,
+    "current_champion_path_opening_bytes": 20592,
+    "current_champion_typed_bytes": 42068,
+    "fixed_adjacent_path_opening_overhang_vs_champion": 592,
+    "full_inventory_miss_vs_champion_typed_bytes": 88,
+    "full_inventory_worst_label_id": "fixed_adjacent_layout",
+    "full_inventory_worst_typed_bytes": 42156,
+    "nanozk_reported_d128_block_proof_bytes": 6900,
+    "proof_size_comparable_external_rows": 0,
+    "rejected_label_count": 1,
+    "supported_label_count": 2,
+    "supported_value_bytes_stable": true,
+    "worst_supported_label_id": "adjacent_label_probe_a",
+    "worst_supported_saving_share": "0.041267",
+    "worst_supported_saving_typed_bytes": 1736,
+    "worst_supported_typed_bytes": 40332
+  },
+  "result": "WORST_SUPPORTED_ADJACENT_LABEL_SAVES_1736_TYPED_BYTES_VS_42068_CHAMPION",
+  "schema": "zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-gate-v1",
+  "source_artifacts": [
+    {
+      "id": "source_adjacent_label_policy",
+      "path": "docs/engineering/evidence/zkai-native-seq32-attention-mlp-rmsnorm-adjacent-label-policy-2026-05.json",
+      "payload_commitment": "blake2b-256:f2bcfec2552cc89befcb489271b357063cf13ea302fb91732cb416249ea427a2",
+      "sha256": "b85b9001dc0e9387b4cc2fc49302c9d7bbe7e9ff8d8f6c9b31c394a21b14b9d1"
+    }
+  ],
+  "validation_commands": [
+    "python3.10 scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv",
+    "python3.10 -m py_compile scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py",
+    "python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate",
+    "python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_adjacent_label_policy_gate",
+    "cargo +nightly-2025-07-14 test --locked --features stwo-backend rmsnorm_input_adjacent_label --lib",
+    "git diff --check",
+    "just gate-fast",
+    "just gate"
+  ]
+}

--- a/docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv
@@ -1,0 +1,5 @@
+variant_id	policy_status	typed_bytes	typed_delta_vs_champion	path_opening_bytes	path_opening_delta_vs_champion	value_bytes	status_reason
+current_duplicate_base	comparison_champion	42068	0	20592	0	21428	baseline for typed/path-opening deltas
+fixed_adjacent_layout	rejected_inflating_label	42156	88	21184	592	20924	path-opening bytes are not below the current champion
+adjacent_label_probe_a	supported_label	40332	-1736	19360	-1232	20924	value bytes stable and path-opening/typed bytes beat the current champion
+adjacent_label_probe_b	supported_label	37532	-4536	16560	-4032	20924	value bytes stable and path-opening/typed bytes beat the current champion

--- a/docs/engineering/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05-19.md
+++ b/docs/engineering/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05-19.md
@@ -79,14 +79,15 @@ This gate has `0` proof-size-comparable external rows.
 - Result:
   `WORST_SUPPORTED_ADJACENT_LABEL_SAVES_1736_TYPED_BYTES_VS_42068_CHAMPION`
 - Mutation guards:
-  `18 / 18` rejected.
+  `22 / 22` rejected.
 
 The mutation suite rejects decision/result drift, full-inventory overclaims,
 fixed-label relabeling, supported-label rejection, typed-byte drift, saving
 erasure, support-criteria erasure, value-stability erasure, source digest and
 commitment drift, validation-command drift, removed non-claims, explicit
 NANOZK overclaims, final-policy overclaims, unknown deterministic-policy
-fields, inventory reordering, and payload-commitment drift.
+fields, inventory reordering, label metadata drift, proof JSON byte drift,
+status-reason drift, champion value-byte drift, and payload-commitment drift.
 
 ## Reproduction
 

--- a/docs/engineering/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05-19.md
+++ b/docs/engineering/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05-19.md
@@ -1,0 +1,115 @@
+# Native Seq32 Attention + D128 MLP Deterministic Adjacent Label Policy
+
+Status: `GO_SUPPORTED_ADJACENT_LABEL_POLICY_BEATS_CURRENT_CHAMPION`.
+
+This gate follows the adjacent-label probe result. The previous experiment
+showed that two adjacent transcript labels beat the current seq32+d128 native
+champion, but the fixed adjacent layout still missed by `88` typed bytes. This
+experiment refuses to promote the whole inventory and instead checks a
+deterministic supported-label rule over the already generated adjacent-label
+evidence.
+
+The workload and statement surface stay fixed:
+
+- two-head `seq32` fused attention with bounded Softmax-table lookup checks;
+- the attention-to-d128 adapter;
+- the seq32-derived d128 RMSNorm/MLP fused surface.
+
+## Result
+
+| variant | policy status | typed bytes | typed delta vs champion | path-opening bytes | path-opening delta | value bytes |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| current duplicate-base champion | comparison champion | `42,068` | `0` | `20,592` | `0` | `21,428` |
+| fixed adjacent layout | rejected inflating label | `42,156` | `+88` | `21,184` | `+592` | `20,924` |
+| adjacent label probe A | supported label | `40,332` | `-1,736` | `19,360` | `-1,232` | `20,924` |
+| adjacent label probe B | supported label | `37,532` | `-4,536` | `16,560` | `-4,032` | `20,924` |
+
+Human read: the full adjacent-label inventory is still not promotable. The
+fixed adjacent label preserves the arithmetic/value surface but inflates
+path-opening material enough to miss the champion. The supported-label policy
+rejects that label and keeps the two checked labels whose worst case saves
+`1,736` typed bytes (`4.1267%`) versus the `42,068` typed-byte champion. The
+best checked supported label saves `4,536` typed bytes (`10.7825%`).
+
+## Mechanism
+
+The policy is not changing the arithmetic. The adjacent rows keep direct value
+bytes stable at `20,924`. The decision is driven by opening material:
+
+- fixed adjacent: `+592` path-opening typed bytes versus the champion;
+- probe A: `-1,232` path-opening typed bytes versus the champion;
+- probe B: `-4,032` path-opening typed bytes versus the champion.
+
+This keeps the research signal narrow: transcript/opening layout matters for
+the larger native boundary, and the supported-label policy is only acceptable
+when the source artifact, digest, payload commitment, value bytes, path-opening
+bytes, and typed-byte deltas are all pinned.
+
+## Guardrails
+
+- Not a final production label-selection policy.
+- Not a generator-backed label inventory.
+- Not robust to unseen labels.
+- Not a NANOZK proof-size win.
+- Not a matched external zkML benchmark.
+- Not a full transformer block proof.
+- Not exact real-valued Softmax.
+- Not timing evidence.
+- Not production-ready zkML.
+
+NANOZK's paper-reported d128 block row remains related-work calibration only.
+This gate has `0` proof-size-comparable external rows.
+
+## Evidence
+
+- Source adjacent-label policy JSON:
+  `docs/engineering/evidence/zkai-native-seq32-attention-mlp-rmsnorm-adjacent-label-policy-2026-05.json`
+- Source adjacent-label policy SHA-256:
+  `b85b9001dc0e9387b4cc2fc49302c9d7bbe7e9ff8d8f6c9b31c394a21b14b9d1`
+- Source adjacent-label payload commitment:
+  `blake2b-256:f2bcfec2552cc89befcb489271b357063cf13ea302fb91732cb416249ea427a2`
+- Deterministic policy gate JSON:
+  `docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json`
+- Deterministic policy gate TSV:
+  `docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv`
+- Gate schema:
+  `zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-gate-v1`
+- Decision:
+  `GO_SUPPORTED_ADJACENT_LABEL_POLICY_BEATS_CURRENT_CHAMPION`
+- Result:
+  `WORST_SUPPORTED_ADJACENT_LABEL_SAVES_1736_TYPED_BYTES_VS_42068_CHAMPION`
+- Mutation guards:
+  `18 / 18` rejected.
+
+The mutation suite rejects decision/result drift, full-inventory overclaims,
+fixed-label relabeling, supported-label rejection, typed-byte drift, saving
+erasure, support-criteria erasure, value-stability erasure, source digest and
+commitment drift, validation-command drift, removed non-claims, explicit
+NANOZK overclaims, final-policy overclaims, unknown deterministic-policy
+fields, inventory reordering, and payload-commitment drift.
+
+## Reproduction
+
+```bash
+python3.10 scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv
+python3.10 -m py_compile scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
+python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate
+python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_adjacent_label_policy_gate
+cargo +nightly-2025-07-14 test --locked --features stwo-backend rmsnorm_input_adjacent_label --lib
+git diff --check
+just gate-fast
+just gate
+```
+
+## Next Attack
+
+The immediate follow-up is generator-backed label inventory:
+
+- derive the supported labels from source-level label generation rather than a
+  hand-curated existing inventory;
+- add unseen-label checks so the worst accepted label still beats `42,068`
+  typed bytes;
+- keep the full-inventory NO-GO explicit until every generated label is
+  below the current champion;
+- continue treating external rows as non-comparable until the proof object and
+  workload class match.

--- a/scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
@@ -241,11 +241,15 @@ class NativeSeq32DeterministicAdjacentLabelPolicyGateTest(unittest.TestCase):
         payload["payload_commitment"] = self.gate.payload_commitment(payload)
         with tempfile.TemporaryDirectory(dir=self.gate.EVIDENCE_DIR) as tmpdir:
             tmp = pathlib.Path(tmpdir)
+            bad_json = tmp / "bad.json"
+            bad_tsv = tmp / "bad.tsv"
             with self.assertRaisesRegex(
                 self.gate.DeterministicAdjacentLabelPolicyGateError,
                 "policy summary drift",
             ):
-                self.gate.write_outputs(payload, tmp / "bad.json", tmp / "bad.tsv")
+                self.gate.write_outputs(payload, bad_json, bad_tsv)
+            self.assertFalse(bad_json.exists())
+            self.assertFalse(bad_tsv.exists())
 
     def test_write_outputs_rejects_path_outside_evidence_dir(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
@@ -186,7 +186,7 @@ class NativeSeq32DeterministicAdjacentLabelPolicyGateTest(unittest.TestCase):
             (2, "adapter_mode", "relabelled"),
             (3, "proof_json_bytes", 1),
             (1, "status_reason", "supported"),
-            (0, "value_bytes", 20_924),
+            (0, "value_bytes", self.gate.ADJACENT_VALUE_BYTES),
         ]
         for row_index, field, value in cases:
             with self.subTest(field=field):

--- a/scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import os
+import pathlib
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+GATE_PATH = (
+    ROOT
+    / "scripts"
+    / "zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py"
+)
+
+
+def load_gate():
+    spec = importlib.util.spec_from_file_location(
+        "zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate",
+        GATE_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class NativeSeq32DeterministicAdjacentLabelPolicyGateTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.gate = load_gate()
+        cls.payload = cls.gate.payload_with_mutations()
+
+    def test_pins_supported_label_policy_go_without_promoting_full_inventory(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        summary = payload["policy_summary"]
+        self.assertEqual(
+            payload["decision"],
+            "GO_SUPPORTED_ADJACENT_LABEL_POLICY_BEATS_CURRENT_CHAMPION",
+        )
+        self.assertEqual(
+            payload["result"],
+            "WORST_SUPPORTED_ADJACENT_LABEL_SAVES_1736_TYPED_BYTES_VS_42068_CHAMPION",
+        )
+        self.assertFalse(
+            payload["full_inventory_policy"][
+                "full_inventory_promotable_vs_current_champion"
+            ]
+        )
+        self.assertEqual(summary["full_inventory_worst_label_id"], "fixed_adjacent_layout")
+        self.assertEqual(summary["full_inventory_worst_typed_bytes"], 42_156)
+        self.assertEqual(summary["full_inventory_miss_vs_champion_typed_bytes"], 88)
+        self.assertEqual(summary["worst_supported_label_id"], "adjacent_label_probe_a")
+        self.assertEqual(summary["worst_supported_typed_bytes"], 40_332)
+        self.assertEqual(summary["worst_supported_saving_typed_bytes"], 1_736)
+        self.assertEqual(summary["best_supported_label_id"], "adjacent_label_probe_b")
+        self.assertEqual(summary["best_supported_typed_bytes"], 37_532)
+        self.assertEqual(summary["best_supported_saving_typed_bytes"], 4_536)
+        self.assertEqual(summary["proof_size_comparable_external_rows"], 0)
+        self.gate.validate_payload(payload)
+
+    def test_label_inventory_rejects_fixed_label_and_supports_both_probes(self) -> None:
+        rows = {row["variant_id"]: row for row in self.__class__.payload["label_inventory"]}
+        self.assertEqual(rows["current_duplicate_base"]["policy_status"], "comparison_champion")
+        self.assertEqual(
+            rows["fixed_adjacent_layout"]["policy_status"],
+            "rejected_inflating_label",
+        )
+        self.assertEqual(
+            rows["fixed_adjacent_layout"]["status_reason"],
+            "path-opening bytes are not below the current champion",
+        )
+        self.assertEqual(rows["adjacent_label_probe_a"]["policy_status"], "supported_label")
+        self.assertEqual(rows["adjacent_label_probe_b"]["policy_status"], "supported_label")
+        self.assertEqual(rows["fixed_adjacent_layout"]["value_bytes"], 20_924)
+        self.assertEqual(rows["adjacent_label_probe_a"]["value_bytes"], 20_924)
+        self.assertEqual(rows["adjacent_label_probe_b"]["value_bytes"], 20_924)
+        self.assertEqual(rows["fixed_adjacent_layout"]["path_opening_delta_vs_champion"], 592)
+        self.assertEqual(rows["adjacent_label_probe_a"]["path_opening_delta_vs_champion"], -1_232)
+        self.assertEqual(rows["adjacent_label_probe_b"]["path_opening_delta_vs_champion"], -4_032)
+
+    def test_mutation_inventory_is_exact(self) -> None:
+        result = self.__class__.payload["mutation_result"]
+        self.assertTrue(result["all_mutations_rejected"])
+        self.assertEqual(result["mutations_rejected"], len(self.gate.MUTATION_NAMES))
+        self.assertEqual(tuple(result["mutation_names"]), self.gate.MUTATION_NAMES)
+        self.assertEqual(
+            tuple(case["name"] for case in result["cases"]),
+            self.gate.MUTATION_NAMES,
+        )
+        self.assertEqual(
+            tuple(case["error"] for case in result["cases"]),
+            tuple(
+                self.gate.EXPECTED_MUTATION_ERRORS[name]
+                for name in self.gate.MUTATION_NAMES
+            ),
+        )
+
+    def test_rejects_full_inventory_overclaim(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        payload["full_inventory_policy"][
+            "full_inventory_promotable_vs_current_champion"
+        ] = True
+        payload["payload_commitment"] = self.gate.payload_commitment(payload)
+        with self.assertRaisesRegex(
+            self.gate.DeterministicAdjacentLabelPolicyGateError,
+            "full inventory overclaim",
+        ):
+            self.gate.validate_payload(payload)
+
+    def test_rejects_fixed_label_supported_relabeling(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        payload["label_inventory"][1]["policy_status"] = "supported_label"
+        payload["payload_commitment"] = self.gate.payload_commitment(payload)
+        with self.assertRaisesRegex(
+            self.gate.DeterministicAdjacentLabelPolicyGateError,
+            "label inventory drift",
+        ):
+            self.gate.validate_payload(payload)
+
+    def test_rejects_support_criteria_erasure(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        payload["deterministic_policy"]["support_criteria"] = []
+        payload["payload_commitment"] = self.gate.payload_commitment(payload)
+        with self.assertRaisesRegex(
+            self.gate.DeterministicAdjacentLabelPolicyGateError,
+            "deterministic policy drift",
+        ):
+            self.gate.validate_payload(payload)
+
+    def test_rejects_source_artifact_digest_relabeling(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        payload["source_artifacts"][0]["sha256"] = "0" * 64
+        payload["payload_commitment"] = self.gate.payload_commitment(payload)
+        with self.assertRaisesRegex(
+            self.gate.DeterministicAdjacentLabelPolicyGateError,
+            "source artifact drift",
+        ):
+            self.gate.validate_payload(payload)
+
+    def test_rejects_nanozk_or_external_proof_size_overclaim(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        payload["claim_boundary"] = payload["claim_boundary"] + ";NANOZK_WIN"
+        payload["payload_commitment"] = self.gate.payload_commitment(payload)
+        with self.assertRaisesRegex(
+            self.gate.DeterministicAdjacentLabelPolicyGateError,
+            "claim_boundary drift",
+        ):
+            self.gate.validate_payload(payload)
+
+    def test_rejects_final_policy_overclaim(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        payload["non_claims"].remove("not a final production label-selection policy")
+        payload["payload_commitment"] = self.gate.payload_commitment(payload)
+        with self.assertRaisesRegex(
+            self.gate.DeterministicAdjacentLabelPolicyGateError,
+            "non_claims drift",
+        ):
+            self.gate.validate_payload(payload)
+
+    def test_rejects_unknown_policy_field(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        payload["deterministic_policy"]["unchecked"] = True
+        payload["payload_commitment"] = self.gate.payload_commitment(payload)
+        with self.assertRaisesRegex(
+            self.gate.DeterministicAdjacentLabelPolicyGateError,
+            "deterministic policy field drift: unexpected unchecked",
+        ):
+            self.gate.validate_payload(payload)
+
+    def test_rejects_label_inventory_order_drift(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        payload["label_inventory"].reverse()
+        payload["payload_commitment"] = self.gate.payload_commitment(payload)
+        with self.assertRaisesRegex(
+            self.gate.DeterministicAdjacentLabelPolicyGateError,
+            "label inventory order drift",
+        ):
+            self.gate.validate_payload(payload)
+
+    def test_rejects_payload_commitment_drift(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        payload["payload_commitment"] = "blake2b-256:" + "0" * 64
+        with self.assertRaisesRegex(
+            self.gate.DeterministicAdjacentLabelPolicyGateError,
+            "payload commitment drift",
+        ):
+            self.gate.validate_payload(payload)
+
+    def test_render_tsv_records_policy_statuses(self) -> None:
+        text = self.gate.render_tsv(self.__class__.payload)
+        self.assertTrue(text.startswith("variant_id\tpolicy_status\ttyped_bytes\t"))
+        self.assertIn(
+            "fixed_adjacent_layout\trejected_inflating_label\t42156\t88\t21184\t592\t20924\t",
+            text,
+        )
+        self.assertIn(
+            "adjacent_label_probe_b\tsupported_label\t37532\t-4536\t16560\t-4032\t20924\t",
+            text,
+        )
+
+    def test_write_outputs_records_json_and_tsv_inside_evidence_tree(self) -> None:
+        with tempfile.TemporaryDirectory(dir=self.gate.EVIDENCE_DIR) as tmpdir:
+            tmp = pathlib.Path(tmpdir)
+            json_out = tmp / "deterministic.json"
+            tsv_out = tmp / "deterministic.tsv"
+            self.gate.write_outputs(self.__class__.payload, json_out, tsv_out)
+            self.assertIn(
+                "GO_SUPPORTED_ADJACENT_LABEL_POLICY_BEATS_CURRENT_CHAMPION",
+                json_out.read_text(encoding="utf-8"),
+            )
+            self.assertIn(
+                "adjacent_label_probe_a\tsupported_label",
+                tsv_out.read_text(encoding="utf-8"),
+            )
+
+    def test_write_outputs_rejects_invalid_payload(self) -> None:
+        payload = copy.deepcopy(self.__class__.payload)
+        payload["policy_summary"]["worst_supported_saving_typed_bytes"] = 0
+        payload["payload_commitment"] = self.gate.payload_commitment(payload)
+        with tempfile.TemporaryDirectory(dir=self.gate.EVIDENCE_DIR) as tmpdir:
+            tmp = pathlib.Path(tmpdir)
+            with self.assertRaisesRegex(
+                self.gate.DeterministicAdjacentLabelPolicyGateError,
+                "policy summary drift",
+            ):
+                self.gate.write_outputs(payload, tmp / "bad.json", tmp / "bad.tsv")
+
+    def test_write_outputs_rejects_path_outside_evidence_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outside = pathlib.Path(tmpdir) / "outside.json"
+            with self.assertRaisesRegex(
+                self.gate.source_gate.AdjacentLabelPolicyGateError,
+                "output path escapes evidence dir",
+            ):
+                self.gate.write_outputs(self.__class__.payload, outside, None)
+            self.assertFalse(outside.exists())
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symlink support required")
+    def test_write_outputs_rejects_symlink_parent(self) -> None:
+        with tempfile.TemporaryDirectory(dir=self.gate.EVIDENCE_DIR) as tmpdir:
+            tmp = pathlib.Path(tmpdir)
+            real_parent = tmp / "real"
+            link_parent = tmp / "link-parent"
+            real_parent.mkdir()
+            os.symlink(real_parent, link_parent)
+            with self.assertRaisesRegex(
+                self.gate.source_gate.AdjacentLabelPolicyGateError,
+                "output path must not traverse symlinks",
+            ):
+                self.gate.write_outputs(
+                    self.__class__.payload,
+                    link_parent / "out.json",
+                    None,
+                )
+            self.assertFalse((real_parent / "out.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
@@ -186,7 +186,7 @@ class NativeSeq32DeterministicAdjacentLabelPolicyGateTest(unittest.TestCase):
             (2, "adapter_mode", "relabelled"),
             (3, "proof_json_bytes", 1),
             (1, "status_reason", "supported"),
-            (0, "value_bytes", self.gate.ADJACENT_VALUE_BYTES),
+            (0, "value_bytes", self.gate.CURRENT_CHAMPION_VALUE_BYTES - 1),
         ]
         for row_index, field, value in cases:
             with self.subTest(field=field):

--- a/scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
+++ b/scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
@@ -181,6 +181,24 @@ class NativeSeq32DeterministicAdjacentLabelPolicyGateTest(unittest.TestCase):
         ):
             self.gate.validate_payload(payload)
 
+    def test_rejects_label_inventory_metadata_drift(self) -> None:
+        cases = [
+            (2, "adapter_mode", "relabelled"),
+            (3, "proof_json_bytes", 1),
+            (1, "status_reason", "supported"),
+            (0, "value_bytes", 20_924),
+        ]
+        for row_index, field, value in cases:
+            with self.subTest(field=field):
+                payload = copy.deepcopy(self.__class__.payload)
+                payload["label_inventory"][row_index][field] = value
+                payload["payload_commitment"] = self.gate.payload_commitment(payload)
+                with self.assertRaisesRegex(
+                    self.gate.DeterministicAdjacentLabelPolicyGateError,
+                    "label inventory drift",
+                ):
+                    self.gate.validate_payload(payload)
+
     def test_rejects_payload_commitment_drift(self) -> None:
         payload = copy.deepcopy(self.__class__.payload)
         payload["payload_commitment"] = "blake2b-256:" + "0" * 64

--- a/scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
+++ b/scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
@@ -122,6 +122,10 @@ MUTATION_NAMES = (
     "final_policy_overclaim",
     "unknown_policy_field",
     "label_inventory_order_drift",
+    "label_adapter_mode_drift",
+    "label_proof_json_drift",
+    "label_status_reason_drift",
+    "champion_value_drift",
     "payload_commitment_drift",
 )
 EXPECTED_MUTATION_ERRORS = {
@@ -142,6 +146,10 @@ EXPECTED_MUTATION_ERRORS = {
     "final_policy_overclaim": "non_claims drift",
     "unknown_policy_field": "deterministic policy field drift: unexpected unchecked",
     "label_inventory_order_drift": "label inventory order drift",
+    "label_adapter_mode_drift": "label inventory drift",
+    "label_proof_json_drift": "label inventory drift",
+    "label_status_reason_drift": "label inventory drift",
+    "champion_value_drift": "label inventory drift",
     "payload_commitment_drift": "payload commitment drift",
 }
 
@@ -506,6 +514,10 @@ def mutation_functions() -> tuple[tuple[str, Callable[[dict[str, Any]], None]], 
         ("final_policy_overclaim", lambda item: item["non_claims"].remove("not a final production label-selection policy")),
         ("unknown_policy_field", lambda item: item["deterministic_policy"].update({"unchecked": True})),
         ("label_inventory_order_drift", lambda item: item["label_inventory"].reverse()),
+        ("label_adapter_mode_drift", lambda item: item["label_inventory"][2].update({"adapter_mode": "relabelled"})),
+        ("label_proof_json_drift", lambda item: item["label_inventory"][3].update({"proof_json_bytes": 1})),
+        ("label_status_reason_drift", lambda item: item["label_inventory"][1].update({"status_reason": "supported"})),
+        ("champion_value_drift", lambda item: item["label_inventory"][0].update({"value_bytes": ADJACENT_VALUE_BYTES})),
         ("payload_commitment_drift", lambda item: item.update({"payload_commitment": "blake2b-256:" + "0" * 64})),
     )
 
@@ -632,15 +644,42 @@ def validate_label_inventory(rows: list[Any]) -> None:
         "adjacent_label_probe_a": 19_360,
         "adjacent_label_probe_b": 16_560,
     }
+    expected_metadata = {
+        CURRENT_CHAMPION_ID: {
+            "adapter_mode": "duplicate_base_preprocessed_v1",
+            "proof_json_bytes": CURRENT_CHAMPION_JSON_BYTES,
+            "status_reason": "baseline for typed/path-opening deltas",
+            "value_bytes": 21_428,
+        },
+        FIXED_ADJACENT_ID: {
+            "adapter_mode": "rmsnorm_input_fused_adjacent_fixed_v1",
+            "proof_json_bytes": 122_688,
+            "status_reason": "path-opening bytes are not below the current champion",
+            "value_bytes": ADJACENT_VALUE_BYTES,
+        },
+        "adjacent_label_probe_a": {
+            "adapter_mode": "rmsnorm_input_fused_adjacent_label_probe_a_v1",
+            "proof_json_bytes": 116_321,
+            "status_reason": "value bytes stable and path-opening/typed bytes beat the current champion",
+            "value_bytes": ADJACENT_VALUE_BYTES,
+        },
+        "adjacent_label_probe_b": {
+            "adapter_mode": "rmsnorm_input_fused_adjacent_label_probe_b_v1",
+            "proof_json_bytes": 106_317,
+            "status_reason": "value bytes stable and path-opening/typed bytes beat the current champion",
+            "value_bytes": ADJACENT_VALUE_BYTES,
+        },
+    }
     for row in parsed:
         variant_id = row["variant_id"]
         if row["policy_status"] != expected_status[variant_id]:
             raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
+        for field, expected in expected_metadata[variant_id].items():
+            if row[field] != expected:
+                raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
         if row["typed_bytes"] != expected_typed[variant_id]:
             raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
         if row["path_opening_bytes"] != expected_path_opening[variant_id]:
-            raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
-        if variant_id != CURRENT_CHAMPION_ID and row["value_bytes"] != ADJACENT_VALUE_BYTES:
             raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
         if row["typed_delta_vs_champion"] != row["typed_bytes"] - CURRENT_CHAMPION_TYPED_BYTES:
             raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")

--- a/scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
+++ b/scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
@@ -51,6 +51,7 @@ ADJACENT_LABEL_INVENTORY = (FIXED_ADJACENT_ID, *SUPPORTED_LABEL_IDS)
 CURRENT_CHAMPION_TYPED_BYTES = 42_068
 CURRENT_CHAMPION_JSON_BYTES = 121_996
 CURRENT_CHAMPION_PATH_OPENING_BYTES = 20_592
+CURRENT_CHAMPION_VALUE_BYTES = 21_428
 ADJACENT_VALUE_BYTES = 20_924
 WORST_SUPPORTED_LABEL_ID = "adjacent_label_probe_a"
 WORST_SUPPORTED_TYPED_BYTES = 40_332
@@ -649,7 +650,7 @@ def validate_label_inventory(rows: list[Any]) -> None:
             "adapter_mode": "duplicate_base_preprocessed_v1",
             "proof_json_bytes": CURRENT_CHAMPION_JSON_BYTES,
             "status_reason": "baseline for typed/path-opening deltas",
-            "value_bytes": 21_428,
+            "value_bytes": CURRENT_CHAMPION_VALUE_BYTES,
         },
         FIXED_ADJACENT_ID: {
             "adapter_mode": "rmsnorm_input_fused_adjacent_fixed_v1",

--- a/scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
+++ b/scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py
@@ -1,0 +1,735 @@
+#!/usr/bin/env python3.10
+"""Gate the deterministic adjacent-label policy for the seq32 attention+MLP proof."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import hashlib
+import io
+import json
+import pathlib
+import sys
+from collections.abc import Callable
+from typing import Any
+
+
+if sys.version_info < (3, 10):
+    raise RuntimeError("zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate requires Python 3.10+")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import zkai_native_seq32_attention_mlp_adjacent_label_policy_gate as source_gate
+
+
+EVIDENCE_DIR = ROOT / "docs" / "engineering" / "evidence"
+SOURCE_POLICY_PATH = EVIDENCE_DIR / "zkai-native-seq32-attention-mlp-rmsnorm-adjacent-label-policy-2026-05.json"
+SOURCE_POLICY_RELATIVE_PATH = SOURCE_POLICY_PATH.relative_to(ROOT).as_posix()
+JSON_OUT = EVIDENCE_DIR / "zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json"
+TSV_OUT = EVIDENCE_DIR / "zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv"
+
+SCHEMA = "zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-gate-v1"
+DECISION = "GO_SUPPORTED_ADJACENT_LABEL_POLICY_BEATS_CURRENT_CHAMPION"
+RESULT = "WORST_SUPPORTED_ADJACENT_LABEL_SAVES_1736_TYPED_BYTES_VS_42068_CHAMPION"
+CLAIM_BOUNDARY = (
+    "DETERMINISTIC_POLICY_OVER_EXISTING_SEQ32_ADJACENT_LABEL_INVENTORY;"
+    "REJECTS_FIXED_LABEL_PATH_OPENING_INFLATION;NOT_A_FINAL_LABEL_GENERATOR_NOT_A_NANOZK_WIN"
+)
+ISSUE_HINT = "seq32-deterministic-adjacent-label-policy"
+PAYLOAD_DOMAIN = "ptvm:zkai:native-seq32-attention-mlp-deterministic-adjacent-label-policy:v1"
+
+EXPECTED_SOURCE_POLICY_SHA256 = "b85b9001dc0e9387b4cc2fc49302c9d7bbe7e9ff8d8f6c9b31c394a21b14b9d1"
+EXPECTED_SOURCE_POLICY_COMMITMENT = "blake2b-256:f2bcfec2552cc89befcb489271b357063cf13ea302fb91732cb416249ea427a2"
+
+CURRENT_CHAMPION_ID = "current_duplicate_base"
+FIXED_ADJACENT_ID = "fixed_adjacent_layout"
+SUPPORTED_LABEL_IDS = ("adjacent_label_probe_a", "adjacent_label_probe_b")
+ADJACENT_LABEL_INVENTORY = (FIXED_ADJACENT_ID, *SUPPORTED_LABEL_IDS)
+CURRENT_CHAMPION_TYPED_BYTES = 42_068
+CURRENT_CHAMPION_JSON_BYTES = 121_996
+CURRENT_CHAMPION_PATH_OPENING_BYTES = 20_592
+ADJACENT_VALUE_BYTES = 20_924
+WORST_SUPPORTED_LABEL_ID = "adjacent_label_probe_a"
+WORST_SUPPORTED_TYPED_BYTES = 40_332
+WORST_SUPPORTED_SAVING_BYTES = 1_736
+BEST_SUPPORTED_LABEL_ID = "adjacent_label_probe_b"
+BEST_SUPPORTED_TYPED_BYTES = 37_532
+BEST_SUPPORTED_SAVING_BYTES = 4_536
+FULL_INVENTORY_WORST_LABEL_ID = FIXED_ADJACENT_ID
+FULL_INVENTORY_WORST_TYPED_BYTES = 42_156
+FULL_INVENTORY_MISS_BYTES = 88
+FIXED_PATH_OPENING_OVERHANG_BYTES = 592
+NANOZK_REPORTED_D128_BLOCK_PROOF_BYTES = 6_900
+
+EXPECTED_INTERPRETATION = {
+    "human_read": (
+        "The full adjacent label inventory is not promotable because the fixed adjacent label is "
+        "88 typed bytes above the current champion. The deterministic supported-label policy rejects "
+        "that path-opening-inflating label and keeps the two checked labels whose worst case saves "
+        "1,736 typed bytes."
+    ),
+    "mechanism_read": (
+        "The policy is not changing arithmetic. Direct value bytes stay fixed at 20,924; the policy "
+        "only rejects labels whose path-opening material grows beyond the current champion."
+    ),
+    "next_experiment": (
+        "Turn this policy into a generator-backed label inventory, then test whether unseen labels "
+        "still keep the worst supported proof below 42,068 typed bytes."
+    ),
+}
+
+NON_CLAIMS = (
+    "not a final production label-selection policy",
+    "not a generator-backed label inventory",
+    "not robust to unseen labels",
+    "not a NANOZK proof-size win",
+    "not a matched external zkML benchmark",
+    "not a full transformer block proof",
+    "not exact real-valued Softmax",
+    "not timing evidence",
+    "not production-ready zkML",
+)
+
+VALIDATION_COMMANDS = (
+    "python3.10 scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv",
+    "python3.10 -m py_compile scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py",
+    "python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate",
+    "python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_adjacent_label_policy_gate",
+    "cargo +nightly-2025-07-14 test --locked --features stwo-backend rmsnorm_input_adjacent_label --lib",
+    "git diff --check",
+    "just gate-fast",
+    "just gate",
+)
+
+MUTATION_NAMES = (
+    "decision_drift",
+    "result_drift",
+    "full_inventory_overclaim",
+    "fixed_label_supported",
+    "probe_a_rejected",
+    "worst_supported_typed_drift",
+    "worst_supported_saving_erased",
+    "support_criteria_erased",
+    "value_stability_erased",
+    "source_digest_drift",
+    "source_commitment_drift",
+    "validation_command_drift",
+    "removed_non_claim",
+    "nanozk_overclaim",
+    "final_policy_overclaim",
+    "unknown_policy_field",
+    "label_inventory_order_drift",
+    "payload_commitment_drift",
+)
+EXPECTED_MUTATION_ERRORS = {
+    "decision_drift": "decision drift",
+    "result_drift": "result drift",
+    "full_inventory_overclaim": "full inventory overclaim",
+    "fixed_label_supported": "label inventory drift",
+    "probe_a_rejected": "label inventory drift",
+    "worst_supported_typed_drift": "deterministic policy drift",
+    "worst_supported_saving_erased": "policy summary drift",
+    "support_criteria_erased": "deterministic policy drift",
+    "value_stability_erased": "policy summary drift",
+    "source_digest_drift": "source artifact drift",
+    "source_commitment_drift": "source artifact drift",
+    "validation_command_drift": "validation command drift",
+    "removed_non_claim": "non_claims drift",
+    "nanozk_overclaim": "claim_boundary drift",
+    "final_policy_overclaim": "non_claims drift",
+    "unknown_policy_field": "deterministic policy field drift: unexpected unchecked",
+    "label_inventory_order_drift": "label inventory order drift",
+    "payload_commitment_drift": "payload commitment drift",
+}
+
+TSV_COLUMNS = (
+    "variant_id",
+    "policy_status",
+    "typed_bytes",
+    "typed_delta_vs_champion",
+    "path_opening_bytes",
+    "path_opening_delta_vs_champion",
+    "value_bytes",
+    "status_reason",
+)
+
+PAYLOAD_KEYS = {
+    "schema",
+    "decision",
+    "result",
+    "claim_boundary",
+    "issue_hint",
+    "source_artifacts",
+    "full_inventory_policy",
+    "deterministic_policy",
+    "label_inventory",
+    "policy_summary",
+    "interpretation",
+    "non_claims",
+    "validation_commands",
+    "mutation_result",
+    "payload_commitment",
+}
+SOURCE_ARTIFACT_KEYS = {"id", "path", "sha256", "payload_commitment"}
+FULL_POLICY_KEYS = {
+    "name",
+    "full_inventory_label_ids",
+    "worst_full_inventory_label_id",
+    "worst_full_inventory_typed_bytes",
+    "delta_vs_current_champion_typed_bytes",
+    "full_inventory_promotable_vs_current_champion",
+    "reason",
+}
+DETERMINISTIC_POLICY_KEYS = {
+    "name",
+    "support_criteria",
+    "rejection_criteria",
+    "supported_label_ids",
+    "rejected_label_ids",
+    "worst_supported_label_id",
+    "worst_supported_typed_bytes",
+    "worst_supported_saving_typed_bytes",
+    "worst_supported_saving_share",
+    "best_supported_label_id",
+    "best_supported_typed_bytes",
+    "best_supported_saving_typed_bytes",
+    "supported_label_count",
+    "rejected_label_count",
+    "supported_labels_promotable_vs_current_champion",
+}
+LABEL_ROW_KEYS = {
+    "variant_id",
+    "adapter_mode",
+    "typed_bytes",
+    "proof_json_bytes",
+    "path_opening_bytes",
+    "value_bytes",
+    "typed_delta_vs_champion",
+    "path_opening_delta_vs_champion",
+    "policy_status",
+    "status_reason",
+}
+SUMMARY_KEYS = {
+    "current_champion_typed_bytes",
+    "current_champion_json_bytes",
+    "current_champion_path_opening_bytes",
+    "fixed_adjacent_path_opening_overhang_vs_champion",
+    "adjacent_value_bytes",
+    "full_inventory_worst_label_id",
+    "full_inventory_worst_typed_bytes",
+    "full_inventory_miss_vs_champion_typed_bytes",
+    "supported_label_count",
+    "rejected_label_count",
+    "worst_supported_label_id",
+    "worst_supported_typed_bytes",
+    "worst_supported_saving_typed_bytes",
+    "worst_supported_saving_share",
+    "best_supported_label_id",
+    "best_supported_typed_bytes",
+    "best_supported_saving_typed_bytes",
+    "supported_value_bytes_stable",
+    "proof_size_comparable_external_rows",
+    "nanozk_reported_d128_block_proof_bytes",
+}
+MUTATION_RESULT_KEYS = {"all_mutations_rejected", "mutations_rejected", "mutation_names", "cases"}
+MUTATION_CASE_KEYS = {"name", "rejected", "error"}
+
+
+class DeterministicAdjacentLabelPolicyGateError(ValueError):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode("utf-8")
+    except (TypeError, ValueError) as err:
+        raise DeterministicAdjacentLabelPolicyGateError(f"invalid JSON value: {err}") from err
+
+
+def payload_commitment(payload: dict[str, Any]) -> str:
+    material = {key: value for key, value in payload.items() if key != "payload_commitment"}
+    digest = hashlib.blake2b(digest_size=32)
+    digest.update(PAYLOAD_DOMAIN.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(canonical_json_bytes(material))
+    return "blake2b-256:" + digest.hexdigest()
+
+
+def _dict(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise DeterministicAdjacentLabelPolicyGateError(f"{label} must be object")
+    return value
+
+
+def _list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise DeterministicAdjacentLabelPolicyGateError(f"{label} must be list")
+    return value
+
+
+def _require_exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    actual = set(value)
+    if actual == expected:
+        return
+    unexpected = sorted(actual - expected)
+    missing = sorted(expected - actual)
+    if unexpected:
+        raise DeterministicAdjacentLabelPolicyGateError(f"{label} field drift: unexpected {unexpected[0]}")
+    raise DeterministicAdjacentLabelPolicyGateError(f"{label} field drift: missing {missing[0]}")
+
+
+def load_source_policy() -> tuple[dict[str, Any], bytes]:
+    try:
+        source, raw = source_gate.load_json_file(SOURCE_POLICY_PATH, "source adjacent label policy")
+        source_gate.validate_payload(source)
+    except source_gate.AdjacentLabelPolicyGateError as err:
+        raise DeterministicAdjacentLabelPolicyGateError(f"source adjacent label policy invalid: {err}") from err
+    source_sha = source_gate.sha256(raw)
+    if source_sha != EXPECTED_SOURCE_POLICY_SHA256:
+        raise DeterministicAdjacentLabelPolicyGateError("source policy digest drift")
+    if source.get("payload_commitment") != EXPECTED_SOURCE_POLICY_COMMITMENT:
+        raise DeterministicAdjacentLabelPolicyGateError("source policy commitment drift")
+    return source, raw
+
+
+def source_variants_by_id(source: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    variants = {}
+    for item in _list(source.get("variants"), "source variants"):
+        row = _dict(item, "source variant")
+        variant_id = row.get("variant_id")
+        if not isinstance(variant_id, str):
+            raise DeterministicAdjacentLabelPolicyGateError("source variant id drift")
+        variants[variant_id] = row
+    for required in (CURRENT_CHAMPION_ID, *ADJACENT_LABEL_INVENTORY):
+        if required not in variants:
+            raise DeterministicAdjacentLabelPolicyGateError(f"missing source variant: {required}")
+    return variants
+
+
+def classify_label(row: dict[str, Any], champion: dict[str, Any]) -> tuple[str, str]:
+    variant_id = row["variant_id"]
+    if variant_id == CURRENT_CHAMPION_ID:
+        return "comparison_champion", "baseline for typed/path-opening deltas"
+    if row["value_bytes"] != ADJACENT_VALUE_BYTES:
+        return "rejected_value_drift", "direct value bytes differ from adjacent policy value bytes"
+    if row["path_opening_bytes"] >= champion["path_opening_bytes"]:
+        return "rejected_inflating_label", "path-opening bytes are not below the current champion"
+    if row["typed_bytes"] >= champion["typed_bytes"]:
+        return "rejected_inflating_label", "typed proof bytes are not below the current champion"
+    return "supported_label", "value bytes stable and path-opening/typed bytes beat the current champion"
+
+
+def build_label_inventory(source: dict[str, Any]) -> list[dict[str, Any]]:
+    variants = source_variants_by_id(source)
+    champion = variants[CURRENT_CHAMPION_ID]
+    rows = []
+    for variant_id in (CURRENT_CHAMPION_ID, *ADJACENT_LABEL_INVENTORY):
+        source_row = variants[variant_id]
+        policy_status, status_reason = classify_label(source_row, champion)
+        rows.append(
+            {
+                "variant_id": variant_id,
+                "adapter_mode": source_row["adapter_mode"],
+                "typed_bytes": source_row["typed_bytes"],
+                "proof_json_bytes": source_row["proof_json_bytes"],
+                "path_opening_bytes": source_row["path_opening_bytes"],
+                "value_bytes": source_row["value_bytes"],
+                "typed_delta_vs_champion": source_row["typed_bytes"] - champion["typed_bytes"],
+                "path_opening_delta_vs_champion": source_row["path_opening_bytes"] - champion["path_opening_bytes"],
+                "policy_status": policy_status,
+                "status_reason": status_reason,
+            }
+        )
+    return rows
+
+
+def build_payload() -> dict[str, Any]:
+    source, raw = load_source_policy()
+    inventory = build_label_inventory(source)
+    by_id = {row["variant_id"]: row for row in inventory}
+    champion = by_id[CURRENT_CHAMPION_ID]
+    adjacent_rows = [by_id[variant_id] for variant_id in ADJACENT_LABEL_INVENTORY]
+    supported = [row for row in adjacent_rows if row["policy_status"] == "supported_label"]
+    rejected = [row for row in adjacent_rows if row["policy_status"].startswith("rejected")]
+    if tuple(row["variant_id"] for row in supported) != SUPPORTED_LABEL_IDS:
+        raise DeterministicAdjacentLabelPolicyGateError("supported label inventory drift")
+    if tuple(row["variant_id"] for row in rejected) != (FIXED_ADJACENT_ID,):
+        raise DeterministicAdjacentLabelPolicyGateError("rejected label inventory drift")
+    worst_supported = max(supported, key=lambda row: row["typed_bytes"])
+    best_supported = min(supported, key=lambda row: row["typed_bytes"])
+    worst_full_inventory = max(adjacent_rows, key=lambda row: row["typed_bytes"])
+    full_inventory_policy = {
+        "name": "full_adjacent_inventory_worst_label_v1",
+        "full_inventory_label_ids": list(ADJACENT_LABEL_INVENTORY),
+        "worst_full_inventory_label_id": worst_full_inventory["variant_id"],
+        "worst_full_inventory_typed_bytes": worst_full_inventory["typed_bytes"],
+        "delta_vs_current_champion_typed_bytes": worst_full_inventory["typed_bytes"] - champion["typed_bytes"],
+        "full_inventory_promotable_vs_current_champion": False,
+        "reason": "the fixed adjacent label inflates path-opening material and misses the champion by 88 typed bytes",
+    }
+    deterministic_policy = {
+        "name": "reject_path_opening_inflation_v1",
+        "support_criteria": [
+            "adapter_mode is an adjacent label probe",
+            "direct value bytes equal 20924",
+            "path_opening_bytes are below the current champion",
+            "typed_bytes are below the current champion",
+            "source envelope and accounting are pinned by digest and payload commitment",
+        ],
+        "rejection_criteria": [
+            "path_opening_bytes are greater than or equal to the current champion",
+            "typed_bytes are greater than or equal to the current champion",
+            "direct value bytes drift from the adjacent label inventory",
+        ],
+        "supported_label_ids": [row["variant_id"] for row in supported],
+        "rejected_label_ids": [row["variant_id"] for row in rejected],
+        "worst_supported_label_id": worst_supported["variant_id"],
+        "worst_supported_typed_bytes": worst_supported["typed_bytes"],
+        "worst_supported_saving_typed_bytes": champion["typed_bytes"] - worst_supported["typed_bytes"],
+        "worst_supported_saving_share": f"{(champion['typed_bytes'] - worst_supported['typed_bytes']) / champion['typed_bytes']:.6f}",
+        "best_supported_label_id": best_supported["variant_id"],
+        "best_supported_typed_bytes": best_supported["typed_bytes"],
+        "best_supported_saving_typed_bytes": champion["typed_bytes"] - best_supported["typed_bytes"],
+        "supported_label_count": len(supported),
+        "rejected_label_count": len(rejected),
+        "supported_labels_promotable_vs_current_champion": True,
+    }
+    policy_summary = {
+        "current_champion_typed_bytes": champion["typed_bytes"],
+        "current_champion_json_bytes": champion["proof_json_bytes"],
+        "current_champion_path_opening_bytes": champion["path_opening_bytes"],
+        "fixed_adjacent_path_opening_overhang_vs_champion": by_id[FIXED_ADJACENT_ID]["path_opening_bytes"] - champion["path_opening_bytes"],
+        "adjacent_value_bytes": ADJACENT_VALUE_BYTES,
+        "full_inventory_worst_label_id": worst_full_inventory["variant_id"],
+        "full_inventory_worst_typed_bytes": worst_full_inventory["typed_bytes"],
+        "full_inventory_miss_vs_champion_typed_bytes": worst_full_inventory["typed_bytes"] - champion["typed_bytes"],
+        "supported_label_count": len(supported),
+        "rejected_label_count": len(rejected),
+        "worst_supported_label_id": worst_supported["variant_id"],
+        "worst_supported_typed_bytes": worst_supported["typed_bytes"],
+        "worst_supported_saving_typed_bytes": champion["typed_bytes"] - worst_supported["typed_bytes"],
+        "worst_supported_saving_share": deterministic_policy["worst_supported_saving_share"],
+        "best_supported_label_id": best_supported["variant_id"],
+        "best_supported_typed_bytes": best_supported["typed_bytes"],
+        "best_supported_saving_typed_bytes": champion["typed_bytes"] - best_supported["typed_bytes"],
+        "supported_value_bytes_stable": all(row["value_bytes"] == ADJACENT_VALUE_BYTES for row in supported),
+        "proof_size_comparable_external_rows": 0,
+        "nanozk_reported_d128_block_proof_bytes": NANOZK_REPORTED_D128_BLOCK_PROOF_BYTES,
+    }
+    payload = {
+        "schema": SCHEMA,
+        "decision": DECISION,
+        "result": RESULT,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "issue_hint": ISSUE_HINT,
+        "source_artifacts": [
+            {
+                "id": "source_adjacent_label_policy",
+                "path": SOURCE_POLICY_RELATIVE_PATH,
+                "sha256": source_gate.sha256(raw),
+                "payload_commitment": source["payload_commitment"],
+            }
+        ],
+        "full_inventory_policy": full_inventory_policy,
+        "deterministic_policy": deterministic_policy,
+        "label_inventory": inventory,
+        "policy_summary": policy_summary,
+        "interpretation": copy.deepcopy(EXPECTED_INTERPRETATION),
+        "non_claims": list(NON_CLAIMS),
+        "validation_commands": list(VALIDATION_COMMANDS),
+    }
+    payload["mutation_result"] = mutation_result(payload)
+    payload["payload_commitment"] = payload_commitment(payload)
+    validate_payload(payload)
+    return payload
+
+
+def expected_mutation_cases() -> list[dict[str, Any]]:
+    return [
+        {"name": name, "rejected": True, "error": EXPECTED_MUTATION_ERRORS[name]}
+        for name in MUTATION_NAMES
+    ]
+
+
+def expected_mutation_result() -> dict[str, Any]:
+    return {
+        "all_mutations_rejected": True,
+        "mutations_rejected": len(MUTATION_NAMES),
+        "mutation_names": list(MUTATION_NAMES),
+        "cases": expected_mutation_cases(),
+    }
+
+
+def mutation_result(payload: dict[str, Any]) -> dict[str, Any]:
+    cases = []
+    for name, mutate in mutation_functions():
+        item = copy.deepcopy(payload)
+        item.pop("mutation_result", None)
+        item.pop("payload_commitment", None)
+        mutate(item)
+        item["mutation_result"] = expected_mutation_result()
+        if name != "payload_commitment_drift":
+            item["payload_commitment"] = payload_commitment(item)
+        try:
+            validate_payload(item)
+        except DeterministicAdjacentLabelPolicyGateError as err:
+            cases.append({"name": name, "rejected": True, "error": str(err)})
+        else:
+            cases.append({"name": name, "rejected": False, "error": ""})
+    return {
+        "all_mutations_rejected": all(case["rejected"] for case in cases),
+        "mutations_rejected": sum(1 for case in cases if case["rejected"]),
+        "mutation_names": list(MUTATION_NAMES),
+        "cases": cases,
+    }
+
+
+def mutation_functions() -> tuple[tuple[str, Callable[[dict[str, Any]], None]], ...]:
+    return (
+        ("decision_drift", lambda item: item.update({"decision": "NO_GO"})),
+        ("result_drift", lambda item: item.update({"result": "NO_RESULT"})),
+        ("full_inventory_overclaim", lambda item: item["full_inventory_policy"].update({"full_inventory_promotable_vs_current_champion": True})),
+        ("fixed_label_supported", lambda item: item["label_inventory"][1].update({"policy_status": "supported_label"})),
+        ("probe_a_rejected", lambda item: item["label_inventory"][2].update({"policy_status": "rejected_inflating_label"})),
+        ("worst_supported_typed_drift", lambda item: item["deterministic_policy"].update({"worst_supported_typed_bytes": 42_156})),
+        ("worst_supported_saving_erased", lambda item: item["policy_summary"].update({"worst_supported_saving_typed_bytes": 0})),
+        ("support_criteria_erased", lambda item: item["deterministic_policy"].update({"support_criteria": []})),
+        ("value_stability_erased", lambda item: item["policy_summary"].update({"supported_value_bytes_stable": False})),
+        ("source_digest_drift", lambda item: item["source_artifacts"][0].update({"sha256": "0" * 64})),
+        ("source_commitment_drift", lambda item: item["source_artifacts"][0].update({"payload_commitment": "blake2b-256:" + "0" * 64})),
+        ("validation_command_drift", lambda item: item["validation_commands"].append("echo untracked")),
+        ("removed_non_claim", lambda item: item["non_claims"].remove("not robust to unseen labels")),
+        ("nanozk_overclaim", lambda item: item.update({"claim_boundary": item["claim_boundary"] + ";NANOZK_WIN"})),
+        ("final_policy_overclaim", lambda item: item["non_claims"].remove("not a final production label-selection policy")),
+        ("unknown_policy_field", lambda item: item["deterministic_policy"].update({"unchecked": True})),
+        ("label_inventory_order_drift", lambda item: item["label_inventory"].reverse()),
+        ("payload_commitment_drift", lambda item: item.update({"payload_commitment": "blake2b-256:" + "0" * 64})),
+    )
+
+
+def validate_payload(payload: dict[str, Any]) -> None:
+    _require_exact_keys(payload, PAYLOAD_KEYS, "payload")
+    expected_top = {
+        "schema": SCHEMA,
+        "decision": DECISION,
+        "result": RESULT,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "issue_hint": ISSUE_HINT,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise DeterministicAdjacentLabelPolicyGateError(f"{key} drift")
+    if "NANOZK_WIN" in str(payload.get("claim_boundary")).split(";"):
+        raise DeterministicAdjacentLabelPolicyGateError("claim_boundary drift")
+    validate_source_artifacts(_list(payload.get("source_artifacts"), "source artifacts"))
+    validate_full_inventory_policy(_dict(payload.get("full_inventory_policy"), "full inventory policy"))
+    validate_deterministic_policy(_dict(payload.get("deterministic_policy"), "deterministic policy"))
+    validate_label_inventory(_list(payload.get("label_inventory"), "label inventory"))
+    validate_policy_summary(_dict(payload.get("policy_summary"), "policy summary"))
+    if payload.get("interpretation") != EXPECTED_INTERPRETATION:
+        raise DeterministicAdjacentLabelPolicyGateError("interpretation drift")
+    if payload.get("non_claims") != list(NON_CLAIMS):
+        raise DeterministicAdjacentLabelPolicyGateError("non_claims drift")
+    if payload.get("validation_commands") != list(VALIDATION_COMMANDS):
+        raise DeterministicAdjacentLabelPolicyGateError("validation command drift")
+    validate_mutation_result(_dict(payload.get("mutation_result"), "mutation result"))
+    if payload.get("payload_commitment") != payload_commitment(payload):
+        raise DeterministicAdjacentLabelPolicyGateError("payload commitment drift")
+
+
+def validate_source_artifacts(artifacts: list[Any]) -> None:
+    expected = [
+        {
+            "id": "source_adjacent_label_policy",
+            "path": SOURCE_POLICY_RELATIVE_PATH,
+            "sha256": EXPECTED_SOURCE_POLICY_SHA256,
+            "payload_commitment": EXPECTED_SOURCE_POLICY_COMMITMENT,
+        }
+    ]
+    for item in artifacts:
+        _require_exact_keys(_dict(item, "source artifact"), SOURCE_ARTIFACT_KEYS, "source artifact")
+    if artifacts != expected:
+        raise DeterministicAdjacentLabelPolicyGateError("source artifact drift")
+
+
+def validate_full_inventory_policy(policy: dict[str, Any]) -> None:
+    _require_exact_keys(policy, FULL_POLICY_KEYS, "full inventory policy")
+    expected = {
+        "name": "full_adjacent_inventory_worst_label_v1",
+        "full_inventory_label_ids": list(ADJACENT_LABEL_INVENTORY),
+        "worst_full_inventory_label_id": FULL_INVENTORY_WORST_LABEL_ID,
+        "worst_full_inventory_typed_bytes": FULL_INVENTORY_WORST_TYPED_BYTES,
+        "delta_vs_current_champion_typed_bytes": FULL_INVENTORY_MISS_BYTES,
+        "full_inventory_promotable_vs_current_champion": False,
+        "reason": "the fixed adjacent label inflates path-opening material and misses the champion by 88 typed bytes",
+    }
+    if policy.get("full_inventory_promotable_vs_current_champion") is not False:
+        raise DeterministicAdjacentLabelPolicyGateError("full inventory overclaim")
+    if policy != expected:
+        raise DeterministicAdjacentLabelPolicyGateError("full inventory policy drift")
+
+
+def validate_deterministic_policy(policy: dict[str, Any]) -> None:
+    _require_exact_keys(policy, DETERMINISTIC_POLICY_KEYS, "deterministic policy")
+    expected = {
+        "name": "reject_path_opening_inflation_v1",
+        "support_criteria": [
+            "adapter_mode is an adjacent label probe",
+            "direct value bytes equal 20924",
+            "path_opening_bytes are below the current champion",
+            "typed_bytes are below the current champion",
+            "source envelope and accounting are pinned by digest and payload commitment",
+        ],
+        "rejection_criteria": [
+            "path_opening_bytes are greater than or equal to the current champion",
+            "typed_bytes are greater than or equal to the current champion",
+            "direct value bytes drift from the adjacent label inventory",
+        ],
+        "supported_label_ids": list(SUPPORTED_LABEL_IDS),
+        "rejected_label_ids": [FIXED_ADJACENT_ID],
+        "worst_supported_label_id": WORST_SUPPORTED_LABEL_ID,
+        "worst_supported_typed_bytes": WORST_SUPPORTED_TYPED_BYTES,
+        "worst_supported_saving_typed_bytes": WORST_SUPPORTED_SAVING_BYTES,
+        "worst_supported_saving_share": "0.041267",
+        "best_supported_label_id": BEST_SUPPORTED_LABEL_ID,
+        "best_supported_typed_bytes": BEST_SUPPORTED_TYPED_BYTES,
+        "best_supported_saving_typed_bytes": BEST_SUPPORTED_SAVING_BYTES,
+        "supported_label_count": 2,
+        "rejected_label_count": 1,
+        "supported_labels_promotable_vs_current_champion": True,
+    }
+    if policy != expected:
+        raise DeterministicAdjacentLabelPolicyGateError("deterministic policy drift")
+
+
+def validate_label_inventory(rows: list[Any]) -> None:
+    expected_ids = (CURRENT_CHAMPION_ID, *ADJACENT_LABEL_INVENTORY)
+    parsed = []
+    for item in rows:
+        row = _dict(item, "label inventory item")
+        _require_exact_keys(row, LABEL_ROW_KEYS, "label inventory item")
+        parsed.append(row)
+    if tuple(row["variant_id"] for row in parsed) != expected_ids:
+        raise DeterministicAdjacentLabelPolicyGateError("label inventory order drift")
+    expected_status = {
+        CURRENT_CHAMPION_ID: "comparison_champion",
+        FIXED_ADJACENT_ID: "rejected_inflating_label",
+        "adjacent_label_probe_a": "supported_label",
+        "adjacent_label_probe_b": "supported_label",
+    }
+    expected_typed = {
+        CURRENT_CHAMPION_ID: CURRENT_CHAMPION_TYPED_BYTES,
+        FIXED_ADJACENT_ID: FULL_INVENTORY_WORST_TYPED_BYTES,
+        "adjacent_label_probe_a": WORST_SUPPORTED_TYPED_BYTES,
+        "adjacent_label_probe_b": BEST_SUPPORTED_TYPED_BYTES,
+    }
+    expected_path_opening = {
+        CURRENT_CHAMPION_ID: CURRENT_CHAMPION_PATH_OPENING_BYTES,
+        FIXED_ADJACENT_ID: CURRENT_CHAMPION_PATH_OPENING_BYTES + FIXED_PATH_OPENING_OVERHANG_BYTES,
+        "adjacent_label_probe_a": 19_360,
+        "adjacent_label_probe_b": 16_560,
+    }
+    for row in parsed:
+        variant_id = row["variant_id"]
+        if row["policy_status"] != expected_status[variant_id]:
+            raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
+        if row["typed_bytes"] != expected_typed[variant_id]:
+            raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
+        if row["path_opening_bytes"] != expected_path_opening[variant_id]:
+            raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
+        if variant_id != CURRENT_CHAMPION_ID and row["value_bytes"] != ADJACENT_VALUE_BYTES:
+            raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
+        if row["typed_delta_vs_champion"] != row["typed_bytes"] - CURRENT_CHAMPION_TYPED_BYTES:
+            raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
+        if row["path_opening_delta_vs_champion"] != row["path_opening_bytes"] - CURRENT_CHAMPION_PATH_OPENING_BYTES:
+            raise DeterministicAdjacentLabelPolicyGateError("label inventory drift")
+
+
+def validate_policy_summary(summary: dict[str, Any]) -> None:
+    _require_exact_keys(summary, SUMMARY_KEYS, "policy summary")
+    expected = {
+        "current_champion_typed_bytes": CURRENT_CHAMPION_TYPED_BYTES,
+        "current_champion_json_bytes": CURRENT_CHAMPION_JSON_BYTES,
+        "current_champion_path_opening_bytes": CURRENT_CHAMPION_PATH_OPENING_BYTES,
+        "fixed_adjacent_path_opening_overhang_vs_champion": FIXED_PATH_OPENING_OVERHANG_BYTES,
+        "adjacent_value_bytes": ADJACENT_VALUE_BYTES,
+        "full_inventory_worst_label_id": FULL_INVENTORY_WORST_LABEL_ID,
+        "full_inventory_worst_typed_bytes": FULL_INVENTORY_WORST_TYPED_BYTES,
+        "full_inventory_miss_vs_champion_typed_bytes": FULL_INVENTORY_MISS_BYTES,
+        "supported_label_count": 2,
+        "rejected_label_count": 1,
+        "worst_supported_label_id": WORST_SUPPORTED_LABEL_ID,
+        "worst_supported_typed_bytes": WORST_SUPPORTED_TYPED_BYTES,
+        "worst_supported_saving_typed_bytes": WORST_SUPPORTED_SAVING_BYTES,
+        "worst_supported_saving_share": "0.041267",
+        "best_supported_label_id": BEST_SUPPORTED_LABEL_ID,
+        "best_supported_typed_bytes": BEST_SUPPORTED_TYPED_BYTES,
+        "best_supported_saving_typed_bytes": BEST_SUPPORTED_SAVING_BYTES,
+        "supported_value_bytes_stable": True,
+        "proof_size_comparable_external_rows": 0,
+        "nanozk_reported_d128_block_proof_bytes": NANOZK_REPORTED_D128_BLOCK_PROOF_BYTES,
+    }
+    if summary != expected:
+        raise DeterministicAdjacentLabelPolicyGateError("policy summary drift")
+
+
+def validate_mutation_result(result: dict[str, Any]) -> None:
+    _require_exact_keys(result, MUTATION_RESULT_KEYS, "mutation result")
+    if result.get("mutation_names") != list(MUTATION_NAMES):
+        raise DeterministicAdjacentLabelPolicyGateError("mutation result drift")
+    cases = [_dict(case, "mutation case") for case in _list(result.get("cases"), "mutation cases")]
+    for case in cases:
+        _require_exact_keys(case, MUTATION_CASE_KEYS, "mutation case")
+    if result.get("mutations_rejected") != len(MUTATION_NAMES) or result.get("all_mutations_rejected") is not True:
+        raise DeterministicAdjacentLabelPolicyGateError("mutation result drift")
+    if cases != expected_mutation_cases():
+        raise DeterministicAdjacentLabelPolicyGateError("mutation result drift")
+
+
+def render_tsv(payload: dict[str, Any]) -> str:
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+    writer.writeheader()
+    for row in payload["label_inventory"]:
+        writer.writerow({column: row[column] for column in TSV_COLUMNS})
+    return output.getvalue()
+
+
+def write_outputs(payload: dict[str, Any], json_path: pathlib.Path | None, tsv_path: pathlib.Path | None) -> None:
+    validate_payload(payload)
+    if json_path is not None:
+        source_gate.atomic_write_text(json_path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if tsv_path is not None:
+        source_gate.atomic_write_text(tsv_path, render_tsv(payload))
+
+
+def payload_with_mutations() -> dict[str, Any]:
+    return build_payload()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write-json", type=pathlib.Path)
+    parser.add_argument("--write-tsv", type=pathlib.Path)
+    args = parser.parse_args()
+    payload = build_payload()
+    write_outputs(payload, args.write_json, args.write_tsv)
+    print(
+        json.dumps(
+            {
+                "decision": payload["decision"],
+                "full_inventory_worst_typed_bytes": payload["policy_summary"]["full_inventory_worst_typed_bytes"],
+                "worst_supported_typed_bytes": payload["policy_summary"]["worst_supported_typed_bytes"],
+                "worst_supported_saving_typed_bytes": payload["policy_summary"]["worst_supported_saving_typed_bytes"],
+                "mutations_rejected": payload["mutation_result"]["mutations_rejected"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a deterministic supported-label gate over the existing seq32+d128 adjacent-label evidence
- keep the full adjacent inventory as a NO-GO because the fixed adjacent label is `42,156` typed bytes, `+88` over the `42,068` champion
- promote only the checked supported labels: probe A at `40,332` typed bytes (`1,736` typed-byte saving) and probe B at `37,532` typed bytes (`4,536` saving)
- pin source digest/commitment, policy criteria, row metadata, TSV/JSON evidence, mutation results, and handoff notes
- opened follow-up issue #686 for generator-backed label inventory and unseen-label checks

## Claim Boundary
This is a transcript/opening-stability policy result over an existing local inventory. It is not a final generator-backed label policy, not robust to unseen labels, not a matched external zkML benchmark, and not a NANOZK proof-size win.

## Validation
- [x] deterministic policy gate writes JSON/TSV evidence
- [x] Python syntax compile for gate and tests
- [x] deterministic policy unit tests
- [x] source adjacent-policy unit tests
- [x] Rust adjacent-label target tests
- [x] whitespace check
- [x] fast local gate
- [x] full local release gate

## Commands Run
- `python3.10 scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py --write-json docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.json --write-tsv docs/engineering/evidence/zkai-native-seq32-attention-mlp-deterministic-adjacent-label-policy-2026-05.tsv`
- `python3.10 -m py_compile scripts/zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py scripts/tests/test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate.py`
- `python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_deterministic_adjacent_label_policy_gate` (`18` tests)
- `python3.10 -m unittest scripts.tests.test_zkai_native_seq32_attention_mlp_adjacent_label_policy_gate` (`22` tests)
- `cargo +nightly-2025-07-14 test --locked --features stwo-backend rmsnorm_input_adjacent_label --lib` (`3` tests)
- `git diff --check`
- `just gate-fast`
- `just gate` (`14 / 14` steps OK)

## Hardening
- [x] full-inventory overclaim rejected
- [x] fixed-label relabeling rejected
- [x] source digest and payload commitment drift rejected
- [x] proof-envelope/source metadata row drift rejected
- [x] explicit NANOZK/external-benchmark overclaim rejected
- [x] label inventory ordering drift rejected
- [x] output path escape and symlink-parent writes rejected
- [x] `22 / 22` mutation cases rejected

GitHub Actions are intentionally not the readiness loop for this repo; this PR relies on local validation plus review feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added engineering docs for a deterministic adjacent-label gate: policy comparisons, typed-byte/path deltas, guardrails, evidence pointers, reproducibility metadata, and reproduction commands.

* **Tests**
  * Added a comprehensive test suite validating gate decisions, strict payload validation, many mutation/rejection cases, TSV/JSON outputs, and output-path safety checks.

* **Chores**
  * Added a CLI-capable deterministic gate tool that builds/validates reproducible payloads, classifies variants, computes commitments, and emits JSON/TSV summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->