### PR TITLE
[codex] Clean high-query q12 sensitivity path

### DIFF
--- a/docs/engineering/evidence/zkai-attention-kv-d8-high-query-sensitivity-2026-06.json
+++ b/docs/engineering/evidence/zkai-attention-kv-d8-high-query-sensitivity-2026-06.json
@@ -28,7 +28,7 @@
     "fri_log_last_layer_degree_bound": 0,
     "pow_bits": 10
   },
-  "interpretation": "On this small d8 surface, q6 and q12 preserve the fused proof-size win. The absolute saving grows from 11739 bytes at q3 to 19226 at q6 and 25530 at q12. Both higher-query rows now require only an explicit FRI-query-count patch; the publication profile remains the default q3 configuration.",
+  "interpretation": "On this small d8 surface, q6 and q12 preserve the fused proof-size win. The absolute saving grows from 11739 bytes at q3 to 19226 at q6 and 25530 at q12. Both higher-query rows now require only an explicit FRI-query-count patch; the publication profile remains the default q3 configuration. The d8 source verifier cap is 98304 raw proof bytes: above the 84266-byte q12 source proof, but checked by a Rust regression to stay below the 1MiB pretty-JSON envelope cap even with worst-case proof-byte formatting.",
   "issue": 765,
   "mutation_cases": [
     {
@@ -49,6 +49,11 @@
     {
       "error": "query-count patch drift",
       "name": "query_count_patch_drift",
+      "rejected": true
+    },
+    {
+      "error": "legacy scratch_patches field",
+      "name": "legacy_scratch_patches_field",
       "rejected": true
     },
     {
@@ -82,8 +87,8 @@
       "rejected": true
     }
   ],
-  "mutations_checked": 10,
-  "mutations_rejected": 10,
+  "mutations_checked": 11,
+  "mutations_rejected": 11,
   "non_claims": [
     "not a headline d64 or d128 high-query rerun",
     "not production-security parameter evidence",
@@ -94,7 +99,7 @@
     "not evidence that higher query count always improves fused-to-split ratio",
     "not a permanent Stwo-AI backend change"
   ],
-  "payload_commitment": "blake2b-256:bb045863ede90efc033c3d0a2446bcbc8fb647601f542bacd258482321f6c626",
+  "payload_commitment": "blake2b-256:c020d1ddc976c88482c90a062cd7f33ce3be01c4e57b71037f5f0634df71c17f",
   "query_count_patches": {
     "q12": [
       {

--- a/docs/engineering/evidence/zkai-attention-kv-d8-high-query-sensitivity-2026-06.json
+++ b/docs/engineering/evidence/zkai-attention-kv-d8-high-query-sensitivity-2026-06.json
@@ -2,7 +2,7 @@
   "aggregate": {
     "q12_fused_growth_vs_q3": 1.800914,
     "q12_fused_to_split_ratio": 0.770888,
-    "q12_requires_resource_limit_retune": true,
+    "q12_requires_resource_limit_retune": false,
     "q12_saving_bytes": 25530,
     "q12_split_growth_vs_q3": 1.874758,
     "q3_fused_to_split_ratio": 0.802497,
@@ -17,10 +17,10 @@
     "surface": "d8_single_head_seq8_bounded_softmax_table_attention"
   },
   "all_mutations_rejected": true,
-  "backend": "unmodified_stwo_2_2_0_with_scratch_pcs_config_patch",
+  "backend": "unmodified_stwo_2_2_0_with_explicit_query_count_patch",
   "claim_boundary": "SMALL_D8_SINGLE_HEAD_SEQ8_HIGHER_FRI_QUERY_SENSITIVITY_FOR_SPLIT_VS_FUSED_PROOF_BYTES;NOT_HEADLINE_D64_D128_MEASUREMENT;NOT_PRODUCTION_SECURITY;NOT_TIMING;NOT_SYSTEM_COMPARISON",
   "date": "2026-06-26",
-  "decision": "GO_SMALL_SURFACE_HIGH_QUERY_SENSITIVITY_WITH_RESOURCE_LIMIT_CAVEAT",
+  "decision": "GO_SMALL_SURFACE_HIGH_QUERY_SENSITIVITY_QUERY_COUNT_ONLY",
   "fixed_fields": {
     "fri_blowup_factor": 2,
     "fri_fold_step": 1,
@@ -28,7 +28,7 @@
     "fri_log_last_layer_degree_bound": 0,
     "pow_bits": 10
   },
-  "interpretation": "On this small d8 surface, q6 and q12 preserve the fused proof-size win. The absolute saving grows from 11739 bytes at q3 to 19226 at q6 and 25530 at q12. The q12 source proof also exceeds the current default d8 source proof byte ceiling, so higher-query experiments need explicit resource-limit retuning before promotion.",
+  "interpretation": "On this small d8 surface, q6 and q12 preserve the fused proof-size win. The absolute saving grows from 11739 bytes at q3 to 19226 at q6 and 25530 at q12. Both higher-query rows now require only an explicit FRI-query-count patch; the publication profile remains the default q3 configuration.",
   "issue": 765,
   "mutation_cases": [
     {
@@ -47,6 +47,11 @@
       "rejected": true
     },
     {
+      "error": "query-count patch drift",
+      "name": "query_count_patch_drift",
+      "rejected": true
+    },
+    {
       "error": "q6 fused_proof_size_bytes drift",
       "name": "q6_size_drift",
       "rejected": true
@@ -58,7 +63,7 @@
     },
     {
       "error": "q12 resource_limit_status drift",
-      "name": "q12_limit_caveat_removed",
+      "name": "q12_resource_status_drift",
       "rejected": true
     },
     {
@@ -77,8 +82,8 @@
       "rejected": true
     }
   ],
-  "mutations_checked": 9,
-  "mutations_rejected": 9,
+  "mutations_checked": 10,
+  "mutations_rejected": 10,
   "non_claims": [
     "not a headline d64 or d128 high-query rerun",
     "not production-security parameter evidence",
@@ -89,7 +94,25 @@
     "not evidence that higher query count always improves fused-to-split ratio",
     "not a permanent Stwo-AI backend change"
   ],
-  "payload_commitment": "blake2b-256:e912f8a45c939178fc611dbffa47713c34c469d5211fa37a63804f0f18c5ac2f",
+  "payload_commitment": "blake2b-256:bb045863ede90efc033c3d0a2446bcbc8fb647601f542bacd258482321f6c626",
+  "query_count_patches": {
+    "q12": [
+      {
+        "from": "FriConfig::new(0, 1, 3, 1)",
+        "path": "src/stwo_backend/mod.rs",
+        "reason": "raise FRI query count while keeping blowup, fold step, and PoW fixed",
+        "to": "FriConfig::new(0, 1, 12, 1)"
+      }
+    ],
+    "q6": [
+      {
+        "from": "FriConfig::new(0, 1, 3, 1)",
+        "path": "src/stwo_backend/mod.rs",
+        "reason": "raise FRI query count while keeping blowup, fold step, and PoW fixed",
+        "to": "FriConfig::new(0, 1, 6, 1)"
+      }
+    ]
+  },
   "rows": [
     {
       "artifacts": {
@@ -382,7 +405,7 @@
         "lifting_log_size": null,
         "pow_bits": 10
       },
-      "resource_limit_status": "verified_after_scratch_source_proof_limit_raise",
+      "resource_limit_status": "verified_with_query_count_patch_only",
       "sidecar_proof_size_bytes": 27164,
       "source_plus_sidecar_raw_proof_bytes": 111430,
       "source_proof_size_bytes": 84266,
@@ -390,30 +413,6 @@
     }
   ],
   "schema": "zkai-attention-kv-d8-high-query-sensitivity-v1",
-  "scratch_patches": {
-    "q12": [
-      {
-        "from": "FriConfig::new(0, 1, 3, 1)",
-        "path": "src/stwo_backend/mod.rs",
-        "reason": "raise FRI query count while keeping blowup, fold step, and PoW fixed",
-        "to": "FriConfig::new(0, 1, 12, 1)"
-      },
-      {
-        "from": "ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES = 65_536",
-        "path": "src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs",
-        "reason": "q12 source proof is 84266 bytes, above the default d8 source proof ceiling",
-        "to": "ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES = 262_144"
-      }
-    ],
-    "q6": [
-      {
-        "from": "FriConfig::new(0, 1, 3, 1)",
-        "path": "src/stwo_backend/mod.rs",
-        "reason": "raise FRI query count while keeping blowup, fold step, and PoW fixed",
-        "to": "FriConfig::new(0, 1, 6, 1)"
-      }
-    ]
-  },
   "surface": "d8_single_head_seq8_bounded_softmax_table_attention",
   "toolchain": "cargo +nightly-2025-07-14 --locked --features stwo-backend",
   "validation_commands": [

--- a/docs/engineering/evidence/zkai-attention-kv-d8-high-query-sensitivity-2026-06.tsv
+++ b/docs/engineering/evidence/zkai-attention-kv-d8-high-query-sensitivity-2026-06.tsv
@@ -1,4 +1,4 @@
 fri_query_count	source_proof_size_bytes	sidecar_proof_size_bytes	source_plus_sidecar_raw_proof_bytes	fused_proof_size_bytes	fused_saves_vs_source_plus_sidecar_bytes	fused_to_split_ratio	fused_growth_vs_q3	split_growth_vs_q3	resource_limit_status
 3	44692	14745	59437	47698	11739	0.802497	1.0	1.0	checked_default_artifact
 6	60828	21287	82115	62889	19226	0.765865	1.318483	1.381547	verified_with_query_count_patch_only
-12	84266	27164	111430	85900	25530	0.770888	1.800914	1.874758	verified_after_scratch_source_proof_limit_raise
+12	84266	27164	111430	85900	25530	0.770888	1.800914	1.874758	verified_with_query_count_patch_only

--- a/docs/engineering/zkai-attention-kv-d8-high-query-sensitivity-2026-06-26.md
+++ b/docs/engineering/zkai-attention-kv-d8-high-query-sensitivity-2026-06-26.md
@@ -1,9 +1,9 @@
 # d8 High-Query Sensitivity
 
 - Issue: `#765`
-- Decision: `GO_SMALL_SURFACE_HIGH_QUERY_SENSITIVITY_WITH_RESOURCE_LIMIT_CAVEAT`
+- Decision: `GO_SMALL_SURFACE_HIGH_QUERY_SENSITIVITY_QUERY_COUNT_ONLY`
 - Surface: `d8_single_head_seq8_bounded_softmax_table_attention`
-- Backend: `unmodified_stwo_2_2_0_with_scratch_pcs_config_patch`
+- Backend: `unmodified_stwo_2_2_0_with_explicit_query_count_patch`
 
 ## Result
 
@@ -17,9 +17,9 @@ This is a small higher-query sensitivity slice, not a new headline row. It rerun
 
 ## Interpretation
 
-On this small d8 surface, q6 and q12 preserve the fused proof-size win. The absolute saving grows from 11739 bytes at q3 to 19226 at q6 and 25530 at q12. The q12 source proof also exceeds the current default d8 source proof byte ceiling, so higher-query experiments need explicit resource-limit retuning before promotion.
+On this small d8 surface, q6 and q12 preserve the fused proof-size win. The absolute saving grows from 11739 bytes at q3 to 19226 at q6 and 25530 at q12. Both higher-query rows now require only an explicit FRI-query-count patch; the publication profile remains the default q3 configuration.
 
-The q12 run is useful but should stay engineering-scoped: the source proof exceeded the current default d8 source proof byte ceiling and verified only after a scratch resource-limit retune.
+The q12 run is useful but should stay engineering-scoped: it is a small d8 sensitivity rerun under an explicit query-count patch, not a headline d64/d128 row or a production-security profile.
 
 ## Reproduction
 
@@ -37,11 +37,6 @@ For q12, patch:
 ```text
 src/stwo_backend/mod.rs:
 FriConfig::new(0, 1, 3, 1) -> FriConfig::new(0, 1, 12, 1)
-
-src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs:
-ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES = 65_536
-->
-ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES = 262_144
 ```
 
 After applying the q6 patch, run:

--- a/docs/engineering/zkai-attention-kv-d8-high-query-sensitivity-2026-06-26.md
+++ b/docs/engineering/zkai-attention-kv-d8-high-query-sensitivity-2026-06-26.md
@@ -17,7 +17,7 @@ This is a small higher-query sensitivity slice, not a new headline row. It rerun
 
 ## Interpretation
 
-On this small d8 surface, q6 and q12 preserve the fused proof-size win. The absolute saving grows from 11739 bytes at q3 to 19226 at q6 and 25530 at q12. Both higher-query rows now require only an explicit FRI-query-count patch; the publication profile remains the default q3 configuration.
+On this small d8 surface, q6 and q12 preserve the fused proof-size win. The absolute saving grows from 11739 bytes at q3 to 19226 at q6 and 25530 at q12. Both higher-query rows now require only an explicit FRI-query-count patch; the publication profile remains the default q3 configuration. The d8 source verifier cap is 98304 raw proof bytes: above the 84266-byte q12 source proof, but checked by a Rust regression to stay below the 1MiB pretty-JSON envelope cap even with worst-case proof-byte formatting.
 
 The q12 run is useful but should stay engineering-scoped: it is a small d8 sensitivity rerun under an explicit query-count patch, not a headline d64/d128 row or a production-security profile.
 

--- a/docs/paper/REPRODUCE.md
+++ b/docs/paper/REPRODUCE.md
@@ -41,9 +41,9 @@ the paper:
 - `docs/engineering/evidence/zkai-attention-kv-d8-high-query-sensitivity-2026-06.json`
 
 The high-query sensitivity gate also checks six proof envelopes under
-`docs/engineering/evidence/high-query/`. Those envelopes are scratch reruns for
-the d8 single-head surface at FRI query counts `6` and `12`; they are
-engineering evidence, not headline d64/d128 rows.
+`docs/engineering/evidence/high-query/`. Those envelopes are explicit
+query-count reruns for the d8 single-head surface at FRI query counts `6` and
+`12`; they are engineering evidence, not headline d64/d128 rows.
 
 ## Fixed Experimental Configuration
 

--- a/docs/paper/evidence/stark-native-transformer-paper-release-manifest-2026-06.json
+++ b/docs/paper/evidence/stark-native-transformer-paper-release-manifest-2026-06.json
@@ -2,8 +2,8 @@
   "artifact_digests": [
     {
       "path": "docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md",
-      "sha256": "af7a24c7425725d057f7d05435015159147fbd38926b080f86d9b2c8e5743a7f",
-      "size_bytes": 45804
+      "sha256": "bdd331de61c01c8d19cf4343711d46c6e595983b9cc59647880a59f984517730",
+      "size_bytes": 45833
     },
     {
       "path": "docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md",

--- a/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
+++ b/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
@@ -449,10 +449,11 @@ bound. A small higher-query sensitivity slice supports the mechanism without
 promoting it into the headline: on the `d8_single_head_seq8` surface, raising
 FRI query count from `3` to `6` and `12` preserved the fused proof-size win. The
 absolute saving grew from `11,739` bytes at `q=3` to `19,226` at `q=6` and
-`25,530` at `q=12`. The caveat is important: the `q=12` source proof exceeded
-the current d8 source-proof byte ceiling and verified only after a scratch
-resource-limit retune. Treat this as a bounded sensitivity check, not as a
-production-security profile or a headline d64/d128 rerun.
+`25,530` at `q=12`. The caveat is important: these rows are small-surface
+sensitivity reruns under an explicit FRI-query-count patch, while the
+publication profile remains the default `q=3` configuration. Treat this as a
+bounded sensitivity check, not as a production-security profile or a headline
+d64/d128 rerun.
 
 ---
 

--- a/scripts/tests/test_zkai_attention_kv_high_query_sensitivity_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_high_query_sensitivity_gate.py
@@ -58,22 +58,19 @@ class HighQuerySensitivityGateTests(unittest.TestCase):
         self.assertEqual(q12["fused_proof_size_bytes"], 85_900)
         self.assertEqual(q12["fused_saves_vs_source_plus_sidecar_bytes"], 25_530)
         self.assertEqual(q12["fused_to_split_ratio"], 0.770888)
-        self.assertEqual(q12["resource_limit_status"], "verified_after_scratch_source_proof_limit_raise")
+        self.assertEqual(q12["resource_limit_status"], "verified_with_query_count_patch_only")
 
-    def test_growth_metrics_and_resource_limit_caveat_are_explicit(self):
+    def test_growth_metrics_and_query_count_patches_are_explicit(self):
         aggregate = self.payload["aggregate"]
         self.assertEqual(aggregate["query_counts_checked"], [3, 6, 12])
         self.assertEqual(aggregate["q12_saving_bytes"], 25_530)
         self.assertEqual(aggregate["q12_fused_growth_vs_q3"], 1.800914)
         self.assertEqual(aggregate["q12_split_growth_vs_q3"], 1.874758)
-        self.assertTrue(aggregate["q12_requires_resource_limit_retune"])
+        self.assertFalse(aggregate["q12_requires_resource_limit_retune"])
 
-        patches = self.payload["scratch_patches"]
+        patches = self.payload["query_count_patches"]
         self.assertEqual(patches["q12"][0]["to"], "FriConfig::new(0, 1, 12, 1)")
-        self.assertEqual(
-            patches["q12"][1]["to"],
-            "ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES = 262_144",
-        )
+        self.assertEqual(len(patches["q12"]), 1)
 
     def test_declared_mutations_reject(self):
         self.assertEqual([item["name"] for item in self.payload["mutation_cases"]], list(gate.MUTATION_NAMES))
@@ -92,8 +89,13 @@ class HighQuerySensitivityGateTests(unittest.TestCase):
         self.assert_rejects(payload, "claim boundary drift")
 
         payload = self.strip_mutation_summary(self.payload)
-        payload["rows"][2]["resource_limit_status"] = "verified_with_query_count_patch_only"
+        payload["rows"][2]["resource_limit_status"] = "verified_after_scratch_source_proof_limit_raise"
         self.assert_rejects(payload, "q12 resource_limit_status drift")
+
+        payload = self.strip_mutation_summary(self.payload)
+        payload["query_count_patches"]["q12"][0]["to"] = "FriConfig::new(0, 1, 16, 1)"
+        payload["payload_commitment"] = gate.payload_commitment(payload)
+        self.assert_rejects(payload, "query-count patch drift")
 
         payload = self.strip_mutation_summary(self.payload)
         payload["rows"][1]["proof_config"]["fri_config"]["n_queries"] = 7

--- a/scripts/tests/test_zkai_attention_kv_high_query_sensitivity_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_high_query_sensitivity_gate.py
@@ -39,6 +39,9 @@ class HighQuerySensitivityGateTests(unittest.TestCase):
         self.assertIn("not a headline d64 or d128 high-query rerun", self.payload["non_claims"])
         self.assertIn("not production-security parameter evidence", self.payload["non_claims"])
 
+    def test_rejects_non_object_payload(self):
+        self.assert_rejects([{"schema": gate.SCHEMA}], "payload must be a JSON object")
+
     def test_q3_q6_q12_rows_keep_fused_smaller_than_split(self):
         q3 = self.row(3)
         self.assertEqual(q3["source_plus_sidecar_raw_proof_bytes"], 59_437)

--- a/scripts/tests/test_zkai_attention_kv_high_query_sensitivity_gate.py
+++ b/scripts/tests/test_zkai_attention_kv_high_query_sensitivity_gate.py
@@ -72,6 +72,15 @@ class HighQuerySensitivityGateTests(unittest.TestCase):
         self.assertEqual(patches["q12"][0]["to"], "FriConfig::new(0, 1, 12, 1)")
         self.assertEqual(len(patches["q12"]), 1)
 
+    def test_query_count_patches_are_detached_from_validator_baseline(self):
+        payload = gate.build_payload()
+        payload = self.strip_mutation_summary(payload)
+        payload["query_count_patches"]["q12"][0]["to"] = "FriConfig::new(0, 1, 16, 1)"
+        payload["payload_commitment"] = gate.payload_commitment(payload)
+
+        self.assertEqual(gate.PATCHES["q12"][0]["to"], "FriConfig::new(0, 1, 12, 1)")
+        self.assert_rejects(payload, "query-count patch drift")
+
     def test_declared_mutations_reject(self):
         self.assertEqual([item["name"] for item in self.payload["mutation_cases"]], list(gate.MUTATION_NAMES))
         self.assertEqual(self.payload["mutations_checked"], len(gate.MUTATION_NAMES))
@@ -96,6 +105,11 @@ class HighQuerySensitivityGateTests(unittest.TestCase):
         payload["query_count_patches"]["q12"][0]["to"] = "FriConfig::new(0, 1, 16, 1)"
         payload["payload_commitment"] = gate.payload_commitment(payload)
         self.assert_rejects(payload, "query-count patch drift")
+
+        payload = self.strip_mutation_summary(self.payload)
+        payload["scratch_patches"] = copy.deepcopy(gate.PATCHES)
+        payload["payload_commitment"] = gate.payload_commitment(payload)
+        self.assert_rejects(payload, "legacy scratch_patches field")
 
         payload = self.strip_mutation_summary(self.payload)
         payload["rows"][1]["proof_config"]["fri_config"]["n_queries"] = 7

--- a/scripts/zkai_attention_kv_high_query_sensitivity_gate.py
+++ b/scripts/zkai_attention_kv_high_query_sensitivity_gate.py
@@ -383,12 +383,14 @@ def build_payload() -> dict[str, Any]:
 
 
 def validate_payload(
-    payload: dict[str, Any],
+    payload: Any,
     *,
     allow_missing_mutation_summary: bool = False,
     expected_rows: list[dict[str, Any]] | None = None,
     expected_aggregate: dict[str, Any] | None = None,
 ) -> None:
+    if not isinstance(payload, dict):
+        raise HighQuerySensitivityGateError("payload must be a JSON object")
     actual_keys = set(payload)
     allowed_keys = PAYLOAD_CORE_KEYS | PAYLOAD_MUTATION_SUMMARY_KEYS
     if "scratch_patches" in payload:

--- a/scripts/zkai_attention_kv_high_query_sensitivity_gate.py
+++ b/scripts/zkai_attention_kv_high_query_sensitivity_gate.py
@@ -155,12 +155,41 @@ MUTATION_NAMES = (
     "claim_boundary_overclaim",
     "missing_non_claim",
     "query_count_patch_drift",
+    "legacy_scratch_patches_field",
     "q6_size_drift",
     "q12_size_drift",
     "q12_resource_status_drift",
     "q6_query_count_drift",
     "q12_query_count_drift",
     "payload_commitment_drift",
+)
+PAYLOAD_CORE_KEYS = frozenset(
+    {
+        "schema",
+        "date",
+        "issue",
+        "decision",
+        "claim_boundary",
+        "surface",
+        "backend",
+        "toolchain",
+        "fixed_fields",
+        "query_count_patches",
+        "rows",
+        "aggregate",
+        "interpretation",
+        "validation_commands",
+        "non_claims",
+        "payload_commitment",
+    }
+)
+PAYLOAD_MUTATION_SUMMARY_KEYS = frozenset(
+    {
+        "mutation_cases",
+        "mutations_checked",
+        "mutations_rejected",
+        "all_mutations_rejected",
+    }
 )
 
 
@@ -329,14 +358,17 @@ def build_payload() -> dict[str, Any]:
             "fri_fold_step": 1,
             "fri_log_last_layer_degree_bound": 0,
         },
-        "query_count_patches": PATCHES,
+        "query_count_patches": copy.deepcopy(PATCHES),
         "rows": rows,
         "aggregate": aggregate,
         "interpretation": (
             "On this small d8 surface, q6 and q12 preserve the fused proof-size win. "
             "The absolute saving grows from 11739 bytes at q3 to 19226 at q6 and 25530 at q12. "
             "Both higher-query rows now require only an explicit FRI-query-count patch; the "
-            "publication profile remains the default q3 configuration."
+            "publication profile remains the default q3 configuration. The d8 source verifier "
+            "cap is 98304 raw proof bytes: above the 84266-byte q12 source proof, but checked "
+            "by a Rust regression to stay below the 1MiB pretty-JSON envelope cap even with "
+            "worst-case proof-byte formatting."
         ),
         "validation_commands": list(VALIDATION_COMMANDS),
         "non_claims": list(NON_CLAIMS),
@@ -357,6 +389,14 @@ def validate_payload(
     expected_rows: list[dict[str, Any]] | None = None,
     expected_aggregate: dict[str, Any] | None = None,
 ) -> None:
+    actual_keys = set(payload)
+    allowed_keys = PAYLOAD_CORE_KEYS | PAYLOAD_MUTATION_SUMMARY_KEYS
+    if "scratch_patches" in payload:
+        raise HighQuerySensitivityGateError("legacy scratch_patches field")
+    if not actual_keys <= allowed_keys or not PAYLOAD_CORE_KEYS <= actual_keys:
+        raise HighQuerySensitivityGateError("top-level key drift")
+    if not allow_missing_mutation_summary and not PAYLOAD_MUTATION_SUMMARY_KEYS <= actual_keys:
+        raise HighQuerySensitivityGateError("mutation summary drift")
     if payload.get("schema") != SCHEMA:
         raise HighQuerySensitivityGateError("schema drift")
     if payload.get("decision") != DECISION:
@@ -415,6 +455,7 @@ def run_mutations(payload: dict[str, Any]) -> list[dict[str, Any]]:
     add("claim_boundary_overclaim", lambda p: p.__setitem__("claim_boundary", "HEADLINE_D64_D128_HIGH_QUERY_PROOF_SIZE_WIN"))
     add("missing_non_claim", lambda p: p["non_claims"].remove("not production-security parameter evidence"))
     add("query_count_patch_drift", lambda p: p["query_count_patches"]["q12"][0].__setitem__("to", "FriConfig::new(0, 1, 16, 1)"))
+    add("legacy_scratch_patches_field", lambda p: p.__setitem__("scratch_patches", copy.deepcopy(PATCHES)))
     add("q6_size_drift", lambda p: p["rows"][1].__setitem__("fused_proof_size_bytes", p["rows"][1]["fused_proof_size_bytes"] - 1))
     add("q12_size_drift", lambda p: p["rows"][2].__setitem__("source_plus_sidecar_raw_proof_bytes", p["rows"][2]["source_plus_sidecar_raw_proof_bytes"] - 1))
     add("q12_resource_status_drift", lambda p: p["rows"][2].__setitem__("resource_limit_status", "verified_after_scratch_source_proof_limit_raise"))

--- a/scripts/zkai_attention_kv_high_query_sensitivity_gate.py
+++ b/scripts/zkai_attention_kv_high_query_sensitivity_gate.py
@@ -3,8 +3,8 @@
 
 The paper headline stays on the fixed q=3 Stwo configuration. This gate records
 one deliberately small sensitivity slice on the same d8 single-head bounded
-attention surface, with q=6 and q=12 scratch reruns. It is engineering evidence,
-not a production-security claim and not a headline d64/d128 rerun.
+attention surface, with q=6 and q=12 query-count reruns. It is engineering
+evidence, not a production-security claim and not a headline d64/d128 rerun.
 """
 
 from __future__ import annotations
@@ -33,13 +33,13 @@ MD_OUT = ROOT / "docs" / "engineering" / "zkai-attention-kv-d8-high-query-sensit
 SCHEMA = "zkai-attention-kv-d8-high-query-sensitivity-v1"
 ISSUE = 765
 DATE = "2026-06-26"
-DECISION = "GO_SMALL_SURFACE_HIGH_QUERY_SENSITIVITY_WITH_RESOURCE_LIMIT_CAVEAT"
+DECISION = "GO_SMALL_SURFACE_HIGH_QUERY_SENSITIVITY_QUERY_COUNT_ONLY"
 CLAIM_BOUNDARY = (
     "SMALL_D8_SINGLE_HEAD_SEQ8_HIGHER_FRI_QUERY_SENSITIVITY_FOR_SPLIT_VS_FUSED_PROOF_BYTES;"
     "NOT_HEADLINE_D64_D128_MEASUREMENT;NOT_PRODUCTION_SECURITY;NOT_TIMING;NOT_SYSTEM_COMPARISON"
 )
 SURFACE = "d8_single_head_seq8_bounded_softmax_table_attention"
-BACKEND = "unmodified_stwo_2_2_0_with_scratch_pcs_config_patch"
+BACKEND = "unmodified_stwo_2_2_0_with_explicit_query_count_patch"
 TOOLCHAIN = "cargo +nightly-2025-07-14 --locked --features stwo-backend"
 PAYLOAD_DOMAIN = "ptvm:zkai:attention-kv-d8-high-query-sensitivity:v1"
 
@@ -106,7 +106,7 @@ EXPECTED_ROWS = {
             "fused": "6d449b33979369cfd6f6970fa5baa940d21753c8112610c77aa4158fd31887ea",
         },
         "proof_size_bytes": {"source": 84_266, "sidecar": 27_164, "fused": 85_900},
-        "resource_limit_status": "verified_after_scratch_source_proof_limit_raise",
+        "resource_limit_status": "verified_with_query_count_patch_only",
     },
 }
 PATCHES = {
@@ -124,13 +124,7 @@ PATCHES = {
             "from": "FriConfig::new(0, 1, 3, 1)",
             "to": "FriConfig::new(0, 1, 12, 1)",
             "reason": "raise FRI query count while keeping blowup, fold step, and PoW fixed",
-        },
-        {
-            "path": "src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs",
-            "from": "ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES = 65_536",
-            "to": "ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES = 262_144",
-            "reason": "q12 source proof is 84266 bytes, above the default d8 source proof ceiling",
-        },
+        }
     ],
 }
 VALIDATION_COMMANDS = (
@@ -160,9 +154,10 @@ MUTATION_NAMES = (
     "decision_overclaim",
     "claim_boundary_overclaim",
     "missing_non_claim",
+    "query_count_patch_drift",
     "q6_size_drift",
     "q12_size_drift",
-    "q12_limit_caveat_removed",
+    "q12_resource_status_drift",
     "q6_query_count_drift",
     "q12_query_count_drift",
     "payload_commitment_drift",
@@ -311,7 +306,7 @@ def expected_rows_and_aggregate() -> tuple[list[dict[str, Any]], dict[str, Any]]
         "q12_saving_bytes": rows[2]["fused_saves_vs_source_plus_sidecar_bytes"],
         "q12_split_growth_vs_q3": rows[2]["split_growth_vs_q3"],
         "q12_fused_growth_vs_q3": rows[2]["fused_growth_vs_q3"],
-        "q12_requires_resource_limit_retune": True,
+        "q12_requires_resource_limit_retune": False,
     }
     return rows, aggregate
 
@@ -334,14 +329,14 @@ def build_payload() -> dict[str, Any]:
             "fri_fold_step": 1,
             "fri_log_last_layer_degree_bound": 0,
         },
-        "scratch_patches": PATCHES,
+        "query_count_patches": PATCHES,
         "rows": rows,
         "aggregate": aggregate,
         "interpretation": (
             "On this small d8 surface, q6 and q12 preserve the fused proof-size win. "
             "The absolute saving grows from 11739 bytes at q3 to 19226 at q6 and 25530 at q12. "
-            "The q12 source proof also exceeds the current default d8 source proof byte ceiling, so "
-            "higher-query experiments need explicit resource-limit retuning before promotion."
+            "Both higher-query rows now require only an explicit FRI-query-count patch; the "
+            "publication profile remains the default q3 configuration."
         ),
         "validation_commands": list(VALIDATION_COMMANDS),
         "non_claims": list(NON_CLAIMS),
@@ -370,6 +365,8 @@ def validate_payload(
         raise HighQuerySensitivityGateError("claim boundary drift")
     if tuple(payload.get("non_claims", ())) != NON_CLAIMS:
         raise HighQuerySensitivityGateError("non-claims drift")
+    if payload.get("query_count_patches") != PATCHES:
+        raise HighQuerySensitivityGateError("query-count patch drift")
     rows = payload.get("rows")
     if not isinstance(rows, list) or [row.get("fri_query_count") for row in rows] != [3, 6, 12]:
         raise HighQuerySensitivityGateError("query row drift")
@@ -417,9 +414,10 @@ def run_mutations(payload: dict[str, Any]) -> list[dict[str, Any]]:
     add("decision_overclaim", lambda p: p.__setitem__("decision", "GO_PRODUCTION_SECURITY_HIGH_QUERY_RESULT"))
     add("claim_boundary_overclaim", lambda p: p.__setitem__("claim_boundary", "HEADLINE_D64_D128_HIGH_QUERY_PROOF_SIZE_WIN"))
     add("missing_non_claim", lambda p: p["non_claims"].remove("not production-security parameter evidence"))
+    add("query_count_patch_drift", lambda p: p["query_count_patches"]["q12"][0].__setitem__("to", "FriConfig::new(0, 1, 16, 1)"))
     add("q6_size_drift", lambda p: p["rows"][1].__setitem__("fused_proof_size_bytes", p["rows"][1]["fused_proof_size_bytes"] - 1))
     add("q12_size_drift", lambda p: p["rows"][2].__setitem__("source_plus_sidecar_raw_proof_bytes", p["rows"][2]["source_plus_sidecar_raw_proof_bytes"] - 1))
-    add("q12_limit_caveat_removed", lambda p: p["rows"][2].__setitem__("resource_limit_status", "verified_with_query_count_patch_only"))
+    add("q12_resource_status_drift", lambda p: p["rows"][2].__setitem__("resource_limit_status", "verified_after_scratch_source_proof_limit_raise"))
     add("q6_query_count_drift", lambda p: p["rows"][1]["proof_config"]["fri_config"].__setitem__("n_queries", 7))
     add("q12_query_count_drift", lambda p: p["rows"][2]["proof_config"]["fri_config"].__setitem__("n_queries", 11))
     add("payload_commitment_drift", lambda p: p.__setitem__("payload_commitment", "blake2b-256:" + "00" * 32))
@@ -493,7 +491,7 @@ def write_md(path: pathlib.Path, payload: dict[str, Any]) -> None:
             "",
             payload["interpretation"],
             "",
-            "The q12 run is useful but should stay engineering-scoped: the source proof exceeded the current default d8 source proof byte ceiling and verified only after a scratch resource-limit retune.",
+            "The q12 run is useful but should stay engineering-scoped: it is a small d8 sensitivity rerun under an explicit query-count patch, not a headline d64/d128 row or a production-security profile.",
             "",
             "## Reproduction",
             "",
@@ -511,11 +509,6 @@ def write_md(path: pathlib.Path, payload: dict[str, Any]) -> None:
             "```text",
             "src/stwo_backend/mod.rs:",
             "FriConfig::new(0, 1, 3, 1) -> FriConfig::new(0, 1, 12, 1)",
-            "",
-            "src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs:",
-            "ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES = 65_536",
-            "->",
-            "ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES = 262_144",
             "```",
             "",
             "After applying the q6 patch, run:",

--- a/src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs
@@ -83,11 +83,10 @@ pub const ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_INPUT_JSON_BYTES
 pub const ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_ENVELOPE_JSON_BYTES: usize =
     1_048_576;
 // The checked artifact path transports proof bytes as a pretty JSON array
-// inside a 1MiB envelope, so the raw proof cap must stay below the transport
-// ceiling rather than advertising a binary-envelope-sized limit. Keep this in
-// the same 128KiB class as the neighboring d8 fused and d16 source surfaces so
-// small higher-query sensitivity reruns do not need ad hoc verifier cap edits.
-pub const ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES: usize = 131_072;
+// inside a 1MiB envelope, so the raw proof cap must stay transport-safe. This
+// 96KiB class still admits the q12 source proof used by the high-query
+// sensitivity gate while leaving headroom for worst-case byte formatting.
+pub const ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES: usize = 98_304;
 
 const ROW_DOMAIN: &str =
     "ptvm:zkai:attention-kv-stwo-native-d8-bounded-softmax-table-score-rows:v1";
@@ -1785,13 +1784,42 @@ mod tests {
         let input = input();
         let mut envelope = prove_zkai_attention_kv_native_d8_bounded_softmax_table_envelope(&input)
             .expect("d8 bounded Softmax-table attention proof");
-        envelope.proof = vec![0; ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES + 1];
-        let error =
-            verify_zkai_attention_kv_native_d8_bounded_softmax_table_envelope(&envelope)
-                .unwrap_err();
+        envelope.proof =
+            vec![0; ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES + 1];
+        let error = verify_zkai_attention_kv_native_d8_bounded_softmax_table_envelope(&envelope)
+            .unwrap_err();
         assert!(error
             .to_string()
             .contains("proof bytes exceed bounded verifier limit"));
+    }
+
+    #[test]
+    fn attention_kv_native_d8_bounded_softmax_table_max_proof_bytes_fit_pretty_envelope() {
+        let input = input();
+        let envelope = ZkAiAttentionKvNativeD8BoundedSoftmaxTableEnvelope {
+            proof_backend: StarkProofBackend::Stwo,
+            proof_backend_version:
+                ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_REQUIRED_BACKEND_VERSION
+                    .to_string(),
+            statement_version: ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_STATEMENT_VERSION
+                .to_string(),
+            semantic_scope: ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_SEMANTIC_SCOPE
+                .to_string(),
+            decision: ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_DECISION.to_string(),
+            input,
+            proof: vec![255; ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES],
+        };
+        let raw = serde_json::to_vec_pretty(&envelope).expect("pretty envelope");
+        assert!(
+            raw.len() <= ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_ENVELOPE_JSON_BYTES
+        );
+        let parsed =
+            zkai_attention_kv_native_d8_bounded_softmax_table_envelope_from_json_slice(&raw)
+                .expect("max proof bytes remain transport-safe");
+        assert_eq!(
+            parsed.proof.len(),
+            ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES
+        );
     }
 
     #[test]

--- a/src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs
@@ -84,8 +84,10 @@ pub const ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_ENVELOPE_JSON_BY
     1_048_576;
 // The checked artifact path transports proof bytes as a pretty JSON array
 // inside a 1MiB envelope, so the raw proof cap must stay below the transport
-// ceiling rather than advertising a binary-envelope-sized limit.
-pub const ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES: usize = 65_536;
+// ceiling rather than advertising a binary-envelope-sized limit. Keep this in
+// the same 128KiB class as the neighboring d8 fused and d16 source surfaces so
+// small higher-query sensitivity reruns do not need ad hoc verifier cap edits.
+pub const ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES: usize = 131_072;
 
 const ROW_DOMAIN: &str =
     "ptvm:zkai:attention-kv-stwo-native-d8-bounded-softmax-table-score-rows:v1";
@@ -1776,6 +1778,20 @@ mod tests {
         assert!(
             verify_zkai_attention_kv_native_d8_bounded_softmax_table_envelope(&envelope).is_err()
         );
+    }
+
+    #[test]
+    fn attention_kv_native_d8_bounded_softmax_table_rejects_oversized_proof_bytes() {
+        let input = input();
+        let mut envelope = prove_zkai_attention_kv_native_d8_bounded_softmax_table_envelope(&input)
+            .expect("d8 bounded Softmax-table attention proof");
+        envelope.proof = vec![0; ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES + 1];
+        let error =
+            verify_zkai_attention_kv_native_d8_bounded_softmax_table_envelope(&envelope)
+                .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("proof bytes exceed bounded verifier limit"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Refs #765.

This PR cleans the `q=12` high-query sensitivity path from PR #766 without changing the measured proof rows.

The previous evidence was correct but carried a weak caveat: the `q=12` source proof required a scratch source-proof byte-limit retune. This PR removes that caveat by raising the d8 bounded Softmax-table source proof cap from `65,536` to a transport-safe `98,304` raw proof bytes. The cap stays above the checked q12 source proof (`84,266` bytes) and below the 1 MiB pretty-JSON envelope transport ceiling, with a Rust regression covering worst-case proof-byte formatting.

The default publication FRI profile remains `q=3`; q6 and q12 remain engineering-scoped query-count sensitivity reruns.

## What changed

- Raised `ZKAI_ATTENTION_KV_NATIVE_D8_BOUNDED_SOFTMAX_TABLE_MAX_PROOF_BYTES` from `65,536` to `98,304`.
- Added a verifier negative test for proof bytes above the bounded cap.
- Added a max-proof pretty-envelope serialization test so the raw cap cannot exceed the checked 1 MiB transport path.
- Updated the high-query sensitivity gate so `q=12` is `verified_with_query_count_patch_only`.
- Replaced `scratch_patches` with validated `query_count_patches` metadata.
- Detached `query_count_patches` from the module-level `PATCHES` constant with `copy.deepcopy`.
- Added fail-closed top-level payload key validation and explicit legacy `scratch_patches` rejection.
- Added mutation coverage for query-count patch drift and legacy scratch-patch reintroduction.
- Regenerated high-query JSON, TSV, and engineering note.

## Result

The measured high-query rows are unchanged:

| profile | split bytes | fused bytes | saving | fused/split |
| --- | ---: | ---: | ---: | ---: |
| q=3 | 59,437 | 47,698 | 11,739 | 0.802497 |
| q=6 | 82,115 | 62,889 | 19,226 | 0.765865 |
| q=12 | 111,430 | 85,900 | 25,530 | 0.770888 |

The interpretation is cleaner: both higher-query rows require only an explicit FRI-query-count patch. They remain small-surface sensitivity evidence, not production-security evidence and not headline d64/d128 rows.

## Hardening

- [x] Trusted-core cap remains bounded by the checked envelope transport path.
- [x] Regression coverage rejects oversized proof bytes.
- [x] Regression coverage proves max proof bytes fit the pretty-JSON envelope cap.
- [x] Gate metadata is copied before emission so payload mutations cannot mutate the validator baseline.
- [x] Legacy `scratch_patches` metadata is rejected after the schema change.
- [x] No oracle, PCS, FRI, or formal-kernel semantics changed; only the d8 source verifier cap and gate metadata validation changed.

## Validation

```bash
.venv/bin/python -m py_compile \
  scripts/zkai_attention_kv_high_query_sensitivity_gate.py \
  scripts/tests/test_zkai_attention_kv_high_query_sensitivity_gate.py

.venv/bin/python -m unittest scripts.tests.test_zkai_attention_kv_high_query_sensitivity_gate

cargo +nightly-2025-07-14 fmt --check

CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' \
  cargo +nightly-2025-07-14 test \
  attention_kv_native_d8_bounded_softmax_table \
  --lib --features stwo-backend

PYTHON_BIN=.venv/bin/python scripts/run_proof_pressure_release_gate.sh
```

Validation result:

- high-query unit tests: `7 passed`
- d8 bounded Softmax-table Rust tests: `12 passed`
- claim-pack unit tests: `23 passed`
- paper preflight suite: `47 passed`
- release gate final no-drift check: `PASS`

## Non-claims

- Not a production-security parameter recommendation.
- Not a default publication FRI config change.
- Not a proving-speed claim.
- Not a headline d64/d128 high-query rerun.
- Not a Stwo optimization or Stwo-AI fork result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified high-query sensitivity behavior so q6 and q12 runs are explicitly query-count reruns, including stricter handling of patch definitions and drift detection.
  * Tightened bounded verifier limits by raising the max proof-byte cap and added checks to reject envelopes whose proof size exceeds the limit.
* **Documentation**
  * Updated reproduction and interpretation guidance to align with the query-count-only workflow and removed outdated resource-limit wording.
* **Tests**
  * Expanded schema/validation coverage to require `query_count_patches` (and reject legacy `scratch_patches`), plus added regression tests around the bounded proof/envelope size behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->