### PR TITLE
Update zkML competitor matrix frontier

### DIFF
--- a/.codex/HANDOFF.md
+++ b/.codex/HANDOFF.md
@@ -20,6 +20,17 @@ before opening or executing frontier issues. The north star is STARK-native
 proof architecture as the backbone for production zkML later; issues are
 hypotheses with explicit GO/NO-GO gates, required artifacts, and non-claims.
 
+Latest May 2026 competitor metric matrix: issue `#682` is now updated around
+the checked statement-only seq32+d128 proof object, not the obsolete `42,068`
+typed-byte row. The local comparison row is `39,516` typed proof bytes /
+`113,388` JSON proof bytes, saving `7,672` typed bytes versus the matched
+local two-proof frontier and `2,552` typed bytes versus the previous
+single-proof champion. The gate still records `0` NANOZK-comparable external
+rows and keeps NANOZK/Jolt/DeepProve/EZKL rows source-backed context only. This
+is a local inner-policy-bound frontier, not a full transformer block proof,
+not a timing result, and not an external zkML benchmark. See
+`docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md`.
+
 Latest dry-run opening sampler: issue `#697` is now checked as a GO for the
 nine-row adjacent label/seed inventory. The source-visible pre-prove inventory
 could not distinguish the final path-opening buckets, but Stwo

--- a/docs/engineering/codex-repo-handoff-2026-04-24.md
+++ b/docs/engineering/codex-repo-handoff-2026-04-24.md
@@ -112,6 +112,17 @@ before opening or executing frontier issues. The north star is STARK-native
 proof architecture as the backbone for production zkML later; issues are
 hypotheses with explicit GO/NO-GO gates, required artifacts, and non-claims.
 
+Latest May 2026 competitor metric matrix: issue `#682` is now updated around
+the checked statement-only seq32+d128 proof object, not the obsolete `42,068`
+typed-byte row. The local comparison row is `39,516` typed proof bytes /
+`113,388` JSON proof bytes, saving `7,672` typed bytes versus the matched
+local two-proof frontier and `2,552` typed bytes versus the previous
+single-proof champion. The gate still records `0` NANOZK-comparable external
+rows and keeps NANOZK/Jolt/DeepProve/EZKL rows source-backed context only. This
+is a local inner-policy-bound frontier, not a full transformer block proof,
+not a timing result, and not an external zkML benchmark. See
+`docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md`.
+
 Latest seq32-derived d128 native MLP surface: issue `#674` fixes the
 source-value mismatch discovered by issue `#673`. The selected two-head seq32
 attention surface now feeds a regenerated d128 RMSNorm/MLP input with `0 / 128`

--- a/docs/engineering/evidence/zkai-d128-native-block-gap-accounting-2026-05.json
+++ b/docs/engineering/evidence/zkai-d128-native-block-gap-accounting-2026-05.json
@@ -142,7 +142,7 @@
     "not exact real-valued Softmax, LayerNorm, or GELU",
     "not production-ready"
   ],
-  "payload_commitment": "sha256:94479c79fb1f3b253148ffca5e1ffe2a612d0280f7fd9e50a7291ac390f2e6fb",
+  "payload_commitment": "sha256:30d42121db754bb23a3cb43b477f4c1347a25f6da50749f2eea475026c7cee09",
   "result": "GO_INTERESTING_PACKAGE_SIGNAL_NO_GO_NANOZK_SIZE_WIN",
   "schema": "zkai-d128-native-block-gap-accounting-v1",
   "source_artifacts": [
@@ -163,12 +163,12 @@
       "schema": "zkai-one-block-executable-package-accounting-v1"
     },
     {
-      "decision": "GO_SOURCE_BACKED_COMPETITOR_MATRIX_NO_GO_MATCHED_BENCHMARK_CLAIMS",
-      "file_sha256": "275b2494effb9658dba051cd77231ae572c55a282dcd752b592b2a7e6172e01a",
+      "decision": "GO_SOURCE_BACKED_COMPETITOR_MATRIX_WITH_STATEMENT_ONLY_FRONTIER_NO_GO_MATCHED_BENCHMARK_CLAIMS",
+      "file_sha256": "03ff22e24861b317769de38f8137bae70c82aa558175fd49b7bc6b49a8321342",
       "kind": "competitor_metric_matrix_json",
       "path": "docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json",
-      "payload_sha256": "114af1b6d149d9049a15c0f5ea3bd4fedc4505c8b7e014212248c77205311ca0",
-      "schema": "zkai-may2026-competitor-metric-matrix-v1"
+      "payload_sha256": "fa9d0abf264c6950455146af855483194b4dc8c3bc5278902c119c3e7103d676",
+      "schema": "zkai-may2026-competitor-metric-matrix-v2"
     },
     {
       "file_sha256": "aa16aa98493ecf9f984d238875890c81b4525ebde21463b76010c92f6767390b",

--- a/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json
+++ b/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json
@@ -88,6 +88,7 @@
   ],
   "local_rows": [
     {
+      "artifact_path": "docs/engineering/evidence/zkai-attention-kv-stwo-fusion-mechanism-ablation-2026-05.json",
       "comparison_status": "LOCAL_MECHANISM_EVIDENCE_NOT_LAYERWISE_FULL_MODEL_BENCHMARK",
       "local_status": "GO_BOUNDED_ARCHITECTURE_MECHANISM",
       "metric": "matched route JSON proof-byte saving",
@@ -98,6 +99,7 @@
       "value": 194097
     },
     {
+      "artifact_path": "docs/engineering/evidence/zkai-d64-block-receipt-composition-gate-2026-05.json",
       "comparison_status": "LOCAL_RECEIPT_CHAIN_NOT_RECURSIVE_PROOF_COMPRESSION",
       "local_status": "GO_STATEMENT_BOUND_RECEIPT_COMPOSITION",
       "metric": "checked slice rows",
@@ -108,6 +110,7 @@
       "value": 49600
     },
     {
+      "artifact_path": "docs/engineering/evidence/zkai-d128-layerwise-comparator-target-2026-05.json",
       "comparison_status": "TARGET_SPEC_ONLY_NOT_LOCAL_PROOF_RESULT",
       "local_status": "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
       "metric": "target estimated linear multiplications",
@@ -118,6 +121,7 @@
       "value": 196608
     },
     {
+      "artifact_path": "docs/engineering/evidence/zkai-stwo-statement-only-attempt-transcript-gate-2026-05.json",
       "comparison_status": "LOCAL_INNER_POLICY_BOUND_PROOF_OBJECT_NOT_EXTERNAL_LAYER_BENCHMARK",
       "local_status": "GO_STWO_SEQ32_D128_INNER_POLICY_BOUND_FRONTIER",
       "metric": "typed proof bytes",
@@ -128,6 +132,7 @@
       "value": 39516
     },
     {
+      "artifact_path": "docs/engineering/evidence/zkai-one-block-executable-package-accounting-2026-05.json",
       "comparison_status": "LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_NOT_MATCHED_LAYER_PROOF_BENCHMARK",
       "local_status": "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF",
       "metric": "compressed artifact plus proof plus public signals",
@@ -138,6 +143,7 @@
       "value": 4752
     },
     {
+      "artifact_path": "docs/engineering/evidence/zkai-one-block-executable-package-accounting-2026-05.json",
       "comparison_status": "LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_WITH_SETUP_NOT_MATCHED_LAYER_PROOF_BENCHMARK",
       "local_status": "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF",
       "metric": "compressed artifact plus proof plus public signals plus verification key",
@@ -157,7 +163,7 @@
     "not exact real-valued Softmax",
     "not production-ready"
   ],
-  "payload_commitment": "sha256:f5f34fc2f4339e077371da4dda02a3b96c51edf5570023b2c6808542d38fbfc4",
+  "payload_commitment": "sha256:1334a4dfb5fab4c6fa1857d4fb25a202bbcca8502baceca18f5d2d4b892ef117",
   "schema": "zkai-may2026-competitor-metric-matrix-v2",
   "source_artifacts": [
     {

--- a/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json
+++ b/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json
@@ -1,6 +1,6 @@
 {
-  "claim_boundary": "SOURCE_BACKED_MAY2026_ZKML_COMPETITOR_MATRIX_WITH_LOCAL_STWO_ATTENTION_FUSION_AND_TRANSFORMER_BLOCK_TARGET_CONTEXT_NOT_A_MATCHED_PUBLIC_BENCHMARK_NOT_FULL_INFERENCE",
-  "decision": "GO_SOURCE_BACKED_COMPETITOR_MATRIX_NO_GO_MATCHED_BENCHMARK_CLAIMS",
+  "claim_boundary": "SOURCE_BACKED_MAY2026_ZKML_COMPETITOR_MATRIX_WITH_LOCAL_STWO_ATTENTION_FUSION_AND_SEQ32_D128_STATEMENT_ONLY_FRONTIER_NOT_A_MATCHED_PUBLIC_BENCHMARK_NOT_FULL_INFERENCE",
+  "decision": "GO_SOURCE_BACKED_COMPETITOR_MATRIX_WITH_STATEMENT_ONLY_FRONTIER_NO_GO_MATCHED_BENCHMARK_CLAIMS",
   "external_rows": [
     {
       "backend_family": "Halo2 IPA SNARK + lookups",
@@ -80,10 +80,11 @@
   ],
   "interpretation": [
     "NANOZK and Jolt Atlas are the relevant layerwise/end-to-end competitors for headline zkML metrics.",
-    "The local repo does not yet have a d128 layer proof to compare on proof size or verifier time.",
+    "The local repo now has a checked seq32+d128 inner-policy-bound Stwo proof object, but it is not a matched external layer proof benchmark.",
     "The local competitive claim is architectural: STARK-native fusion saves duplicated opening/decommitment plumbing.",
+    "The current checked local frontier is 39,516 typed proof bytes for the statement-only seq32+d128 proof object, saving 7,672 typed bytes versus the matched local two-proof frontier.",
     "The executable package-accounting rows show a smaller verifier-facing package than the source statement chain, but they are external receipt accounting rather than native layer proof evidence.",
-    "The next real block milestone is a parameterized d64 then d128 RMSNorm/SwiGLU/residual proof surface with the same statement bindings."
+    "The next real comparison milestone is object-class matching: full transformer-block surface, stable binary accounting, and timing policy before any NANOZK/Jolt/DeepProve comparison."
   ],
   "local_rows": [
     {
@@ -117,6 +118,16 @@
       "value": 196608
     },
     {
+      "comparison_status": "LOCAL_INNER_POLICY_BOUND_PROOF_OBJECT_NOT_EXTERNAL_LAYER_BENCHMARK",
+      "local_status": "GO_STWO_SEQ32_D128_INNER_POLICY_BOUND_FRONTIER",
+      "metric": "typed proof bytes",
+      "support": "113388 JSON proof bytes; saves 7672 typed bytes vs matched local two-proof frontier; saves 2552 typed bytes vs previous single-proof champion; 20 / 20 mutations rejected; 0 NANOZK-comparable rows; still 1984 typed bytes above legacy wrapper-only context",
+      "surface": "seq32+d128 statement-only native proof object",
+      "system": "provable-transformer-vm",
+      "unit": "bytes",
+      "value": 39516
+    },
+    {
       "comparison_status": "LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_NOT_MATCHED_LAYER_PROOF_BENCHMARK",
       "local_status": "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF",
       "metric": "compressed artifact plus proof plus public signals",
@@ -139,15 +150,15 @@
   ],
   "non_claims": [
     "not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero",
-    "not a local d128 proof result",
-    "not proof-size or verifier-time evidence for a local d128 transformer block",
+    "not a proof-size or verifier-time comparison against any external zkML system",
+    "not a full d128 transformer block proof",
     "not native proof-size evidence from the external package-accounting rows",
     "not full transformer inference",
     "not exact real-valued Softmax",
     "not production-ready"
   ],
-  "payload_commitment": "sha256:1f3102fded6ee40d98a4c7ba2759c8938786fe36845edf91e24d628bf27a3fb4",
-  "schema": "zkai-may2026-competitor-metric-matrix-v1",
+  "payload_commitment": "sha256:f5f34fc2f4339e077371da4dda02a3b96c51edf5570023b2c6808542d38fbfc4",
+  "schema": "zkai-may2026-competitor-metric-matrix-v2",
   "source_artifacts": [
     {
       "kind": "published_zkml_numbers_tsv",
@@ -173,11 +184,16 @@
       "kind": "local_one_block_package_accounting_json",
       "path": "docs/engineering/evidence/zkai-one-block-executable-package-accounting-2026-05.json",
       "sha256": "c7eae55c04fac6e1412752c07bfdf32deeb4e2059a51c3b279037905ce703277"
+    },
+    {
+      "kind": "local_seq32_d128_statement_only_attempt_gate_json",
+      "path": "docs/engineering/evidence/zkai-stwo-statement-only-attempt-transcript-gate-2026-05.json",
+      "sha256": "d6e8d8ebe36fc438b61ba879cc9d6979cf437a76fe2beda98477138e0e341881"
     }
   ],
   "validation_commands": [
-    "python3 scripts/zkai_may2026_competitor_metric_matrix_gate.py --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv",
-    "python3 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate",
+    "python3.10 scripts/zkai_may2026_competitor_metric_matrix_gate.py --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv",
+    "python3.10 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate",
     "git diff --check",
     "just gate-fast",
     "just gate"

--- a/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv
+++ b/docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv
@@ -7,5 +7,6 @@ external	EZKL (reported by Jolt Atlas)	NanoGPT proof	237	0.34	NA			SOURCE_BACKED
 local	provable-transformer-vm	Stwo attention/Softmax-table fusion				matched route JSON proof-byte saving	194097	LOCAL_MECHANISM_EVIDENCE_NOT_LAYERWISE_FULL_MODEL_BENCHMARK
 local	provable-transformer-vm	d64 RMSNorm/SwiGLU/residual block receipt				checked slice rows	49600	LOCAL_RECEIPT_CHAIN_NOT_RECURSIVE_PROOF_COMPRESSION
 local	provable-transformer-vm	d128 RMSNorm/SwiGLU/residual comparator target				target estimated linear multiplications	196608	TARGET_SPEC_ONLY_NOT_LOCAL_PROOF_RESULT
+local	provable-transformer-vm	seq32+d128 statement-only native proof object				typed proof bytes	39516	LOCAL_INNER_POLICY_BOUND_PROOF_OBJECT_NOT_EXTERNAL_LAYER_BENCHMARK
 local	provable-transformer-vm	attention-derived d128 executable package without VK				compressed artifact plus proof plus public signals	4752	LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_NOT_MATCHED_LAYER_PROOF_BENCHMARK
 local	provable-transformer-vm	attention-derived d128 executable package with VK				compressed artifact plus proof plus public signals plus verification key	10608	LOCAL_EXECUTABLE_PACKAGE_ACCOUNTING_WITH_SETUP_NOT_MATCHED_LAYER_PROOF_BENCHMARK

--- a/docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md
+++ b/docs/engineering/zkai-may2026-competitor-metric-matrix-2026-05-13.md
@@ -13,10 +13,10 @@ The comparison posture is:
 
 > NANOZK, Jolt Atlas, and EZKL are the relevant public metric references for
 > layerwise or end-to-end zkML proving. This repository should compare against
-> them honestly, but its current strongest local result is architectural:
-> STARK-native attention/Softmax-table fusion saves duplicated opening and
-> decommitment plumbing, and the attention-derived one-block route now has
-> explicit external package accounting.
+> them honestly, but its current strongest local result is still architectural:
+> STARK-native boundaries can share opening/decommitment plumbing, and the
+> current checked seq32+d128 statement-only proof object is a local frontier,
+> not a matched external benchmark.
 
 ## Evidence
 
@@ -35,11 +35,14 @@ The evidence graph is intentionally acyclic:
 
 ```text
 published zkML TSV -> one-block surface -> package accounting -> competitor matrix
+statement-only seq32+d128 gate ----------------------------^
 ```
 
 The one-block surface reads the published zkML TSV directly for NANOZK context.
 The competitor matrix can therefore consume package accounting without feeding
-back into the surface that package accounting depends on.
+back into the surface that package accounting depends on. The statement-only
+gate is consumed as a separate local source artifact so the newest native
+seq32+d128 row is pinned by its own mutation and overclaim guards.
 
 ## Source-Backed External Rows
 
@@ -63,18 +66,34 @@ These are source-backed context rows, not local reproductions.
 | Stwo attention/Softmax-table fusion | `GO_BOUNDED_ARCHITECTURE_MECHANISM` | `194,097` matched JSON proof bytes saved |
 | d64 RMSNorm/SwiGLU/residual block receipt | `GO_STATEMENT_BOUND_RECEIPT_COMPOSITION` | `49,600` checked slice rows |
 | d128 RMSNorm/SwiGLU/residual comparator target | `NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING` | `196,608` estimated linear multiplications |
+| seq32+d128 statement-only native proof object | `GO_STWO_SEQ32_D128_INNER_POLICY_BOUND_FRONTIER` | `39,516` typed proof bytes; `113,388` JSON proof bytes; saves `7,672` typed bytes versus matched local two-proof frontier |
 | attention-derived d128 executable package without VK | `GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF` | `4,752` bytes, `0.324945x` source |
 | attention-derived d128 executable package with VK | `GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF` | `10,608` bytes, `0.725383x` source |
 
 ## Interpretation
 
 The repo should not claim that it beats NANOZK or Jolt Atlas on layer proof
-size or end-to-end proving time. It does not yet have the matched local d128
-proof artifact needed for that comparison.
+size or end-to-end proving time. It now has a checked seq32+d128 local proof
+object, but the object class is still not matched to those external layerwise
+or end-to-end rows.
 
 The sharper claim is that the STARK-native route exposes a different mechanism:
-attention arithmetic and lookup-heavy table membership can share proof-system
-opening structure when fused into one native proof object.
+attention arithmetic, lookup-heavy table membership, and statement-bound
+metadata can share proof-system opening structure when fused into one native
+proof object.
+
+The newest local row is the statement-only attempt transcript profile:
+
+```text
+matched local two-proof frontier: 47,188 typed bytes
+previous single-proof champion: 42,068 typed bytes
+statement-only seq32+d128 proof object: 39,516 typed bytes
+JSON proof bytes: 113,388
+NANOZK-comparable external rows: 0
+```
+
+That is a real local improvement, but it is not a NANOZK/Jolt/DeepProve
+comparison. The matrix keeps the external rows as source-backed context only.
 
 The new package-accounting rows are useful because they make the attention-derived
 one-block statement route comparable as an artifact package:
@@ -85,15 +104,16 @@ compressed transcript + proof + public signals: 4,752 bytes
 compressed transcript + proof + public signals + VK: 10,608 bytes
 ```
 
-This is still not a native layer proof. The next block milestone is a
-parameterized d64 then d128 RMSNorm/SwiGLU/residual proof surface with the same
-statement bindings used by the d128 comparator target.
+This package accounting is still not native layer proof-size evidence. The next
+comparison milestone is object-class matching: full transformer-block surface,
+stable binary accounting, and timing policy before any NANOZK/Jolt/DeepProve
+comparison.
 
 ## Non-Claims
 
 - Not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero.
-- Not a local d128 proof result.
-- Not proof-size or verifier-time evidence for a local d128 transformer block.
+- Not a proof-size or verifier-time comparison against any external zkML system.
+- Not a full d128 transformer block proof.
 - Not native proof-size evidence from the external package-accounting rows.
 - Not full transformer inference.
 - Not exact real-valued Softmax.
@@ -102,11 +122,11 @@ statement bindings used by the d128 comparator target.
 ## Validation
 
 ```bash
-python3 scripts/zkai_may2026_competitor_metric_matrix_gate.py \
+python3.10 scripts/zkai_may2026_competitor_metric_matrix_gate.py \
   --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json \
   --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv
 
-python3 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate
+python3.10 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate
 
 git diff --check
 

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -23,9 +23,9 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         self.assertEqual(payload["schema"], gate.SCHEMA)
         self.assertEqual(payload["decision"], gate.DECISION)
         self.assertEqual(payload["claim_boundary"], gate.CLAIM_BOUNDARY)
-        self.assertEqual(len(payload["source_artifacts"]), 5)
+        self.assertEqual(len(payload["source_artifacts"]), 6)
         self.assertEqual(len(payload["external_rows"]), 5)
-        self.assertEqual(len(payload["local_rows"]), 5)
+        self.assertEqual(len(payload["local_rows"]), 6)
         self.assertIn("not a matched benchmark", payload["non_claims"][0])
 
         external = {(row["system"], row["workload_label"]): row for row in payload["external_rows"]}
@@ -38,6 +38,17 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         self.assertEqual(local["Stwo attention/Softmax-table fusion"]["value"], 194097)
         self.assertEqual(local["d64 RMSNorm/SwiGLU/residual block receipt"]["value"], 49600)
         self.assertEqual(local["d128 RMSNorm/SwiGLU/residual comparator target"]["value"], 196608)
+        self.assertEqual(local["seq32+d128 statement-only native proof object"]["value"], 39516)
+        self.assertEqual(
+            local["seq32+d128 statement-only native proof object"]["local_status"],
+            "GO_STWO_SEQ32_D128_INNER_POLICY_BOUND_FRONTIER",
+        )
+        self.assertEqual(
+            local["seq32+d128 statement-only native proof object"]["comparison_status"],
+            "LOCAL_INNER_POLICY_BOUND_PROOF_OBJECT_NOT_EXTERNAL_LAYER_BENCHMARK",
+        )
+        self.assertIn("saves 7672 typed bytes", local["seq32+d128 statement-only native proof object"]["support"])
+        self.assertIn("0 NANOZK-comparable rows", local["seq32+d128 statement-only native proof object"]["support"])
         self.assertEqual(local["attention-derived d128 executable package without VK"]["value"], 4752)
         self.assertEqual(local["attention-derived d128 executable package with VK"]["value"], 10608)
         self.assertEqual(
@@ -74,6 +85,8 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         self.assertIn("external\tNANOZK\tTransformer block proof\t6.3\t0.023\t6.9 KB", tsv)
         self.assertIn("local\tprovable-transformer-vm\tStwo attention/Softmax-table fusion", tsv)
         self.assertIn("matched route JSON proof-byte saving\t194097", tsv)
+        self.assertIn("local\tprovable-transformer-vm\tseq32+d128 statement-only native proof object", tsv)
+        self.assertIn("typed proof bytes\t39516", tsv)
         self.assertIn("attention-derived d128 executable package without VK", tsv)
         self.assertIn("compressed artifact plus proof plus public signals\t4752", tsv)
 
@@ -86,6 +99,7 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
             gate.D64_BLOCK_RECEIPT,
             gate.D128_TARGET,
             gate.PACKAGE_ACCOUNTING,
+            gate.STATEMENT_ONLY_ATTEMPT_GATE,
         ):
             raw = gate.read_source_bytes(path, "test source")
             artifact = source_by_path[str(path.relative_to(gate.ROOT))]
@@ -318,46 +332,53 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         d64 = gate.load_json(gate.D64_BLOCK_RECEIPT)
         d128 = gate.load_json(gate.D128_TARGET)
         package = gate.load_json(gate.PACKAGE_ACCOUNTING)
+        statement_only = gate.load_json(gate.STATEMENT_ONLY_ATTEMPT_GATE)
 
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion savings must be integer"):
-            gate._local_rows(fusion, d64, d128, package)
+            gate._local_rows(fusion, d64, d128, package, statement_only)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         fusion["section_delta"]["opening_bucket_savings_share"] = "0.927722"
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion opening share must be numeric"):
-            gate._local_rows(fusion, d64, d128, package)
+            gate._local_rows(fusion, d64, d128, package, statement_only)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         fusion["section_delta"]["opening_bucket_savings_share"] = math.inf
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion opening share must be finite"):
-            gate._local_rows(fusion, d64, d128, package)
+            gate._local_rows(fusion, d64, d128, package, statement_only)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         fusion["section_delta"]["opening_bucket_savings_share"] = 1.1
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion opening share must be between 0 and 1"):
-            gate._local_rows(fusion, d64, d128, package)
+            gate._local_rows(fusion, d64, d128, package, statement_only)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         fusion["route_matrix"]["fused_savings_bytes_total"] = 0
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "fusion savings must be positive"):
-            gate._local_rows(fusion, d64, d128, package)
+            gate._local_rows(fusion, d64, d128, package, statement_only)
 
         fusion = gate.load_json(gate.FUSION_MECHANISM)
         d64 = gate.load_json(gate.D64_BLOCK_RECEIPT)
         d64["summary"]["mutations_rejected"] = d64["summary"]["mutation_cases"] - 1
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "d64 mutation rejection summary drift"):
-            gate._local_rows(fusion, d64, d128, package)
+            gate._local_rows(fusion, d64, d128, package, statement_only)
 
         d64 = gate.load_json(gate.D64_BLOCK_RECEIPT)
         package = gate.load_json(gate.PACKAGE_ACCOUNTING)
         package["summary"]["package_without_vk_bytes"] = 1
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "package without VK bytes drift"):
-            gate._local_rows(fusion, d64, d128, package)
+            gate._local_rows(fusion, d64, d128, package, statement_only)
 
         package = gate.load_json(gate.PACKAGE_ACCOUNTING)
         package["all_mutations_rejected"] = False
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "package accounting mutations"):
-            gate._local_rows(fusion, d64, d128, package)
+            gate._local_rows(fusion, d64, d128, package, statement_only)
+
+        package = gate.load_json(gate.PACKAGE_ACCOUNTING)
+        statement_only = gate.load_json(gate.STATEMENT_ONLY_ATTEMPT_GATE)
+        statement_only["binding_summary"]["best_typed_bytes"] = 42068
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "statement-only typed bytes drift"):
+            gate._local_rows(fusion, d64, d128, package, statement_only)
 
     def test_load_tsv_rejects_missing_required_columns(self):
         with tempfile.NamedTemporaryFile(

--- a/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py
@@ -27,6 +27,11 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         self.assertEqual(len(payload["external_rows"]), 5)
         self.assertEqual(len(payload["local_rows"]), 6)
         self.assertIn("not a matched benchmark", payload["non_claims"][0])
+        source_paths = {artifact["path"] for artifact in payload["source_artifacts"]}
+        for row in payload["external_rows"]:
+            self.assertTrue(row["source_url"])
+        for row in payload["local_rows"]:
+            self.assertIn(row["artifact_path"], source_paths)
 
         external = {(row["system"], row["workload_label"]): row for row in payload["external_rows"]}
         self.assertEqual(external[("NANOZK", "Transformer block proof")]["proof_size_reported"], "6.9 KB")
@@ -39,6 +44,10 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         self.assertEqual(local["d64 RMSNorm/SwiGLU/residual block receipt"]["value"], 49600)
         self.assertEqual(local["d128 RMSNorm/SwiGLU/residual comparator target"]["value"], 196608)
         self.assertEqual(local["seq32+d128 statement-only native proof object"]["value"], 39516)
+        self.assertEqual(
+            local["seq32+d128 statement-only native proof object"]["artifact_path"],
+            "docs/engineering/evidence/zkai-stwo-statement-only-attempt-transcript-gate-2026-05.json",
+        )
         self.assertEqual(
             local["seq32+d128 statement-only native proof object"]["local_status"],
             "GO_STWO_SEQ32_D128_INNER_POLICY_BOUND_FRONTIER",
@@ -73,6 +82,17 @@ class May2026CompetitorMetricMatrixGateTests(unittest.TestCase):
         payload["payload_commitment"] = gate.payload_commitment(payload)
         with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "payload drift"):
             gate.validate_payload(payload)
+
+    def test_rejects_missing_local_artifact_path(self):
+        payload = copy.deepcopy(self.payload)
+        del payload["local_rows"][3]["artifact_path"]
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "local row 3 missing artifact_path"):
+            gate._assert_row_source_references(payload)
+
+        payload = copy.deepcopy(self.payload)
+        payload["local_rows"][3]["artifact_path"] = "docs/engineering/evidence/missing.json"
+        with self.assertRaisesRegex(gate.CompetitorMetricMatrixError, "local row 3 artifact_path not in source_artifacts"):
+            gate._assert_row_source_references(payload)
 
     def test_rejects_commitment_drift(self):
         payload = copy.deepcopy(self.payload)

--- a/scripts/zkai_d128_native_block_gap_accounting_gate.py
+++ b/scripts/zkai_d128_native_block_gap_accounting_gate.py
@@ -46,7 +46,10 @@ CLAIM_BOUNDARY = (
 EXPECTED_SURFACE_DECISION = "GO_ONE_TRANSFORMER_BLOCK_SURFACE_NO_GO_MATCHED_LAYER_PROOF"
 EXPECTED_PACKAGE_DECISION = "GO_ONE_BLOCK_EXECUTABLE_PACKAGE_ACCOUNTING_NO_GO_NATIVE_PROOF_SIZE"
 EXPECTED_PACKAGE_RESULT = "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_BLOCK_PROOF"
-EXPECTED_MATRIX_DECISION = "GO_SOURCE_BACKED_COMPETITOR_MATRIX_NO_GO_MATCHED_BENCHMARK_CLAIMS"
+EXPECTED_MATRIX_SCHEMA = "zkai-may2026-competitor-metric-matrix-v2"
+EXPECTED_MATRIX_DECISION = (
+    "GO_SOURCE_BACKED_COMPETITOR_MATRIX_WITH_STATEMENT_ONLY_FRONTIER_NO_GO_MATCHED_BENCHMARK_CLAIMS"
+)
 
 EXPECTED_NANOZK_BLOCK_PROOF_BYTES_DECIMAL = 6_900
 EXPECTED_NANOZK_BLOCK_PROOF_SIZE = "6.9 KB"
@@ -326,7 +329,7 @@ def checked_sources() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], d
         if package_summary.get(field) != expected:
             raise D128NativeBlockGapAccountingError(f"package field drift: {field}")
 
-    if matrix.get("schema") != "zkai-may2026-competitor-metric-matrix-v1":
+    if matrix.get("schema") != EXPECTED_MATRIX_SCHEMA:
         raise D128NativeBlockGapAccountingError("competitor matrix schema drift")
     if matrix.get("decision") != EXPECTED_MATRIX_DECISION:
         raise D128NativeBlockGapAccountingError("competitor matrix decision drift")

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -26,20 +26,21 @@ FUSION_MECHANISM = ENGINEERING_EVIDENCE / "zkai-attention-kv-stwo-fusion-mechani
 D64_BLOCK_RECEIPT = ENGINEERING_EVIDENCE / "zkai-d64-block-receipt-composition-gate-2026-05.json"
 D128_TARGET = ENGINEERING_EVIDENCE / "zkai-d128-layerwise-comparator-target-2026-05.json"
 PACKAGE_ACCOUNTING = ENGINEERING_EVIDENCE / "zkai-one-block-executable-package-accounting-2026-05.json"
+STATEMENT_ONLY_ATTEMPT_GATE = ENGINEERING_EVIDENCE / "zkai-stwo-statement-only-attempt-transcript-gate-2026-05.json"
 JSON_OUT = ENGINEERING_EVIDENCE / "zkai-may2026-competitor-metric-matrix.json"
 TSV_OUT = ENGINEERING_EVIDENCE / "zkai-may2026-competitor-metric-matrix.tsv"
 
-SCHEMA = "zkai-may2026-competitor-metric-matrix-v1"
-DECISION = "GO_SOURCE_BACKED_COMPETITOR_MATRIX_NO_GO_MATCHED_BENCHMARK_CLAIMS"
+SCHEMA = "zkai-may2026-competitor-metric-matrix-v2"
+DECISION = "GO_SOURCE_BACKED_COMPETITOR_MATRIX_WITH_STATEMENT_ONLY_FRONTIER_NO_GO_MATCHED_BENCHMARK_CLAIMS"
 CLAIM_BOUNDARY = (
     "SOURCE_BACKED_MAY2026_ZKML_COMPETITOR_MATRIX_WITH_LOCAL_STWO_ATTENTION_FUSION_AND_"
-    "TRANSFORMER_BLOCK_TARGET_CONTEXT_NOT_A_MATCHED_PUBLIC_BENCHMARK_NOT_FULL_INFERENCE"
+    "SEQ32_D128_STATEMENT_ONLY_FRONTIER_NOT_A_MATCHED_PUBLIC_BENCHMARK_NOT_FULL_INFERENCE"
 )
 MAX_SOURCE_BYTES = 16 * 1024 * 1024
 
 VALIDATION_COMMANDS = [
-    "python3 scripts/zkai_may2026_competitor_metric_matrix_gate.py --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv",
-    "python3 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate",
+    "python3.10 scripts/zkai_may2026_competitor_metric_matrix_gate.py --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv",
+    "python3.10 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate",
     "git diff --check",
     "just gate-fast",
     "just gate",
@@ -47,8 +48,8 @@ VALIDATION_COMMANDS = [
 
 NON_CLAIMS = [
     "not a matched benchmark against NANOZK, Jolt Atlas, EZKL, DeepProve-1, or RISC Zero",
-    "not a local d128 proof result",
-    "not proof-size or verifier-time evidence for a local d128 transformer block",
+    "not a proof-size or verifier-time comparison against any external zkML system",
+    "not a full d128 transformer block proof",
     "not native proof-size evidence from the external package-accounting rows",
     "not full transformer inference",
     "not exact real-valued Softmax",
@@ -65,6 +66,18 @@ EXPECTED_PACKAGE_WITH_VK_SAVING_BYTES = 4_016
 EXPECTED_PACKAGE_MUTATIONS = 12
 EXPECTED_PACKAGE_RECEIPT_MUTATIONS = 40
 EXPECTED_PACKAGE_PUBLIC_SIGNAL_COUNT = 17
+EXPECTED_STATEMENT_ONLY_SCHEMA = "zkai-stwo-statement-only-attempt-transcript-gate-v1"
+EXPECTED_STATEMENT_ONLY_DECISION = "GO_STATEMENT_ONLY_ATTEMPT_POLICY_TRANSCRIPT_REDUCES_REGENERATED_STWO_PROOF_BYTES"
+EXPECTED_STATEMENT_ONLY_RESULT = "STATEMENT_ONLY_PROBE_B_VERIFIES_AT_39516_TYPED_BYTES_SAVING_1376_VS_FULL_POLICY_MIX"
+EXPECTED_STATEMENT_ONLY_PROFILE_ID = "statement_only_probe_b"
+EXPECTED_STATEMENT_ONLY_TYPED_BYTES = 39_516
+EXPECTED_STATEMENT_ONLY_JSON_BYTES = 113_388
+EXPECTED_STATEMENT_ONLY_TYPED_SAVING_VS_MATCHED_FRONTIER = 7_672
+EXPECTED_STATEMENT_ONLY_JSON_SAVING_VS_MATCHED_FRONTIER = 27_450
+EXPECTED_STATEMENT_ONLY_TYPED_SAVING_VS_PREVIOUS_CHAMPION = 2_552
+EXPECTED_STATEMENT_ONLY_TYPED_COST_VS_LEGACY_WRAPPER = 1_984
+EXPECTED_STATEMENT_ONLY_MUTATIONS = 20
+EXPECTED_STATEMENT_ONLY_NANOZK_COMPARABLE_ROWS = 0
 
 EXPECTED_EXTERNAL_ROWS = {
     ("NANOZK", "Transformer block proof", "Per-layer block proof"): {
@@ -358,6 +371,7 @@ def _local_rows(
     d64: dict[str, Any],
     d128: dict[str, Any],
     package: dict[str, Any],
+    statement_only: dict[str, Any],
 ) -> list[dict[str, Any]]:
     if _string_source_field(fusion, ("decision",), "fusion decision") != (
         "GO_STARK_NATIVE_FUSION_MECHANISM_ABLATION_FOR_PAPER_ARCHITECTURE_CLAIM"
@@ -384,6 +398,15 @@ def _local_rows(
         raise CompetitorMetricMatrixError("package accounting result drift")
     if not _bool_source_field(package, ("all_mutations_rejected",), "package accounting all mutations rejected"):
         raise CompetitorMetricMatrixError("package accounting mutations must all reject")
+    if _string_source_field(statement_only, ("schema",), "statement-only schema") != EXPECTED_STATEMENT_ONLY_SCHEMA:
+        raise CompetitorMetricMatrixError("statement-only schema drift")
+    if (
+        _string_source_field(statement_only, ("decision",), "statement-only decision")
+        != EXPECTED_STATEMENT_ONLY_DECISION
+    ):
+        raise CompetitorMetricMatrixError("statement-only decision drift")
+    if _string_source_field(statement_only, ("result",), "statement-only result") != EXPECTED_STATEMENT_ONLY_RESULT:
+        raise CompetitorMetricMatrixError("statement-only result drift")
 
     fused_savings = _integer_source_field(fusion, ("route_matrix", "fused_savings_bytes_total"), "fusion savings")
     matched_profiles = _integer_source_field(
@@ -426,6 +449,52 @@ def _local_rows(
     package_public_signals = _integer_source_field(
         package, ("summary", "receipt_public_signal_count"), "package public signals"
     )
+    statement_binding = _source_field(statement_only, ("binding_summary",), "statement-only binding summary")
+    if not isinstance(statement_binding, dict):
+        raise CompetitorMetricMatrixError("statement-only binding summary malformed")
+    statement_mutation = _source_field(statement_only, ("mutation_result",), "statement-only mutation result")
+    if not isinstance(statement_mutation, dict):
+        raise CompetitorMetricMatrixError("statement-only mutation result malformed")
+    statement_profile_id = _string_source_field(
+        statement_only, ("binding_summary", "best_profile_id"), "statement-only best profile"
+    )
+    statement_typed_bytes = _integer_source_field(
+        statement_only, ("binding_summary", "best_typed_bytes"), "statement-only typed bytes"
+    )
+    statement_json_bytes = _integer_source_field(
+        statement_only, ("binding_summary", "best_json_bytes"), "statement-only JSON bytes"
+    )
+    statement_typed_saving_vs_matched = _integer_source_field(
+        statement_only,
+        ("binding_summary", "best_typed_saving_vs_matched_two_proof_frontier"),
+        "statement-only typed saving vs matched frontier",
+    )
+    statement_json_saving_vs_matched = _integer_source_field(
+        statement_only,
+        ("binding_summary", "best_json_saving_vs_matched_two_proof_frontier"),
+        "statement-only JSON saving vs matched frontier",
+    )
+    statement_typed_saving_vs_previous = _integer_source_field(
+        statement_only,
+        ("binding_summary", "best_typed_saving_vs_previous_single_proof_champion"),
+        "statement-only typed saving vs previous champion",
+    )
+    statement_typed_cost_vs_legacy = _integer_source_field(
+        statement_only,
+        ("binding_summary", "best_typed_cost_vs_legacy_wrapper_b"),
+        "statement-only typed cost vs legacy wrapper",
+    )
+    statement_nanozk_rows = _integer_source_field(
+        statement_only,
+        ("binding_summary", "nanozk_comparable_external_rows"),
+        "statement-only NANOZK comparable rows",
+    )
+    statement_rejected = _integer_source_field(
+        statement_only, ("mutation_result", "rejected"), "statement-only rejected mutations"
+    )
+    statement_accepted = _integer_source_field(
+        statement_only, ("mutation_result", "accepted"), "statement-only accepted mutations"
+    )
     if fused_savings <= 0:
         raise CompetitorMetricMatrixError("fusion savings must be positive")
     if matched_profiles <= 0:
@@ -451,6 +520,36 @@ def _local_rows(
         "package public signals": (package_public_signals, EXPECTED_PACKAGE_PUBLIC_SIGNAL_COUNT),
     }
     for label, (actual, expected) in expected_package_values.items():
+        if actual != expected:
+            raise CompetitorMetricMatrixError(f"{label} drift")
+    expected_statement_values = {
+        "statement-only profile id": (statement_profile_id, EXPECTED_STATEMENT_ONLY_PROFILE_ID),
+        "statement-only typed bytes": (statement_typed_bytes, EXPECTED_STATEMENT_ONLY_TYPED_BYTES),
+        "statement-only JSON bytes": (statement_json_bytes, EXPECTED_STATEMENT_ONLY_JSON_BYTES),
+        "statement-only typed saving vs matched frontier": (
+            statement_typed_saving_vs_matched,
+            EXPECTED_STATEMENT_ONLY_TYPED_SAVING_VS_MATCHED_FRONTIER,
+        ),
+        "statement-only JSON saving vs matched frontier": (
+            statement_json_saving_vs_matched,
+            EXPECTED_STATEMENT_ONLY_JSON_SAVING_VS_MATCHED_FRONTIER,
+        ),
+        "statement-only typed saving vs previous champion": (
+            statement_typed_saving_vs_previous,
+            EXPECTED_STATEMENT_ONLY_TYPED_SAVING_VS_PREVIOUS_CHAMPION,
+        ),
+        "statement-only typed cost vs legacy wrapper": (
+            statement_typed_cost_vs_legacy,
+            EXPECTED_STATEMENT_ONLY_TYPED_COST_VS_LEGACY_WRAPPER,
+        ),
+        "statement-only NANOZK comparable rows": (
+            statement_nanozk_rows,
+            EXPECTED_STATEMENT_ONLY_NANOZK_COMPARABLE_ROWS,
+        ),
+        "statement-only rejected mutations": (statement_rejected, EXPECTED_STATEMENT_ONLY_MUTATIONS),
+        "statement-only accepted mutations": (statement_accepted, 0),
+    }
+    for label, (actual, expected) in expected_statement_values.items():
         if actual != expected:
             raise CompetitorMetricMatrixError(f"{label} drift")
 
@@ -484,6 +583,23 @@ def _local_rows(
             "unit": "linear_muls",
             "support": first_blocker,
             "comparison_status": "TARGET_SPEC_ONLY_NOT_LOCAL_PROOF_RESULT",
+        },
+        {
+            "system": "provable-transformer-vm",
+            "surface": "seq32+d128 statement-only native proof object",
+            "local_status": "GO_STWO_SEQ32_D128_INNER_POLICY_BOUND_FRONTIER",
+            "metric": "typed proof bytes",
+            "value": statement_typed_bytes,
+            "unit": "bytes",
+            "support": (
+                f"{statement_json_bytes} JSON proof bytes; saves {statement_typed_saving_vs_matched} "
+                "typed bytes vs matched local two-proof frontier; saves "
+                f"{statement_typed_saving_vs_previous} typed bytes vs previous single-proof champion; "
+                f"{statement_rejected} / {EXPECTED_STATEMENT_ONLY_MUTATIONS} mutations rejected; "
+                f"{statement_nanozk_rows} NANOZK-comparable rows; still {statement_typed_cost_vs_legacy} "
+                "typed bytes above legacy wrapper-only context"
+            ),
+            "comparison_status": "LOCAL_INNER_POLICY_BOUND_PROOF_OBJECT_NOT_EXTERNAL_LAYER_BENCHMARK",
         },
         {
             "system": "provable-transformer-vm",
@@ -550,11 +666,13 @@ def build_payload_uncommitted() -> dict[str, Any]:
     d64_raw = read_source_bytes(D64_BLOCK_RECEIPT, "d64 block receipt JSON")
     d128_raw = read_source_bytes(D128_TARGET, "d128 target JSON")
     package_raw = read_source_bytes(PACKAGE_ACCOUNTING, "one-block package accounting JSON")
+    statement_only_raw = read_source_bytes(STATEMENT_ONLY_ATTEMPT_GATE, "statement-only attempt gate JSON")
     published = _parse_tsv_bytes(PUBLISHED_ZKML_NUMBERS, published_raw)
     fusion = _parse_json_bytes(FUSION_MECHANISM, fusion_raw)
     d64 = _parse_json_bytes(D64_BLOCK_RECEIPT, d64_raw)
     d128 = _parse_json_bytes(D128_TARGET, d128_raw)
     package = _parse_json_bytes(PACKAGE_ACCOUNTING, package_raw)
+    statement_only = _parse_json_bytes(STATEMENT_ONLY_ATTEMPT_GATE, statement_only_raw)
     return {
         "schema": SCHEMA,
         "decision": DECISION,
@@ -565,15 +683,21 @@ def build_payload_uncommitted() -> dict[str, Any]:
             _source_from_bytes(D64_BLOCK_RECEIPT, "local_d64_block_receipt_json", d64_raw),
             _source_from_bytes(D128_TARGET, "local_d128_target_json", d128_raw),
             _source_from_bytes(PACKAGE_ACCOUNTING, "local_one_block_package_accounting_json", package_raw),
+            _source_from_bytes(
+                STATEMENT_ONLY_ATTEMPT_GATE,
+                "local_seq32_d128_statement_only_attempt_gate_json",
+                statement_only_raw,
+            ),
         ],
         "external_rows": _external_rows(published),
-        "local_rows": _local_rows(fusion, d64, d128, package),
+        "local_rows": _local_rows(fusion, d64, d128, package, statement_only),
         "interpretation": [
             "NANOZK and Jolt Atlas are the relevant layerwise/end-to-end competitors for headline zkML metrics.",
-            "The local repo does not yet have a d128 layer proof to compare on proof size or verifier time.",
+            "The local repo now has a checked seq32+d128 inner-policy-bound Stwo proof object, but it is not a matched external layer proof benchmark.",
             "The local competitive claim is architectural: STARK-native fusion saves duplicated opening/decommitment plumbing.",
+            "The current checked local frontier is 39,516 typed proof bytes for the statement-only seq32+d128 proof object, saving 7,672 typed bytes versus the matched local two-proof frontier.",
             "The executable package-accounting rows show a smaller verifier-facing package than the source statement chain, but they are external receipt accounting rather than native layer proof evidence.",
-            "The next real block milestone is a parameterized d64 then d128 RMSNorm/SwiGLU/residual proof surface with the same statement bindings.",
+            "The next real comparison milestone is object-class matching: full transformer-block surface, stable binary accounting, and timing policy before any NANOZK/Jolt/DeepProve comparison.",
         ],
         "non_claims": NON_CLAIMS,
         "validation_commands": VALIDATION_COMMANDS,

--- a/scripts/zkai_may2026_competitor_metric_matrix_gate.py
+++ b/scripts/zkai_may2026_competitor_metric_matrix_gate.py
@@ -203,6 +203,16 @@ def _source_from_bytes(path: pathlib.Path, kind: str, raw: bytes) -> dict[str, s
     }
 
 
+def _artifact_path(path: pathlib.Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def _list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise CompetitorMetricMatrixError(f"{label} must be list")
+    return value
+
+
 def _parse_json_bytes(path: pathlib.Path, raw: bytes) -> dict[str, Any]:
     try:
         payload = json.loads(
@@ -557,6 +567,7 @@ def _local_rows(
         {
             "system": "provable-transformer-vm",
             "surface": "Stwo attention/Softmax-table fusion",
+            "artifact_path": _artifact_path(FUSION_MECHANISM),
             "local_status": "GO_BOUNDED_ARCHITECTURE_MECHANISM",
             "metric": "matched route JSON proof-byte saving",
             "value": fused_savings,
@@ -567,6 +578,7 @@ def _local_rows(
         {
             "system": "provable-transformer-vm",
             "surface": "d64 RMSNorm/SwiGLU/residual block receipt",
+            "artifact_path": _artifact_path(D64_BLOCK_RECEIPT),
             "local_status": "GO_STATEMENT_BOUND_RECEIPT_COMPOSITION",
             "metric": "checked slice rows",
             "value": total_checked_rows,
@@ -577,6 +589,7 @@ def _local_rows(
         {
             "system": "provable-transformer-vm",
             "surface": "d128 RMSNorm/SwiGLU/residual comparator target",
+            "artifact_path": _artifact_path(D128_TARGET),
             "local_status": "NO_GO_LOCAL_D128_PROOF_ARTIFACT_MISSING",
             "metric": "target estimated linear multiplications",
             "value": target_linear_muls,
@@ -587,6 +600,7 @@ def _local_rows(
         {
             "system": "provable-transformer-vm",
             "surface": "seq32+d128 statement-only native proof object",
+            "artifact_path": _artifact_path(STATEMENT_ONLY_ATTEMPT_GATE),
             "local_status": "GO_STWO_SEQ32_D128_INNER_POLICY_BOUND_FRONTIER",
             "metric": "typed proof bytes",
             "value": statement_typed_bytes,
@@ -604,6 +618,7 @@ def _local_rows(
         {
             "system": "provable-transformer-vm",
             "surface": "attention-derived d128 executable package without VK",
+            "artifact_path": _artifact_path(PACKAGE_ACCOUNTING),
             "local_status": "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF",
             "metric": "compressed artifact plus proof plus public signals",
             "value": package_without_vk_bytes,
@@ -618,6 +633,7 @@ def _local_rows(
         {
             "system": "provable-transformer-vm",
             "surface": "attention-derived d128 executable package with VK",
+            "artifact_path": _artifact_path(PACKAGE_ACCOUNTING),
             "local_status": "GO_EXTERNAL_RECEIPT_PACKAGE_ACCOUNTING_NO_GO_NATIVE_LAYER_PROOF",
             "metric": "compressed artifact plus proof plus public signals plus verification key",
             "value": package_with_vk_bytes,
@@ -656,8 +672,28 @@ def validate_payload(payload: dict[str, Any], *, expected: dict[str, Any] | None
         if payload.get("non_claims") != NON_CLAIMS:
             raise CompetitorMetricMatrixError("non_claims drift")
         raise CompetitorMetricMatrixError("payload drift")
+    _assert_row_source_references(payload)
     if payload.get("payload_commitment") != payload_commitment(payload):
         raise CompetitorMetricMatrixError("payload commitment drift")
+
+
+def _assert_row_source_references(payload: dict[str, Any]) -> None:
+    source_paths = {
+        artifact["path"]
+        for artifact in _list(payload.get("source_artifacts"), "source_artifacts")
+        if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
+    }
+    for index, row in enumerate(_list(payload.get("external_rows"), "external_rows")):
+        if not isinstance(row, dict) or not isinstance(row.get("source_url"), str) or not row["source_url"]:
+            raise CompetitorMetricMatrixError(f"external row {index} missing source_url")
+    for index, row in enumerate(_list(payload.get("local_rows"), "local_rows")):
+        if not isinstance(row, dict):
+            raise CompetitorMetricMatrixError(f"local row {index} malformed")
+        artifact_path = row.get("artifact_path")
+        if not isinstance(artifact_path, str) or not artifact_path:
+            raise CompetitorMetricMatrixError(f"local row {index} missing artifact_path")
+        if artifact_path not in source_paths:
+            raise CompetitorMetricMatrixError(f"local row {index} artifact_path not in source_artifacts")
 
 
 def build_payload_uncommitted() -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Closes #682.

Updates the May 2026 zkML competitor metric matrix around the merged statement-only seq32+d128 local frontier from PR #712.

- adds the checked `seq32+d128 statement-only native proof object` row at `39,516` typed proof bytes / `113,388` JSON proof bytes
- records the row as a local inner-policy-bound frontier, not an external layer benchmark
- keeps NANOZK, Jolt Atlas, EZKL, DeepProve, RISC Zero/SP1 context separated as source-backed/non-local rows
- updates the matrix schema to `zkai-may2026-competitor-metric-matrix-v2`
- pins the statement-only gate JSON as a source artifact and adds drift tests for the new row
- adds per-row artifact paths for local rows and source URLs for external rows, after Qodo flagged the traceability gap
- updates the d128 native block gap gate so downstream accounting accepts the v2 matrix decision instead of silently depending on the old schema

## Key Numbers

- matched local two-proof frontier: `47,188` typed bytes
- previous single-proof champion: `42,068` typed bytes
- statement-only row: `39,516` typed bytes
- typed saving vs matched local frontier: `7,672` bytes
- typed saving vs previous single-proof champion: `2,552` bytes
- NANOZK-comparable external rows: `0`

## Non-Claims

- not a NANOZK/Jolt/DeepProve/EZKL benchmark win
- not a proof-size or timing comparison against any external zkML system
- not a full d128 transformer block proof
- not full transformer inference
- not production-ready

## Local Validation

- `python3.10 scripts/zkai_may2026_competitor_metric_matrix_gate.py --write-json docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.json --write-tsv docs/engineering/evidence/zkai-may2026-competitor-metric-matrix.tsv`
- `python3.10 scripts/zkai_d128_native_block_gap_accounting_gate.py --write-json docs/engineering/evidence/zkai-d128-native-block-gap-accounting-2026-05.json --write-tsv docs/engineering/evidence/zkai-d128-native-block-gap-accounting-2026-05.tsv`
- `python3.10 -m py_compile scripts/zkai_may2026_competitor_metric_matrix_gate.py scripts/tests/test_zkai_may2026_competitor_metric_matrix_gate.py scripts/zkai_d128_native_block_gap_accounting_gate.py scripts/tests/test_zkai_d128_native_block_gap_accounting_gate.py`
- `python3.10 -m unittest scripts.tests.test_zkai_may2026_competitor_metric_matrix_gate scripts.tests.test_zkai_d128_native_block_gap_accounting_gate` (`30` tests)
- `git diff --check`
- `just gate-fast`
- `just gate` (`14 / 14`)

GitHub Actions are not part of the normal validation loop for this research PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified May 2026 competitor metric matrix methodology, specifying which comparisons are architectural assessments versus external benchmarks.
  * Updated documentation to reflect statement-only proof artifact treatment and refined boundary definitions for metric claims.

* **Tests**
  * Enhanced validation tests for competitor metric matrix payload integrity and source artifact path references.
  * Added coverage for statement-only gate inputs and improved negative test assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omarespejel/provable-transformer-vm/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->