### PR TITLE
Clarify Stwo-AI scope in proof-pressure paper

### DIFF
--- a/docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
+++ b/docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
@@ -5,7 +5,8 @@
     "local median-of-5 verifier timing does not support a fused verifier-time win claim",
     "model-faithful quantized attention is bridged only for the checked d8 fixture trace",
     "production Starknet verifier packaging, calldata/accounting, and deployment gates are not complete",
-    "no full transformer runtime, tokenizer/model-weight import, or accuracy/perplexity gate is bound"
+    "no full transformer runtime, tokenizer/model-weight import, or accuracy/perplexity gate is bound",
+    "Stwo-AI backend specialization remains future work until repeated verifier-bound gains appear on the same surfaces"
   ],
   "claim_boundary": "STARK_NATIVE_PROOF_ARCHITECTURE_CLAIM_FOR_BOUNDED_INTEGER_ATTENTION_AND_SOFTMAX_TABLE_LOOKUP_MEMBERSHIP_NOT_EXACT_SOFTMAX_NOT_FULL_INFERENCE_NOT_PUBLIC_BENCHMARK_NOT_PRODUCTION_READY",
   "decision": "GO_PAPER_CLAIM_PACK_NO_GO_PUBLIC_OR_PRODUCTION_CLAIMS",
@@ -49,13 +50,19 @@
       "id": "model_faithful_bridge",
       "path": "docs/engineering/evidence/zkai-attention-kv-model-faithful-quantized-attention-bridge-2026-05.json",
       "supports": "checked equivalence between model-facing integer attention policy and the d8 fixture trace"
+    },
+    {
+      "id": "stwo_ai_layout_diagnostic",
+      "path": "docs/engineering/evidence/zkai-stwo-ai-d64-four-head-seq64-chunk4-policy-gate-2026-06.json",
+      "supports": "verifier-bound route-layout diagnostic showing Stwo-AI remains future backend-specialization work"
     }
   ],
   "go_criteria_satisfied": [
     "checked source, sidecar, and fused proof evidence exists for the cited profiles",
     "machine-readable gates reject overclaim and evidence-drift mutations",
     "timing evidence is separated from proof-size evidence",
-    "model-facing quantized policy is bridge-checked before runtime integration"
+    "model-facing quantized policy is bridge-checked before runtime integration",
+    "Stwo-AI diagnostic evidence is kept out of the headline proof-size claim"
   ],
   "go_posture": [
     "GO to present a bounded STARK-native proof-architecture claim in the paper evidence pack.",
@@ -111,6 +118,7 @@
     "not production-ready",
     "not Starknet deployed",
     "not a stable upstream Stwo proof wire format",
+    "not a Stwo fork or upstream Stwo optimization",
     "not recursion or PCD",
     "not model accuracy, perplexity, tokenizer, weight-import, or runtime evidence"
   ],
@@ -118,11 +126,12 @@
     "One checked proof object can bind attention arithmetic and statement-bound Softmax-table membership for the same bounded fixture family.",
     "Matched source-plus-sidecar controls show proof-object byte savings across checked width, head-count, sequence-length, and combined-axis profiles.",
     "Section-delta and typed-component evidence both point to shared opening and decommitment structure as the dominant source of savings.",
-    "A model-facing quantized attention policy is checked equivalent to the existing d8 bounded Softmax-table fixture trace at the trace boundary."
+    "A model-facing quantized attention policy is checked equivalent to the existing d8 bounded Softmax-table fixture trace at the trace boundary.",
+    "Stwo-AI backend specialization is future work informed by opening, decommitment, table-identity, and layout evidence, not a premise of the current proof-size result."
   ],
-  "payload_commitment": "sha256:4687e28a3bfe6ed5aea2ea0daca408438db0909ad793c8f0b1fcc2cdb6bcf17b",
+  "payload_commitment": "sha256:aa5a8984973b4fe66816715507cfb475c0df263608f17c6d15e5eab625f62773",
   "schema": "stark-native-transformer-paper-claim-pack-v1",
-  "thesis": "Checked Stwo evidence supports a paper-facing architecture claim: bounded integer attention arithmetic and Softmax-table LogUp membership can be fused into one native STARK proof object, sharing proof-system commitment and opening plumbing across the arithmetic and lookup-heavy parts.",
+  "thesis": "Checked proofs generated on the existing Stwo backend support a paper-facing architecture claim: bounded integer attention arithmetic and Softmax-table LogUp membership can be fused into one native STARK proof object, sharing proof-system commitment and opening plumbing across the arithmetic and lookup-heavy parts. The claim is about STARK-native boundary placement, not an upstream Stwo optimization.",
   "thesis_id": "stark_native_attention_arithmetic_softmax_table_fusion",
   "validation_commands": [
     "just gate-fast",

--- a/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
+++ b/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
@@ -6,7 +6,7 @@ Starknet Foundation
 **Abdelhamid Bakhta**  
 StarkWare
 
-*May 2026 draft*
+*June 2026 draft*
 
 ## Abstract
 
@@ -44,6 +44,13 @@ labels. They support a bounded thesis: transformer proving should choose
 boundaries around actual proof pressure. STARK-native fusion is useful where it
 shares commitment, opening, and decommitment structure; width-heavy dense
 arithmetic may need different boundaries or side protocols.
+
+The implementation vehicle in these experiments is Stwo, but the result is not
+a Stwo-optimization result. The checked proofs use the existing Stwo backend
+surface; the main intervention is where transformer work is placed inside a
+STARK proof object. This leaves room for later Stwo-AI work on opening layout,
+table grouping, and query planning, while keeping the current claim about
+STARK-native boundary architecture.
 
 The paper also separates proof validity from statement validity. A proof can
 verify while the application misstates the model, input, output, numeric policy,
@@ -170,7 +177,11 @@ opening geometry, host memory, or timing measurements.
 ## 3. Experimental Object
 
 The experimental object is a family of native Stwo proof artifacts for bounded
-integer attention fixtures. Each matched row records:
+integer attention fixtures. Stwo is used here as an open Circle STARK
+implementation vehicle. The experiments do not patch Stwo's prover, verifier,
+FRI protocol, hash channels, or security configuration; they change the
+transformer proof boundary and the statement-bound artifact construction built
+on top of that backend. Each matched row records:
 
 - source arithmetic proof payload bytes;
 - LogUp sidecar proof payload bytes;
@@ -208,6 +219,15 @@ fused routes:
 | FRI query count | `3` |
 | FRI fold step | `1` |
 | PCS lifting log size | `None` |
+
+This is important for interpretation. A proof-size saving under the same backend
+configuration is evidence about boundary placement and shared STARK plumbing,
+not evidence that a private prover fork made the byte count smaller. Stwo's
+public documentation describes a `StarkProof` as containing commitments,
+openings, and FRI proof material [10], and its polynomial commitment scheme
+requires Merkle decommitments for verifier queries [11]. The mechanism measured
+below is therefore exactly the kind of mechanism a STARK proof object pays for:
+commit, open, decommit, and carry FRI witness material.
 
 The large `d128_h4_seq64` row is represented by checked gate and route-matrix
 evidence with proof commitments, exact byte counts, mutation rejection, and
@@ -363,6 +383,15 @@ valid proof object. The way to reduce duplicated opening material is to choose a
 larger or better-aligned proof boundary, not to remove witness material that the
 verifier needs.
 
+This is also where a future Stwo-AI agenda becomes concrete. If the savings are
+dominated by opening and decommitment geometry, then a useful backend
+specialization would not be "make a prover for AI" in the abstract. It would
+target specific STARK plumbing: how transformer-shaped columns are grouped,
+which lookup tables share identity, how heterogeneous domains are lifted, how
+openings are batched, and how higher-soundness query settings change the fused
+versus split ratio. The current paper does not require those changes; it shows
+where they would matter.
+
 ---
 
 ## 7. Statement Validity: Why Proof Verification Is Not Enough
@@ -412,7 +441,7 @@ NANOZK studies layerwise proof objects for LLM inference [1]. Jolt Atlas uses
 lookup arguments for ONNX-style tensor operations [2]. zkLLM and zkAttn study
 LLM and attention-specific proving paths [3]. DeepProve reports full-model LLM
 inference proving [4]. EZKL, RISC Zero, SP1, and Stwo expose different
-deployment and proof-system surfaces for verifiable computation [5-9].
+deployment and proof-system surfaces for verifiable computation [5-11].
 
 These systems motivate, rather than settle, the boundary-selection question
 studied here. Their public artifacts do not expose the same scoped object as the
@@ -424,6 +453,15 @@ docs or source-reported infrastructure references. The comparison is
 architectural: many zkML systems are already choosing specialized proof
 boundaries, and the evidence here shows one STARK-native boundary where
 lookup-heavy attention work amortizes proof bytes.
+
+The Stwo comparison is different from the NANOZK or Jolt Atlas comparison
+because Stwo is the backend used by the artifacts, not an external zkML system
+being beaten. Stwo's public repository describes it as a production Circle STARK
+prover and verifier with modular core proof-system, constraint-framework, AIR,
+and lookup components [9]. That modularity is why this paper can study a
+transformer boundary on top of Stwo without claiming to optimize Stwo itself.
+It is also why a future Stwo-AI line should be framed as backend specialization
+for transformer-shaped STARK workloads, not as a premise of the current result.
 
 ---
 
@@ -459,6 +497,10 @@ The scope of the result is limited in several ways.
    query count, blowup factor, or proof-of-work setting can move both absolute
    proof bytes and fused-to-split ratios; this paper does not measure that
    higher-soundness regime.
+10. **Backend optimization scope.** The paper does not claim a Stwo-AI fork,
+    upstream Stwo patch, SIMD change, verifier rewrite, or new PCS. The checked
+    savings come from proof-boundary construction over the existing backend
+    surface. Backend specialization is future work.
 
 These limitations narrow the contribution to a specific systems claim: the
 reported artifacts expose a proof-size scaling pattern and a plausible mechanism
@@ -558,6 +600,16 @@ duplicated, compose through typed boundaries where separate proof objects are
 preferable, and test dense regions with protocols specialized for dense
 arithmetic when appropriate.
 
+It also clarifies what a Stwo-AI project should and should not mean. The
+interesting target is not another round of marginal row-order tuning. Small
+verifier-bound layout experiments after the main proof-pressure work show that
+layout can still move proof bytes inside the current backend, but the gain is
+diagnostic rather than headline-sized. The larger research question is whether
+the backend can expose or improve the parts that the evidence identifies as
+load-bearing: opening layout, decommitment batching, lifted-domain policy,
+lookup-table identity, and higher-soundness proof-size behavior. That is a
+backend research agenda informed by this paper, not the paper's main claim.
+
 ---
 
 ## 12. Future Work
@@ -572,12 +624,18 @@ The next step is to close the remaining comparison and block-surface gaps.
 3. **Binary proof accounting.** Replace or supplement JSON and local typed bytes
    with stable binary or raw serialized accounting when the backend exposes a
    suitable surface.
-4. **GKR or sumcheck side protocol.** Test dense projection and MLP regions with
+4. **Stwo-AI backend specialization.** Use the measured opening and
+   decommitment bottleneck to test backend-facing changes: deterministic
+   transformer column grouping, lookup-table identity reuse, opening batching,
+   lifted-domain layout policy, and higher-soundness query settings. Treat this
+   as future work unless it produces a repeated, verifier-bound reduction on the
+   same surfaces.
+5. **GKR or sumcheck side protocol.** Test dense projection and MLP regions with
    a side protocol rather than assuming one STARK-native monolith is best.
-5. **Median timing policy.** Extend median-of-five timing to the `d128`
+6. **Median timing policy.** Extend median-of-five timing to the `d128`
    sequence rows and any external baseline before making public performance
    claims.
-6. **Statement-relabeling benchmark.** Turn the Tablero correctness layer into a
+7. **Statement-relabeling benchmark.** Turn the Tablero correctness layer into a
    clean benchmark across EZKL, snarkjs, RISC Zero-style receipts, JSTprove or
    Remainder, and Jolt Atlas if suitable public artifacts are available.
 
@@ -606,3 +664,8 @@ how proof artifacts become valid application claims.
 8. StarkWare. *S-two 2.0.0 is a Developer-Friendly, Fully Open-Source Toolkit*.
    Published 2026. <https://starkware.co/blog/s-two-2-0-0-prover-for-developers/>
 9. StarkWare Labs. *stwo Source Repository*. <https://github.com/starkware-libs/stwo>
+10. Starknet Documentation. *S-two STARK Prover*. 2026.
+    <https://docs.starknet.io/learn/S-two-book/how-it-works/stark_proof/prove>
+11. Starknet Documentation. *S-two Polynomial Commitment Scheme Technical
+    Overview*. 2026.
+    <https://docs.starknet.io/learn/S-two-book/how-it-works/pcs/overview>

--- a/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
+++ b/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
@@ -12,12 +12,13 @@ The current evidence supports a bounded paper-facing thesis:
 This is a proof-architecture claim over checked bounded integer attention
 fixtures. It is not a claim about exact real-valued Softmax, full model
 inference, public benchmark performance, production readiness, recursion, PCD,
-or Starknet deployment.
+Starknet deployment, or upstream Stwo optimization.
 
 ## Defensible Claims
 
-1. Native Stwo evidence now checks source arithmetic, LogUp sidecar, and fused
-   proof objects for a controlled Softmax-table route family.
+1. Unmodified Stwo-backed evidence now checks source arithmetic, LogUp sidecar,
+   and fused proof objects for a controlled Softmax-table route family. The
+   contribution is the STARK-native boundary, not a Stwo fork.
 2. The checked route matrix has twelve matched rows across width, head-count,
    sequence-length, and combined-axis profiles, with fused proof bytes smaller
    than source-plus-sidecar proof bytes in each row.
@@ -48,6 +49,8 @@ or Starknet deployment.
   `docs/engineering/evidence/zkai-attention-kv-stwo-native-two-head-seq32-fused-softmax-table-gate-2026-05.json`
 - Model-faithful bridge:
   `docs/engineering/evidence/zkai-attention-kv-model-faithful-quantized-attention-bridge-2026-05.json`
+- Stwo-AI layout diagnostic:
+  `docs/engineering/evidence/zkai-stwo-ai-d64-four-head-seq64-chunk4-policy-gate-2026-06.json`
 - Machine-readable claim pack:
   `docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json`
 
@@ -86,6 +89,9 @@ GO:
   plumbing.
 - Say the d8 fixture now has a checked model-facing quantized-attention bridge
   at the trace boundary.
+- Say Stwo-AI remains future backend-specialization work around openings,
+  decommitments, table identity, and layout, not an assumption behind the current
+  result.
 
 NO-GO:
 
@@ -96,6 +102,8 @@ NO-GO:
 - Do not describe the local accounting stream as upstream Stwo proof
   serialization.
 - Do not claim backend-internal source-vs-lookup byte attribution.
+- Do not describe this as a Stwo fork, upstream Stwo patch, SIMD improvement, or
+  custom Stwo-AI prover result.
 
 ## Blockers
 
@@ -110,6 +118,8 @@ NO-GO:
    and adversarial integration hardening remain incomplete.
 6. No tokenizer/model-weight import, full runtime, accuracy, or perplexity gate
    is bound.
+7. Stwo-AI backend specialization remains a future-work agenda until it produces
+   repeated verifier-bound gains on the same surfaces.
 
 ## Validation
 

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -54,6 +54,7 @@ NON_CLAIMS = [
     "not production-ready",
     "not Starknet deployed",
     "not a stable upstream Stwo proof wire format",
+    "not a Stwo fork or upstream Stwo optimization",
     "not recursion or PCD",
     "not model accuracy, perplexity, tokenizer, weight-import, or runtime evidence",
 ]
@@ -65,6 +66,7 @@ BLOCKERS = [
     "model-faithful quantized attention is bridged only for the checked d8 fixture trace",
     "production Starknet verifier packaging, calldata/accounting, and deployment gates are not complete",
     "no full transformer runtime, tokenizer/model-weight import, or accuracy/perplexity gate is bound",
+    "Stwo-AI backend specialization remains future work until repeated verifier-bound gains appear on the same surfaces",
 ]
 
 NO_GO_POSTURE = [
@@ -113,6 +115,11 @@ EVIDENCE_REFS = [
         "id": "model_faithful_bridge",
         "path": "docs/engineering/evidence/zkai-attention-kv-model-faithful-quantized-attention-bridge-2026-05.json",
         "supports": "checked equivalence between model-facing integer attention policy and the d8 fixture trace",
+    },
+    {
+        "id": "stwo_ai_layout_diagnostic",
+        "path": "docs/engineering/evidence/zkai-stwo-ai-d64-four-head-seq64-chunk4-policy-gate-2026-06.json",
+        "supports": "verifier-bound route-layout diagnostic showing Stwo-AI remains future backend-specialization work",
     },
 ]
 
@@ -267,9 +274,11 @@ def build_payload() -> dict[str, Any]:
         "thesis_id": THESIS_ID,
         "claim_boundary": CLAIM_BOUNDARY,
         "thesis": (
-            "Checked Stwo evidence supports a paper-facing architecture claim: bounded integer attention "
-            "arithmetic and Softmax-table LogUp membership can be fused into one native STARK proof object, "
-            "sharing proof-system commitment and opening plumbing across the arithmetic and lookup-heavy parts."
+            "Checked proofs generated on the existing Stwo backend support a paper-facing architecture claim: "
+            "bounded integer attention arithmetic and Softmax-table LogUp membership can be fused into one "
+            "native STARK proof object, sharing proof-system commitment and opening plumbing across the "
+            "arithmetic and lookup-heavy parts. The claim is about STARK-native boundary placement, not an "
+            "upstream Stwo optimization."
         ),
         "paper_claims": [
             (
@@ -288,6 +297,10 @@ def build_payload() -> dict[str, Any]:
                 "A model-facing quantized attention policy is checked equivalent to the existing d8 bounded "
                 "Softmax-table fixture trace at the trace boundary."
             ),
+            (
+                "Stwo-AI backend specialization is future work informed by opening, decommitment, table-identity, "
+                "and layout evidence, not a premise of the current proof-size result."
+            ),
         ],
         "evidence_refs": list(EVIDENCE_REFS),
         "go_posture": [
@@ -299,6 +312,7 @@ def build_payload() -> dict[str, Any]:
             "machine-readable gates reject overclaim and evidence-drift mutations",
             "timing evidence is separated from proof-size evidence",
             "model-facing quantized policy is bridge-checked before runtime integration",
+            "Stwo-AI diagnostic evidence is kept out of the headline proof-size claim",
         ],
         "no_go_posture": list(NO_GO_POSTURE),
         "non_claims": list(NON_CLAIMS),


### PR DESCRIPTION
## Summary

- clarify that the proof-pressure result is a STARK-native boundary-selection result over the existing Stwo backend, not an upstream Stwo optimization
- add a concrete Stwo-AI future-work framing around openings, decommitments, table identity, lifted-domain policy, and higher-soundness query settings
- update the short claim pack and generated machine-readable claim pack so the same non-claim is gate-checked
- add primary Stwo documentation references for `StarkProof`, commitments, openings, FRI proof material, and PCS decommitments

## Why

The current evidence is strongest when framed as full STARK proof-boundary architecture: choose where transformer work shares commitment, opening, and decommitment plumbing. It should not sound like the measured saving came from Stwo internals. That leaves Stwo-AI as a serious follow-up agenda, but not as the premise of the paper.

## Validation

- `python3.10 scripts/zkai_paper_claim_pack_gate.py --write-json docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json`
- `python3.10 -m py_compile scripts/zkai_paper_claim_pack_gate.py scripts/tests/test_zkai_paper_claim_pack_gate.py`
- `python3.10 -m unittest scripts.tests.test_zkai_paper_claim_pack_gate`
- `python3.10 scripts/paper/paper_preflight.py --repo-root .`
- `scripts/run_paper_preflight_suite.sh`
- `git diff --check`

## Non-claims

- not a Stwo fork
- not an upstream Stwo patch
- not a proving-speed claim
- not a full inference or external benchmark claim


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined technical papers to clarify scope of proof-boundary placement contributions versus upstream optimization work
  * Expanded sections on proof-size interpretation, backend-specialization roadmap, and evidence references
  * Added future work directions and guardrails against scope misrepresentation

* **Chores**
  * Updated validation rules and evidence reference tracking for claim-pack submissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->