### PR TITLE
Gate Stwo query-preview split prototype

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -2791,6 +2791,8 @@ bytes, `16,560` path-opening bytes, `16,618` query span, `5,969` min pairwise
 query gap, and `9,656` typed bytes saved versus the `47,188` typed-byte matched
 two-proof frontier. See
 `docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`.
+Follow-up issue `#706` tracks bounded transcript grinding or a deterministic
+policy commitment with explicit soundness accounting.
 
 Stwo query-preview split prototype reproducibility metadata:
 

--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -2778,6 +2778,54 @@ Bounded Stwo query-policy hook reproducibility metadata:
   `just gate-fast`;
   `just gate`.
 
+Latest Stwo query-preview split prototype: issue `#704` is now checked as a
+source-pinned narrow result. The split is API-feasible but not a sound label
+policy. Stwo `2.2.0` already separates transcript-derived query drawing from
+`decommit_on_queries`, so a prover-side preview seam can expose canonical
+queries after proof-of-work mix and before FRI/tree decommitment. But the
+committed trace, layout, labels, FRI commitment, and transcript state are fixed
+before preview; choosing a better label after seeing queries is transcript
+grinding unless it has explicit soundness-loss accounting or a verifier-bound
+deterministic policy commitment. The numeric anchor remains `37,532` typed
+bytes, `16,560` path-opening bytes, `16,618` query span, `5,969` min pairwise
+query gap, and `9,656` typed bytes saved versus the `47,188` typed-byte matched
+two-proof frontier. See
+`docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`.
+
+Stwo query-preview split prototype reproducibility metadata:
+
+- Gate schema: `zkai-stwo-query-preview-split-prototype-gate-v1`.
+- Decision:
+  `NARROW_CLAIM_QUERY_PREVIEW_SPLIT_IS_API_FEASIBLE_NOT_SOUND_LABEL_POLICY`.
+- Result:
+  `NO_GO_SOUND_QUERY_GEOMETRY_CONTROL_WITHOUT_GRINDING_OR_POLICY_COMMITMENT`.
+- Timing mode: source-bound proof-system API audit only; no new proof-size
+  frontier, no regenerated proof under a new Stwo API, and no timing claim.
+- Evidence paths:
+  `docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json`
+  and
+  `docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv`.
+- Gate JSON SHA-256:
+  `0a3348d51fa36219e8253e1c1a7fdea4d4f5a694f5edc24cc36d5bf7f8cbd442`.
+- Gate TSV SHA-256:
+  `7adcfb39ae6c7f461ee2d2d6549457ff99432067f36600249072ab9c6f3e3864`.
+- Payload commitment:
+  `blake2b-256:e956134a2e69b6d633effe9cf9a9c5f789b47f7d41ce972465ec619b1946800f`.
+- Route classification:
+  `preview_only_split` is `FEASIBLE_API_PATCH`; `policy_commitment_mix` is
+  `FOLLOWUP_MATCHED_TRANSCRIPT_PATCH`; `external_query_override` is
+  `REJECTED_UNSOUND`; `transcript_grinding_search` is
+  `FOLLOWUP_SECURITY_BUDGET_REQUIRED`.
+- Step counts: `18` mutation cases, `18` Python unit tests, and `14` local
+  release-gate steps.
+- Local validation commands:
+  `python3.10 scripts/zkai_stwo_query_preview_split_prototype_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv`;
+  `python3.10 -m py_compile scripts/zkai_stwo_query_preview_split_prototype_gate.py scripts/tests/test_zkai_stwo_query_preview_split_prototype_gate.py`;
+  `python3.10 -m unittest scripts.tests.test_zkai_stwo_query_preview_split_prototype_gate`;
+  `git diff --check`;
+  `just gate-fast`;
+  `just gate`.
+
 ## Resume protocol
 
 1. Read `AGENTS.md`.

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -140,8 +140,9 @@ This is the fast local entrypoint for a fresh agent working in this repository.
 134. `docs/engineering/zkai-seq32-value-compatible-boundary-frontier-2026-05-18.md`
 135. `docs/engineering/zkai-native-seq32-attention-mlp-predecommit-opening-policy-2026-05-19.md`
 136. `docs/engineering/zkai-bounded-stwo-query-policy-hook-2026-05-19.md`
-137. `docs/engineering/reproducibility.md`
-138. `git status --short --branch`
+137. `docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`
+138. `docs/engineering/reproducibility.md`
+139. `git status --short --branch`
 
 ## What this repository is now
 
@@ -219,19 +220,22 @@ This repository currently has three live lanes.
      not a NANOZK comparison; it says the next lever is transcript/query
      opening geometry. See
      `docs/engineering/zkai-native-seq32-attention-mlp-dry-run-opening-sampler-2026-05-19.md`.
-   - The current pre-decommitment opening-policy gate is a checked narrow
-     claim, not a true pre-decommitment GO. `adjacent_label_probe_b` remains
-     `37,532` typed bytes with `16,560` path-opening bytes, but the current
-     wrapper only sees query locations after Stwo `prove_ex` returns
-     `ExtendedStarkProof::aux`. The bounded Stwo query-policy hook gate then
-     pins the next blocker: Stwo `2.2.0` draws FRI queries inside
-     `FriProver::decommit(channel)` and the verifier samples them from the
-     transcript, so a sound policy needs a matched prover/verifier API patch,
-     not a repo-local wrapper override. Follow-up issue `#704` tracks the
-     bounded Stwo query-preview split prototype. See
-     `docs/engineering/zkai-native-seq32-attention-mlp-predecommit-opening-policy-2026-05-19.md`
+   - The current pre-decommitment opening-policy line is now narrowed through
+     the bounded Stwo query-preview split prototype. `adjacent_label_probe_b`
+     remains `37,532` typed bytes with `16,560` path-opening bytes and a
+     `9,656` typed-byte saving versus the `47,188` typed-byte matched
+     two-proof frontier. Stwo `2.2.0` can expose a prover-side preview seam
+     after transcript query draw and before FRI/tree decommitment because
+     `FriProver::decommit(channel)` already calls public `decommit_on_queries`.
+     But the committed trace/layout/labels and FRI commitment are fixed before
+     preview, so choosing labels after seeing queries is transcript grinding,
+     not a sound policy. The next paper-grade attack needs either a
+     verifier-bound deterministic policy commitment or explicit grinding
+     soundness accounting. See
+     `docs/engineering/zkai-native-seq32-attention-mlp-predecommit-opening-policy-2026-05-19.md`,
+     `docs/engineering/zkai-bounded-stwo-query-policy-hook-2026-05-19.md`,
      and
-     `docs/engineering/zkai-bounded-stwo-query-policy-hook-2026-05-19.md`.
+     `docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`.
    - The current source-backed adapter frontier is a correctness GO and a
      proof-shape learning result, not a compression breakthrough. The compact
      selector verifies at `40,812` local typed bytes, only `112` typed bytes

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -94,8 +94,9 @@ If you are in a local checkout, prefer `AGENTS.md`, `.codex/START_HERE.md`, and
 83. `docs/engineering/zkai-seq32-value-compatible-boundary-frontier-2026-05-18.md`
 84. `docs/engineering/zkai-native-seq32-attention-mlp-predecommit-opening-policy-2026-05-19.md`
 85. `docs/engineering/zkai-bounded-stwo-query-policy-hook-2026-05-19.md`
-86. `docs/engineering/reproducibility.md`
-87. `git status --short --branch`
+86. `docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`
+87. `docs/engineering/reproducibility.md`
+88. `git status --short --branch`
 
 ## Current lane split
 
@@ -2723,6 +2724,54 @@ Bounded Stwo query-policy hook reproducibility metadata:
   `python3.10 scripts/zkai_bounded_stwo_query_policy_hook_gate.py --write-json docs/engineering/evidence/zkai-bounded-stwo-query-policy-hook-2026-05.json --write-tsv docs/engineering/evidence/zkai-bounded-stwo-query-policy-hook-2026-05.tsv`;
   `python3.10 -m py_compile scripts/zkai_bounded_stwo_query_policy_hook_gate.py scripts/tests/test_zkai_bounded_stwo_query_policy_hook_gate.py`;
   `python3.10 -m unittest scripts.tests.test_zkai_bounded_stwo_query_policy_hook_gate`;
+  `git diff --check`;
+  `just gate-fast`;
+  `just gate`.
+
+Latest Stwo query-preview split prototype: issue `#704` is now checked as a
+source-pinned narrow result. The split is API-feasible but not a sound label
+policy. Stwo `2.2.0` already separates transcript-derived query drawing from
+`decommit_on_queries`, so a prover-side preview seam can expose canonical
+queries after proof-of-work mix and before FRI/tree decommitment. But the
+committed trace, layout, labels, FRI commitment, and transcript state are fixed
+before preview; choosing a better label after seeing queries is transcript
+grinding unless it has explicit soundness-loss accounting or a verifier-bound
+deterministic policy commitment. The numeric anchor remains `37,532` typed
+bytes, `16,560` path-opening bytes, `16,618` query span, `5,969` min pairwise
+query gap, and `9,656` typed bytes saved versus the `47,188` typed-byte matched
+two-proof frontier. See
+`docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`.
+
+Stwo query-preview split prototype reproducibility metadata:
+
+- Gate schema: `zkai-stwo-query-preview-split-prototype-gate-v1`.
+- Decision:
+  `NARROW_CLAIM_QUERY_PREVIEW_SPLIT_IS_API_FEASIBLE_NOT_SOUND_LABEL_POLICY`.
+- Result:
+  `NO_GO_SOUND_QUERY_GEOMETRY_CONTROL_WITHOUT_GRINDING_OR_POLICY_COMMITMENT`.
+- Timing mode: source-bound proof-system API audit only; no new proof-size
+  frontier, no regenerated proof under a new Stwo API, and no timing claim.
+- Evidence paths:
+  `docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json`
+  and
+  `docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv`.
+- Gate JSON SHA-256:
+  `0a3348d51fa36219e8253e1c1a7fdea4d4f5a694f5edc24cc36d5bf7f8cbd442`.
+- Gate TSV SHA-256:
+  `7adcfb39ae6c7f461ee2d2d6549457ff99432067f36600249072ab9c6f3e3864`.
+- Payload commitment:
+  `blake2b-256:e956134a2e69b6d633effe9cf9a9c5f789b47f7d41ce972465ec619b1946800f`.
+- Route classification:
+  `preview_only_split` is `FEASIBLE_API_PATCH`; `policy_commitment_mix` is
+  `FOLLOWUP_MATCHED_TRANSCRIPT_PATCH`; `external_query_override` is
+  `REJECTED_UNSOUND`; `transcript_grinding_search` is
+  `FOLLOWUP_SECURITY_BUDGET_REQUIRED`.
+- Step counts: `18` mutation cases, `18` Python unit tests, and `14` local
+  release-gate steps.
+- Local validation commands:
+  `python3.10 scripts/zkai_stwo_query_preview_split_prototype_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv`;
+  `python3.10 -m py_compile scripts/zkai_stwo_query_preview_split_prototype_gate.py scripts/tests/test_zkai_stwo_query_preview_split_prototype_gate.py`;
+  `python3.10 -m unittest scripts.tests.test_zkai_stwo_query_preview_split_prototype_gate`;
   `git diff --check`;
   `just gate-fast`;
   `just gate`.

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -2741,6 +2741,8 @@ bytes, `16,560` path-opening bytes, `16,618` query span, `5,969` min pairwise
 query gap, and `9,656` typed bytes saved versus the `47,188` typed-byte matched
 two-proof frontier. See
 `docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`.
+Follow-up issue `#706` tracks bounded transcript grinding or a deterministic
+policy commitment with explicit soundness accounting.
 
 Stwo query-preview split prototype reproducibility metadata:
 

--- a/docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json
+++ b/docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json
@@ -1,0 +1,381 @@
+{
+  "current_metric_anchor": {
+    "matched_two_proof_frontier_typed_bytes": 47188,
+    "min_pairwise_query_gap": 5969,
+    "path_opening_bytes": 16560,
+    "query_span": 16618,
+    "saving_vs_two_proof_frontier_share": "20.4628%",
+    "saving_vs_two_proof_frontier_typed_bytes": 9656,
+    "selected_row": "adjacent_label_probe_b",
+    "typed_bytes": 37532
+  },
+  "decision": "NARROW_CLAIM_QUERY_PREVIEW_SPLIT_IS_API_FEASIBLE_NOT_SOUND_LABEL_POLICY",
+  "forbidden_policy_inputs": {
+    "final_envelope_json": true,
+    "final_path_opening_bytes": true,
+    "final_proof_bytes": true,
+    "grouped_accounting": true,
+    "post_decommitment_aux_as_selector": true,
+    "record_streams": true,
+    "unbounded_abort_and_retry": true
+  },
+  "interpretation": {
+    "human_read": "The Stwo split is useful, but not in the naive way. We can expose canonical queries before expensive decommitment, which is a real API seam. We cannot then change labels or layouts after seeing those queries without turning the experiment into transcript grinding.",
+    "next_experiment": "Prototype the preview-only Stwo API first for early measurement, then test a bounded transcript-grinding or policy-commitment route before regenerating proof-size frontiers.",
+    "why_it_matters": "This keeps the breakthrough path honest. The current 37,532 typed-byte champion and 20.4628% saving over the two-proof frontier remain an opening geometry signal, but the next paper-grade claim needs either a deterministic precommitted policy or explicit security-budgeted grinding."
+  },
+  "issue": "https://github.com/omarespejel/provable-transformer-vm/issues/704",
+  "mutation_result": {
+    "all_mutations_rejected": true,
+    "cases": [
+      {
+        "error": "base payload drift",
+        "name": "decision_overclaim",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "result_overclaim",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "preview_claims_label_control",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "external_query_override_allowed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "stage_order_flip",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "committed_trace_mutable_after_preview",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "proof_size_frontier_claimed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "metric_anchor_drift",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "core_query_source_digest_drift",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "core_query_marker_erasure",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "verifier_marker_erasure",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "policy_reads_final_bytes",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "transcript_grinding_without_budget",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "policy_commitment_verifier_patch_removed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "validation_command_removed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "non_claim_removed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "source_artifact_digest_drift",
+        "rejected": true
+      },
+      {
+        "error": "payload commitment drift",
+        "name": "payload_commitment_drift",
+        "rejected": true
+      }
+    ],
+    "mutation_names": [
+      "decision_overclaim",
+      "result_overclaim",
+      "preview_claims_label_control",
+      "external_query_override_allowed",
+      "stage_order_flip",
+      "committed_trace_mutable_after_preview",
+      "proof_size_frontier_claimed",
+      "metric_anchor_drift",
+      "core_query_source_digest_drift",
+      "core_query_marker_erasure",
+      "verifier_marker_erasure",
+      "policy_reads_final_bytes",
+      "transcript_grinding_without_budget",
+      "policy_commitment_verifier_patch_removed",
+      "validation_command_removed",
+      "non_claim_removed",
+      "source_artifact_digest_drift",
+      "payload_commitment_drift"
+    ],
+    "mutations_rejected": 18
+  },
+  "non_claims": [
+    "not a new proof-size frontier",
+    "not a regenerated seq32+d128 proof under a new Stwo API",
+    "not a production label-selection policy",
+    "not a sound post-query label chooser",
+    "not an external query override",
+    "not a NANOZK proof-size comparison",
+    "not a full transformer block proof",
+    "not timing evidence",
+    "not production-ready zkML"
+  ],
+  "payload_commitment": "blake2b-256:e956134a2e69b6d633effe9cf9a9c5f789b47f7d41ce972465ec619b1946800f",
+  "preview_split_assessment": {
+    "api_preview_split_feasible": true,
+    "cannot_change_committed_trace_or_layout_after_preview": true,
+    "followup_needed": "security-budgeted transcript grinding or a verifier-bound deterministic policy commitment",
+    "proof_size_delta_typed_bytes": 0,
+    "regenerate_proof_size_frontier_now": false,
+    "sound_label_policy_feasible_now": false
+  },
+  "prototype_routes": [
+    {
+      "can_change_committed_trace_after_preview": false,
+      "can_claim_probe_b_control": false,
+      "external_query_choice": false,
+      "interpretation": "Expose transcript-drawn queries after PoW mix and before FRI/tree decommitments. This can support measurement or bounded early abort, but does not justify choosing labels after seeing the queries.",
+      "preview_before_fri_decommit": true,
+      "preview_before_trace_decommit": true,
+      "requires_prover_patch": true,
+      "requires_security_budget": false,
+      "requires_verifier_patch": false,
+      "route_id": "preview_only_split",
+      "status": "FEASIBLE_API_PATCH"
+    },
+    {
+      "can_change_committed_trace_after_preview": false,
+      "can_claim_probe_b_control": false,
+      "external_query_choice": false,
+      "interpretation": "Bind a deterministic policy commitment into prover and verifier transcript before canonical query draw. It can make policy semantics explicit, but still cannot read final proof bytes or post-decommitment accounting.",
+      "preview_before_fri_decommit": true,
+      "preview_before_trace_decommit": true,
+      "requires_prover_patch": true,
+      "requires_security_budget": false,
+      "requires_verifier_patch": true,
+      "route_id": "policy_commitment_mix",
+      "status": "FOLLOWUP_MATCHED_TRANSCRIPT_PATCH"
+    },
+    {
+      "can_change_committed_trace_after_preview": false,
+      "can_claim_probe_b_control": false,
+      "external_query_choice": true,
+      "interpretation": "Letting the prover choose FRI query locations directly breaks the Fiat-Shamir verifier story unless the verifier derives the same positions from a bound policy.",
+      "preview_before_fri_decommit": true,
+      "preview_before_trace_decommit": true,
+      "requires_prover_patch": true,
+      "requires_security_budget": true,
+      "requires_verifier_patch": true,
+      "route_id": "external_query_override",
+      "status": "REJECTED_UNSOUND"
+    },
+    {
+      "can_change_committed_trace_after_preview": false,
+      "can_claim_probe_b_control": false,
+      "external_query_choice": false,
+      "interpretation": "Abort-and-retry after seeing canonical queries is transcript grinding. It may be a research lever only with explicit soundness-loss accounting, bounded attempts, and verifier-visible constraints.",
+      "preview_before_fri_decommit": true,
+      "preview_before_trace_decommit": true,
+      "requires_prover_patch": false,
+      "requires_security_budget": true,
+      "requires_verifier_patch": true,
+      "route_id": "transcript_grinding_search",
+      "status": "FOLLOWUP_SECURITY_BUDGET_REQUIRED"
+    }
+  ],
+  "reproducibility_metadata": {
+    "cargo_dependency": "stwo = 2.2.0",
+    "local_release_gate_step_count": 14,
+    "mutation_step_count": 18,
+    "stwo_version": "2.2.0",
+    "unittest_step_count": 18
+  },
+  "result": "NO_GO_SOUND_QUERY_GEOMETRY_CONTROL_WITHOUT_GRINDING_OR_POLICY_COMMITMENT",
+  "schema": "zkai-stwo-query-preview-split-prototype-gate-v1",
+  "source_artifacts": [
+    {
+      "id": "rust_native_seq32_attention_mlp_source",
+      "path": "src/stwo_backend/native_seq32_attention_mlp_single_proof.rs",
+      "sha256": "7818c25b034da111cddd090783ea6bc66fd0c4dc2c67f95e3281899d0235344b",
+      "size_bytes": 145752
+    },
+    {
+      "id": "cli_native_seq32_attention_mlp_source",
+      "path": "src/bin/zkai_native_seq32_attention_mlp_single_proof.rs",
+      "sha256": "ea68996b62dd763255e20479672bf7a392494a710c87eb2c0da84482873b4b52",
+      "size_bytes": 32531
+    },
+    {
+      "id": "predecommit_opening_policy_evidence",
+      "path": "docs/engineering/evidence/zkai-native-seq32-attention-mlp-predecommit-opening-policy-2026-05.json",
+      "sha256": "07d711adf35a960f64c2cb644ba0e912b0d167698f2c4597d1294075eaa36084",
+      "size_bytes": 27731
+    },
+    {
+      "id": "predecommit_opening_policy_tsv",
+      "path": "docs/engineering/evidence/zkai-native-seq32-attention-mlp-predecommit-opening-policy-2026-05.tsv",
+      "sha256": "9d27db58076a846b5cdfa15b5f8e74cdcd703cf41292c03f33f867a75e531a81",
+      "size_bytes": 2010
+    },
+    {
+      "crate": "stwo",
+      "id": "stwo_2_2_prover_mod",
+      "path": "stwo-2.2.0/src/prover/mod.rs",
+      "sha256": "1a26ddc000bbda77ad8a36bf5f152a4f79947f784c9f31236164cc644d8f7bd5",
+      "size_bytes": 5423,
+      "version": "2.2.0"
+    },
+    {
+      "crate": "stwo",
+      "id": "stwo_2_2_prover_pcs_mod",
+      "path": "stwo-2.2.0/src/prover/pcs/mod.rs",
+      "sha256": "214158108b0381079e9cd96c7020eaf7e36fbb0ca3cdfefdcaa5b03ba5d9ce99",
+      "size_bytes": 16156,
+      "version": "2.2.0"
+    },
+    {
+      "crate": "stwo",
+      "id": "stwo_2_2_prover_fri",
+      "path": "stwo-2.2.0/src/prover/fri.rs",
+      "sha256": "475d667b19f5914cd11e65fc9f7230151029ae73d86e7241b7e9abc031023171",
+      "size_bytes": 23912,
+      "version": "2.2.0"
+    },
+    {
+      "crate": "stwo",
+      "id": "stwo_2_2_core_pcs_verifier",
+      "path": "stwo-2.2.0/src/core/pcs/verifier.rs",
+      "sha256": "797c32b03c3c4348c9b995bdccc30a9600cce085bafbce3bb9e7e49067dbabf6",
+      "size_bytes": 4885,
+      "version": "2.2.0"
+    },
+    {
+      "crate": "stwo",
+      "id": "stwo_2_2_core_fri",
+      "path": "stwo-2.2.0/src/core/fri.rs",
+      "sha256": "27af206dae322e9c60d6a44f6de3b01422d9c0a90089bf9009636c8e16dd95ce",
+      "size_bytes": 47762,
+      "version": "2.2.0"
+    },
+    {
+      "crate": "stwo",
+      "id": "stwo_2_2_core_queries",
+      "path": "stwo-2.2.0/src/core/queries.rs",
+      "sha256": "fd978cad026f3b684844503c543dfe3cb4fbf003108f92ecf945807c5d92e633",
+      "size_bytes": 4323,
+      "version": "2.2.0"
+    }
+  ],
+  "source_audit": {
+    "core_query_markers": {
+      "draw_queries_is_public": true,
+      "draw_queries_masks_domain": true,
+      "draw_queries_reads_transcript_words": true,
+      "queries_new_sorts_and_dedups": true
+    },
+    "current_stage_boundary": "repo wrapper observes query locations only after Stwo prove_ex returns ExtendedStarkProof aux",
+    "current_stwo_query_boundary": "Stwo prover draws FRI queries inside FriProver::decommit(channel), then uses those positions for FRI and trace Merkle decommitments; verifier redraws positions from the transcript channel",
+    "external_policy_markers_absent": {
+      "decommit_with_query_policy": true,
+      "external_query_policy": true,
+      "prove_ex_with_query_policy": true,
+      "query_policy_commitment": true
+    },
+    "preview_split_source_read": "FriProver::decommit already factors canonical query drawing from decommit_on_queries; a prover-side API can expose the drawn Queries before calling decommit_on_queries, while the verifier keeps sampling the same positions from the Fiat-Shamir transcript.",
+    "repo_markers": {
+      "prove_single_extended_delegates_to_stwo_prove_ex": true,
+      "sampler_boundary_names_extended_aux_only": true,
+      "sampler_calls_full_extended_proof": true,
+      "sampler_reads_extended_aux_query_locations": true
+    },
+    "stwo_markers": {
+      "fri_decommit_draws_queries_from_channel": true,
+      "fri_decommit_on_queries_is_public": true,
+      "fri_decommit_uses_decommit_on_queries": true,
+      "fri_verifier_draws_queries_from_channel": true,
+      "pcs_commits_fri_before_pow": true,
+      "pcs_decommit_calls_fri_prover_decommit_channel": true,
+      "pcs_trace_decommit_uses_query_positions": true,
+      "prove_ex_calls_commitment_scheme_prove_values": true,
+      "verifier_samples_query_positions_from_channel": true
+    },
+    "stwo_version": "2.2.0"
+  },
+  "stage_order": [
+    {
+      "can_change_after_preview": false,
+      "relative_to_query_preview": "before",
+      "source_fact": "commitment_scheme trees are already committed before FRI queries are drawn",
+      "stage_id": "trace_commitments",
+      "transcript_bound": true
+    },
+    {
+      "can_change_after_preview": false,
+      "relative_to_query_preview": "before",
+      "source_fact": "FRI commit and proof_of_work are mixed before FriProver::decommit draws queries",
+      "stage_id": "fri_commitment_and_pow_mix",
+      "transcript_bound": true
+    },
+    {
+      "can_change_after_preview": false,
+      "relative_to_query_preview": "preview_point",
+      "source_fact": "draw_queries(channel, first_layer_log_size, n_queries) is transcript-derived",
+      "stage_id": "canonical_query_draw",
+      "transcript_bound": true
+    },
+    {
+      "can_change_after_preview": false,
+      "relative_to_query_preview": "after",
+      "source_fact": "decommit_on_queries consumes the same canonical Queries",
+      "stage_id": "fri_decommit_on_queries",
+      "transcript_bound": true
+    },
+    {
+      "can_change_after_preview": false,
+      "relative_to_query_preview": "after",
+      "source_fact": "tree.decommit(query_positions) uses verifier-replayed query positions",
+      "stage_id": "trace_tree_decommit",
+      "transcript_bound": true
+    }
+  ],
+  "validation_commands": [
+    "python3.10 scripts/zkai_stwo_query_preview_split_prototype_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv",
+    "python3.10 -m py_compile scripts/zkai_stwo_query_preview_split_prototype_gate.py scripts/tests/test_zkai_stwo_query_preview_split_prototype_gate.py",
+    "python3.10 -m unittest scripts.tests.test_zkai_stwo_query_preview_split_prototype_gate",
+    "git diff --check",
+    "just gate-fast",
+    "just gate"
+  ]
+}

--- a/docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv
@@ -1,0 +1,5 @@
+route_id	status	requires_prover_patch	requires_verifier_patch	external_query_choice	preview_before_fri_decommit	preview_before_trace_decommit	can_change_committed_trace_after_preview	can_claim_probe_b_control	requires_security_budget
+preview_only_split	FEASIBLE_API_PATCH	true	false	false	true	true	false	false	false
+policy_commitment_mix	FOLLOWUP_MATCHED_TRANSCRIPT_PATCH	true	true	false	true	true	false	false	false
+external_query_override	REJECTED_UNSOUND	true	true	true	true	true	false	false	true
+transcript_grinding_search	FOLLOWUP_SECURITY_BUDGET_REQUIRED	false	true	false	true	true	false	false	true

--- a/docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md
+++ b/docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md
@@ -126,8 +126,10 @@ variables before validation. If the source is not available locally, run
 
 ## Next Attack
 
-Open a follow-up for bounded transcript grinding or deterministic policy
-commitment. The smallest useful experiment should:
+Follow-up: https://github.com/omarespejel/provable-transformer-vm/issues/706
+
+The bounded transcript-grinding or deterministic policy-commitment experiment
+should:
 
 - keep canonical Fiat-Shamir query derivation intact;
 - make every retry budget explicit;

--- a/docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md
+++ b/docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md
@@ -1,0 +1,138 @@
+# Stwo Query-Preview Split Prototype
+
+Date: 2026-05-19
+Issue: https://github.com/omarespejel/provable-transformer-vm/issues/704
+
+## Decision
+
+`NARROW_CLAIM_QUERY_PREVIEW_SPLIT_IS_API_FEASIBLE_NOT_SOUND_LABEL_POLICY`
+
+## Result
+
+This gate checks the next opening-geometry attack after the bounded Stwo query
+policy hook. The previous result showed that the current Stwo `2.2.0` API draws
+FRI queries inside decommitment, so a repo-local wrapper cannot soundly inject
+an external query policy.
+
+The source-level read is now sharper:
+
+- Stwo draws canonical queries from the Fiat-Shamir transcript with
+  `draw_queries(channel, first_layer_log_size, n_queries)`;
+- `FriProver::decommit(channel)` already factors the work into query draw plus
+  `decommit_on_queries(&queries)`;
+- the verifier samples the same query positions from the transcript;
+- the trace/Fri commitments and proof-of-work mix happen before the query draw;
+- FRI and trace Merkle decommitments happen after the query draw.
+
+So a prover-side `query_preview_split` is API-feasible: expose the canonical
+transcript-drawn query positions after proof-of-work mix and before expensive
+FRI/tree decommitment.
+
+The important non-win:
+
+`NO_GO_SOUND_QUERY_GEOMETRY_CONTROL_WITHOUT_GRINDING_OR_POLICY_COMMITMENT`
+
+## Human Read
+
+The current opening-geometry signal remains interesting:
+
+| selected row | typed bytes | path-opening bytes | query span | min pairwise query gap | saving vs two-proof frontier |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `adjacent_label_probe_b` | `37,532` | `16,560` | `16,618` | `5,969` | `9,656` typed bytes (`20.4628%`) |
+
+But the split does not let us honestly say "choose the good label after seeing
+the queries." By the time queries are previewed, the committed trace, layout,
+labels, FRI commitment, and proof-of-work transcript state are already fixed.
+Changing them after preview means restarting the proof with a different
+transcript. That is transcript grinding, not free proof-size control.
+
+This is still useful. It tells us the next breakthrough path is not more
+wrapper-side label guessing. It is either:
+
+1. a deterministic, verifier-bound policy commitment before query draw; or
+2. a bounded transcript-grinding experiment with explicit soundness-loss
+   accounting and verifier-visible limits.
+
+## Route Classification
+
+| route | status | prover patch | verifier patch | external query choice | can claim probe-B control |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `preview_only_split` | `FEASIBLE_API_PATCH` | yes | no | no | no |
+| `policy_commitment_mix` | `FOLLOWUP_MATCHED_TRANSCRIPT_PATCH` | yes | yes | no | no |
+| `external_query_override` | `REJECTED_UNSOUND` | yes | yes | yes | no |
+| `transcript_grinding_search` | `FOLLOWUP_SECURITY_BUDGET_REQUIRED` | no | yes | no | no |
+
+## Why This Matters
+
+For the paper path, this separates three things that are easy to confuse:
+
+- proof-size measurement;
+- proof-system API structure;
+- sound policy control over query/opening geometry.
+
+The current `37,532` typed-byte champion is still the local seq32+d128
+opening-geometry signal. This PR does not improve it. It prevents us from
+promoting the wrong mechanism. A paper-grade query-geometry claim needs either
+a policy that is fixed before the transcript draws queries, or a grinding
+budget that is explicit enough to be audited.
+
+## Evidence
+
+Machine-readable evidence:
+
+- `docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json`
+- `docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv`
+
+Evidence hashes:
+
+- Gate JSON SHA-256:
+  `0a3348d51fa36219e8253e1c1a7fdea4d4f5a694f5edc24cc36d5bf7f8cbd442`
+- Gate TSV SHA-256:
+  `7adcfb39ae6c7f461ee2d2d6549457ff99432067f36600249072ab9c6f3e3864`
+- Payload commitment:
+  `blake2b-256:e956134a2e69b6d633effe9cf9a9c5f789b47f7d41ce972465ec619b1946800f`
+- Mutation guards:
+  `18 / 18` rejected.
+- Unit tests:
+  `18`.
+
+## Reproduction
+
+```bash
+python3.10 scripts/zkai_stwo_query_preview_split_prototype_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv
+python3.10 -m py_compile scripts/zkai_stwo_query_preview_split_prototype_gate.py scripts/tests/test_zkai_stwo_query_preview_split_prototype_gate.py
+python3.10 -m unittest scripts.tests.test_zkai_stwo_query_preview_split_prototype_gate
+git diff --check
+just gate-fast
+just gate
+```
+
+The gate reads Stwo `2.2.0` source from `STWO_SOURCE_ROOT` when set, otherwise
+from the local Cargo registry. `STWO_SOURCE_ROOT` supports `~` and environment
+variables before validation. If the source is not available locally, run
+`cargo fetch` before regenerating the evidence.
+
+## Non-Claims
+
+- Not a new proof-size frontier.
+- Not a regenerated seq32+d128 proof under a new Stwo API.
+- Not a production label-selection policy.
+- Not a sound post-query label chooser.
+- Not an external query override.
+- Not a NANOZK proof-size comparison.
+- Not a full transformer block proof.
+- Not timing evidence.
+- Not production-ready zkML.
+
+## Next Attack
+
+Open a follow-up for bounded transcript grinding or deterministic policy
+commitment. The smallest useful experiment should:
+
+- keep canonical Fiat-Shamir query derivation intact;
+- make every retry budget explicit;
+- account for soundness loss before reporting proof-size improvement;
+- bind policy metadata into the verifier-facing statement if a deterministic
+  policy is used;
+- reject any route that reads final proof bytes or post-decommitment accounting
+  before selecting a policy.

--- a/scripts/tests/test_zkai_stwo_query_preview_split_prototype_gate.py
+++ b/scripts/tests/test_zkai_stwo_query_preview_split_prototype_gate.py
@@ -1,0 +1,209 @@
+import copy
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+GATE_PATH = ROOT / "scripts" / "zkai_stwo_query_preview_split_prototype_gate.py"
+
+
+def load_gate():
+    spec = importlib.util.spec_from_file_location(
+        "stwo_query_preview_split_prototype_gate",
+        GATE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class StwoQueryPreviewSplitPrototypeGateTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.gate = load_gate()
+        try:
+            cls.payload = cls.gate.build_payload()
+        except cls.gate.hook_gate.BoundedStwoQueryPolicyHookGateError as err:
+            if "Stwo 2.2.0 source is not available" in str(err):
+                raise unittest.SkipTest(str(err)) from err
+            raise
+
+    def route(self, route_id):
+        return self.gate.route(self.payload, route_id)
+
+    def test_payload_records_preview_split_narrow_no_go(self):
+        self.assertEqual(
+            self.payload["decision"],
+            "NARROW_CLAIM_QUERY_PREVIEW_SPLIT_IS_API_FEASIBLE_NOT_SOUND_LABEL_POLICY",
+        )
+        self.assertEqual(
+            self.payload["result"],
+            "NO_GO_SOUND_QUERY_GEOMETRY_CONTROL_WITHOUT_GRINDING_OR_POLICY_COMMITMENT",
+        )
+        assessment = self.payload["preview_split_assessment"]
+        self.assertTrue(assessment["api_preview_split_feasible"])
+        self.assertFalse(assessment["sound_label_policy_feasible_now"])
+        self.assertFalse(assessment["regenerate_proof_size_frontier_now"])
+        self.assertEqual(assessment["proof_size_delta_typed_bytes"], 0)
+
+    def test_source_audit_pins_existing_stwo_query_flow(self):
+        markers = self.payload["source_audit"]["stwo_markers"]
+        self.assertTrue(markers["fri_decommit_draws_queries_from_channel"])
+        self.assertTrue(markers["fri_decommit_uses_decommit_on_queries"])
+        self.assertTrue(markers["fri_decommit_on_queries_is_public"])
+        self.assertTrue(markers["pcs_trace_decommit_uses_query_positions"])
+        self.assertTrue(markers["verifier_samples_query_positions_from_channel"])
+
+    def test_core_query_markers_pin_transcript_derived_queries(self):
+        markers = self.payload["source_audit"]["core_query_markers"]
+        self.assertTrue(markers["draw_queries_is_public"])
+        self.assertTrue(markers["draw_queries_reads_transcript_words"])
+        self.assertTrue(markers["draw_queries_masks_domain"])
+        self.assertTrue(markers["queries_new_sorts_and_dedups"])
+
+    def test_stage_order_keeps_preview_after_commitments_before_decommitments(self):
+        stages = {item["stage_id"]: item for item in self.payload["stage_order"]}
+        self.assertEqual(stages["trace_commitments"]["relative_to_query_preview"], "before")
+        self.assertEqual(
+            stages["fri_commitment_and_pow_mix"]["relative_to_query_preview"],
+            "before",
+        )
+        self.assertEqual(stages["canonical_query_draw"]["relative_to_query_preview"], "preview_point")
+        self.assertEqual(stages["fri_decommit_on_queries"]["relative_to_query_preview"], "after")
+        self.assertEqual(stages["trace_tree_decommit"]["relative_to_query_preview"], "after")
+        self.assertFalse(stages["trace_commitments"]["can_change_after_preview"])
+
+    def test_preview_only_route_is_feasible_but_not_label_control(self):
+        preview = self.route("preview_only_split")
+        self.assertEqual(preview["status"], "FEASIBLE_API_PATCH")
+        self.assertTrue(preview["requires_prover_patch"])
+        self.assertFalse(preview["requires_verifier_patch"])
+        self.assertFalse(preview["external_query_choice"])
+        self.assertTrue(preview["preview_before_fri_decommit"])
+        self.assertTrue(preview["preview_before_trace_decommit"])
+        self.assertFalse(preview["can_change_committed_trace_after_preview"])
+        self.assertFalse(preview["can_claim_probe_b_control"])
+
+    def test_policy_override_and_grinding_routes_are_bounded(self):
+        policy = self.route("policy_commitment_mix")
+        override = self.route("external_query_override")
+        grinding = self.route("transcript_grinding_search")
+        self.assertTrue(policy["requires_verifier_patch"])
+        self.assertFalse(policy["external_query_choice"])
+        self.assertEqual(override["status"], "REJECTED_UNSOUND")
+        self.assertTrue(override["external_query_choice"])
+        self.assertTrue(override["requires_security_budget"])
+        self.assertTrue(grinding["requires_security_budget"])
+        self.assertFalse(grinding["can_claim_probe_b_control"])
+
+    def test_current_metric_anchor_is_derived_from_previous_gate(self):
+        self.assertEqual(
+            self.payload["current_metric_anchor"],
+            self.gate.hook_gate.predecommit_metric_anchor(),
+        )
+        anchor = self.payload["current_metric_anchor"]
+        self.assertEqual(anchor["selected_row"], "adjacent_label_probe_b")
+        self.assertEqual(anchor["typed_bytes"], 37_532)
+        self.assertEqual(anchor["matched_two_proof_frontier_typed_bytes"], 47_188)
+        self.assertEqual(anchor["saving_vs_two_proof_frontier_typed_bytes"], 9_656)
+
+    def test_forbidden_policy_inputs_remain_forbidden(self):
+        forbidden = self.payload["forbidden_policy_inputs"]
+        self.assertTrue(forbidden["final_envelope_json"])
+        self.assertTrue(forbidden["final_proof_bytes"])
+        self.assertTrue(forbidden["post_decommitment_aux_as_selector"])
+        self.assertTrue(forbidden["unbounded_abort_and_retry"])
+
+    def test_source_artifacts_include_core_queries_digest(self):
+        artifact = self.gate.find_source_artifact(self.payload, "stwo_2_2_core_queries")
+        self.assertEqual(artifact["sha256"], self.gate.EXPECTED_CORE_QUERIES_SHA256)
+        self.assertEqual(
+            artifact["path"],
+            "stwo-2.2.0/src/core/queries.rs",
+        )
+
+    def test_all_mutations_rejected(self):
+        mutation = self.payload["mutation_result"]
+        self.assertTrue(mutation["all_mutations_rejected"])
+        self.assertEqual(mutation["mutations_rejected"], len(self.gate.MUTATION_NAMES))
+        self.assertEqual(mutation["mutation_names"], list(self.gate.MUTATION_NAMES))
+
+    def test_validate_mutation_result_rejects_malformed_case(self):
+        bad_result = copy.deepcopy(self.payload["mutation_result"])
+        bad_result["cases"][0] = "not-a-mutation-case"
+        with self.assertRaisesRegex(
+            self.gate.StwoQueryPreviewSplitPrototypeGateError,
+            "mutation case schema drift",
+        ):
+            self.gate.validate_mutation_result(bad_result)
+
+    def test_missing_route_and_artifact_helpers_reject(self):
+        with self.assertRaisesRegex(
+            self.gate.StwoQueryPreviewSplitPrototypeGateError,
+            "route missing",
+        ):
+            self.gate.route(self.payload, "missing-route")
+        with self.assertRaisesRegex(
+            self.gate.StwoQueryPreviewSplitPrototypeGateError,
+            "source artifact missing",
+        ):
+            self.gate.find_source_artifact(self.payload, "missing-artifact")
+
+    def test_pinned_unittest_count_matches_loaded_suite(self):
+        count = unittest.TestLoader().loadTestsFromTestCase(type(self)).countTestCases()
+        self.assertEqual(count, self.gate.EXPECTED_UNITTEST_STEP_COUNT)
+        self.assertEqual(count, self.payload["reproducibility_metadata"]["unittest_step_count"])
+
+    def test_committed_evidence_contains_integrity_fields(self):
+        evidence = json.loads(self.gate.JSON_OUT.read_text())
+        self.assertEqual(evidence["payload_commitment"], self.payload["payload_commitment"])
+        self.assertEqual(evidence["mutation_result"], self.payload["mutation_result"])
+        self.gate.validate_payload(evidence)
+
+    def test_payload_commitment_and_tsv_are_stable(self):
+        payload_a = self.gate.build_payload()
+        payload_b = self.gate.build_payload()
+        self.assertEqual(payload_a["payload_commitment"], self.gate.payload_commitment(payload_a))
+        self.assertEqual(payload_a["payload_commitment"], payload_b["payload_commitment"])
+        tsv = self.gate.render_tsv(payload_a)
+        self.assertEqual(tsv, self.gate.render_tsv(payload_b))
+        self.assertIn("preview_only_split\tFEASIBLE_API_PATCH", tsv)
+        self.assertIn("external_query_override\tREJECTED_UNSOUND", tsv)
+
+    def test_writes_paired_json_and_tsv_outputs(self):
+        with tempfile.TemporaryDirectory(dir=self.gate.EVIDENCE_DIR) as tmp:
+            tmp_path = pathlib.Path(tmp)
+            json_path = tmp_path / "out.json"
+            tsv_path = tmp_path / "out.tsv"
+            self.gate.write_outputs(json_path, tsv_path, self.payload)
+            loaded = json.loads(json_path.read_text())
+            self.assertEqual(loaded["payload_commitment"], self.payload["payload_commitment"])
+            lines = tsv_path.read_text().splitlines()
+            self.assertEqual(lines[0], "\t".join(self.gate.TSV_COLUMNS))
+            self.assertEqual(len(lines), 1 + len(self.payload["prototype_routes"]))
+
+    def test_base_payload_rejects_overclaim(self):
+        item = self.gate.build_payload_without_mutations()
+        item["preview_split_assessment"]["sound_label_policy_feasible_now"] = True
+        with self.assertRaisesRegex(
+            self.gate.StwoQueryPreviewSplitPrototypeGateError,
+            "base payload drift",
+        ):
+            self.gate.validate_base_payload(item)
+
+    def test_payload_commitment_drift_rejects(self):
+        item = copy.deepcopy(self.payload)
+        item["payload_commitment"] = "blake2b-256:" + ("0" * 64)
+        with self.assertRaisesRegex(
+            self.gate.StwoQueryPreviewSplitPrototypeGateError,
+            "payload commitment drift",
+        ):
+            self.gate.validate_payload(item)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/zkai_stwo_query_preview_split_prototype_gate.py
+++ b/scripts/zkai_stwo_query_preview_split_prototype_gate.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3.10
+"""Gate the Stwo query-preview split prototype boundary for seq32 attention+MLP."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import hashlib
+import io
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+if sys.version_info < (3, 10):
+    raise RuntimeError("zkai_stwo_query_preview_split_prototype_gate requires Python 3.10+")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import zkai_bounded_stwo_query_policy_hook_gate as hook_gate
+from scripts import zkai_native_seq32_attention_mlp_dry_run_opening_sampler_gate as sampler_gate
+
+
+EVIDENCE_DIR = ROOT / "docs" / "engineering" / "evidence"
+JSON_OUT = EVIDENCE_DIR / "zkai-stwo-query-preview-split-prototype-2026-05.json"
+TSV_OUT = EVIDENCE_DIR / "zkai-stwo-query-preview-split-prototype-2026-05.tsv"
+
+SCHEMA = "zkai-stwo-query-preview-split-prototype-gate-v1"
+DECISION = "NARROW_CLAIM_QUERY_PREVIEW_SPLIT_IS_API_FEASIBLE_NOT_SOUND_LABEL_POLICY"
+RESULT = "NO_GO_SOUND_QUERY_GEOMETRY_CONTROL_WITHOUT_GRINDING_OR_POLICY_COMMITMENT"
+ISSUE_HINT = "https://github.com/omarespejel/provable-transformer-vm/issues/704"
+PAYLOAD_DOMAIN = "ptvm:zkai:stwo-query-preview-split-prototype:v1"
+
+STWO_VERSION = hook_gate.STWO_VERSION
+MAX_STWO_SOURCE_BYTES = hook_gate.MAX_STWO_SOURCE_BYTES
+CORE_QUERIES_RELATIVE_PATH = "src/core/queries.rs"
+EXPECTED_CORE_QUERIES_SHA256 = (
+    "fd978cad026f3b684844503c543dfe3cb4fbf003108f92ecf945807c5d92e633"
+)
+
+QUERY_SOURCE_MARKERS = {
+    "draw_queries_is_public": "pub fn draw_queries(",
+    "draw_queries_reads_transcript_words": "let random_words = channel.draw_u32s();",
+    "draw_queries_masks_domain": "let query_mask = (1 << log_domain_size) - 1;",
+    "queries_new_sorts_and_dedups": "BTreeSet::from_iter(raw_positions.iter())",
+}
+
+EXPECTED_UNITTEST_STEP_COUNT = 18
+TSV_COLUMNS = (
+    "route_id",
+    "status",
+    "requires_prover_patch",
+    "requires_verifier_patch",
+    "external_query_choice",
+    "preview_before_fri_decommit",
+    "preview_before_trace_decommit",
+    "can_change_committed_trace_after_preview",
+    "can_claim_probe_b_control",
+    "requires_security_budget",
+)
+VALIDATION_COMMANDS = (
+    "python3.10 scripts/zkai_stwo_query_preview_split_prototype_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv",
+    "python3.10 -m py_compile scripts/zkai_stwo_query_preview_split_prototype_gate.py scripts/tests/test_zkai_stwo_query_preview_split_prototype_gate.py",
+    "python3.10 -m unittest scripts.tests.test_zkai_stwo_query_preview_split_prototype_gate",
+    "git diff --check",
+    "just gate-fast",
+    "just gate",
+)
+NON_CLAIMS = (
+    "not a new proof-size frontier",
+    "not a regenerated seq32+d128 proof under a new Stwo API",
+    "not a production label-selection policy",
+    "not a sound post-query label chooser",
+    "not an external query override",
+    "not a NANOZK proof-size comparison",
+    "not a full transformer block proof",
+    "not timing evidence",
+    "not production-ready zkML",
+)
+MUTATION_NAMES = (
+    "decision_overclaim",
+    "result_overclaim",
+    "preview_claims_label_control",
+    "external_query_override_allowed",
+    "stage_order_flip",
+    "committed_trace_mutable_after_preview",
+    "proof_size_frontier_claimed",
+    "metric_anchor_drift",
+    "core_query_source_digest_drift",
+    "core_query_marker_erasure",
+    "verifier_marker_erasure",
+    "policy_reads_final_bytes",
+    "transcript_grinding_without_budget",
+    "policy_commitment_verifier_patch_removed",
+    "validation_command_removed",
+    "non_claim_removed",
+    "source_artifact_digest_drift",
+    "payload_commitment_drift",
+)
+
+
+class StwoQueryPreviewSplitPrototypeGateError(Exception):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode()
+    except (TypeError, ValueError) as err:
+        raise StwoQueryPreviewSplitPrototypeGateError(
+            f"non-canonical JSON value: {err}"
+        ) from err
+
+
+def blake2b_commitment(domain: str, value: Any) -> str:
+    digest = hashlib.blake2b(
+        domain.encode() + b"\0" + canonical_json_bytes(value),
+        digest_size=32,
+    ).hexdigest()
+    return f"blake2b-256:{digest}"
+
+
+def payload_commitment(payload: dict[str, Any]) -> str:
+    item = copy.deepcopy(payload)
+    item.pop("payload_commitment", None)
+    return blake2b_commitment(PAYLOAD_DOMAIN, item)
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def read_text_bytes(raw: bytes, label: str) -> str:
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as err:
+        raise StwoQueryPreviewSplitPrototypeGateError(f"{label} is not UTF-8") from err
+
+
+def stwo_core_queries_artifact(stwo_root: pathlib.Path) -> dict[str, Any]:
+    raw = hook_gate.read_external_file(
+        stwo_root / CORE_QUERIES_RELATIVE_PATH,
+        "stwo core queries source",
+        MAX_STWO_SOURCE_BYTES,
+    )
+    digest = sha256_bytes(raw)
+    if digest != EXPECTED_CORE_QUERIES_SHA256:
+        raise StwoQueryPreviewSplitPrototypeGateError("stwo core queries digest drift")
+    return {
+        "id": "stwo_2_2_core_queries",
+        "crate": "stwo",
+        "version": STWO_VERSION,
+        "path": f"stwo-{STWO_VERSION}/{CORE_QUERIES_RELATIVE_PATH}",
+        "sha256": digest,
+        "size_bytes": len(raw),
+    }
+
+
+def source_artifacts(stwo_root: pathlib.Path) -> list[dict[str, Any]]:
+    artifacts = hook_gate.source_artifacts(stwo_root)
+    artifacts.append(stwo_core_queries_artifact(stwo_root))
+    return artifacts
+
+
+def core_query_markers(stwo_root: pathlib.Path) -> dict[str, bool]:
+    raw = hook_gate.read_external_file(
+        stwo_root / CORE_QUERIES_RELATIVE_PATH,
+        "stwo core queries source",
+        MAX_STWO_SOURCE_BYTES,
+    )
+    text = read_text_bytes(raw, "stwo core queries source")
+    markers = {name: marker in text for name, marker in QUERY_SOURCE_MARKERS.items()}
+    missing = [name for name, present in markers.items() if not present]
+    if missing:
+        raise StwoQueryPreviewSplitPrototypeGateError(
+            f"core query source marker drift: {missing}"
+        )
+    return markers
+
+
+def source_audit(stwo_root: pathlib.Path) -> dict[str, Any]:
+    audit = hook_gate.audit_source_markers(stwo_root)
+    audit["core_query_markers"] = core_query_markers(stwo_root)
+    audit["preview_split_source_read"] = (
+        "FriProver::decommit already factors canonical query drawing from "
+        "decommit_on_queries; a prover-side API can expose the drawn Queries before "
+        "calling decommit_on_queries, while the verifier keeps sampling the same "
+        "positions from the Fiat-Shamir transcript."
+    )
+    return audit
+
+
+def stage_order() -> list[dict[str, Any]]:
+    return [
+        {
+            "stage_id": "trace_commitments",
+            "relative_to_query_preview": "before",
+            "transcript_bound": True,
+            "can_change_after_preview": False,
+            "source_fact": "commitment_scheme trees are already committed before FRI queries are drawn",
+        },
+        {
+            "stage_id": "fri_commitment_and_pow_mix",
+            "relative_to_query_preview": "before",
+            "transcript_bound": True,
+            "can_change_after_preview": False,
+            "source_fact": "FRI commit and proof_of_work are mixed before FriProver::decommit draws queries",
+        },
+        {
+            "stage_id": "canonical_query_draw",
+            "relative_to_query_preview": "preview_point",
+            "transcript_bound": True,
+            "can_change_after_preview": False,
+            "source_fact": "draw_queries(channel, first_layer_log_size, n_queries) is transcript-derived",
+        },
+        {
+            "stage_id": "fri_decommit_on_queries",
+            "relative_to_query_preview": "after",
+            "transcript_bound": True,
+            "can_change_after_preview": False,
+            "source_fact": "decommit_on_queries consumes the same canonical Queries",
+        },
+        {
+            "stage_id": "trace_tree_decommit",
+            "relative_to_query_preview": "after",
+            "transcript_bound": True,
+            "can_change_after_preview": False,
+            "source_fact": "tree.decommit(query_positions) uses verifier-replayed query positions",
+        },
+    ]
+
+
+def prototype_routes() -> list[dict[str, Any]]:
+    return [
+        {
+            "route_id": "preview_only_split",
+            "status": "FEASIBLE_API_PATCH",
+            "requires_prover_patch": True,
+            "requires_verifier_patch": False,
+            "external_query_choice": False,
+            "preview_before_fri_decommit": True,
+            "preview_before_trace_decommit": True,
+            "can_change_committed_trace_after_preview": False,
+            "can_claim_probe_b_control": False,
+            "requires_security_budget": False,
+            "interpretation": (
+                "Expose transcript-drawn queries after PoW mix and before FRI/tree "
+                "decommitments. This can support measurement or bounded early abort, but "
+                "does not justify choosing labels after seeing the queries."
+            ),
+        },
+        {
+            "route_id": "policy_commitment_mix",
+            "status": "FOLLOWUP_MATCHED_TRANSCRIPT_PATCH",
+            "requires_prover_patch": True,
+            "requires_verifier_patch": True,
+            "external_query_choice": False,
+            "preview_before_fri_decommit": True,
+            "preview_before_trace_decommit": True,
+            "can_change_committed_trace_after_preview": False,
+            "can_claim_probe_b_control": False,
+            "requires_security_budget": False,
+            "interpretation": (
+                "Bind a deterministic policy commitment into prover and verifier transcript "
+                "before canonical query draw. It can make policy semantics explicit, but still "
+                "cannot read final proof bytes or post-decommitment accounting."
+            ),
+        },
+        {
+            "route_id": "external_query_override",
+            "status": "REJECTED_UNSOUND",
+            "requires_prover_patch": True,
+            "requires_verifier_patch": True,
+            "external_query_choice": True,
+            "preview_before_fri_decommit": True,
+            "preview_before_trace_decommit": True,
+            "can_change_committed_trace_after_preview": False,
+            "can_claim_probe_b_control": False,
+            "requires_security_budget": True,
+            "interpretation": (
+                "Letting the prover choose FRI query locations directly breaks the "
+                "Fiat-Shamir verifier story unless the verifier derives the same positions "
+                "from a bound policy."
+            ),
+        },
+        {
+            "route_id": "transcript_grinding_search",
+            "status": "FOLLOWUP_SECURITY_BUDGET_REQUIRED",
+            "requires_prover_patch": False,
+            "requires_verifier_patch": True,
+            "external_query_choice": False,
+            "preview_before_fri_decommit": True,
+            "preview_before_trace_decommit": True,
+            "can_change_committed_trace_after_preview": False,
+            "can_claim_probe_b_control": False,
+            "requires_security_budget": True,
+            "interpretation": (
+                "Abort-and-retry after seeing canonical queries is transcript grinding. "
+                "It may be a research lever only with explicit soundness-loss accounting, "
+                "bounded attempts, and verifier-visible constraints."
+            ),
+        },
+    ]
+
+
+def build_payload_without_mutations() -> dict[str, Any]:
+    stwo_root = hook_gate.find_stwo_source_root()
+    metric_anchor = hook_gate.predecommit_metric_anchor()
+    return {
+        "schema": SCHEMA,
+        "decision": DECISION,
+        "result": RESULT,
+        "issue": ISSUE_HINT,
+        "current_metric_anchor": metric_anchor,
+        "source_audit": source_audit(stwo_root),
+        "stage_order": stage_order(),
+        "prototype_routes": prototype_routes(),
+        "preview_split_assessment": {
+            "api_preview_split_feasible": True,
+            "sound_label_policy_feasible_now": False,
+            "regenerate_proof_size_frontier_now": False,
+            "proof_size_delta_typed_bytes": 0,
+            "cannot_change_committed_trace_or_layout_after_preview": True,
+            "followup_needed": (
+                "security-budgeted transcript grinding or a verifier-bound deterministic "
+                "policy commitment"
+            ),
+        },
+        "forbidden_policy_inputs": {
+            "final_envelope_json": True,
+            "final_proof_bytes": True,
+            "grouped_accounting": True,
+            "record_streams": True,
+            "final_path_opening_bytes": True,
+            "post_decommitment_aux_as_selector": True,
+            "unbounded_abort_and_retry": True,
+        },
+        "interpretation": {
+            "human_read": (
+                "The Stwo split is useful, but not in the naive way. We can expose canonical "
+                "queries before expensive decommitment, which is a real API seam. We cannot "
+                "then change labels or layouts after seeing those queries without turning the "
+                "experiment into transcript grinding."
+            ),
+            "why_it_matters": (
+                "This keeps the breakthrough path honest. The current 37,532 typed-byte "
+                "champion and 20.4628% saving over the two-proof frontier remain an opening "
+                "geometry signal, but the next paper-grade claim needs either a deterministic "
+                "precommitted policy or explicit security-budgeted grinding."
+            ),
+            "next_experiment": (
+                "Prototype the preview-only Stwo API first for early measurement, then test a "
+                "bounded transcript-grinding or policy-commitment route before regenerating "
+                "proof-size frontiers."
+            ),
+        },
+        "source_artifacts": source_artifacts(stwo_root),
+        "validation_commands": list(VALIDATION_COMMANDS),
+        "non_claims": list(NON_CLAIMS),
+        "reproducibility_metadata": {
+            "stwo_version": STWO_VERSION,
+            "cargo_dependency": "stwo = 2.2.0",
+            "mutation_step_count": len(MUTATION_NAMES),
+            "unittest_step_count": EXPECTED_UNITTEST_STEP_COUNT,
+            "local_release_gate_step_count": 14,
+        },
+    }
+
+
+def route(payload: dict[str, Any], route_id: str) -> dict[str, Any]:
+    for item in payload.get("prototype_routes", []):
+        if item.get("route_id") == route_id:
+            return item
+    raise StwoQueryPreviewSplitPrototypeGateError(f"route missing: {route_id}")
+
+
+def find_source_artifact(item: dict[str, Any], artifact_id: str) -> dict[str, Any]:
+    for artifact in item.get("source_artifacts", []):
+        if artifact.get("id") == artifact_id:
+            return artifact
+    raise StwoQueryPreviewSplitPrototypeGateError(f"source artifact missing: {artifact_id}")
+
+
+def validate_base_payload(payload: dict[str, Any]) -> None:
+    expected = build_payload_without_mutations()
+    if payload != expected:
+        raise StwoQueryPreviewSplitPrototypeGateError("base payload drift")
+    if payload["decision"] != DECISION or payload["result"] != RESULT:
+        raise StwoQueryPreviewSplitPrototypeGateError("claim boundary drift")
+    metric = payload["current_metric_anchor"]
+    if metric != hook_gate.predecommit_metric_anchor():
+        raise StwoQueryPreviewSplitPrototypeGateError("metric anchor drift")
+    assessment = payload["preview_split_assessment"]
+    if not assessment["api_preview_split_feasible"]:
+        raise StwoQueryPreviewSplitPrototypeGateError("preview split feasibility drift")
+    if assessment["sound_label_policy_feasible_now"]:
+        raise StwoQueryPreviewSplitPrototypeGateError("sound label policy overclaim")
+    if assessment["regenerate_proof_size_frontier_now"]:
+        raise StwoQueryPreviewSplitPrototypeGateError("proof-size frontier overclaim")
+    if assessment["proof_size_delta_typed_bytes"] != 0:
+        raise StwoQueryPreviewSplitPrototypeGateError("proof-size delta drift")
+    preview = route(payload, "preview_only_split")
+    if not preview["preview_before_fri_decommit"] or not preview["preview_before_trace_decommit"]:
+        raise StwoQueryPreviewSplitPrototypeGateError("preview timing drift")
+    if preview["can_change_committed_trace_after_preview"]:
+        raise StwoQueryPreviewSplitPrototypeGateError("committed trace mutability overclaim")
+    if preview["can_claim_probe_b_control"]:
+        raise StwoQueryPreviewSplitPrototypeGateError("probe-b control overclaim")
+    external = route(payload, "external_query_override")
+    if external["status"] != "REJECTED_UNSOUND":
+        raise StwoQueryPreviewSplitPrototypeGateError("external query override not rejected")
+    grinding = route(payload, "transcript_grinding_search")
+    if not grinding["requires_security_budget"]:
+        raise StwoQueryPreviewSplitPrototypeGateError("missing grinding security budget")
+    policy = route(payload, "policy_commitment_mix")
+    if not policy["requires_verifier_patch"]:
+        raise StwoQueryPreviewSplitPrototypeGateError("policy verifier patch requirement drift")
+    if payload["validation_commands"] != list(VALIDATION_COMMANDS):
+        raise StwoQueryPreviewSplitPrototypeGateError("validation command drift")
+    if payload["non_claims"] != list(NON_CLAIMS):
+        raise StwoQueryPreviewSplitPrototypeGateError("non-claim drift")
+    if payload["reproducibility_metadata"]["mutation_step_count"] != len(MUTATION_NAMES):
+        raise StwoQueryPreviewSplitPrototypeGateError("mutation count drift")
+
+
+def validate_payload(payload: dict[str, Any]) -> None:
+    item = copy.deepcopy(payload)
+    supplied_commitment = item.pop("payload_commitment", None)
+    mutation_result = item.pop("mutation_result", None)
+    validate_base_payload(item)
+    if supplied_commitment != payload_commitment(payload):
+        raise StwoQueryPreviewSplitPrototypeGateError("payload commitment drift")
+    expected_mutation = run_mutations(item)
+    if mutation_result != expected_mutation:
+        raise StwoQueryPreviewSplitPrototypeGateError("mutation result drift")
+    validate_mutation_result(mutation_result)
+
+
+def validate_mutation_result(mutation_result: Any) -> None:
+    if not isinstance(mutation_result, dict):
+        raise StwoQueryPreviewSplitPrototypeGateError("mutation result missing")
+    if mutation_result.get("mutation_names") != list(MUTATION_NAMES):
+        raise StwoQueryPreviewSplitPrototypeGateError("mutation names drift")
+    cases = mutation_result.get("cases")
+    if not isinstance(cases, list) or len(cases) != len(MUTATION_NAMES):
+        raise StwoQueryPreviewSplitPrototypeGateError("mutation case count drift")
+    for case in cases:
+        if not isinstance(case, dict):
+            raise StwoQueryPreviewSplitPrototypeGateError("mutation case schema drift")
+        if (
+            not isinstance(case.get("name"), str)
+            or not isinstance(case.get("rejected"), bool)
+            or not isinstance(case.get("error"), str)
+        ):
+            raise StwoQueryPreviewSplitPrototypeGateError("mutation case schema drift")
+    rejected_names = [case["name"] for case in cases if case["rejected"]]
+    if rejected_names != list(MUTATION_NAMES):
+        raise StwoQueryPreviewSplitPrototypeGateError("mutation rejection drift")
+    if mutation_result.get("mutations_rejected") != len(MUTATION_NAMES):
+        raise StwoQueryPreviewSplitPrototypeGateError("mutation rejected count drift")
+    if mutation_result.get("all_mutations_rejected") is not True:
+        raise StwoQueryPreviewSplitPrototypeGateError("mutation all-rejected drift")
+
+
+def mutate_payload(name: str, item: dict[str, Any]) -> None:
+    if name == "decision_overclaim":
+        item["decision"] = "GO_QUERY_GEOMETRY_CONTROL"
+    elif name == "result_overclaim":
+        item["result"] = "BEATS_NANOZK_WITH_QUERY_PREVIEW"
+    elif name == "preview_claims_label_control":
+        route(item, "preview_only_split")["can_claim_probe_b_control"] = True
+    elif name == "external_query_override_allowed":
+        route(item, "external_query_override")["status"] = "FEASIBLE_API_PATCH"
+    elif name == "stage_order_flip":
+        item["stage_order"][0]["relative_to_query_preview"] = "after"
+    elif name == "committed_trace_mutable_after_preview":
+        route(item, "preview_only_split")["can_change_committed_trace_after_preview"] = True
+    elif name == "proof_size_frontier_claimed":
+        item["preview_split_assessment"]["regenerate_proof_size_frontier_now"] = True
+    elif name == "metric_anchor_drift":
+        item["current_metric_anchor"]["typed_bytes"] = 36_000
+    elif name == "core_query_source_digest_drift":
+        find_source_artifact(item, "stwo_2_2_core_queries")["sha256"] = "0" * 64
+    elif name == "core_query_marker_erasure":
+        item["source_audit"]["core_query_markers"]["draw_queries_reads_transcript_words"] = False
+    elif name == "verifier_marker_erasure":
+        item["source_audit"]["stwo_markers"]["verifier_samples_query_positions_from_channel"] = (
+            False
+        )
+    elif name == "policy_reads_final_bytes":
+        item["forbidden_policy_inputs"]["final_proof_bytes"] = False
+    elif name == "transcript_grinding_without_budget":
+        route(item, "transcript_grinding_search")["requires_security_budget"] = False
+    elif name == "policy_commitment_verifier_patch_removed":
+        route(item, "policy_commitment_mix")["requires_verifier_patch"] = False
+    elif name == "validation_command_removed":
+        item["validation_commands"].pop()
+    elif name == "non_claim_removed":
+        item["non_claims"].remove("not a NANOZK proof-size comparison")
+    elif name == "source_artifact_digest_drift":
+        find_source_artifact(item, "stwo_2_2_prover_fri")["sha256"] = "1" * 64
+    elif name == "payload_commitment_drift":
+        item["payload_commitment"] = "blake2b-256:" + ("0" * 64)
+    else:
+        raise StwoQueryPreviewSplitPrototypeGateError(f"unknown mutation: {name}")
+
+
+def run_mutations(base_payload: dict[str, Any]) -> dict[str, Any]:
+    cases = []
+    for name in MUTATION_NAMES:
+        item = copy.deepcopy(base_payload)
+        mutate_payload(name, item)
+        rejected = False
+        error = ""
+        try:
+            if name == "payload_commitment_drift":
+                validate_payload(item)
+            else:
+                validate_base_payload(item)
+        except (StwoQueryPreviewSplitPrototypeGateError, hook_gate.BoundedStwoQueryPolicyHookGateError) as err:
+            rejected = True
+            error = str(err)
+        cases.append({"name": name, "rejected": rejected, "error": error})
+    rejected_count = sum(1 for case in cases if case["rejected"])
+    return {
+        "all_mutations_rejected": rejected_count == len(MUTATION_NAMES),
+        "mutations_rejected": rejected_count,
+        "mutation_names": list(MUTATION_NAMES),
+        "cases": cases,
+    }
+
+
+def build_payload() -> dict[str, Any]:
+    payload = build_payload_without_mutations()
+    payload["mutation_result"] = run_mutations(payload)
+    payload["payload_commitment"] = payload_commitment(payload)
+    validate_payload(payload)
+    return payload
+
+
+def render_tsv(payload: dict[str, Any]) -> str:
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+    writer.writeheader()
+    for item in payload["prototype_routes"]:
+        writer.writerow(
+            {
+                "route_id": item["route_id"],
+                "status": item["status"],
+                "requires_prover_patch": str(item["requires_prover_patch"]).lower(),
+                "requires_verifier_patch": str(item["requires_verifier_patch"]).lower(),
+                "external_query_choice": str(item["external_query_choice"]).lower(),
+                "preview_before_fri_decommit": str(item["preview_before_fri_decommit"]).lower(),
+                "preview_before_trace_decommit": str(
+                    item["preview_before_trace_decommit"]
+                ).lower(),
+                "can_change_committed_trace_after_preview": str(
+                    item["can_change_committed_trace_after_preview"]
+                ).lower(),
+                "can_claim_probe_b_control": str(item["can_claim_probe_b_control"]).lower(),
+                "requires_security_budget": str(item["requires_security_budget"]).lower(),
+            }
+        )
+    return output.getvalue()
+
+
+def write_outputs(json_path: pathlib.Path, tsv_path: pathlib.Path, payload: dict[str, Any]) -> None:
+    validate_payload(payload)
+    json_data = json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True).encode() + b"\n"
+    tsv_data = render_tsv(payload).encode()
+    try:
+        sampler_gate.atomic_write_pair(json_path, json_data, tsv_path, tsv_data)
+    except sampler_gate.DryRunOpeningSamplerGateError as err:
+        raise StwoQueryPreviewSplitPrototypeGateError(str(err)) from err
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write-json", type=pathlib.Path)
+    parser.add_argument("--write-tsv", type=pathlib.Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    payload = build_payload()
+    if args.write_json or args.write_tsv:
+        if not args.write_json or not args.write_tsv:
+            raise StwoQueryPreviewSplitPrototypeGateError(
+                "--write-json and --write-tsv must be paired"
+            )
+        write_outputs(args.write_json, args.write_tsv, payload)
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (
+        StwoQueryPreviewSplitPrototypeGateError,
+        hook_gate.BoundedStwoQueryPolicyHookGateError,
+    ) as err:
+        print(f"error: {err}", file=sys.stderr)
+        raise SystemExit(2) from None


### PR DESCRIPTION
## Summary
- add a source-pinned Stwo query-preview split prototype gate for issue #704
- classify `preview_only_split` as API-feasible while rejecting sound label control without grinding/security budget or a verifier-bound policy commitment
- record JSON/TSV evidence, handoff updates, and 18 mutation guards

## Key result
`NARROW_CLAIM_QUERY_PREVIEW_SPLIT_IS_API_FEASIBLE_NOT_SOUND_LABEL_POLICY`

The current numeric anchor stays unchanged: `adjacent_label_probe_b` remains `37,532` typed bytes with `16,560` path-opening bytes, saving `9,656` typed bytes (`20.4628%`) versus the `47,188` typed-byte matched two-proof frontier. This PR does not claim a new proof-size frontier.

Source read: Stwo `2.2.0` already separates transcript-derived query drawing from `decommit_on_queries`, so a prover-side preview seam is feasible after PoW mix and before FRI/tree decommitment. But the committed trace/layout/labels and FRI commitment are fixed before preview, so choosing labels after seeing queries is transcript grinding unless bounded and accounted for.

## Evidence
- `docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`
- `docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json`
- `docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv`

Evidence hashes:
- JSON SHA-256: `0a3348d51fa36219e8253e1c1a7fdea4d4f5a694f5edc24cc36d5bf7f8cbd442`
- TSV SHA-256: `7adcfb39ae6c7f461ee2d2d6549457ff99432067f36600249072ab9c6f3e3864`
- payload commitment: `blake2b-256:e956134a2e69b6d633effe9cf9a9c5f789b47f7d41ce972465ec619b1946800f`
- mutation guards: `18 / 18` rejected

## Validation
- [x] `python3.10 scripts/zkai_stwo_query_preview_split_prototype_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv`
- [x] `python3.10 -m py_compile scripts/zkai_stwo_query_preview_split_prototype_gate.py scripts/tests/test_zkai_stwo_query_preview_split_prototype_gate.py`
- [x] `python3.10 -m unittest scripts.tests.test_zkai_stwo_query_preview_split_prototype_gate`
- [x] `git diff --check`
- [x] `just gate-fast`
- [x] `just gate`

## Hardening
- [x] source artifacts pinned by id/path/digest, including Stwo `2.2.0` `src/core/queries.rs`
- [x] canonical query draw and verifier replay markers pinned
- [x] mutation guards reject overclaim drift, external-query override, final-proof-byte selection, unbounded grinding, and payload commitment drift
- [x] explicit non-claims kept in docs/evidence: no proof-size frontier, no sound post-query label chooser, no NANOZK comparison

## Non-claims
- not a new proof-size frontier
- not a regenerated seq32+d128 proof under a new Stwo API
- not a production label-selection policy
- not a sound post-query label chooser
- not an external query override
- not a NANOZK proof-size comparison
- not a full transformer block proof
- not timing evidence
- not production-ready zkML

## Follow-up
- #706 tracks bounded transcript grinding / deterministic policy commitment with explicit soundness accounting.

Closes #704