### PR TITLE
[codex] Tighten proof-pressure reviewer entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Current public proof surfaces:
 | Inspect a full trace             | `cargo run --bin tvm -- run programs/fibonacci.tvm --trace`                                                                             | Emits the full machine-state trace               |
 | Prove execution                  | `cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- prove-stark programs/fibonacci.tvm -o fib.proof.json`              | Active proof path                                |
 | Verify a proof                   | `cargo +nightly-2025-07-14 run --features stwo-backend --bin tvm -- verify-stark fib.proof.json`                                                                                    | CLI default uses `production-v1` / `ProductionV1`, including lockstep semantic checks |
-| Regenerate paper artifacts       | `./scripts/generate_repro_bundle.sh`                                                                                                    | Publication-facing bundle                        |
+| Validate proof-pressure paper    | `scripts/run_proof_pressure_release_gate.sh`                                                                                            | Current paper release gate; set `PYTHON_BIN` if needed |
+| Regenerate older paper bundle    | `./scripts/generate_repro_bundle.sh`                                                                                                    | Legacy publication bundle                        |
 
 ## Toolchains
 

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -1,25 +1,22 @@
 # Paper Package
 
-This directory contains the technical-review paper package for:
+This directory contains the current reviewer-facing package for the June 2026
+proof-pressure boundary paper:
 
-`Tablero: Typed Verifier Boundaries for Layered STARK Systems, with Evidence from STARK-zkML`
+`Proof-Pressure Boundaries for STARK-Native Bounded Attention`
 
-It also contains a newer proof-boundary draft:
+The paper studies a scoped bounded-attention artifact class over an unmodified
+Stwo backend. Its core result is proof-architecture evidence: on checked
+sequence-axis rows, lookup and trace work grow quickly while fused proof payload
+bytes remain below the matched source-plus-sidecar split frontier. It is not a
+claim of full transformer inference, production security, exact real-valued
+Softmax, proving-speed improvement, or system-level superiority over zkML
+systems.
 
-- `proof-pressure-boundaries-for-stark-native-transformers-2026.md`
-- `appendix-zkml-statement-validity-2026.md`
-- `REPRODUCE.md`
-
-The repository root README links these two zkML architecture drafts for
-top-level discoverability.
-
-That draft is the current home for the June 2026 STARK-native bounded-attention
-proof-pressure result: lookup and trace work grow quickly on checked sequence
-rows while fused proof payload bytes remain below the matched split frontier. It
-should be read as a scoped proof-architecture paper, not as a replacement for the
-Tablero statement-validity paper. The statement-validity appendix is a short
-companion note that explains how proof artifacts are bound to model, input,
-output, policy, verifier-domain, and application-claim meaning.
+The statement-validity appendix is a companion note. It explains how proof
+artifacts are bound to model surface, input, output, numeric policy,
+verifier-domain, and application-claim meaning. It is not the proof-size result
+and should not be read as a new proving protocol.
 
 Proof-pressure reviewer path:
 
@@ -38,7 +35,7 @@ The small high-query sensitivity slice lives in
 `../engineering/zkai-attention-kv-d8-high-query-sensitivity-2026-06-26.md` and
 is engineering evidence only, not a headline production-security result.
 
-Primary presentation files:
+Tablero presentation files:
 
 - `tablero-typed-verifier-boundaries-2026.md`
 - `abstract-tablero-2026.md`

--- a/docs/paper/REPRODUCE.md
+++ b/docs/paper/REPRODUCE.md
@@ -73,23 +73,35 @@ The gate regenerates the machine-readable claim pack and figures, runs the
 paper preflight, checks Python syntax and unit tests for the claim-pack gate,
 and fails if committed paper artifacts drift.
 
+If the default `python3.10` binary is not available, point the gate at an
+equivalent Python 3.10+ interpreter:
+
+```bash
+PYTHON_BIN=.venv/bin/python scripts/run_proof_pressure_release_gate.sh
+```
+
+For launch or external audit, run this command on the exact release commit and
+record that regeneration produced no diff against the committed paper artifacts.
+
 ## Individual Commands
 
 The release gate expands to the commands pinned in
 `docs/paper/PAPER_RELEASE_AUDIT_PACKET_2026_06_04.md`, including:
 
 ```bash
-python3.10 scripts/zkai_paper_claim_pack_gate.py \
+PYTHON_BIN="${PYTHON_BIN:-python3.10}"
+
+"$PYTHON_BIN" scripts/zkai_paper_claim_pack_gate.py \
   --write-json docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
 
-python3.10 scripts/paper/generate_proof_pressure_boundaries_figures.py
+"$PYTHON_BIN" scripts/paper/generate_proof_pressure_boundaries_figures.py
 
-python3.10 scripts/zkai_attention_kv_high_query_sensitivity_gate.py \
+"$PYTHON_BIN" scripts/zkai_attention_kv_high_query_sensitivity_gate.py \
   --write-json docs/engineering/evidence/zkai-attention-kv-d8-high-query-sensitivity-2026-06.json \
   --write-tsv docs/engineering/evidence/zkai-attention-kv-d8-high-query-sensitivity-2026-06.tsv \
   --write-md docs/engineering/zkai-attention-kv-d8-high-query-sensitivity-2026-06-26.md
 
-python3.10 scripts/paper/paper_preflight.py --repo-root .
+"$PYTHON_BIN" scripts/paper/paper_preflight.py --repo-root .
 
 scripts/run_paper_preflight_suite.sh
 

--- a/docs/paper/appendix-zkml-statement-validity-2026.md
+++ b/docs/paper/appendix-zkml-statement-validity-2026.md
@@ -1,7 +1,7 @@
 # Proof Validity Is Not Statement Validity: Typed Boundaries for zkML Proof Artifacts
 
 **Companion note for**  
-`Proof-Pressure Boundaries for Scoped STARK-Native Transformer Surfaces`
+`Proof-Pressure Boundaries for STARK-Native Bounded Attention`
 
 *June 2026 draft*
 

--- a/docs/paper/evidence/stark-native-transformer-paper-release-manifest-2026-06.json
+++ b/docs/paper/evidence/stark-native-transformer-paper-release-manifest-2026-06.json
@@ -2,8 +2,8 @@
   "artifact_digests": [
     {
       "path": "docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md",
-      "sha256": "bdd331de61c01c8d19cf4343711d46c6e595983b9cc59647880a59f984517730",
-      "size_bytes": 45833
+      "sha256": "7b50d2f4ded277319acd1f078349e8ecb1663ae82114819bd4615e46da659ea3",
+      "size_bytes": 46029
     },
     {
       "path": "docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md",

--- a/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
+++ b/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
@@ -58,8 +58,10 @@ boundary that avoids paying the same expensive structure twice.
 We use **proof pressure** to mean the parts of a workload that
 disproportionately contribute to proof material: commitments, openings,
 decommitments, FRI material, lookup arguments, trace growth, and statement
-plumbing. A proof-pressure boundary is a statement boundary chosen to share or
-isolate this material deliberately.
+plumbing. A proof-pressure boundary is a proof-object boundary chosen to share
+or isolate this material deliberately. It is related to, but distinct from, the
+typed statement boundary discussed in Section 7: one chooses where proof bytes
+are paid, the other says what the resulting artifact is allowed to mean.
 
 The evaluated surfaces are attention-shaped subcomputations. They do not
 constitute a full transformer inference proof and do not include all model


### PR DESCRIPTION
Refs #765

## Summary
- Make `docs/paper/README.md` lead with the proof-pressure boundary paper as the current reviewer-facing package.
- Clarify that proof-pressure boundaries are proof-object boundaries, distinct from typed statement boundaries.
- Align the statement-validity appendix companion title with the current bounded-attention paper title.
- Put the canonical release gate and `PYTHON_BIN` override directly in `docs/paper/REPRODUCE.md`.
- Update the root README quick-start so paper reviewers use `scripts/run_proof_pressure_release_gate.sh`, while the older repro bundle is labeled legacy.
- Refresh the release manifest digest for the edited main paper.

## Why
Issue #765 is about making the launch package read like a serious scoped proof-architecture artifact. The previous paper package entrypoint still opened with the older Tablero presentation path, and one main-paper sentence blurred proof-size boundary placement with statement-validity boundaries.

## Validation
- `git diff --check`
- `PYTHON_BIN=.venv/bin/python scripts/run_proof_pressure_release_gate.sh`

The release gate passed after the commit: claim-pack unit tests, high-query unit tests, figure generation, paper preflight, preflight suite, and final no-drift check.

## Non-claims preserved
- Not full transformer inference.
- Not exact real-valued Softmax.
- Not a proving-speed claim.
- Not production-security evidence.
- Not a Stwo optimization or Stwo-AI fork result.
- Not a system-level comparison against other zkML systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance and descriptions for the June 2026 proof-pressure boundary paper, including clearer scope notes for the companion material.
  * Improved release-gate and reproduction instructions, adding a Python fallback via environment configuration when the default interpreter is unavailable.
  * Refined wording to better distinguish boundary concepts and what the results do vs. do not claim.
  * Split quick-start guidance into separate steps for validating the current paper and regenerating older paper bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->