### PR TITLE
Gate Stwo query grinding budget

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -2853,14 +2853,14 @@ Stwo query-grinding budget reproducibility metadata:
   `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json`
   and `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`.
 - Gate JSON SHA-256:
-  `85c9dd80c68063006d9822c5022aff276f8c025269255cdfce47800451d0e3ec`.
+  `a5ef30dc1cdd2aa0bc72163a40f2c66358265a1ef0f29d0e41ff4cf972951303`.
 - Gate TSV SHA-256:
   `6961f51c3863814883bcb6cd554b919572d532bdfe34bebffe1099f6ec2bb587`.
 - Inventory commitment:
-  `blake2b-256:f39a42cb0945b73cc326e2993e409af1e5b69c9bfc1f79faa2ad0e4db874e1b5`.
+  `blake2b-256:6b58d3f30c5a0b0e5d1aa78890f72c5830d973f3b3795bc1917fc0253266c37e`.
 - Payload commitment:
-  `blake2b-256:9dd16fba4ad07e7a61748742041ebe41df64e8e3785de94aa98ca1550ac926c8`.
-- Step counts: `21` mutation cases, `18` Python unit tests, and `14` local
+  `blake2b-256:139ebaf55f70c771cf1d1f9f6fb8a132bc2215118e46a6ca4dbd2d6da4e0aea6`.
+- Step counts: `22` mutation cases, `18` Python unit tests, and `14` local
   release-gate steps.
 - Local validation commands:
   `python3.10 scripts/zkai_stwo_query_grinding_budget_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`;

--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -2828,6 +2828,48 @@ Stwo query-preview split prototype reproducibility metadata:
   `just gate-fast`;
   `just gate`.
 
+Latest Stwo query-grinding budget gate: issue `#706` is now checked as a
+narrow mechanism GO, not a proof-size frontier. A fixed two-probe attempt
+domain (`adjacent_label_probe_a`, `adjacent_label_probe_b`) recovers the
+current probe-B champion from the checked nine-row inventory with `1.000000`
+bit of relative Fiat-Shamir grinding loss. It saves `4,624` typed bytes versus
+the fixed adjacent layout (`42,156` to `37,532` typed bytes), but it does not
+beat the current champion and it is not promotable until regenerated proofs
+bind the attempt domain and selected attempt id in verifier-facing metadata.
+Seed-only budget `6` is a no-go (`40,268` typed bytes, `2.584963` loss bits),
+and all-inventory budget `9` is unnecessary extra grinding (`3.169925` loss
+bits for the same champion). See
+`docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md`.
+
+Stwo query-grinding budget reproducibility metadata:
+
+- Gate schema: `zkai-stwo-query-grinding-budget-gate-v1`.
+- Decision:
+  `NARROW_CLAIM_SMALL_VERIFIER_BOUND_RETRY_BUDGET_CAN_RECOVER_PROBE_B_INVENTORY`.
+- Result: `GO_MECHANISM_LEAD_NOT_PROOF_SIZE_FRONTIER`.
+- Timing mode: inventory/budget accounting only; no regenerated proof object,
+  no new proof-size frontier, and no absolute soundness claim.
+- Evidence paths:
+  `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json`
+  and `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`.
+- Gate JSON SHA-256:
+  `85c9dd80c68063006d9822c5022aff276f8c025269255cdfce47800451d0e3ec`.
+- Gate TSV SHA-256:
+  `6961f51c3863814883bcb6cd554b919572d532bdfe34bebffe1099f6ec2bb587`.
+- Inventory commitment:
+  `blake2b-256:f39a42cb0945b73cc326e2993e409af1e5b69c9bfc1f79faa2ad0e4db874e1b5`.
+- Payload commitment:
+  `blake2b-256:9dd16fba4ad07e7a61748742041ebe41df64e8e3785de94aa98ca1550ac926c8`.
+- Step counts: `21` mutation cases, `18` Python unit tests, and `14` local
+  release-gate steps.
+- Local validation commands:
+  `python3.10 scripts/zkai_stwo_query_grinding_budget_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`;
+  `python3.10 -m py_compile scripts/zkai_stwo_query_grinding_budget_gate.py scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py`;
+  `python3.10 -m unittest scripts.tests.test_zkai_stwo_query_grinding_budget_gate`;
+  `git diff --check`;
+  `just gate-fast`;
+  `just gate`.
+
 ## Resume protocol
 
 1. Read `AGENTS.md`.

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -141,8 +141,9 @@ This is the fast local entrypoint for a fresh agent working in this repository.
 135. `docs/engineering/zkai-native-seq32-attention-mlp-predecommit-opening-policy-2026-05-19.md`
 136. `docs/engineering/zkai-bounded-stwo-query-policy-hook-2026-05-19.md`
 137. `docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`
-138. `docs/engineering/reproducibility.md`
-139. `git status --short --branch`
+138. `docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md`
+139. `docs/engineering/reproducibility.md`
+140. `git status --short --branch`
 
 ## What this repository is now
 
@@ -236,6 +237,18 @@ This repository currently has three live lanes.
      `docs/engineering/zkai-bounded-stwo-query-policy-hook-2026-05-19.md`,
      and
      `docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`.
+   - The bounded query-grinding budget gate turns that follow-up into a narrow
+     mechanism GO, not a new frontier. A two-probe verifier-bound attempt
+     domain (`adjacent_label_probe_a`, `adjacent_label_probe_b`) recovers the
+     current `adjacent_label_probe_b` champion at `37,532` typed bytes with
+     `1.000000` bit of relative Fiat-Shamir grinding loss. It saves `4,624`
+     typed bytes versus the fixed adjacent layout, but it does not beat the
+     champion and is not promotable until regenerated proofs bind the attempt
+     domain and selected attempt id in verifier-facing metadata. Seed-only
+     budget `6` is a no-go (`40,268` typed bytes, `2.584963` loss bits), and
+     all-inventory budget `9` is unnecessary extra grinding (`3.169925` loss
+     bits for the same champion). See
+     `docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md`.
    - The current source-backed adapter frontier is a correctness GO and a
      proof-shape learning result, not a compression breakthrough. The compact
      selector verifies at `40,812` local typed bytes, only `112` typed bytes

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -2804,14 +2804,14 @@ Stwo query-grinding budget reproducibility metadata:
   `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json`
   and `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`.
 - Gate JSON SHA-256:
-  `85c9dd80c68063006d9822c5022aff276f8c025269255cdfce47800451d0e3ec`.
+  `a5ef30dc1cdd2aa0bc72163a40f2c66358265a1ef0f29d0e41ff4cf972951303`.
 - Gate TSV SHA-256:
   `6961f51c3863814883bcb6cd554b919572d532bdfe34bebffe1099f6ec2bb587`.
 - Inventory commitment:
-  `blake2b-256:f39a42cb0945b73cc326e2993e409af1e5b69c9bfc1f79faa2ad0e4db874e1b5`.
+  `blake2b-256:6b58d3f30c5a0b0e5d1aa78890f72c5830d973f3b3795bc1917fc0253266c37e`.
 - Payload commitment:
-  `blake2b-256:9dd16fba4ad07e7a61748742041ebe41df64e8e3785de94aa98ca1550ac926c8`.
-- Step counts: `21` mutation cases, `18` Python unit tests, and `14` local
+  `blake2b-256:139ebaf55f70c771cf1d1f9f6fb8a132bc2215118e46a6ca4dbd2d6da4e0aea6`.
+- Step counts: `22` mutation cases, `18` Python unit tests, and `14` local
   release-gate steps.
 - Local validation commands:
   `python3.10 scripts/zkai_stwo_query_grinding_budget_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`;

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -95,8 +95,9 @@ If you are in a local checkout, prefer `AGENTS.md`, `.codex/START_HERE.md`, and
 84. `docs/engineering/zkai-native-seq32-attention-mlp-predecommit-opening-policy-2026-05-19.md`
 85. `docs/engineering/zkai-bounded-stwo-query-policy-hook-2026-05-19.md`
 86. `docs/engineering/zkai-stwo-query-preview-split-prototype-2026-05-19.md`
-87. `docs/engineering/reproducibility.md`
-88. `git status --short --branch`
+87. `docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md`
+88. `docs/engineering/reproducibility.md`
+89. `git status --short --branch`
 
 ## Current lane split
 
@@ -2774,6 +2775,48 @@ Stwo query-preview split prototype reproducibility metadata:
   `python3.10 scripts/zkai_stwo_query_preview_split_prototype_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-preview-split-prototype-2026-05.tsv`;
   `python3.10 -m py_compile scripts/zkai_stwo_query_preview_split_prototype_gate.py scripts/tests/test_zkai_stwo_query_preview_split_prototype_gate.py`;
   `python3.10 -m unittest scripts.tests.test_zkai_stwo_query_preview_split_prototype_gate`;
+  `git diff --check`;
+  `just gate-fast`;
+  `just gate`.
+
+Latest Stwo query-grinding budget gate: issue `#706` is now checked as a
+narrow mechanism GO, not a proof-size frontier. A fixed two-probe attempt
+domain (`adjacent_label_probe_a`, `adjacent_label_probe_b`) recovers the
+current probe-B champion from the checked nine-row inventory with `1.000000`
+bit of relative Fiat-Shamir grinding loss. It saves `4,624` typed bytes versus
+the fixed adjacent layout (`42,156` to `37,532` typed bytes), but it does not
+beat the current champion and it is not promotable until regenerated proofs
+bind the attempt domain and selected attempt id in verifier-facing metadata.
+Seed-only budget `6` is a no-go (`40,268` typed bytes, `2.584963` loss bits),
+and all-inventory budget `9` is unnecessary extra grinding (`3.169925` loss
+bits for the same champion). See
+`docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md`.
+
+Stwo query-grinding budget reproducibility metadata:
+
+- Gate schema: `zkai-stwo-query-grinding-budget-gate-v1`.
+- Decision:
+  `NARROW_CLAIM_SMALL_VERIFIER_BOUND_RETRY_BUDGET_CAN_RECOVER_PROBE_B_INVENTORY`.
+- Result: `GO_MECHANISM_LEAD_NOT_PROOF_SIZE_FRONTIER`.
+- Timing mode: inventory/budget accounting only; no regenerated proof object,
+  no new proof-size frontier, and no absolute soundness claim.
+- Evidence paths:
+  `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json`
+  and `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`.
+- Gate JSON SHA-256:
+  `85c9dd80c68063006d9822c5022aff276f8c025269255cdfce47800451d0e3ec`.
+- Gate TSV SHA-256:
+  `6961f51c3863814883bcb6cd554b919572d532bdfe34bebffe1099f6ec2bb587`.
+- Inventory commitment:
+  `blake2b-256:f39a42cb0945b73cc326e2993e409af1e5b69c9bfc1f79faa2ad0e4db874e1b5`.
+- Payload commitment:
+  `blake2b-256:9dd16fba4ad07e7a61748742041ebe41df64e8e3785de94aa98ca1550ac926c8`.
+- Step counts: `21` mutation cases, `18` Python unit tests, and `14` local
+  release-gate steps.
+- Local validation commands:
+  `python3.10 scripts/zkai_stwo_query_grinding_budget_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`;
+  `python3.10 -m py_compile scripts/zkai_stwo_query_grinding_budget_gate.py scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py`;
+  `python3.10 -m unittest scripts.tests.test_zkai_stwo_query_grinding_budget_gate`;
   `git diff --check`;
   `just gate-fast`;
   `just gate`.

--- a/docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json
+++ b/docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json
@@ -1,10 +1,14 @@
 {
   "baseline": {
     "adapter_mode": "rmsnorm_input_fused_adjacent_fixed_v1",
+    "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
     "final_path_opening_bytes": 21184,
     "final_typed_bytes": 42156,
     "min_pairwise_query_gap": 30179,
+    "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+    "predicted_path_opening_bytes": 21184,
     "query_location_span": 291186,
+    "selected_without_final_accounting": false,
     "variant_id": "fixed_adjacent_layout"
   },
   "budget_rule": {
@@ -17,10 +21,14 @@
   },
   "champion": {
     "adapter_mode": "rmsnorm_input_fused_adjacent_label_probe_b_v1",
+    "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
     "final_path_opening_bytes": 16560,
     "final_typed_bytes": 37532,
     "min_pairwise_query_gap": 5969,
+    "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+    "predicted_path_opening_bytes": 16560,
     "query_location_span": 16618,
+    "selected_without_final_accounting": true,
     "variant_id": "adjacent_label_probe_b"
   },
   "decision": "NARROW_CLAIM_SMALL_VERIFIER_BOUND_RETRY_BUDGET_CAN_RECOVER_PROBE_B_INVENTORY",
@@ -37,79 +45,115 @@
     "why_it_matters": "This turns query geometry from post-hoc label selection into a bounded proof-system policy question. The next implementation should bind the attempt domain in the verifier-facing statement before claiming size wins."
   },
   "inventory": {
-    "commitment": "blake2b-256:f39a42cb0945b73cc326e2993e409af1e5b69c9bfc1f79faa2ad0e4db874e1b5",
+    "commitment": "blake2b-256:6b58d3f30c5a0b0e5d1aa78890f72c5830d973f3b3795bc1917fc0253266c37e",
     "row_count": 9,
     "rows": [
       {
         "adapter_mode": "rmsnorm_input_fused_adjacent_label_probe_a_v1",
+        "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
         "final_path_opening_bytes": 19360,
         "final_typed_bytes": 40332,
         "min_pairwise_query_gap": 14670,
+        "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+        "predicted_path_opening_bytes": 19360,
         "query_location_span": 110651,
+        "selected_without_final_accounting": false,
         "variant_id": "adjacent_label_probe_a"
       },
       {
         "adapter_mode": "rmsnorm_input_fused_adjacent_label_probe_b_v1",
+        "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
         "final_path_opening_bytes": 16560,
         "final_typed_bytes": 37532,
         "min_pairwise_query_gap": 5969,
+        "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+        "predicted_path_opening_bytes": 16560,
         "query_location_span": 16618,
+        "selected_without_final_accounting": true,
         "variant_id": "adjacent_label_probe_b"
       },
       {
         "adapter_mode": "rmsnorm_input_fused_adjacent_fixed_v1",
+        "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
         "final_path_opening_bytes": 21184,
         "final_typed_bytes": 42156,
         "min_pairwise_query_gap": 30179,
+        "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+        "predicted_path_opening_bytes": 21184,
         "query_location_span": 291186,
+        "selected_without_final_accounting": false,
         "variant_id": "fixed_adjacent_layout"
       },
       {
         "adapter_mode": "rmsnorm_input_fused_adjacent_seed_00_v1",
+        "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
         "final_path_opening_bytes": 20512,
         "final_typed_bytes": 41484,
         "min_pairwise_query_gap": 34301,
+        "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+        "predicted_path_opening_bytes": 20512,
         "query_location_span": 180956,
+        "selected_without_final_accounting": false,
         "variant_id": "adjacent_seed_00"
       },
       {
         "adapter_mode": "rmsnorm_input_fused_adjacent_seed_01_v1",
+        "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
         "final_path_opening_bytes": 20512,
         "final_typed_bytes": 41484,
         "min_pairwise_query_gap": 49574,
+        "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+        "predicted_path_opening_bytes": 20512,
         "query_location_span": 145631,
+        "selected_without_final_accounting": false,
         "variant_id": "adjacent_seed_01"
       },
       {
         "adapter_mode": "rmsnorm_input_fused_adjacent_seed_02_v1",
+        "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
         "final_path_opening_bytes": 19296,
         "final_typed_bytes": 40268,
         "min_pairwise_query_gap": 32220,
+        "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+        "predicted_path_opening_bytes": 19296,
         "query_location_span": 86468,
+        "selected_without_final_accounting": false,
         "variant_id": "adjacent_seed_02"
       },
       {
         "adapter_mode": "rmsnorm_input_fused_adjacent_seed_03_v1",
+        "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
         "final_path_opening_bytes": 21184,
         "final_typed_bytes": 42156,
         "min_pairwise_query_gap": 80748,
+        "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+        "predicted_path_opening_bytes": 21184,
         "query_location_span": 391501,
+        "selected_without_final_accounting": false,
         "variant_id": "adjacent_seed_03"
       },
       {
         "adapter_mode": "rmsnorm_input_fused_adjacent_seed_04_v1",
+        "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
         "final_path_opening_bytes": 21184,
         "final_typed_bytes": 42156,
         "min_pairwise_query_gap": 57938,
+        "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+        "predicted_path_opening_bytes": 21184,
         "query_location_span": 422330,
+        "selected_without_final_accounting": false,
         "variant_id": "adjacent_seed_04"
       },
       {
         "adapter_mode": "rmsnorm_input_fused_adjacent_seed_05_v1",
+        "api_control_status": "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER",
         "final_path_opening_bytes": 19360,
         "final_typed_bytes": 40332,
         "min_pairwise_query_gap": 15995,
+        "policy_stage": "post_transcript_pre_accounting_not_true_predecommit",
+        "predicted_path_opening_bytes": 19360,
         "query_location_span": 125812,
+        "selected_without_final_accounting": false,
         "variant_id": "adjacent_seed_05"
       }
     ],
@@ -137,6 +181,11 @@
       {
         "error": "base payload drift",
         "name": "inventory_commitment_drift",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "inventory_trust_field_drift",
         "rejected": true
       },
       {
@@ -230,6 +279,7 @@
       "result_overclaim",
       "inventory_count_drift",
       "inventory_commitment_drift",
+      "inventory_trust_field_drift",
       "baseline_metric_drift",
       "champion_metric_drift",
       "two_probe_claims_new_frontier",
@@ -248,7 +298,7 @@
       "non_claim_removed",
       "payload_commitment_drift"
     ],
-    "mutations_rejected": 21
+    "mutations_rejected": 22
   },
   "non_claims": [
     "not a new proof-size frontier",
@@ -261,7 +311,7 @@
     "not timing evidence"
   ],
   "parent_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/704",
-  "payload_commitment": "blake2b-256:9dd16fba4ad07e7a61748742041ebe41df64e8e3785de94aa98ca1550ac926c8",
+  "payload_commitment": "blake2b-256:139ebaf55f70c771cf1d1f9f6fb8a132bc2215118e46a6ca4dbd2d6da4e0aea6",
   "policy_rows": [
     {
       "allowed_variant_ids": [
@@ -358,7 +408,7 @@
   ],
   "reproducibility_metadata": {
     "local_release_gate_step_count": 14,
-    "mutation_step_count": 21,
+    "mutation_step_count": 22,
     "unittest_step_count": 18
   },
   "result": "GO_MECHANISM_LEAD_NOT_PROOF_SIZE_FRONTIER",

--- a/docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json
+++ b/docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json
@@ -1,0 +1,374 @@
+{
+  "baseline": {
+    "adapter_mode": "rmsnorm_input_fused_adjacent_fixed_v1",
+    "final_path_opening_bytes": 21184,
+    "final_typed_bytes": 42156,
+    "min_pairwise_query_gap": 30179,
+    "query_location_span": 291186,
+    "variant_id": "fixed_adjacent_layout"
+  },
+  "budget_rule": {
+    "absolute_soundness_claim": false,
+    "paper_prototype_max_loss_bits": "2.000000",
+    "relative_security_loss": "attempt_budget multiplies Fiat-Shamir search space",
+    "security_loss_bits_formula": "log2(attempt_budget)",
+    "verifier_must_bind_attempt_domain": true,
+    "verifier_must_reject_attempts_outside_domain": true
+  },
+  "champion": {
+    "adapter_mode": "rmsnorm_input_fused_adjacent_label_probe_b_v1",
+    "final_path_opening_bytes": 16560,
+    "final_typed_bytes": 37532,
+    "min_pairwise_query_gap": 5969,
+    "query_location_span": 16618,
+    "variant_id": "adjacent_label_probe_b"
+  },
+  "decision": "NARROW_CLAIM_SMALL_VERIFIER_BOUND_RETRY_BUDGET_CAN_RECOVER_PROBE_B_INVENTORY",
+  "forbidden_policy_inputs": {
+    "final_envelope_json": true,
+    "final_proof_bytes": true,
+    "post_decommitment_accounting": true,
+    "unbounded_retry_count": true,
+    "uncommitted_attempt_domain": true
+  },
+  "interpretation": {
+    "human_read": "The small controlled signal is real: a two-attempt probe policy recovers the existing probe-B row from the checked inventory with one bit of relative Fiat-Shamir grinding loss. It does not improve the current champion and does not become a frontier until regenerated proofs enforce the attempt domain.",
+    "next_experiment": "Prototype a verifier-bound attempt-domain metadata path and regenerate the seq32+d128 proof for the two-probe policy.",
+    "why_it_matters": "This turns query geometry from post-hoc label selection into a bounded proof-system policy question. The next implementation should bind the attempt domain in the verifier-facing statement before claiming size wins."
+  },
+  "inventory": {
+    "commitment": "blake2b-256:f39a42cb0945b73cc326e2993e409af1e5b69c9bfc1f79faa2ad0e4db874e1b5",
+    "row_count": 9,
+    "rows": [
+      {
+        "adapter_mode": "rmsnorm_input_fused_adjacent_label_probe_a_v1",
+        "final_path_opening_bytes": 19360,
+        "final_typed_bytes": 40332,
+        "min_pairwise_query_gap": 14670,
+        "query_location_span": 110651,
+        "variant_id": "adjacent_label_probe_a"
+      },
+      {
+        "adapter_mode": "rmsnorm_input_fused_adjacent_label_probe_b_v1",
+        "final_path_opening_bytes": 16560,
+        "final_typed_bytes": 37532,
+        "min_pairwise_query_gap": 5969,
+        "query_location_span": 16618,
+        "variant_id": "adjacent_label_probe_b"
+      },
+      {
+        "adapter_mode": "rmsnorm_input_fused_adjacent_fixed_v1",
+        "final_path_opening_bytes": 21184,
+        "final_typed_bytes": 42156,
+        "min_pairwise_query_gap": 30179,
+        "query_location_span": 291186,
+        "variant_id": "fixed_adjacent_layout"
+      },
+      {
+        "adapter_mode": "rmsnorm_input_fused_adjacent_seed_00_v1",
+        "final_path_opening_bytes": 20512,
+        "final_typed_bytes": 41484,
+        "min_pairwise_query_gap": 34301,
+        "query_location_span": 180956,
+        "variant_id": "adjacent_seed_00"
+      },
+      {
+        "adapter_mode": "rmsnorm_input_fused_adjacent_seed_01_v1",
+        "final_path_opening_bytes": 20512,
+        "final_typed_bytes": 41484,
+        "min_pairwise_query_gap": 49574,
+        "query_location_span": 145631,
+        "variant_id": "adjacent_seed_01"
+      },
+      {
+        "adapter_mode": "rmsnorm_input_fused_adjacent_seed_02_v1",
+        "final_path_opening_bytes": 19296,
+        "final_typed_bytes": 40268,
+        "min_pairwise_query_gap": 32220,
+        "query_location_span": 86468,
+        "variant_id": "adjacent_seed_02"
+      },
+      {
+        "adapter_mode": "rmsnorm_input_fused_adjacent_seed_03_v1",
+        "final_path_opening_bytes": 21184,
+        "final_typed_bytes": 42156,
+        "min_pairwise_query_gap": 80748,
+        "query_location_span": 391501,
+        "variant_id": "adjacent_seed_03"
+      },
+      {
+        "adapter_mode": "rmsnorm_input_fused_adjacent_seed_04_v1",
+        "final_path_opening_bytes": 21184,
+        "final_typed_bytes": 42156,
+        "min_pairwise_query_gap": 57938,
+        "query_location_span": 422330,
+        "variant_id": "adjacent_seed_04"
+      },
+      {
+        "adapter_mode": "rmsnorm_input_fused_adjacent_seed_05_v1",
+        "final_path_opening_bytes": 19360,
+        "final_typed_bytes": 40332,
+        "min_pairwise_query_gap": 15995,
+        "query_location_span": 125812,
+        "variant_id": "adjacent_seed_05"
+      }
+    ],
+    "source_path": "docs/engineering/evidence/zkai-native-seq32-attention-mlp-predecommit-opening-policy-2026-05.tsv"
+  },
+  "issue": "https://github.com/omarespejel/provable-transformer-vm/issues/706",
+  "mutation_result": {
+    "all_mutations_rejected": true,
+    "cases": [
+      {
+        "error": "base payload drift",
+        "name": "decision_overclaim",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "result_overclaim",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "inventory_count_drift",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "inventory_commitment_drift",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "baseline_metric_drift",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "champion_metric_drift",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "two_probe_claims_new_frontier",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "two_probe_security_loss_understated",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "two_probe_verifier_bound_removed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "seed_only_promoted",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "all_inventory_promoted",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "unbounded_policy_allowed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "final_envelope_json_allowed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "final_proof_bytes_allowed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "post_decommitment_accounting_allowed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "unbounded_retry_count_allowed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "uncommitted_attempt_domain_allowed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "max_loss_bits_drift",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "validation_command_removed",
+        "rejected": true
+      },
+      {
+        "error": "base payload drift",
+        "name": "non_claim_removed",
+        "rejected": true
+      },
+      {
+        "error": "payload commitment drift",
+        "name": "payload_commitment_drift",
+        "rejected": true
+      }
+    ],
+    "mutation_names": [
+      "decision_overclaim",
+      "result_overclaim",
+      "inventory_count_drift",
+      "inventory_commitment_drift",
+      "baseline_metric_drift",
+      "champion_metric_drift",
+      "two_probe_claims_new_frontier",
+      "two_probe_security_loss_understated",
+      "two_probe_verifier_bound_removed",
+      "seed_only_promoted",
+      "all_inventory_promoted",
+      "unbounded_policy_allowed",
+      "final_envelope_json_allowed",
+      "final_proof_bytes_allowed",
+      "post_decommitment_accounting_allowed",
+      "unbounded_retry_count_allowed",
+      "uncommitted_attempt_domain_allowed",
+      "max_loss_bits_drift",
+      "validation_command_removed",
+      "non_claim_removed",
+      "payload_commitment_drift"
+    ],
+    "mutations_rejected": 21
+  },
+  "non_claims": [
+    "not a new proof-size frontier",
+    "not regenerated proof objects under a grinding API",
+    "not an absolute soundness claim",
+    "not a verifier implementation",
+    "not a production query policy",
+    "not a NANOZK proof-size comparison",
+    "not a full transformer block proof",
+    "not timing evidence"
+  ],
+  "parent_issue": "https://github.com/omarespejel/provable-transformer-vm/issues/704",
+  "payload_commitment": "blake2b-256:9dd16fba4ad07e7a61748742041ebe41df64e8e3785de94aa98ca1550ac926c8",
+  "policy_rows": [
+    {
+      "allowed_variant_ids": [
+        "fixed_adjacent_layout"
+      ],
+      "attempt_budget": 1,
+      "best_path_opening_bytes": 21184,
+      "best_typed_bytes": 42156,
+      "best_variant_id": "fixed_adjacent_layout",
+      "claims_new_frontier": false,
+      "improvement_vs_champion_typed_bytes": -4624,
+      "improvement_vs_fixed_typed_bytes": 0,
+      "policy_id": "fixed_layout_budget_1",
+      "requires_verifier_bound_attempt_domain": false,
+      "security_loss_bits": "0.000000",
+      "status": "BASELINE_NO_GRINDING"
+    },
+    {
+      "allowed_variant_ids": [
+        "adjacent_label_probe_a",
+        "adjacent_label_probe_b"
+      ],
+      "attempt_budget": 2,
+      "best_path_opening_bytes": 16560,
+      "best_typed_bytes": 37532,
+      "best_variant_id": "adjacent_label_probe_b",
+      "claims_new_frontier": false,
+      "improvement_vs_champion_typed_bytes": 0,
+      "improvement_vs_fixed_typed_bytes": 4624,
+      "policy_id": "two_probe_budget_2",
+      "requires_verifier_bound_attempt_domain": true,
+      "security_loss_bits": "1.000000",
+      "status": "MECHANISM_GO_REQUIRES_VERIFIER_BOUND_ATTEMPT_DOMAIN"
+    },
+    {
+      "allowed_variant_ids": [
+        "adjacent_seed_00",
+        "adjacent_seed_01",
+        "adjacent_seed_02",
+        "adjacent_seed_03",
+        "adjacent_seed_04",
+        "adjacent_seed_05"
+      ],
+      "attempt_budget": 6,
+      "best_path_opening_bytes": 19296,
+      "best_typed_bytes": 40268,
+      "best_variant_id": "adjacent_seed_02",
+      "claims_new_frontier": false,
+      "improvement_vs_champion_typed_bytes": -2736,
+      "improvement_vs_fixed_typed_bytes": 1888,
+      "policy_id": "seed_only_budget_6",
+      "requires_verifier_bound_attempt_domain": true,
+      "security_loss_bits": "2.584963",
+      "status": "NO_GO_SEED_ONLY_DOES_NOT_RECOVER_CHAMPION"
+    },
+    {
+      "allowed_variant_ids": [
+        "adjacent_label_probe_a",
+        "adjacent_label_probe_b",
+        "fixed_adjacent_layout",
+        "adjacent_seed_00",
+        "adjacent_seed_01",
+        "adjacent_seed_02",
+        "adjacent_seed_03",
+        "adjacent_seed_04",
+        "adjacent_seed_05"
+      ],
+      "attempt_budget": 9,
+      "best_path_opening_bytes": 16560,
+      "best_typed_bytes": 37532,
+      "best_variant_id": "adjacent_label_probe_b",
+      "claims_new_frontier": false,
+      "improvement_vs_champion_typed_bytes": 0,
+      "improvement_vs_fixed_typed_bytes": 4624,
+      "policy_id": "all_inventory_budget_9",
+      "requires_verifier_bound_attempt_domain": true,
+      "security_loss_bits": "3.169925",
+      "status": "NO_GO_UNNEEDED_EXTRA_GRINDING"
+    },
+    {
+      "allowed_variant_ids": [],
+      "attempt_budget": null,
+      "best_path_opening_bytes": null,
+      "best_typed_bytes": null,
+      "best_variant_id": null,
+      "claims_new_frontier": false,
+      "improvement_vs_champion_typed_bytes": null,
+      "improvement_vs_fixed_typed_bytes": null,
+      "policy_id": "unbounded_abort_and_retry",
+      "requires_verifier_bound_attempt_domain": true,
+      "security_loss_bits": null,
+      "status": "REJECTED_UNBOUNDED_SECURITY_LOSS"
+    }
+  ],
+  "reproducibility_metadata": {
+    "local_release_gate_step_count": 14,
+    "mutation_step_count": 21,
+    "unittest_step_count": 18
+  },
+  "result": "GO_MECHANISM_LEAD_NOT_PROOF_SIZE_FRONTIER",
+  "schema": "zkai-stwo-query-grinding-budget-gate-v1",
+  "validation_commands": [
+    "python3.10 scripts/zkai_stwo_query_grinding_budget_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv",
+    "python3.10 -m py_compile scripts/zkai_stwo_query_grinding_budget_gate.py scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py",
+    "python3.10 -m unittest scripts.tests.test_zkai_stwo_query_grinding_budget_gate",
+    "git diff --check",
+    "just gate-fast",
+    "just gate"
+  ]
+}

--- a/docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv
+++ b/docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv
@@ -1,0 +1,6 @@
+policy_id	status	attempt_budget	security_loss_bits	best_variant_id	best_typed_bytes	improvement_vs_fixed_typed_bytes	improvement_vs_champion_typed_bytes	requires_verifier_bound_attempt_domain	claims_new_frontier
+fixed_layout_budget_1	BASELINE_NO_GRINDING	1	0.000000	fixed_adjacent_layout	42156	0	-4624	False	False
+two_probe_budget_2	MECHANISM_GO_REQUIRES_VERIFIER_BOUND_ATTEMPT_DOMAIN	2	1.000000	adjacent_label_probe_b	37532	4624	0	True	False
+seed_only_budget_6	NO_GO_SEED_ONLY_DOES_NOT_RECOVER_CHAMPION	6	2.584963	adjacent_seed_02	40268	1888	-2736	True	False
+all_inventory_budget_9	NO_GO_UNNEEDED_EXTRA_GRINDING	9	3.169925	adjacent_label_probe_b	37532	4624	0	True	False
+unbounded_abort_and_retry	REJECTED_UNBOUNDED_SECURITY_LOSS							True	False

--- a/docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md
+++ b/docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md
@@ -90,6 +90,20 @@ Evidence hashes:
 - Unit tests:
   `18`.
 
+## Reproducibility Metadata
+
+- Gate schema: `zkai-stwo-query-grinding-budget-gate-v1`
+- Decision:
+  `NARROW_CLAIM_SMALL_VERIFIER_BOUND_RETRY_BUDGET_CAN_RECOVER_PROBE_B_INVENTORY`
+- Result: `GO_MECHANISM_LEAD_NOT_PROOF_SIZE_FRONTIER`
+- Timing mode: inventory/budget accounting only; no regenerated proof object,
+  no new proof-size frontier, and no absolute soundness claim
+- Step counts: `21` mutation cases, `18` Python unit tests, and `14` local
+  release-gate steps
+- Evidence paths:
+  `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json`
+  and `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`
+
 ## Reproduction
 
 ```bash

--- a/docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md
+++ b/docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md
@@ -78,15 +78,15 @@ Machine-readable evidence:
 Evidence hashes:
 
 - Gate JSON SHA-256:
-  `85c9dd80c68063006d9822c5022aff276f8c025269255cdfce47800451d0e3ec`
+  `a5ef30dc1cdd2aa0bc72163a40f2c66358265a1ef0f29d0e41ff4cf972951303`
 - Gate TSV SHA-256:
   `6961f51c3863814883bcb6cd554b919572d532bdfe34bebffe1099f6ec2bb587`
 - Inventory commitment:
-  `blake2b-256:f39a42cb0945b73cc326e2993e409af1e5b69c9bfc1f79faa2ad0e4db874e1b5`
+  `blake2b-256:6b58d3f30c5a0b0e5d1aa78890f72c5830d973f3b3795bc1917fc0253266c37e`
 - Payload commitment:
-  `blake2b-256:9dd16fba4ad07e7a61748742041ebe41df64e8e3785de94aa98ca1550ac926c8`
+  `blake2b-256:139ebaf55f70c771cf1d1f9f6fb8a132bc2215118e46a6ca4dbd2d6da4e0aea6`
 - Mutation guards:
-  `21 / 21` rejected.
+  `22 / 22` rejected.
 - Unit tests:
   `18`.
 
@@ -98,7 +98,7 @@ Evidence hashes:
 - Result: `GO_MECHANISM_LEAD_NOT_PROOF_SIZE_FRONTIER`
 - Timing mode: inventory/budget accounting only; no regenerated proof object,
   no new proof-size frontier, and no absolute soundness claim
-- Step counts: `21` mutation cases, `18` Python unit tests, and `14` local
+- Step counts: `22` mutation cases, `18` Python unit tests, and `14` local
   release-gate steps
 - Evidence paths:
   `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json`

--- a/docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md
+++ b/docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md
@@ -1,0 +1,122 @@
+# Stwo Query-Grinding Budget
+
+Date: 2026-05-19
+Issue: https://github.com/omarespejel/provable-transformer-vm/issues/706
+
+## Decision
+
+`NARROW_CLAIM_SMALL_VERIFIER_BOUND_RETRY_BUDGET_CAN_RECOVER_PROBE_B_INVENTORY`
+
+## Result
+
+`GO_MECHANISM_LEAD_NOT_PROOF_SIZE_FRONTIER`
+
+This gate checks whether the query-preview split can become a controlled
+research mechanism instead of post-hoc label selection.
+
+The answer is narrowly positive:
+
+- a fixed two-probe attempt domain recovers the current probe-B row;
+- the relative Fiat-Shamir grinding loss is `log2(2) = 1.000000` bit;
+- the result saves `4,624` typed bytes versus the fixed adjacent layout;
+- it does not improve the current champion, because the best row is still
+  `adjacent_label_probe_b` at `37,532` typed bytes;
+- it is not promotable as a proof-size frontier until regenerated proofs bind
+  the attempt domain in verifier-facing metadata.
+
+## Human Read
+
+The useful result is small but real. We have a way to talk about query geometry
+without pretending that the prover gets free choice after seeing queries.
+
+Instead of saying "pick the label that gives the smallest proof," the honest
+mechanism is:
+
+1. predefine a small attempt domain;
+2. bind that domain into the verifier-facing statement;
+3. let the prover try only those attempts;
+4. charge the Fiat-Shamir search space by `log2(attempt_budget)`;
+5. reject unbounded retry or final-proof-byte selection.
+
+On the checked inventory, the two-probe domain
+`adjacent_label_probe_a, adjacent_label_probe_b` is enough to recover the
+champion:
+
+| policy | attempts | loss bits | best row | best typed bytes | vs fixed layout | vs champion |
+| --- | ---: | ---: | --- | ---: | ---: | ---: |
+| `fixed_layout_budget_1` | `1` | `0.000000` | `fixed_adjacent_layout` | `42,156` | `0` | `-4,624` |
+| `two_probe_budget_2` | `2` | `1.000000` | `adjacent_label_probe_b` | `37,532` | `+4,624` | `0` |
+| `seed_only_budget_6` | `6` | `2.584963` | `adjacent_seed_02` | `40,268` | `+1,888` | `-2,736` |
+| `all_inventory_budget_9` | `9` | `3.169925` | `adjacent_label_probe_b` | `37,532` | `+4,624` | `0` |
+
+The seed-only sweep is a no-go: it spends more budget and still misses the
+champion by `2,736` typed bytes. The all-inventory sweep is also a no-go: it
+spends `3.169925` bits to get the same result as the two-probe policy.
+
+## Why This Matters
+
+For the paper path, this turns query/opening geometry into a proof-system policy
+problem:
+
+- the retry budget is explicit;
+- the security cost is explicit;
+- the allowed attempts are bounded;
+- the non-claim is explicit: no regenerated proof object and no new frontier.
+
+This is better than both extremes:
+
+- it avoids throwing away the query-geometry signal;
+- it avoids pretending post-query selection is free compression.
+
+## Evidence
+
+Machine-readable evidence:
+
+- `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json`
+- `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`
+
+Evidence hashes:
+
+- Gate JSON SHA-256:
+  `85c9dd80c68063006d9822c5022aff276f8c025269255cdfce47800451d0e3ec`
+- Gate TSV SHA-256:
+  `6961f51c3863814883bcb6cd554b919572d532bdfe34bebffe1099f6ec2bb587`
+- Inventory commitment:
+  `blake2b-256:f39a42cb0945b73cc326e2993e409af1e5b69c9bfc1f79faa2ad0e4db874e1b5`
+- Payload commitment:
+  `blake2b-256:9dd16fba4ad07e7a61748742041ebe41df64e8e3785de94aa98ca1550ac926c8`
+- Mutation guards:
+  `21 / 21` rejected.
+- Unit tests:
+  `18`.
+
+## Reproduction
+
+```bash
+python3.10 scripts/zkai_stwo_query_grinding_budget_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv
+python3.10 -m py_compile scripts/zkai_stwo_query_grinding_budget_gate.py scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
+python3.10 -m unittest scripts.tests.test_zkai_stwo_query_grinding_budget_gate
+git diff --check
+just gate-fast
+just gate
+```
+
+## Non-Claims
+
+- Not a new proof-size frontier.
+- Not regenerated proof objects under a grinding API.
+- Not an absolute soundness claim.
+- Not a verifier implementation.
+- Not a production query policy.
+- Not a NANOZK proof-size comparison.
+- Not a full transformer block proof.
+- Not timing evidence.
+
+## Next Attack
+
+The next implementation should bind the allowed attempt domain and selected
+attempt id in the verifier-facing statement, then regenerate the seq32+d128
+proof under the two-probe policy. A future claim is only promotable if the
+verifier rejects attempts outside the domain and mutation guards reject
+unbounded retry, final proof bytes, and post-decommitment accounting as policy
+inputs.

--- a/scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
+++ b/scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
@@ -47,6 +47,8 @@ class StwoQueryGrindingBudgetGateTest(unittest.TestCase):
         self.assertEqual(inventory["source_path"], str(self.gate.INVENTORY_TSV.relative_to(self.gate.ROOT)))
         self.assertTrue(inventory["commitment"].startswith("blake2b-256:"))
         self.assertEqual(len(inventory["rows"]), 9)
+        header = self.gate.INVENTORY_TSV.read_text(encoding="utf-8").splitlines()[0].split("\t")
+        self.assertEqual(tuple(header), self.gate.REQUIRED_INVENTORY_COLUMNS)
 
     def test_baseline_and_champion_metrics_are_pinned(self):
         self.assertEqual(self.payload["baseline"]["variant_id"], "fixed_adjacent_layout")
@@ -142,7 +144,7 @@ class StwoQueryGrindingBudgetGateTest(unittest.TestCase):
         self.assertEqual(count, self.payload["reproducibility_metadata"]["unittest_step_count"])
 
     def test_committed_evidence_contains_integrity_fields(self):
-        evidence = json.loads(self.gate.JSON_OUT.read_text())
+        evidence = json.loads(self.gate.JSON_OUT.read_text(encoding="utf-8"))
         self.assertEqual(evidence["payload_commitment"], self.payload["payload_commitment"])
         self.assertEqual(evidence["mutation_result"], self.payload["mutation_result"])
         self.gate.validate_payload(evidence)
@@ -163,9 +165,9 @@ class StwoQueryGrindingBudgetGateTest(unittest.TestCase):
             json_path = tmp_path / "out.json"
             tsv_path = tmp_path / "out.tsv"
             self.gate.write_outputs(json_path, tsv_path, self.payload)
-            loaded = json.loads(json_path.read_text())
+            loaded = json.loads(json_path.read_text(encoding="utf-8"))
             self.assertEqual(loaded["payload_commitment"], self.payload["payload_commitment"])
-            lines = tsv_path.read_text().splitlines()
+            lines = tsv_path.read_text(encoding="utf-8").splitlines()
             self.assertEqual(lines[0], "\t".join(self.gate.TSV_COLUMNS))
             self.assertEqual(len(lines), 1 + len(self.payload["policy_rows"]))
 

--- a/scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
+++ b/scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
@@ -1,0 +1,183 @@
+import copy
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+GATE_PATH = ROOT / "scripts" / "zkai_stwo_query_grinding_budget_gate.py"
+
+
+def load_gate():
+    spec = importlib.util.spec_from_file_location("stwo_query_grinding_budget_gate", GATE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class StwoQueryGrindingBudgetGateTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.gate = load_gate()
+        try:
+            cls.payload = cls.gate.build_payload()
+        except cls.gate.hook_gate.BoundedStwoQueryPolicyHookGateError as err:
+            if "Stwo 2.2.0 source is not available" in str(err):
+                raise unittest.SkipTest(str(err)) from err
+            raise
+
+    def policy(self, policy_id):
+        return self.gate.policy_row(self.payload, policy_id)
+
+    def test_payload_records_mechanism_go_not_frontier(self):
+        self.assertEqual(
+            self.payload["decision"],
+            "NARROW_CLAIM_SMALL_VERIFIER_BOUND_RETRY_BUDGET_CAN_RECOVER_PROBE_B_INVENTORY",
+        )
+        self.assertEqual(self.payload["result"], "GO_MECHANISM_LEAD_NOT_PROOF_SIZE_FRONTIER")
+        self.assertEqual(self.payload["issue"], self.gate.ISSUE_HINT)
+        self.assertFalse(self.payload["budget_rule"]["absolute_soundness_claim"])
+
+    def test_inventory_is_loaded_from_pinned_predecommit_tsv(self):
+        inventory = self.payload["inventory"]
+        self.assertEqual(inventory["row_count"], 9)
+        self.assertEqual(inventory["source_path"], str(self.gate.INVENTORY_TSV.relative_to(self.gate.ROOT)))
+        self.assertTrue(inventory["commitment"].startswith("blake2b-256:"))
+        self.assertEqual(len(inventory["rows"]), 9)
+
+    def test_baseline_and_champion_metrics_are_pinned(self):
+        self.assertEqual(self.payload["baseline"]["variant_id"], "fixed_adjacent_layout")
+        self.assertEqual(self.payload["baseline"]["final_typed_bytes"], 42_156)
+        self.assertEqual(self.payload["champion"]["variant_id"], "adjacent_label_probe_b")
+        self.assertEqual(self.payload["champion"]["final_typed_bytes"], 37_532)
+        self.assertEqual(self.payload["champion"]["final_path_opening_bytes"], 16_560)
+
+    def test_two_probe_budget_recovers_champion_with_one_bit_loss(self):
+        row = self.policy("two_probe_budget_2")
+        self.assertEqual(row["status"], "MECHANISM_GO_REQUIRES_VERIFIER_BOUND_ATTEMPT_DOMAIN")
+        self.assertEqual(row["attempt_budget"], 2)
+        self.assertEqual(row["security_loss_bits"], "1.000000")
+        self.assertEqual(row["best_variant_id"], "adjacent_label_probe_b")
+        self.assertEqual(row["best_typed_bytes"], 37_532)
+        self.assertEqual(row["improvement_vs_fixed_typed_bytes"], 4_624)
+        self.assertEqual(row["improvement_vs_champion_typed_bytes"], 0)
+        self.assertTrue(row["requires_verifier_bound_attempt_domain"])
+        self.assertFalse(row["claims_new_frontier"])
+
+    def test_seed_only_budget_is_no_go(self):
+        row = self.policy("seed_only_budget_6")
+        self.assertEqual(row["status"], "NO_GO_SEED_ONLY_DOES_NOT_RECOVER_CHAMPION")
+        self.assertEqual(row["attempt_budget"], 6)
+        self.assertEqual(row["security_loss_bits"], "2.584963")
+        self.assertEqual(row["best_variant_id"], "adjacent_seed_02")
+        self.assertEqual(row["best_typed_bytes"], 40_268)
+        self.assertEqual(row["improvement_vs_champion_typed_bytes"], -2_736)
+
+    def test_all_inventory_budget_is_unneeded_extra_grinding(self):
+        row = self.policy("all_inventory_budget_9")
+        self.assertEqual(row["status"], "NO_GO_UNNEEDED_EXTRA_GRINDING")
+        self.assertEqual(row["attempt_budget"], 9)
+        self.assertEqual(row["security_loss_bits"], "3.169925")
+        self.assertEqual(row["best_variant_id"], "adjacent_label_probe_b")
+        self.assertEqual(row["improvement_vs_champion_typed_bytes"], 0)
+
+    def test_unbounded_retry_is_rejected(self):
+        row = self.policy("unbounded_abort_and_retry")
+        self.assertEqual(row["status"], "REJECTED_UNBOUNDED_SECURITY_LOSS")
+        self.assertIsNone(row["attempt_budget"])
+        self.assertTrue(row["requires_verifier_bound_attempt_domain"])
+        self.assertFalse(row["claims_new_frontier"])
+
+    def test_budget_rule_records_relative_not_absolute_security(self):
+        rule = self.payload["budget_rule"]
+        self.assertEqual(rule["security_loss_bits_formula"], "log2(attempt_budget)")
+        self.assertEqual(rule["paper_prototype_max_loss_bits"], "2.000000")
+        self.assertTrue(rule["verifier_must_bind_attempt_domain"])
+        self.assertTrue(rule["verifier_must_reject_attempts_outside_domain"])
+        self.assertFalse(rule["absolute_soundness_claim"])
+
+    def test_forbidden_policy_inputs_remain_forbidden(self):
+        forbidden = self.payload["forbidden_policy_inputs"]
+        self.assertTrue(forbidden["final_envelope_json"])
+        self.assertTrue(forbidden["final_proof_bytes"])
+        self.assertTrue(forbidden["post_decommitment_accounting"])
+        self.assertTrue(forbidden["unbounded_retry_count"])
+        self.assertTrue(forbidden["uncommitted_attempt_domain"])
+
+    def test_loss_bits_helper_is_exact_for_budget_points(self):
+        self.assertEqual(self.gate.loss_bits(1), "0.000000")
+        self.assertEqual(self.gate.loss_bits(2), "1.000000")
+        self.assertEqual(self.gate.loss_bits(4), "2.000000")
+        self.assertEqual(self.gate.loss_bits(9), "3.169925")
+        with self.assertRaisesRegex(self.gate.StwoQueryGrindingBudgetGateError, "positive"):
+            self.gate.loss_bits(0)
+
+    def test_find_variant_and_policy_helpers_reject_missing_values(self):
+        with self.assertRaisesRegex(self.gate.StwoQueryGrindingBudgetGateError, "variant missing"):
+            self.gate.find_variant(self.payload["inventory"]["rows"], "missing")
+        with self.assertRaisesRegex(self.gate.StwoQueryGrindingBudgetGateError, "policy missing"):
+            self.gate.policy_row(self.payload, "missing")
+
+    def test_all_mutations_rejected(self):
+        mutation = self.payload["mutation_result"]
+        self.assertTrue(mutation["all_mutations_rejected"])
+        self.assertEqual(mutation["mutations_rejected"], len(self.gate.MUTATION_NAMES))
+        self.assertEqual(mutation["mutation_names"], list(self.gate.MUTATION_NAMES))
+
+    def test_validate_mutation_result_rejects_malformed_case(self):
+        bad_result = copy.deepcopy(self.payload["mutation_result"])
+        bad_result["cases"][0] = "not-a-mutation-case"
+        with self.assertRaisesRegex(
+            self.gate.StwoQueryGrindingBudgetGateError,
+            "mutation case schema drift",
+        ):
+            self.gate.validate_mutation_result(bad_result)
+
+    def test_pinned_unittest_count_matches_loaded_suite(self):
+        count = unittest.TestLoader().loadTestsFromTestCase(type(self)).countTestCases()
+        self.assertEqual(count, self.gate.EXPECTED_UNITTEST_STEP_COUNT)
+        self.assertEqual(count, self.payload["reproducibility_metadata"]["unittest_step_count"])
+
+    def test_committed_evidence_contains_integrity_fields(self):
+        evidence = json.loads(self.gate.JSON_OUT.read_text())
+        self.assertEqual(evidence["payload_commitment"], self.payload["payload_commitment"])
+        self.assertEqual(evidence["mutation_result"], self.payload["mutation_result"])
+        self.gate.validate_payload(evidence)
+
+    def test_payload_commitment_and_tsv_are_stable(self):
+        payload_a = self.gate.build_payload()
+        payload_b = self.gate.build_payload()
+        self.assertEqual(payload_a["payload_commitment"], self.gate.payload_commitment(payload_a))
+        self.assertEqual(payload_a["payload_commitment"], payload_b["payload_commitment"])
+        tsv = self.gate.render_tsv(payload_a)
+        self.assertEqual(tsv, self.gate.render_tsv(payload_b))
+        self.assertIn("two_probe_budget_2\tMECHANISM_GO", tsv)
+        self.assertIn("unbounded_abort_and_retry\tREJECTED_UNBOUNDED_SECURITY_LOSS", tsv)
+
+    def test_writes_paired_json_and_tsv_outputs(self):
+        with tempfile.TemporaryDirectory(dir=self.gate.EVIDENCE_DIR) as tmp:
+            tmp_path = pathlib.Path(tmp)
+            json_path = tmp_path / "out.json"
+            tsv_path = tmp_path / "out.tsv"
+            self.gate.write_outputs(json_path, tsv_path, self.payload)
+            loaded = json.loads(json_path.read_text())
+            self.assertEqual(loaded["payload_commitment"], self.payload["payload_commitment"])
+            lines = tsv_path.read_text().splitlines()
+            self.assertEqual(lines[0], "\t".join(self.gate.TSV_COLUMNS))
+            self.assertEqual(len(lines), 1 + len(self.payload["policy_rows"]))
+
+    def test_payload_commitment_drift_rejects(self):
+        item = copy.deepcopy(self.payload)
+        item["payload_commitment"] = "blake2b-256:" + ("0" * 64)
+        with self.assertRaisesRegex(
+            self.gate.StwoQueryGrindingBudgetGateError,
+            "payload commitment drift",
+        ):
+            self.gate.validate_payload(item)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
+++ b/scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
@@ -49,6 +49,14 @@ class StwoQueryGrindingBudgetGateTest(unittest.TestCase):
         self.assertEqual(len(inventory["rows"]), 9)
         header = self.gate.INVENTORY_TSV.read_text(encoding="utf-8").splitlines()[0].split("\t")
         self.assertEqual(tuple(header), self.gate.REQUIRED_INVENTORY_COLUMNS)
+        selected_ids = [row["variant_id"] for row in inventory["rows"] if row["selected_without_final_accounting"]]
+        self.assertEqual(selected_ids, ["adjacent_label_probe_b"])
+        self.assertTrue(
+            all(row["policy_stage"] == self.gate.EXPECTED_POLICY_STAGE for row in inventory["rows"])
+        )
+        self.assertTrue(
+            all(row["api_control_status"] == self.gate.EXPECTED_API_CONTROL_STATUS for row in inventory["rows"])
+        )
 
     def test_baseline_and_champion_metrics_are_pinned(self):
         self.assertEqual(self.payload["baseline"]["variant_id"], "fixed_adjacent_layout")

--- a/scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
+++ b/scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
@@ -46,6 +46,7 @@ class StwoQueryGrindingBudgetGateTest(unittest.TestCase):
         self.assertEqual(inventory["row_count"], 9)
         self.assertEqual(inventory["source_path"], str(self.gate.INVENTORY_TSV.relative_to(self.gate.ROOT)))
         self.assertTrue(inventory["commitment"].startswith("blake2b-256:"))
+        self.assertEqual(inventory["commitment"], self.gate.EXPECTED_INVENTORY_COMMITMENT)
         self.assertEqual(len(inventory["rows"]), 9)
         header = self.gate.INVENTORY_TSV.read_text(encoding="utf-8").splitlines()[0].split("\t")
         self.assertEqual(tuple(header), self.gate.REQUIRED_INVENTORY_COLUMNS)
@@ -154,6 +155,7 @@ class StwoQueryGrindingBudgetGateTest(unittest.TestCase):
     def test_committed_evidence_contains_integrity_fields(self):
         evidence = json.loads(self.gate.JSON_OUT.read_text(encoding="utf-8"))
         self.assertEqual(evidence["payload_commitment"], self.payload["payload_commitment"])
+        self.assertEqual(evidence["payload_commitment"], self.gate.EXPECTED_PAYLOAD_COMMITMENT)
         self.assertEqual(evidence["mutation_result"], self.payload["mutation_result"])
         self.gate.validate_payload(evidence)
 

--- a/scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
+++ b/scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py
@@ -131,6 +131,11 @@ class StwoQueryGrindingBudgetGateTest(unittest.TestCase):
             self.gate.find_variant(self.payload["inventory"]["rows"], "missing")
         with self.assertRaisesRegex(self.gate.StwoQueryGrindingBudgetGateError, "policy missing"):
             self.gate.policy_row(self.payload, "missing")
+        with self.assertRaisesRegex(
+            self.gate.StwoQueryGrindingBudgetGateError,
+            "query_location_span is negative: -1",
+        ):
+            self.gate.parse_int({"query_location_span": "-1"}, "query_location_span")
 
     def test_all_mutations_rejected(self):
         mutation = self.payload["mutation_result"]

--- a/scripts/zkai_stwo_query_grinding_budget_gate.py
+++ b/scripts/zkai_stwo_query_grinding_budget_gate.py
@@ -45,6 +45,12 @@ EXPECTED_UNITTEST_STEP_COUNT = 18
 MAX_PAPER_PROTOTYPE_LOSS_BITS = "2.000000"
 EXPECTED_POLICY_STAGE = "post_transcript_pre_accounting_not_true_predecommit"
 EXPECTED_API_CONTROL_STATUS = "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER"
+EXPECTED_INVENTORY_COMMITMENT = (
+    "blake2b-256:6b58d3f30c5a0b0e5d1aa78890f72c5830d973f3b3795bc1917fc0253266c37e"
+)
+EXPECTED_PAYLOAD_COMMITMENT = (
+    "blake2b-256:139ebaf55f70c771cf1d1f9f6fb8a132bc2215118e46a6ca4dbd2d6da4e0aea6"
+)
 
 TSV_COLUMNS = (
     "policy_id",
@@ -394,6 +400,8 @@ def validate_base_payload(payload: dict[str, Any]) -> None:
         raise StwoQueryGrindingBudgetGateError("claim boundary drift")
     if payload["inventory"]["row_count"] != EXPECTED_INVENTORY_COUNT:
         raise StwoQueryGrindingBudgetGateError("inventory count drift")
+    if payload["inventory"]["commitment"] != EXPECTED_INVENTORY_COMMITMENT:
+        raise StwoQueryGrindingBudgetGateError("published inventory commitment drift")
     baseline = payload["baseline"]
     champion = payload["champion"]
     if baseline["variant_id"] != BASELINE_VARIANT_ID or baseline["final_typed_bytes"] != 42_156:
@@ -446,6 +454,8 @@ def validate_payload(payload: dict[str, Any]) -> None:
     validate_base_payload(item)
     if supplied_commitment != payload_commitment(payload):
         raise StwoQueryGrindingBudgetGateError("payload commitment drift")
+    if supplied_commitment != EXPECTED_PAYLOAD_COMMITMENT:
+        raise StwoQueryGrindingBudgetGateError("published payload commitment drift")
     expected_mutation = run_mutations(item)
     if mutation_result != expected_mutation:
         raise StwoQueryGrindingBudgetGateError("mutation result drift")

--- a/scripts/zkai_stwo_query_grinding_budget_gate.py
+++ b/scripts/zkai_stwo_query_grinding_budget_gate.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3.10
+"""Gate bounded transcript-grinding budgets for Stwo query geometry."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import hashlib
+import io
+import json
+import math
+import pathlib
+import sys
+from typing import Any
+
+
+if sys.version_info < (3, 10):
+    raise RuntimeError("zkai_stwo_query_grinding_budget_gate requires Python 3.10+")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import zkai_stwo_query_preview_split_prototype_gate as preview_gate
+from scripts import zkai_bounded_stwo_query_policy_hook_gate as hook_gate
+from scripts import zkai_native_seq32_attention_mlp_dry_run_opening_sampler_gate as sampler_gate
+
+
+EVIDENCE_DIR = ROOT / "docs" / "engineering" / "evidence"
+JSON_OUT = EVIDENCE_DIR / "zkai-stwo-query-grinding-budget-2026-05.json"
+TSV_OUT = EVIDENCE_DIR / "zkai-stwo-query-grinding-budget-2026-05.tsv"
+
+SCHEMA = "zkai-stwo-query-grinding-budget-gate-v1"
+DECISION = "NARROW_CLAIM_SMALL_VERIFIER_BOUND_RETRY_BUDGET_CAN_RECOVER_PROBE_B_INVENTORY"
+RESULT = "GO_MECHANISM_LEAD_NOT_PROOF_SIZE_FRONTIER"
+ISSUE_HINT = "https://github.com/omarespejel/provable-transformer-vm/issues/706"
+PAYLOAD_DOMAIN = "ptvm:zkai:stwo-query-grinding-budget:v1"
+
+INVENTORY_TSV = hook_gate.PREDECOMMIT_TSV_PATH
+BASELINE_VARIANT_ID = "fixed_adjacent_layout"
+CHAMPION_VARIANT_ID = "adjacent_label_probe_b"
+EXPECTED_INVENTORY_COUNT = 9
+EXPECTED_UNITTEST_STEP_COUNT = 18
+MAX_PAPER_PROTOTYPE_LOSS_BITS = "2.000000"
+
+TSV_COLUMNS = (
+    "policy_id",
+    "status",
+    "attempt_budget",
+    "security_loss_bits",
+    "best_variant_id",
+    "best_typed_bytes",
+    "improvement_vs_fixed_typed_bytes",
+    "improvement_vs_champion_typed_bytes",
+    "requires_verifier_bound_attempt_domain",
+    "claims_new_frontier",
+)
+VALIDATION_COMMANDS = (
+    "python3.10 scripts/zkai_stwo_query_grinding_budget_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv",
+    "python3.10 -m py_compile scripts/zkai_stwo_query_grinding_budget_gate.py scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py",
+    "python3.10 -m unittest scripts.tests.test_zkai_stwo_query_grinding_budget_gate",
+    "git diff --check",
+    "just gate-fast",
+    "just gate",
+)
+NON_CLAIMS = (
+    "not a new proof-size frontier",
+    "not regenerated proof objects under a grinding API",
+    "not an absolute soundness claim",
+    "not a verifier implementation",
+    "not a production query policy",
+    "not a NANOZK proof-size comparison",
+    "not a full transformer block proof",
+    "not timing evidence",
+)
+MUTATION_NAMES = (
+    "decision_overclaim",
+    "result_overclaim",
+    "inventory_count_drift",
+    "inventory_commitment_drift",
+    "baseline_metric_drift",
+    "champion_metric_drift",
+    "two_probe_claims_new_frontier",
+    "two_probe_security_loss_understated",
+    "two_probe_verifier_bound_removed",
+    "seed_only_promoted",
+    "all_inventory_promoted",
+    "unbounded_policy_allowed",
+    "final_envelope_json_allowed",
+    "final_proof_bytes_allowed",
+    "post_decommitment_accounting_allowed",
+    "unbounded_retry_count_allowed",
+    "uncommitted_attempt_domain_allowed",
+    "max_loss_bits_drift",
+    "validation_command_removed",
+    "non_claim_removed",
+    "payload_commitment_drift",
+)
+
+
+class StwoQueryGrindingBudgetGateError(Exception):
+    pass
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode()
+    except (TypeError, ValueError) as err:
+        raise StwoQueryGrindingBudgetGateError(f"non-canonical JSON value: {err}") from err
+
+
+def blake2b_commitment(domain: str, value: Any) -> str:
+    digest = hashlib.blake2b(
+        domain.encode() + b"\0" + canonical_json_bytes(value),
+        digest_size=32,
+    ).hexdigest()
+    return f"blake2b-256:{digest}"
+
+
+def payload_commitment(payload: dict[str, Any]) -> str:
+    item = copy.deepcopy(payload)
+    item.pop("payload_commitment", None)
+    return blake2b_commitment(PAYLOAD_DOMAIN, item)
+
+
+def parse_int(row: dict[str, str], field: str) -> int:
+    try:
+        return int(row[field])
+    except (KeyError, ValueError) as err:
+        raise StwoQueryGrindingBudgetGateError(f"inventory field {field} is invalid") from err
+
+
+def load_inventory() -> list[dict[str, Any]]:
+    raw = hook_gate.read_repo_file(INVENTORY_TSV, "predecommit inventory TSV", hook_gate.MAX_EVIDENCE_BYTES)
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as err:
+        raise StwoQueryGrindingBudgetGateError("predecommit inventory TSV is not UTF-8") from err
+    rows = list(csv.DictReader(io.StringIO(text), delimiter="\t"))
+    if len(rows) != EXPECTED_INVENTORY_COUNT:
+        raise StwoQueryGrindingBudgetGateError("inventory row count drift")
+    inventory = []
+    for row in rows:
+        inventory.append(
+            {
+                "variant_id": row["variant_id"],
+                "adapter_mode": row["adapter_mode"],
+                "query_location_span": parse_int(row, "query_location_span"),
+                "min_pairwise_query_gap": parse_int(row, "min_pairwise_query_gap"),
+                "final_path_opening_bytes": parse_int(row, "final_path_opening_bytes"),
+                "final_typed_bytes": parse_int(row, "final_typed_bytes"),
+            }
+        )
+    return inventory
+
+
+def find_variant(inventory: list[dict[str, Any]], variant_id: str) -> dict[str, Any]:
+    matches = [row for row in inventory if row["variant_id"] == variant_id]
+    if len(matches) != 1:
+        raise StwoQueryGrindingBudgetGateError(f"variant missing: {variant_id}")
+    return matches[0]
+
+
+def best_variant(inventory: list[dict[str, Any]], variant_ids: tuple[str, ...]) -> dict[str, Any]:
+    rows = [find_variant(inventory, variant_id) for variant_id in variant_ids]
+    return min(rows, key=lambda row: (row["final_typed_bytes"], row["query_location_span"], row["variant_id"]))
+
+
+def loss_bits(attempt_budget: int) -> str:
+    if attempt_budget <= 0:
+        raise StwoQueryGrindingBudgetGateError("attempt budget must be positive")
+    return f"{math.log2(attempt_budget):.6f}"
+
+
+def policy(
+    inventory: list[dict[str, Any]],
+    policy_id: str,
+    variant_ids: tuple[str, ...],
+    status: str,
+    requires_verifier_bound_attempt_domain: bool,
+    claims_new_frontier: bool,
+) -> dict[str, Any]:
+    baseline = find_variant(inventory, BASELINE_VARIANT_ID)
+    champion = find_variant(inventory, CHAMPION_VARIANT_ID)
+    best = best_variant(inventory, variant_ids)
+    return {
+        "policy_id": policy_id,
+        "status": status,
+        "allowed_variant_ids": list(variant_ids),
+        "attempt_budget": len(variant_ids),
+        "security_loss_bits": loss_bits(len(variant_ids)),
+        "best_variant_id": best["variant_id"],
+        "best_typed_bytes": best["final_typed_bytes"],
+        "best_path_opening_bytes": best["final_path_opening_bytes"],
+        "improvement_vs_fixed_typed_bytes": baseline["final_typed_bytes"] - best["final_typed_bytes"],
+        "improvement_vs_champion_typed_bytes": champion["final_typed_bytes"] - best["final_typed_bytes"],
+        "requires_verifier_bound_attempt_domain": requires_verifier_bound_attempt_domain,
+        "claims_new_frontier": claims_new_frontier,
+    }
+
+
+def policies(inventory: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        policy(
+            inventory,
+            "fixed_layout_budget_1",
+            ("fixed_adjacent_layout",),
+            "BASELINE_NO_GRINDING",
+            False,
+            False,
+        ),
+        policy(
+            inventory,
+            "two_probe_budget_2",
+            ("adjacent_label_probe_a", "adjacent_label_probe_b"),
+            "MECHANISM_GO_REQUIRES_VERIFIER_BOUND_ATTEMPT_DOMAIN",
+            True,
+            False,
+        ),
+        policy(
+            inventory,
+            "seed_only_budget_6",
+            (
+                "adjacent_seed_00",
+                "adjacent_seed_01",
+                "adjacent_seed_02",
+                "adjacent_seed_03",
+                "adjacent_seed_04",
+                "adjacent_seed_05",
+            ),
+            "NO_GO_SEED_ONLY_DOES_NOT_RECOVER_CHAMPION",
+            True,
+            False,
+        ),
+        policy(
+            inventory,
+            "all_inventory_budget_9",
+            tuple(row["variant_id"] for row in inventory),
+            "NO_GO_UNNEEDED_EXTRA_GRINDING",
+            True,
+            False,
+        ),
+        {
+            "policy_id": "unbounded_abort_and_retry",
+            "status": "REJECTED_UNBOUNDED_SECURITY_LOSS",
+            "allowed_variant_ids": [],
+            "attempt_budget": None,
+            "security_loss_bits": None,
+            "best_variant_id": None,
+            "best_typed_bytes": None,
+            "best_path_opening_bytes": None,
+            "improvement_vs_fixed_typed_bytes": None,
+            "improvement_vs_champion_typed_bytes": None,
+            "requires_verifier_bound_attempt_domain": True,
+            "claims_new_frontier": False,
+        },
+    ]
+
+
+def build_payload_without_mutations() -> dict[str, Any]:
+    preview_payload = preview_gate.build_payload_without_mutations()
+    inventory = load_inventory()
+    baseline = find_variant(inventory, BASELINE_VARIANT_ID)
+    champion = find_variant(inventory, CHAMPION_VARIANT_ID)
+    policy_rows = policies(inventory)
+    return {
+        "schema": SCHEMA,
+        "decision": DECISION,
+        "result": RESULT,
+        "issue": ISSUE_HINT,
+        "parent_issue": preview_payload["issue"],
+        "inventory": {
+            "source_path": str(INVENTORY_TSV.relative_to(ROOT)),
+            "row_count": len(inventory),
+            "commitment": blake2b_commitment("ptvm:zkai:grinding-inventory:v1", inventory),
+            "rows": inventory,
+        },
+        "baseline": baseline,
+        "champion": champion,
+        "policy_rows": policy_rows,
+        "budget_rule": {
+            "relative_security_loss": "attempt_budget multiplies Fiat-Shamir search space",
+            "security_loss_bits_formula": "log2(attempt_budget)",
+            "paper_prototype_max_loss_bits": MAX_PAPER_PROTOTYPE_LOSS_BITS,
+            "verifier_must_bind_attempt_domain": True,
+            "verifier_must_reject_attempts_outside_domain": True,
+            "absolute_soundness_claim": False,
+        },
+        "forbidden_policy_inputs": {
+            "final_envelope_json": True,
+            "final_proof_bytes": True,
+            "post_decommitment_accounting": True,
+            "unbounded_retry_count": True,
+            "uncommitted_attempt_domain": True,
+        },
+        "interpretation": {
+            "human_read": (
+                "The small controlled signal is real: a two-attempt probe policy recovers "
+                "the existing probe-B row from the checked inventory with one bit of relative "
+                "Fiat-Shamir grinding loss. It does not improve the current champion and does "
+                "not become a frontier until regenerated proofs enforce the attempt domain."
+            ),
+            "why_it_matters": (
+                "This turns query geometry from post-hoc label selection into a bounded "
+                "proof-system policy question. The next implementation should bind the "
+                "attempt domain in the verifier-facing statement before claiming size wins."
+            ),
+            "next_experiment": (
+                "Prototype a verifier-bound attempt-domain metadata path and regenerate the "
+                "seq32+d128 proof for the two-probe policy."
+            ),
+        },
+        "validation_commands": list(VALIDATION_COMMANDS),
+        "non_claims": list(NON_CLAIMS),
+        "reproducibility_metadata": {
+            "mutation_step_count": len(MUTATION_NAMES),
+            "unittest_step_count": EXPECTED_UNITTEST_STEP_COUNT,
+            "local_release_gate_step_count": 14,
+        },
+    }
+
+
+def policy_row(payload: dict[str, Any], policy_id: str) -> dict[str, Any]:
+    for row in payload.get("policy_rows", []):
+        if row.get("policy_id") == policy_id:
+            return row
+    raise StwoQueryGrindingBudgetGateError(f"policy missing: {policy_id}")
+
+
+def validate_base_payload(payload: dict[str, Any]) -> None:
+    expected = build_payload_without_mutations()
+    if payload != expected:
+        raise StwoQueryGrindingBudgetGateError("base payload drift")
+    if payload["decision"] != DECISION or payload["result"] != RESULT:
+        raise StwoQueryGrindingBudgetGateError("claim boundary drift")
+    if payload["inventory"]["row_count"] != EXPECTED_INVENTORY_COUNT:
+        raise StwoQueryGrindingBudgetGateError("inventory count drift")
+    baseline = payload["baseline"]
+    champion = payload["champion"]
+    if baseline["variant_id"] != BASELINE_VARIANT_ID or baseline["final_typed_bytes"] != 42_156:
+        raise StwoQueryGrindingBudgetGateError("baseline metric drift")
+    if champion["variant_id"] != CHAMPION_VARIANT_ID or champion["final_typed_bytes"] != 37_532:
+        raise StwoQueryGrindingBudgetGateError("champion metric drift")
+    two_probe = policy_row(payload, "two_probe_budget_2")
+    if two_probe["security_loss_bits"] != "1.000000":
+        raise StwoQueryGrindingBudgetGateError("two-probe security loss drift")
+    if not two_probe["requires_verifier_bound_attempt_domain"]:
+        raise StwoQueryGrindingBudgetGateError("two-probe verifier-bound domain missing")
+    if two_probe["claims_new_frontier"]:
+        raise StwoQueryGrindingBudgetGateError("two-probe frontier overclaim")
+    if two_probe["improvement_vs_fixed_typed_bytes"] != 4_624:
+        raise StwoQueryGrindingBudgetGateError("two-probe improvement drift")
+    if two_probe["improvement_vs_champion_typed_bytes"] != 0:
+        raise StwoQueryGrindingBudgetGateError("champion improvement overclaim")
+    seed_only = policy_row(payload, "seed_only_budget_6")
+    if not seed_only["status"].startswith("NO_GO"):
+        raise StwoQueryGrindingBudgetGateError("seed-only promotion drift")
+    all_inventory = policy_row(payload, "all_inventory_budget_9")
+    if all_inventory["status"] != "NO_GO_UNNEEDED_EXTRA_GRINDING":
+        raise StwoQueryGrindingBudgetGateError("all-inventory promotion drift")
+    unbounded = policy_row(payload, "unbounded_abort_and_retry")
+    if unbounded["status"] != "REJECTED_UNBOUNDED_SECURITY_LOSS":
+        raise StwoQueryGrindingBudgetGateError("unbounded retry not rejected")
+    for policy_item in payload["policy_rows"]:
+        if policy_item["claims_new_frontier"]:
+            raise StwoQueryGrindingBudgetGateError("policy row frontier overclaim")
+        if (
+            policy_item["status"].startswith("MECHANISM_GO")
+            and policy_item["requires_verifier_bound_attempt_domain"] is not True
+        ):
+            raise StwoQueryGrindingBudgetGateError("mechanism policy missing verifier-bound domain")
+    for field, forbidden in payload["forbidden_policy_inputs"].items():
+        if forbidden is not True:
+            raise StwoQueryGrindingBudgetGateError(f"forbidden policy input allowed: {field}")
+    if payload["budget_rule"]["paper_prototype_max_loss_bits"] != MAX_PAPER_PROTOTYPE_LOSS_BITS:
+        raise StwoQueryGrindingBudgetGateError("max loss-bit drift")
+    if payload["validation_commands"] != list(VALIDATION_COMMANDS):
+        raise StwoQueryGrindingBudgetGateError("validation command drift")
+    if payload["non_claims"] != list(NON_CLAIMS):
+        raise StwoQueryGrindingBudgetGateError("non-claim drift")
+
+
+def validate_payload(payload: dict[str, Any]) -> None:
+    item = copy.deepcopy(payload)
+    supplied_commitment = item.pop("payload_commitment", None)
+    mutation_result = item.pop("mutation_result", None)
+    validate_base_payload(item)
+    if supplied_commitment != payload_commitment(payload):
+        raise StwoQueryGrindingBudgetGateError("payload commitment drift")
+    expected_mutation = run_mutations(item)
+    if mutation_result != expected_mutation:
+        raise StwoQueryGrindingBudgetGateError("mutation result drift")
+    validate_mutation_result(mutation_result)
+
+
+def validate_mutation_result(mutation_result: Any) -> None:
+    if not isinstance(mutation_result, dict):
+        raise StwoQueryGrindingBudgetGateError("mutation result missing")
+    if mutation_result.get("mutation_names") != list(MUTATION_NAMES):
+        raise StwoQueryGrindingBudgetGateError("mutation names drift")
+    cases = mutation_result.get("cases")
+    if not isinstance(cases, list) or len(cases) != len(MUTATION_NAMES):
+        raise StwoQueryGrindingBudgetGateError("mutation case count drift")
+    for case in cases:
+        if not isinstance(case, dict):
+            raise StwoQueryGrindingBudgetGateError("mutation case schema drift")
+        if (
+            not isinstance(case.get("name"), str)
+            or not isinstance(case.get("rejected"), bool)
+            or not isinstance(case.get("error"), str)
+        ):
+            raise StwoQueryGrindingBudgetGateError("mutation case schema drift")
+    if [case["name"] for case in cases if case["rejected"]] != list(MUTATION_NAMES):
+        raise StwoQueryGrindingBudgetGateError("mutation rejection drift")
+    if mutation_result.get("mutations_rejected") != len(MUTATION_NAMES):
+        raise StwoQueryGrindingBudgetGateError("mutation rejected count drift")
+    if mutation_result.get("all_mutations_rejected") is not True:
+        raise StwoQueryGrindingBudgetGateError("mutation all-rejected drift")
+
+
+def mutate_payload(name: str, item: dict[str, Any]) -> None:
+    if name == "decision_overclaim":
+        item["decision"] = "GO_GRINDING_BREAKTHROUGH"
+    elif name == "result_overclaim":
+        item["result"] = "NEW_PROOF_SIZE_FRONTIER"
+    elif name == "inventory_count_drift":
+        item["inventory"]["row_count"] = 8
+    elif name == "inventory_commitment_drift":
+        item["inventory"]["commitment"] = "blake2b-256:" + ("0" * 64)
+    elif name == "baseline_metric_drift":
+        item["baseline"]["final_typed_bytes"] = 41_000
+    elif name == "champion_metric_drift":
+        item["champion"]["final_typed_bytes"] = 36_000
+    elif name == "two_probe_claims_new_frontier":
+        policy_row(item, "two_probe_budget_2")["claims_new_frontier"] = True
+    elif name == "two_probe_security_loss_understated":
+        policy_row(item, "two_probe_budget_2")["security_loss_bits"] = "0.000000"
+    elif name == "two_probe_verifier_bound_removed":
+        policy_row(item, "two_probe_budget_2")["requires_verifier_bound_attempt_domain"] = False
+    elif name == "seed_only_promoted":
+        policy_row(item, "seed_only_budget_6")["status"] = "GO"
+    elif name == "all_inventory_promoted":
+        policy_row(item, "all_inventory_budget_9")["status"] = "GO"
+    elif name == "unbounded_policy_allowed":
+        policy_row(item, "unbounded_abort_and_retry")["status"] = "GO"
+    elif name == "final_envelope_json_allowed":
+        item["forbidden_policy_inputs"]["final_envelope_json"] = False
+    elif name == "final_proof_bytes_allowed":
+        item["forbidden_policy_inputs"]["final_proof_bytes"] = False
+    elif name == "post_decommitment_accounting_allowed":
+        item["forbidden_policy_inputs"]["post_decommitment_accounting"] = False
+    elif name == "unbounded_retry_count_allowed":
+        item["forbidden_policy_inputs"]["unbounded_retry_count"] = False
+    elif name == "uncommitted_attempt_domain_allowed":
+        item["forbidden_policy_inputs"]["uncommitted_attempt_domain"] = False
+    elif name == "max_loss_bits_drift":
+        item["budget_rule"]["paper_prototype_max_loss_bits"] = "8.000000"
+    elif name == "validation_command_removed":
+        item["validation_commands"].pop()
+    elif name == "non_claim_removed":
+        item["non_claims"].remove("not a new proof-size frontier")
+    elif name == "payload_commitment_drift":
+        item["payload_commitment"] = "blake2b-256:" + ("0" * 64)
+    else:
+        raise StwoQueryGrindingBudgetGateError(f"unknown mutation: {name}")
+
+
+def run_mutations(base_payload: dict[str, Any]) -> dict[str, Any]:
+    cases = []
+    for name in MUTATION_NAMES:
+        item = copy.deepcopy(base_payload)
+        mutate_payload(name, item)
+        rejected = False
+        error = ""
+        try:
+            if name == "payload_commitment_drift":
+                validate_payload(item)
+            else:
+                validate_base_payload(item)
+        except (StwoQueryGrindingBudgetGateError, preview_gate.StwoQueryPreviewSplitPrototypeGateError, hook_gate.BoundedStwoQueryPolicyHookGateError) as err:
+            rejected = True
+            error = str(err)
+        cases.append({"name": name, "rejected": rejected, "error": error})
+    rejected_count = sum(1 for case in cases if case["rejected"])
+    return {
+        "all_mutations_rejected": rejected_count == len(MUTATION_NAMES),
+        "mutations_rejected": rejected_count,
+        "mutation_names": list(MUTATION_NAMES),
+        "cases": cases,
+    }
+
+
+def build_payload() -> dict[str, Any]:
+    payload = build_payload_without_mutations()
+    payload["mutation_result"] = run_mutations(payload)
+    payload["payload_commitment"] = payload_commitment(payload)
+    validate_payload(payload)
+    return payload
+
+
+def render_tsv(payload: dict[str, Any]) -> str:
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n")
+    writer.writeheader()
+    for row in payload["policy_rows"]:
+        writer.writerow({column: row[column] for column in TSV_COLUMNS})
+    return output.getvalue()
+
+
+def write_outputs(json_path: pathlib.Path, tsv_path: pathlib.Path, payload: dict[str, Any]) -> None:
+    validate_payload(payload)
+    json_data = json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True).encode() + b"\n"
+    tsv_data = render_tsv(payload).encode()
+    try:
+        sampler_gate.atomic_write_pair(json_path, json_data, tsv_path, tsv_data)
+    except sampler_gate.DryRunOpeningSamplerGateError as err:
+        raise StwoQueryGrindingBudgetGateError(str(err)) from err
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write-json", type=pathlib.Path)
+    parser.add_argument("--write-tsv", type=pathlib.Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    payload = build_payload()
+    if args.write_json or args.write_tsv:
+        if not args.write_json or not args.write_tsv:
+            raise StwoQueryGrindingBudgetGateError("--write-json and --write-tsv must be paired")
+        write_outputs(args.write_json, args.write_tsv, payload)
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (
+        StwoQueryGrindingBudgetGateError,
+        preview_gate.StwoQueryPreviewSplitPrototypeGateError,
+        hook_gate.BoundedStwoQueryPolicyHookGateError,
+    ) as err:
+        print(f"error: {err}", file=sys.stderr)
+        raise SystemExit(2) from None

--- a/scripts/zkai_stwo_query_grinding_budget_gate.py
+++ b/scripts/zkai_stwo_query_grinding_budget_gate.py
@@ -56,6 +56,18 @@ TSV_COLUMNS = (
     "requires_verifier_bound_attempt_domain",
     "claims_new_frontier",
 )
+REQUIRED_INVENTORY_COLUMNS = (
+    "variant_id",
+    "adapter_mode",
+    "policy_stage",
+    "query_location_span",
+    "min_pairwise_query_gap",
+    "selected_without_final_accounting",
+    "predicted_path_opening_bytes",
+    "final_path_opening_bytes",
+    "final_typed_bytes",
+    "api_control_status",
+)
 VALIDATION_COMMANDS = (
     "python3.10 scripts/zkai_stwo_query_grinding_budget_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv",
     "python3.10 -m py_compile scripts/zkai_stwo_query_grinding_budget_gate.py scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py",
@@ -143,21 +155,27 @@ def load_inventory() -> list[dict[str, Any]]:
         text = raw.decode("utf-8")
     except UnicodeDecodeError as err:
         raise StwoQueryGrindingBudgetGateError("predecommit inventory TSV is not UTF-8") from err
-    rows = list(csv.DictReader(io.StringIO(text), delimiter="\t"))
+    reader = csv.DictReader(io.StringIO(text), delimiter="\t")
+    if tuple(reader.fieldnames or ()) != REQUIRED_INVENTORY_COLUMNS:
+        raise StwoQueryGrindingBudgetGateError("inventory header drift")
+    rows = list(reader)
     if len(rows) != EXPECTED_INVENTORY_COUNT:
         raise StwoQueryGrindingBudgetGateError("inventory row count drift")
     inventory = []
     for row in rows:
-        inventory.append(
-            {
-                "variant_id": row["variant_id"],
-                "adapter_mode": row["adapter_mode"],
-                "query_location_span": parse_int(row, "query_location_span"),
-                "min_pairwise_query_gap": parse_int(row, "min_pairwise_query_gap"),
-                "final_path_opening_bytes": parse_int(row, "final_path_opening_bytes"),
-                "final_typed_bytes": parse_int(row, "final_typed_bytes"),
-            }
-        )
+        try:
+            inventory.append(
+                {
+                    "variant_id": row["variant_id"],
+                    "adapter_mode": row["adapter_mode"],
+                    "query_location_span": parse_int(row, "query_location_span"),
+                    "min_pairwise_query_gap": parse_int(row, "min_pairwise_query_gap"),
+                    "final_path_opening_bytes": parse_int(row, "final_path_opening_bytes"),
+                    "final_typed_bytes": parse_int(row, "final_typed_bytes"),
+                }
+            )
+        except KeyError as err:
+            raise StwoQueryGrindingBudgetGateError(f"inventory field missing: {err.args[0]}") from err
     return inventory
 
 
@@ -179,30 +197,43 @@ def loss_bits(attempt_budget: int) -> str:
     return f"{math.log2(attempt_budget):.6f}"
 
 
-def policy(
-    inventory: list[dict[str, Any]],
-    policy_id: str,
-    variant_ids: tuple[str, ...],
-    status: str,
-    requires_verifier_bound_attempt_domain: bool,
-    claims_new_frontier: bool,
-) -> dict[str, Any]:
+def classify_policy(policy_id: str, best: dict[str, Any], attempt_budget: int) -> str:
+    if policy_id == "fixed_layout_budget_1":
+        return "BASELINE_NO_GRINDING"
+    if policy_id == "two_probe_budget_2":
+        if attempt_budget == 2 and best["variant_id"] == CHAMPION_VARIANT_ID:
+            return "MECHANISM_GO_REQUIRES_VERIFIER_BOUND_ATTEMPT_DOMAIN"
+        return "NO_GO_TWO_PROBE_DOES_NOT_RECOVER_CHAMPION"
+    if policy_id == "seed_only_budget_6":
+        if best["variant_id"] == CHAMPION_VARIANT_ID:
+            return "NO_GO_SEED_ONLY_RECOVERS_CHAMPION_BUT_SPENDS_EXTRA_BUDGET"
+        return "NO_GO_SEED_ONLY_DOES_NOT_RECOVER_CHAMPION"
+    if policy_id == "all_inventory_budget_9":
+        if best["variant_id"] == CHAMPION_VARIANT_ID:
+            return "NO_GO_UNNEEDED_EXTRA_GRINDING"
+        return "NO_GO_ALL_INVENTORY_DOES_NOT_RECOVER_CHAMPION"
+    raise StwoQueryGrindingBudgetGateError(f"unknown policy: {policy_id}")
+
+
+def policy(inventory: list[dict[str, Any]], policy_id: str, variant_ids: tuple[str, ...]) -> dict[str, Any]:
     baseline = find_variant(inventory, BASELINE_VARIANT_ID)
     champion = find_variant(inventory, CHAMPION_VARIANT_ID)
     best = best_variant(inventory, variant_ids)
+    attempt_budget = len(variant_ids)
+    status = classify_policy(policy_id, best, attempt_budget)
     return {
         "policy_id": policy_id,
         "status": status,
         "allowed_variant_ids": list(variant_ids),
-        "attempt_budget": len(variant_ids),
-        "security_loss_bits": loss_bits(len(variant_ids)),
+        "attempt_budget": attempt_budget,
+        "security_loss_bits": loss_bits(attempt_budget),
         "best_variant_id": best["variant_id"],
         "best_typed_bytes": best["final_typed_bytes"],
         "best_path_opening_bytes": best["final_path_opening_bytes"],
         "improvement_vs_fixed_typed_bytes": baseline["final_typed_bytes"] - best["final_typed_bytes"],
         "improvement_vs_champion_typed_bytes": champion["final_typed_bytes"] - best["final_typed_bytes"],
-        "requires_verifier_bound_attempt_domain": requires_verifier_bound_attempt_domain,
-        "claims_new_frontier": claims_new_frontier,
+        "requires_verifier_bound_attempt_domain": attempt_budget > 1,
+        "claims_new_frontier": False,
     }
 
 
@@ -212,17 +243,11 @@ def policies(inventory: list[dict[str, Any]]) -> list[dict[str, Any]]:
             inventory,
             "fixed_layout_budget_1",
             ("fixed_adjacent_layout",),
-            "BASELINE_NO_GRINDING",
-            False,
-            False,
         ),
         policy(
             inventory,
             "two_probe_budget_2",
             ("adjacent_label_probe_a", "adjacent_label_probe_b"),
-            "MECHANISM_GO_REQUIRES_VERIFIER_BOUND_ATTEMPT_DOMAIN",
-            True,
-            False,
         ),
         policy(
             inventory,
@@ -235,17 +260,11 @@ def policies(inventory: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "adjacent_seed_04",
                 "adjacent_seed_05",
             ),
-            "NO_GO_SEED_ONLY_DOES_NOT_RECOVER_CHAMPION",
-            True,
-            False,
         ),
         policy(
             inventory,
             "all_inventory_budget_9",
             tuple(row["variant_id"] for row in inventory),
-            "NO_GO_UNNEEDED_EXTRA_GRINDING",
-            True,
-            False,
         ),
         {
             "policy_id": "unbounded_abort_and_retry",

--- a/scripts/zkai_stwo_query_grinding_budget_gate.py
+++ b/scripts/zkai_stwo_query_grinding_budget_gate.py
@@ -43,6 +43,8 @@ CHAMPION_VARIANT_ID = "adjacent_label_probe_b"
 EXPECTED_INVENTORY_COUNT = 9
 EXPECTED_UNITTEST_STEP_COUNT = 18
 MAX_PAPER_PROTOTYPE_LOSS_BITS = "2.000000"
+EXPECTED_POLICY_STAGE = "post_transcript_pre_accounting_not_true_predecommit"
+EXPECTED_API_CONTROL_STATUS = "NO_TRUE_PREDECOMMIT_CONTROL_HOOK_IN_CURRENT_WRAPPER"
 
 TSV_COLUMNS = (
     "policy_id",
@@ -91,6 +93,7 @@ MUTATION_NAMES = (
     "result_overclaim",
     "inventory_count_drift",
     "inventory_commitment_drift",
+    "inventory_trust_field_drift",
     "baseline_metric_drift",
     "champion_metric_drift",
     "two_probe_claims_new_frontier",
@@ -145,8 +148,24 @@ def payload_commitment(payload: dict[str, Any]) -> str:
 def parse_int(row: dict[str, str], field: str) -> int:
     try:
         return int(row[field])
-    except (KeyError, ValueError) as err:
+    except (KeyError, TypeError, ValueError) as err:
         raise StwoQueryGrindingBudgetGateError(f"inventory field {field} is invalid") from err
+
+
+def parse_text(row: dict[str, str], field: str) -> str:
+    value = row.get(field)
+    if not isinstance(value, str) or value == "":
+        raise StwoQueryGrindingBudgetGateError(f"inventory field {field} is invalid")
+    return value
+
+
+def parse_bool_token(row: dict[str, str], field: str) -> bool:
+    value = parse_text(row, field)
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise StwoQueryGrindingBudgetGateError(f"inventory field {field} is invalid")
 
 
 def load_inventory() -> list[dict[str, Any]]:
@@ -163,19 +182,33 @@ def load_inventory() -> list[dict[str, Any]]:
         raise StwoQueryGrindingBudgetGateError("inventory row count drift")
     inventory = []
     for row in rows:
-        try:
-            inventory.append(
-                {
-                    "variant_id": row["variant_id"],
-                    "adapter_mode": row["adapter_mode"],
-                    "query_location_span": parse_int(row, "query_location_span"),
-                    "min_pairwise_query_gap": parse_int(row, "min_pairwise_query_gap"),
-                    "final_path_opening_bytes": parse_int(row, "final_path_opening_bytes"),
-                    "final_typed_bytes": parse_int(row, "final_typed_bytes"),
-                }
-            )
-        except KeyError as err:
-            raise StwoQueryGrindingBudgetGateError(f"inventory field missing: {err.args[0]}") from err
+        policy_stage = parse_text(row, "policy_stage")
+        if policy_stage != EXPECTED_POLICY_STAGE:
+            raise StwoQueryGrindingBudgetGateError("inventory policy stage drift")
+        api_control_status = parse_text(row, "api_control_status")
+        if api_control_status != EXPECTED_API_CONTROL_STATUS:
+            raise StwoQueryGrindingBudgetGateError("inventory API control status drift")
+        predicted_path_opening_bytes = parse_int(row, "predicted_path_opening_bytes")
+        final_path_opening_bytes = parse_int(row, "final_path_opening_bytes")
+        if predicted_path_opening_bytes != final_path_opening_bytes:
+            raise StwoQueryGrindingBudgetGateError("inventory predicted path-opening drift")
+        inventory.append(
+            {
+                "variant_id": parse_text(row, "variant_id"),
+                "adapter_mode": parse_text(row, "adapter_mode"),
+                "policy_stage": policy_stage,
+                "query_location_span": parse_int(row, "query_location_span"),
+                "min_pairwise_query_gap": parse_int(row, "min_pairwise_query_gap"),
+                "selected_without_final_accounting": parse_bool_token(row, "selected_without_final_accounting"),
+                "predicted_path_opening_bytes": predicted_path_opening_bytes,
+                "final_path_opening_bytes": final_path_opening_bytes,
+                "final_typed_bytes": parse_int(row, "final_typed_bytes"),
+                "api_control_status": api_control_status,
+            }
+        )
+    selected_ids = [row["variant_id"] for row in inventory if row["selected_without_final_accounting"]]
+    if selected_ids != [CHAMPION_VARIANT_ID]:
+        raise StwoQueryGrindingBudgetGateError("inventory selected-without-final-accounting drift")
     return inventory
 
 
@@ -453,6 +486,8 @@ def mutate_payload(name: str, item: dict[str, Any]) -> None:
         item["inventory"]["row_count"] = 8
     elif name == "inventory_commitment_drift":
         item["inventory"]["commitment"] = "blake2b-256:" + ("0" * 64)
+    elif name == "inventory_trust_field_drift":
+        item["inventory"]["rows"][0]["api_control_status"] = "POST_DECOMMITMENT_CONTROL_ALLOWED"
     elif name == "baseline_metric_drift":
         item["baseline"]["final_typed_bytes"] = 41_000
     elif name == "champion_metric_drift":

--- a/scripts/zkai_stwo_query_grinding_budget_gate.py
+++ b/scripts/zkai_stwo_query_grinding_budget_gate.py
@@ -153,9 +153,12 @@ def payload_commitment(payload: dict[str, Any]) -> str:
 
 def parse_int(row: dict[str, str], field: str) -> int:
     try:
-        return int(row[field])
+        value = int(row[field])
     except (KeyError, TypeError, ValueError) as err:
         raise StwoQueryGrindingBudgetGateError(f"inventory field {field} is invalid") from err
+    if value < 0:
+        raise StwoQueryGrindingBudgetGateError(f"inventory field {field} is negative: {value}")
+    return value
 
 
 def parse_text(row: dict[str, str], field: str) -> str:


### PR DESCRIPTION
## Summary

This PR closes the follow-up from the Stwo query-preview split by turning post-query label selection into a bounded mechanism gate.

It adds a checked Stwo query-grinding budget artifact for issue #706:

- fixed adjacent layout: `42,156` typed bytes
- current champion: `adjacent_label_probe_b` at `37,532` typed bytes
- two-probe attempt domain: `adjacent_label_probe_a`, `adjacent_label_probe_b`
- relative Fiat-Shamir grinding loss: `log2(2) = 1.000000` bit
- improvement versus fixed layout: `4,624` typed bytes
- improvement versus current champion: `0` typed bytes

## Claim Boundary

Decision: `NARROW_CLAIM_SMALL_VERIFIER_BOUND_RETRY_BUDGET_CAN_RECOVER_PROBE_B_INVENTORY`

Result: `GO_MECHANISM_LEAD_NOT_PROOF_SIZE_FRONTIER`

The useful result is that a small verifier-bound attempt domain can recover the existing probe-B row from the checked inventory. This is not a new proof-size frontier. It is a mechanism lead for the next proof-object PR.

## Evidence

- `docs/engineering/zkai-stwo-query-grinding-budget-2026-05-19.md`
- `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json`
- `docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`

Evidence hashes:

- JSON SHA-256: `a5ef30dc1cdd2aa0bc72163a40f2c66358265a1ef0f29d0e41ff4cf972951303`
- TSV SHA-256: `6961f51c3863814883bcb6cd554b919572d532bdfe34bebffe1099f6ec2bb587`
- Inventory commitment: `blake2b-256:6b58d3f30c5a0b0e5d1aa78890f72c5830d973f3b3795bc1917fc0253266c37e`
- Payload commitment: `blake2b-256:139ebaf55f70c771cf1d1f9f6fb8a132bc2215118e46a6ca4dbd2d6da4e0aea6`

## Hardening

The gate rejects `22 / 22` mutation cases, including:

- claim/result overclaim drift
- inventory count, commitment, and trust-field drift
- baseline/champion metric drift
- two-probe undercharged security loss
- removing verifier-bound attempt-domain requirements
- promoting seed-only or all-inventory policies
- allowing final envelope JSON, final proof bytes, post-decommitment accounting, unbounded retry count, or uncommitted attempt domain as policy inputs
- validation-command and non-claim drift
- payload-commitment drift

It also pins and commits the full pre-decommitment inventory trust surface:

- `policy_stage`
- `selected_without_final_accounting`
- `predicted_path_opening_bytes`
- `api_control_status`

## Non-Claims

- not a new proof-size frontier
- not regenerated proof objects under a grinding API
- not an absolute soundness claim
- not a verifier implementation
- not a production query policy
- not a NANOZK proof-size comparison
- not a full transformer block proof
- not timing evidence

## Local Validation

GitHub Actions are not part of the research readiness loop. Validation was local:

- `python3.10 scripts/zkai_stwo_query_grinding_budget_gate.py --write-json docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.json --write-tsv docs/engineering/evidence/zkai-stwo-query-grinding-budget-2026-05.tsv`
- `python3.10 -m py_compile scripts/zkai_stwo_query_grinding_budget_gate.py scripts/tests/test_zkai_stwo_query_grinding_budget_gate.py`
- `python3.10 -m unittest scripts.tests.test_zkai_stwo_query_grinding_budget_gate`
- `git diff --check`
- `just gate-fast`
- `just gate` (`14 / 14` local release-gate steps OK)

Closes #706.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed Stwo query-grinding budget docs: decision gate record, human-readable rationale, policy comparison, quantified Fiat–Shamir loss and typed-byte accounting, explicit seed-only/all-inventory budget outcomes, and full reproducibility metadata; updated handoff read order.

* **Tests**
  * Added comprehensive validation tests for deterministic outputs, evidence integrity, inventory/payload validation, mutation handling, and reproducibility.

* **Chores**
  * Added CLI tooling to build, validate, mutate, and atomically publish reproducible budget-gate evidence (paired JSON+TSV).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->