### PR TITLE
Sync proof-pressure claim pack with current evidence

### DIFF
--- a/docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
+++ b/docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
@@ -14,7 +14,7 @@
     {
       "id": "route_matrix",
       "path": "docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json",
-      "supports": "twelve checked source-sidecar-fused route rows with matched proof-byte ratios"
+      "supports": "thirty checked source-sidecar-fused route rows with matched proof-byte ratios"
     },
     {
       "id": "controlled_component_grid",
@@ -129,7 +129,7 @@
     "A model-facing quantized attention policy is checked equivalent to the existing d8 bounded Softmax-table fixture trace at the trace boundary.",
     "Stwo-AI backend specialization is future work informed by opening, decommitment, table-identity, and layout evidence, not a premise of the current proof-size result."
   ],
-  "payload_commitment": "sha256:aa5a8984973b4fe66816715507cfb475c0df263608f17c6d15e5eab625f62773",
+  "payload_commitment": "sha256:a0a2548f826fb81c2c89c826e934c35081b162ccfc4f893746a5db974c0c3083",
   "schema": "stark-native-transformer-paper-claim-pack-v1",
   "thesis": "Checked proofs generated on the existing Stwo backend support a paper-facing architecture claim: bounded integer attention arithmetic and Softmax-table LogUp membership can be fused into one native STARK proof object, sharing proof-system commitment and opening plumbing across the arithmetic and lookup-heavy parts. The claim is about STARK-native boundary placement, not an upstream Stwo optimization.",
   "thesis_id": "stark_native_attention_arithmetic_softmax_table_fusion",

--- a/docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
+++ b/docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
@@ -14,7 +14,7 @@
     {
       "id": "route_matrix",
       "path": "docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json",
-      "supports": "thirty checked source-sidecar-fused route rows with matched proof-byte ratios"
+      "supports": "thirty checked source-sidecar-fused route_rows entries with matched proof-byte ratios"
     },
     {
       "id": "controlled_component_grid",
@@ -129,7 +129,7 @@
     "A model-facing quantized attention policy is checked equivalent to the existing d8 bounded Softmax-table fixture trace at the trace boundary.",
     "Stwo-AI backend specialization is future work informed by opening, decommitment, table-identity, and layout evidence, not a premise of the current proof-size result."
   ],
-  "payload_commitment": "sha256:a0a2548f826fb81c2c89c826e934c35081b162ccfc4f893746a5db974c0c3083",
+  "payload_commitment": "sha256:1937017bbdcf8eca3bd457f15dfb759e99b6009bf1855cc01a7737d9c2d81a8a",
   "schema": "stark-native-transformer-paper-claim-pack-v1",
   "thesis": "Checked proofs generated on the existing Stwo backend support a paper-facing architecture claim: bounded integer attention arithmetic and Softmax-table LogUp membership can be fused into one native STARK proof object, sharing proof-system commitment and opening plumbing across the arithmetic and lookup-heavy parts. The claim is about STARK-native boundary placement, not an upstream Stwo optimization.",
   "thesis_id": "stark_native_attention_arithmetic_softmax_table_fusion",

--- a/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
+++ b/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
@@ -440,8 +440,10 @@ Several recent systems approach verifiable ML from different proof boundaries.
 NANOZK studies layerwise proof objects for LLM inference [1]. Jolt Atlas uses
 lookup arguments for ONNX-style tensor operations [2]. zkLLM and zkAttn study
 LLM and attention-specific proving paths [3]. DeepProve reports full-model LLM
-inference proving [4]. EZKL, RISC Zero, SP1, and Stwo expose different
-deployment and proof-system surfaces for verifiable computation [5-11].
+inference proving and, in its June 2026 public release, exposes source and
+benchmark-facing documentation [4]. EZKL, RISC Zero, SP1, and Stwo expose
+different deployment and proof-system surfaces for verifiable computation
+[5-11].
 
 These systems motivate, rather than settle, the boundary-selection question
 studied here. Their public artifacts do not expose the same scoped object as the
@@ -656,8 +658,8 @@ how proof artifacts become valid application claims.
 3. Haochen Sun, Jason Li, and Hongyang Zhang. *zkLLM: Zero Knowledge Proofs for
    Large Language Models*. arXiv:2404.16109, 2024.
    <https://arxiv.org/abs/2404.16109>
-4. Lagrange Labs. *DeepProve-1: The First zkML System to Prove a Full LLM
-   Inference*. 2025. <https://lagrange.dev/blog/deepprove-1>
+4. Lagrange Labs. *DeepProve*. Public site and source repository, 2026.
+   <https://lagrange.dev/deepprove>; <https://github.com/Lagrange-Labs/deep-prove>
 5. EZKL Docs. *Products*. <https://docs.ezkl.xyz/products/>
 6. RISC Zero. *risc0 Source Repository*. <https://github.com/risc0/risc0>
 7. Succinct Labs. *SP1 Source Repository*. <https://github.com/succinctlabs/sp1>

--- a/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
+++ b/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
@@ -19,9 +19,9 @@ Starknet deployment, or upstream Stwo optimization.
 1. Unmodified Stwo-backed evidence now checks source arithmetic, LogUp sidecar,
    and fused proof objects for a controlled Softmax-table route family. The
    contribution is the STARK-native boundary, not a Stwo fork.
-2. The checked route matrix has thirty matched rows across width, head-count,
-   sequence-length, and combined-axis profiles, with fused proof bytes smaller
-   than source-plus-sidecar proof bytes in each row.
+2. The checked route matrix has thirty matched `route_rows` entries across
+   width, head-count, sequence-length, and combined-axis profiles, with fused
+   proof bytes smaller than source-plus-sidecar proof bytes in each entry.
 3. The section-delta and typed-size evidence agree on the mechanism: the fused
    object mostly avoids duplicated opening/decommitment structure.
 4. The local binary typed accounting slice gives deterministic repo-owned
@@ -77,7 +77,8 @@ Per-row Stwo backend versions are recorded in the section-delta artifact fields
 The route rows carry the step counts, lookup claims, trace rows, and serialized
 proof byte columns used below.
 
-The route matrix records thirty checked matched profiles. Across those rows,
+The route matrix records thirty checked matched `route_rows` entries. Across
+those entries,
 the fused proof bytes total `6,397,632` versus `7,164,515` bytes for the
 matched source-plus-sidecar controls, a `766,883` byte aggregate saving.
 Matched fused ratios range from `0.676723` to `0.964602`.

--- a/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
+++ b/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
@@ -56,6 +56,27 @@ Starknet deployment, or upstream Stwo optimization.
 
 ## Quantitative Core
 
+Reproduction context: the route-matrix numbers below are taken from
+`route_rows` in
+`docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json`
+under route id
+`local_stwo_attention_kv_fused_softmax_table_controlled_route_matrix` and
+timing policy `proof_existence_and_byte_accounting_only_not_public_benchmark`.
+They are regenerated with
+`python3.10 scripts/zkai_attention_kv_fused_softmax_table_route_matrix_gate.py --write-json docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json --write-tsv docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.tsv`.
+The section-delta numbers are taken from `profile_rows` in
+`docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-section-delta-2026-05.json`
+under route id `local_stwo_attention_kv_fused_softmax_table_section_delta`,
+proof-object scope
+`matched_serialized_stark_proof_json_sections_for_source_sidecar_and_fused_envelopes`,
+and timing policy `proof_bytes_only_not_timing_not_public_benchmark`. They are
+regenerated with
+`python3.10 scripts/zkai_attention_kv_fused_softmax_table_section_delta_gate.py --write-json docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-section-delta-2026-05.json --write-tsv docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-section-delta-2026-05.tsv`.
+Per-row Stwo backend versions are recorded in the section-delta artifact fields
+`profile_rows[*].artifacts.{source,sidecar,fused}.proof_backend_version`.
+The route rows carry the step counts, lookup claims, trace rows, and serialized
+proof byte columns used below.
+
 The route matrix records thirty checked matched profiles. Across those rows,
 the fused proof bytes total `6,397,632` versus `7,164,515` bytes for the
 matched source-plus-sidecar controls, a `766,883` byte aggregate saving.

--- a/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
+++ b/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
@@ -19,7 +19,7 @@ Starknet deployment, or upstream Stwo optimization.
 1. Unmodified Stwo-backed evidence now checks source arithmetic, LogUp sidecar,
    and fused proof objects for a controlled Softmax-table route family. The
    contribution is the STARK-native boundary, not a Stwo fork.
-2. The checked route matrix has twelve matched rows across width, head-count,
+2. The checked route matrix has thirty matched rows across width, head-count,
    sequence-length, and combined-axis profiles, with fused proof bytes smaller
    than source-plus-sidecar proof bytes in each row.
 3. The section-delta and typed-size evidence agree on the mechanism: the fused
@@ -56,26 +56,40 @@ Starknet deployment, or upstream Stwo optimization.
 
 ## Quantitative Core
 
-The route matrix records twelve checked matched profiles. Across those rows,
-the fused proof bytes total `862,483` versus `1,072,887` bytes for the matched
-source-plus-sidecar controls, a `210,404` byte aggregate saving. Matched fused
-ratios range from `0.676723` to `0.919259`.
+The route matrix records thirty checked matched profiles. Across those rows,
+the fused proof bytes total `6,397,632` versus `7,164,515` bytes for the
+matched source-plus-sidecar controls, a `766,883` byte aggregate saving.
+Matched fused ratios range from `0.676723` to `0.964602`.
+
+The paper headline is narrower than the full route matrix. It focuses on four
+sequence-axis rows where `seq32` to `seq64` grows lookup claims by
+`3.729730x` and trace rows by `4.000000x`, while fused proof payload bytes grow
+only `1.064910x` to `1.080697x`. The split frontier is also sublinear, so the
+claim is not that only fusion has logarithmic STARK behavior. The claim is that
+the fused route keeps the smaller proof-size frontier against the matched split
+comparator.
 
 The controlled component grid records ten checked fine-grained typed-component
 profiles. The source-plus-sidecar typed estimate totals `285,584` bytes and the
 fused typed estimate totals `234,296` bytes, a `51,288` byte (`17.9590%`)
 aggregate saving. Per-profile typed saving ranges from `9.1035%` to `27.7371%`.
 
-The section-delta evidence attributes `92.7722%` of the serialized proof-byte
-saving to the opening bucket, dominated by FRI proof and decommitment material.
-The typed-size evidence similarly shows decommitment-dominated savings, with
-FRI plus trace decommitments accounting for `36,896` of `42,492` typed-estimate
-saved bytes in the checked nine-profile slice.
+The section-delta evidence now checks eleven profiles, including the
+`d64_four_head_seq64` decision-gate row. It records `1,129,927` source-plus-sidecar
+serialized proof bytes, `905,969` fused serialized proof bytes, and `223,958`
+saved bytes. Of that saving, `209,155` bytes, or `93.3903%`, are in the opening
+bucket, dominated by FRI proof and decommitment material.
 
-The seq32 extension is the strongest sequence-axis row in the current route
-matrix: `d8`, two heads, `32` steps per head, `1,184` lookup claims, `2,048`
-trace rows, `66,327` fused proof bytes, and `98,012` source-plus-sidecar proof
-bytes, for a `0.676723` fused ratio.
+The `d64_four_head_seq64` row ties that mechanism to the main headline surface:
+`315,785` split proof bytes versus `276,503` fused proof bytes, saving `39,282`
+bytes at a `0.875605` fused ratio. Its opening bucket accounts for `37,827` of
+those saved bytes.
+
+The attention-derived `d128` MLP-side attribution is a separate typed-accounting
+slice, not the same surface as the attention sequence rows. It still points in
+the same direction: six separate proof objects total `59,344` typed bytes, the
+fused proof is `22,576` typed bytes, and FRI plus trace decommitments account
+for `33,280` of `36,768` saved typed bytes (`90.5135%`).
 
 ## GO / NO-GO Posture
 

--- a/scripts/tests/test_zkai_paper_claim_pack_gate.py
+++ b/scripts/tests/test_zkai_paper_claim_pack_gate.py
@@ -62,6 +62,30 @@ class PaperClaimPackGateTests(unittest.TestCase):
         with self.assertRaisesRegex(gate.ClaimPackGateError, "missing evidence path"):
             gate.validate_payload(mutated)
 
+    def test_rejects_route_matrix_row_count_drift_even_when_commitment_is_refreshed(self):
+        route_ref = next(ref for ref in self.payload["evidence_refs"] if ref["id"] == "route_matrix")
+        route_path = gate.ROOT / route_ref["path"]
+        route_data = json.loads(route_path.read_text(encoding="utf-8"))
+        route_data["route_rows"] = route_data["route_rows"][:-1]
+        with tempfile.NamedTemporaryFile(
+            dir=gate.ROOT / "docs" / "engineering" / "evidence",
+            prefix="claim-pack-route-matrix-drift-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            path = gate.pathlib.Path(handle.name)
+            path.write_text(json.dumps(route_data), encoding="utf-8")
+        try:
+            mutated = copy.deepcopy(self.payload)
+            next(ref for ref in mutated["evidence_refs"] if ref["id"] == "route_matrix")["path"] = path.relative_to(
+                gate.ROOT
+            ).as_posix()
+            mutated["payload_commitment"] = gate.payload_commitment(mutated)
+            with self.assertRaisesRegex(gate.ClaimPackGateError, "route_matrix row count"):
+                gate.validate_payload(mutated)
+        finally:
+            path.unlink(missing_ok=True)
+
     def test_rejects_symlinked_evidence_parent_even_when_commitment_is_refreshed(self):
         with tempfile.TemporaryDirectory() as tmp:
             outside_dir = gate.pathlib.Path(tmp) / "outside"

--- a/scripts/tests/test_zkai_paper_claim_pack_gate.py
+++ b/scripts/tests/test_zkai_paper_claim_pack_gate.py
@@ -11,6 +11,30 @@ class PaperClaimPackGateTests(unittest.TestCase):
         self.payload = gate.build_payload()
         gate.validate_payload(self.payload)
 
+    def route_matrix_payload_with(self, route_data):
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=gate.ROOT / "docs" / "engineering" / "evidence",
+            prefix="claim-pack-route-matrix-drift-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            json.dump(route_data, handle, sort_keys=True)
+            handle.flush()
+            path = gate.pathlib.Path(handle.name)
+        mutated = copy.deepcopy(self.payload)
+        next(ref for ref in mutated["evidence_refs"] if ref["id"] == "route_matrix")["path"] = path.relative_to(
+            gate.ROOT
+        ).as_posix()
+        mutated["payload_commitment"] = gate.payload_commitment(mutated)
+        return mutated, path
+
+    def route_matrix_data(self):
+        route_ref = next(ref for ref in self.payload["evidence_refs"] if ref["id"] == "route_matrix")
+        route_path = gate.ROOT / route_ref["path"]
+        return json.loads(route_path.read_text(encoding="utf-8"))
+
     def test_binds_narrow_thesis_and_non_claims(self):
         self.assertEqual(self.payload["decision"], gate.DECISION)
         self.assertIn("STARK-native proof-architecture", self.payload["go_posture"][0])
@@ -63,25 +87,41 @@ class PaperClaimPackGateTests(unittest.TestCase):
             gate.validate_payload(mutated)
 
     def test_rejects_route_matrix_row_count_drift_even_when_commitment_is_refreshed(self):
-        route_ref = next(ref for ref in self.payload["evidence_refs"] if ref["id"] == "route_matrix")
-        route_path = gate.ROOT / route_ref["path"]
-        route_data = json.loads(route_path.read_text(encoding="utf-8"))
+        route_data = self.route_matrix_data()
         route_data["route_rows"] = route_data["route_rows"][:-1]
-        with tempfile.NamedTemporaryFile(
-            dir=gate.ROOT / "docs" / "engineering" / "evidence",
-            prefix="claim-pack-route-matrix-drift-",
-            suffix=".json",
-            delete=False,
-        ) as handle:
-            path = gate.pathlib.Path(handle.name)
-            path.write_text(json.dumps(route_data), encoding="utf-8")
+        mutated, path = self.route_matrix_payload_with(route_data)
         try:
-            mutated = copy.deepcopy(self.payload)
-            next(ref for ref in mutated["evidence_refs"] if ref["id"] == "route_matrix")["path"] = path.relative_to(
-                gate.ROOT
-            ).as_posix()
-            mutated["payload_commitment"] = gate.payload_commitment(mutated)
             with self.assertRaisesRegex(gate.ClaimPackGateError, "route_matrix row count"):
+                gate.validate_payload(mutated)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_rejects_route_matrix_missing_required_field_even_when_commitment_is_refreshed(self):
+        route_data = self.route_matrix_data()
+        del route_data["route_rows"][0]["fused_proof_size_bytes"]
+        mutated, path = self.route_matrix_payload_with(route_data)
+        try:
+            with self.assertRaisesRegex(gate.ClaimPackGateError, "fused_proof_size_bytes"):
+                gate.validate_payload(mutated)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_rejects_route_matrix_row_arithmetic_drift_even_when_commitment_is_refreshed(self):
+        route_data = self.route_matrix_data()
+        route_data["route_rows"][0]["fused_saves_vs_source_plus_sidecar_bytes"] += 1
+        mutated, path = self.route_matrix_payload_with(route_data)
+        try:
+            with self.assertRaisesRegex(gate.ClaimPackGateError, "saving mismatch"):
+                gate.validate_payload(mutated)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_rejects_route_matrix_ratio_drift_even_when_commitment_is_refreshed(self):
+        route_data = self.route_matrix_data()
+        route_data["route_rows"][0]["fused_to_source_plus_sidecar_ratio"] += 0.01
+        mutated, path = self.route_matrix_payload_with(route_data)
+        try:
+            with self.assertRaisesRegex(gate.ClaimPackGateError, "ratio mismatch"):
                 gate.validate_payload(mutated)
         finally:
             path.unlink(missing_ok=True)

--- a/scripts/tests/test_zkai_paper_claim_pack_gate.py
+++ b/scripts/tests/test_zkai_paper_claim_pack_gate.py
@@ -126,6 +126,16 @@ class PaperClaimPackGateTests(unittest.TestCase):
         finally:
             path.unlink(missing_ok=True)
 
+    def test_rejects_route_matrix_non_finite_ratio_even_when_commitment_is_refreshed(self):
+        route_data = self.route_matrix_data()
+        route_data["route_rows"][0]["fused_to_source_plus_sidecar_ratio"] = float("nan")
+        mutated, path = self.route_matrix_payload_with(route_data)
+        try:
+            with self.assertRaisesRegex(gate.ClaimPackGateError, "must be finite"):
+                gate.validate_payload(mutated)
+        finally:
+            path.unlink(missing_ok=True)
+
     def test_rejects_symlinked_evidence_parent_even_when_commitment_is_refreshed(self):
         with tempfile.TemporaryDirectory() as tmp:
             outside_dir = gate.pathlib.Path(tmp) / "outside"

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -13,6 +13,7 @@ import argparse
 import copy
 import hashlib
 import json
+import math
 import pathlib
 import re
 import sys
@@ -360,7 +361,10 @@ def _required_route_matrix_ratio(row: dict[str, Any], index: int) -> float:
     value = row.get(ROUTE_MATRIX_RATIO_FIELD)
     if type(value) not in (int, float):
         raise ClaimPackGateError(f"route_matrix row {index} {ROUTE_MATRIX_RATIO_FIELD} must be numeric")
-    return float(value)
+    ratio = float(value)
+    if not math.isfinite(ratio):
+        raise ClaimPackGateError(f"route_matrix row {index} {ROUTE_MATRIX_RATIO_FIELD} must be finite")
+    return ratio
 
 
 def _assert_exact_list(value: Any, expected: list[str], label: str) -> None:

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -79,7 +79,7 @@ EVIDENCE_REFS = [
     {
         "id": "route_matrix",
         "path": "docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json",
-        "supports": "thirty checked source-sidecar-fused route rows with matched proof-byte ratios",
+        "supports": "thirty checked source-sidecar-fused route_rows entries with matched proof-byte ratios",
     },
     {
         "id": "controlled_component_grid",

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -79,7 +79,7 @@ EVIDENCE_REFS = [
     {
         "id": "route_matrix",
         "path": "docs/engineering/evidence/zkai-attention-kv-fused-softmax-table-route-matrix-2026-05.json",
-        "supports": "twelve checked source-sidecar-fused route rows with matched proof-byte ratios",
+        "supports": "thirty checked source-sidecar-fused route rows with matched proof-byte ratios",
     },
     {
         "id": "controlled_component_grid",

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -160,6 +160,40 @@ EXPECTED_ROUTE_MATRIX_SPLIT_PROOF_BYTES_TOTAL = 7_164_515
 EXPECTED_ROUTE_MATRIX_SAVING_BYTES_TOTAL = 766_883
 EXPECTED_ROUTE_MATRIX_MIN_RATIO = 0.676723
 EXPECTED_ROUTE_MATRIX_MAX_RATIO = 0.964602
+EXPECTED_ROUTE_MATRIX_PROFILE_IDS = (
+    "d8_single_head_seq8",
+    "d16_single_head_seq8",
+    "d32_single_head_seq8",
+    "d8_two_head_seq8",
+    "d8_four_head_seq8",
+    "d8_eight_head_seq8",
+    "d8_sixteen_head_seq8",
+    "d8_two_head_seq16",
+    "d8_two_head_seq32",
+    "d16_two_head_seq8",
+    "d32_two_head_seq8",
+    "d16_two_head_seq16",
+    "d16_two_head_seq32",
+    "d32_two_head_seq16",
+    "d32_four_head_seq16",
+    "d32_two_head_seq32",
+    "d32_four_head_seq32",
+    "d64_single_head_seq16",
+    "d64_two_head_seq16",
+    "d64_four_head_seq16",
+    "d64_two_head_seq32",
+    "d64_two_head_seq64",
+    "d64_four_head_seq32",
+    "d64_four_head_seq64",
+    "d128_single_head_seq16",
+    "d128_two_head_seq32",
+    "d128_two_head_seq64",
+    "d128_four_head_seq32",
+    "d128_four_head_seq64",
+    "d256_two_head_seq32",
+)
+ROUTE_MATRIX_RATIO_FIELD = "fused_to_source_plus_sidecar_ratio"
+ROUTE_MATRIX_RATIO_TOLERANCE = 0.000001
 
 
 class ClaimPackGateError(ValueError):
@@ -249,15 +283,52 @@ def _assert_evidence_paths_exist(payload: dict[str, Any]) -> None:
 def _assert_route_matrix_integrity(full_path: pathlib.Path) -> None:
     with full_path.open(encoding="utf-8") as handle:
         route_data = json.load(handle)
+    profiles_checked = route_data.get("profiles_checked")
+    if profiles_checked != EXPECTED_ROUTE_MATRIX_ROW_COUNT:
+        raise ClaimPackGateError(
+            f"route_matrix profiles_checked {profiles_checked} != {EXPECTED_ROUTE_MATRIX_ROW_COUNT}"
+        )
+    profile_ids = route_data.get("profile_ids")
+    if profile_ids != list(EXPECTED_ROUTE_MATRIX_PROFILE_IDS):
+        raise ClaimPackGateError("route_matrix profile_ids drift")
     rows = route_data.get("route_rows")
     if not isinstance(rows, list):
         raise ClaimPackGateError("route_matrix route_rows must be a list")
     row_count = len(rows)
     if row_count != EXPECTED_ROUTE_MATRIX_ROW_COUNT:
         raise ClaimPackGateError(f"route_matrix row count {row_count} != {EXPECTED_ROUTE_MATRIX_ROW_COUNT}")
-    fused_total = sum(int(row.get("fused_proof_size_bytes", 0)) for row in rows)
-    split_total = sum(int(row.get("source_plus_sidecar_raw_proof_bytes", 0)) for row in rows)
-    saving_total = sum(int(row.get("fused_saves_vs_source_plus_sidecar_bytes", 0)) for row in rows)
+    fused_total = 0
+    split_total = 0
+    saving_total = 0
+    ratios = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ClaimPackGateError(f"route_matrix row {index} must be an object")
+        profile_id = row.get("profile_id")
+        expected_profile_id = EXPECTED_ROUTE_MATRIX_PROFILE_IDS[index]
+        if profile_id != expected_profile_id:
+            raise ClaimPackGateError(
+                f"route_matrix row {index} profile_id {profile_id!r} != {expected_profile_id!r}"
+            )
+        fused = _required_route_matrix_int(row, index, "fused_proof_size_bytes")
+        split = _required_route_matrix_int(row, index, "source_plus_sidecar_raw_proof_bytes")
+        saving = _required_route_matrix_int(row, index, "fused_saves_vs_source_plus_sidecar_bytes")
+        ratio = _required_route_matrix_ratio(row, index)
+        if split <= 0:
+            raise ClaimPackGateError(f"route_matrix row {index} split proof bytes must be > 0")
+        if fused <= 0:
+            raise ClaimPackGateError(f"route_matrix row {index} fused proof bytes must be > 0")
+        if fused >= split:
+            raise ClaimPackGateError(f"route_matrix row {index} must satisfy fused < split")
+        if saving != split - fused:
+            raise ClaimPackGateError(f"route_matrix row {index} saving mismatch")
+        expected_ratio = fused / split
+        if abs(expected_ratio - ratio) > ROUTE_MATRIX_RATIO_TOLERANCE:
+            raise ClaimPackGateError(f"route_matrix row {index} ratio mismatch")
+        fused_total += fused
+        split_total += split
+        saving_total += saving
+        ratios.append(ratio)
     if fused_total != EXPECTED_ROUTE_MATRIX_FUSED_PROOF_BYTES_TOTAL:
         raise ClaimPackGateError(
             f"route_matrix fused proof bytes {fused_total} != {EXPECTED_ROUTE_MATRIX_FUSED_PROOF_BYTES_TOTAL}"
@@ -270,13 +341,26 @@ def _assert_route_matrix_integrity(full_path: pathlib.Path) -> None:
         raise ClaimPackGateError(
             f"route_matrix saving bytes {saving_total} != {EXPECTED_ROUTE_MATRIX_SAVING_BYTES_TOTAL}"
         )
-    ratios = [float(row["fused_to_source_plus_sidecar_ratio"]) for row in rows]
     min_ratio = min(ratios)
     max_ratio = max(ratios)
-    if abs(min_ratio - EXPECTED_ROUTE_MATRIX_MIN_RATIO) > 0.000001:
+    if abs(min_ratio - EXPECTED_ROUTE_MATRIX_MIN_RATIO) > ROUTE_MATRIX_RATIO_TOLERANCE:
         raise ClaimPackGateError(f"route_matrix min ratio {min_ratio:.6f} != {EXPECTED_ROUTE_MATRIX_MIN_RATIO}")
-    if abs(max_ratio - EXPECTED_ROUTE_MATRIX_MAX_RATIO) > 0.000001:
+    if abs(max_ratio - EXPECTED_ROUTE_MATRIX_MAX_RATIO) > ROUTE_MATRIX_RATIO_TOLERANCE:
         raise ClaimPackGateError(f"route_matrix max ratio {max_ratio:.6f} != {EXPECTED_ROUTE_MATRIX_MAX_RATIO}")
+
+
+def _required_route_matrix_int(row: dict[str, Any], index: int, field: str) -> int:
+    value = row.get(field)
+    if type(value) is not int:
+        raise ClaimPackGateError(f"route_matrix row {index} {field} must be an integer")
+    return value
+
+
+def _required_route_matrix_ratio(row: dict[str, Any], index: int) -> float:
+    value = row.get(ROUTE_MATRIX_RATIO_FIELD)
+    if type(value) not in (int, float):
+        raise ClaimPackGateError(f"route_matrix row {index} {ROUTE_MATRIX_RATIO_FIELD} must be numeric")
+    return float(value)
 
 
 def _assert_exact_list(value: Any, expected: list[str], label: str) -> None:

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -153,6 +153,14 @@ EXPECTED_MUTATION_NAMES = (
     "unknown_field_injection",
 )
 
+ROUTE_MATRIX_REF_ID = "route_matrix"
+EXPECTED_ROUTE_MATRIX_ROW_COUNT = 30
+EXPECTED_ROUTE_MATRIX_FUSED_PROOF_BYTES_TOTAL = 6_397_632
+EXPECTED_ROUTE_MATRIX_SPLIT_PROOF_BYTES_TOTAL = 7_164_515
+EXPECTED_ROUTE_MATRIX_SAVING_BYTES_TOTAL = 766_883
+EXPECTED_ROUTE_MATRIX_MIN_RATIO = 0.676723
+EXPECTED_ROUTE_MATRIX_MAX_RATIO = 0.964602
+
 
 class ClaimPackGateError(ValueError):
     pass
@@ -234,6 +242,41 @@ def _assert_evidence_paths_exist(payload: dict[str, Any]) -> None:
         if not full_path.is_file():
             raise ClaimPackGateError(f"missing evidence path: {path}")
         _assert_repo_contained(full_path, f"evidence_refs[{index}].path")
+        if ref.get("id") == ROUTE_MATRIX_REF_ID:
+            _assert_route_matrix_integrity(full_path)
+
+
+def _assert_route_matrix_integrity(full_path: pathlib.Path) -> None:
+    with full_path.open(encoding="utf-8") as handle:
+        route_data = json.load(handle)
+    rows = route_data.get("route_rows")
+    if not isinstance(rows, list):
+        raise ClaimPackGateError("route_matrix route_rows must be a list")
+    row_count = len(rows)
+    if row_count != EXPECTED_ROUTE_MATRIX_ROW_COUNT:
+        raise ClaimPackGateError(f"route_matrix row count {row_count} != {EXPECTED_ROUTE_MATRIX_ROW_COUNT}")
+    fused_total = sum(int(row.get("fused_proof_size_bytes", 0)) for row in rows)
+    split_total = sum(int(row.get("source_plus_sidecar_raw_proof_bytes", 0)) for row in rows)
+    saving_total = sum(int(row.get("fused_saves_vs_source_plus_sidecar_bytes", 0)) for row in rows)
+    if fused_total != EXPECTED_ROUTE_MATRIX_FUSED_PROOF_BYTES_TOTAL:
+        raise ClaimPackGateError(
+            f"route_matrix fused proof bytes {fused_total} != {EXPECTED_ROUTE_MATRIX_FUSED_PROOF_BYTES_TOTAL}"
+        )
+    if split_total != EXPECTED_ROUTE_MATRIX_SPLIT_PROOF_BYTES_TOTAL:
+        raise ClaimPackGateError(
+            f"route_matrix split proof bytes {split_total} != {EXPECTED_ROUTE_MATRIX_SPLIT_PROOF_BYTES_TOTAL}"
+        )
+    if saving_total != EXPECTED_ROUTE_MATRIX_SAVING_BYTES_TOTAL:
+        raise ClaimPackGateError(
+            f"route_matrix saving bytes {saving_total} != {EXPECTED_ROUTE_MATRIX_SAVING_BYTES_TOTAL}"
+        )
+    ratios = [float(row["fused_to_source_plus_sidecar_ratio"]) for row in rows]
+    min_ratio = min(ratios)
+    max_ratio = max(ratios)
+    if abs(min_ratio - EXPECTED_ROUTE_MATRIX_MIN_RATIO) > 0.000001:
+        raise ClaimPackGateError(f"route_matrix min ratio {min_ratio:.6f} != {EXPECTED_ROUTE_MATRIX_MIN_RATIO}")
+    if abs(max_ratio - EXPECTED_ROUTE_MATRIX_MAX_RATIO) > 0.000001:
+        raise ClaimPackGateError(f"route_matrix max ratio {max_ratio:.6f} != {EXPECTED_ROUTE_MATRIX_MAX_RATIO}")
 
 
 def _assert_exact_list(value: Any, expected: list[str], label: str) -> None:


### PR DESCRIPTION
## Summary
- update the proof-pressure paper related-work reference to the June 2026 public DeepProve site and source release
- sync the human claim-pack markdown with the current 30-row route matrix and 11-profile section-delta evidence
- regenerate the machine-readable claim-pack JSON after changing the route-matrix support text from twelve rows to thirty rows

## Research note
I checked the public Lagrange DeepProve release. The announcement says a research paper is available, but the public DeepProve repo currently exposes README/docs/bench material and still says the formal paper link is to be added. The paper should therefore treat DeepProve as docs/source-reported related work, not as a matched comparator row.

The main paper style is already directionally right: specific object, benchmark table early, mechanism section, limitations, and reproduction commands. The necessary fix was not style; it was stale claim-pack accounting.

## Validation
- `python3.10 scripts/zkai_paper_claim_pack_gate.py --write-json docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json`
- `python3.10 -m py_compile scripts/zkai_paper_claim_pack_gate.py scripts/tests/test_zkai_paper_claim_pack_gate.py`
- `python3.10 -m unittest scripts.tests.test_zkai_paper_claim_pack_gate`
- `python3.10 scripts/paper/paper_preflight.py --repo-root .`
- `scripts/run_paper_preflight_suite.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded related-work entry and updated the DeepProve (2026) reference; expanded quantitative sections and revised proof-claim metrics with larger route‑matrix coverage and additional profiles.
* **Chores / Validation**
  * Strengthened claim-pack integrity checks to enforce expected route‑matrix row count, per-row invariants, aggregated proof‑byte totals, and fused/split ratio bounds.
* **Tests**
  * Added tests that reject tampered route‑matrix evidence for row‑count, missing‑field, arithmetic, ratio, and non‑finite value drifts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Hardening
- Trusted-core paths: no prover, verifier, backend routing, or proof semantics code changed.
- Claim hardening: the claim-pack gate now enforces the route_matrix route_rows count, fused and split byte totals, saving total, and min and max ratio bounds.
- Reproducibility: the quantitative core names route ids, timing policies, evidence paths, and regeneration commands.
- Not applicable: no production security-profile change, no backend optimization claim, and no public timing benchmark claim.
