### PR TITLE
Clarify proof-pressure measurement profile

### DIFF
--- a/docs/paper/PAPER_D64_HIGH_QUERY_AUDIT_PACKET_2026_06_27.md
+++ b/docs/paper/PAPER_D64_HIGH_QUERY_AUDIT_PACKET_2026_06_27.md
@@ -60,12 +60,16 @@ Payload commitment:
 
 ## Reproduction Commands
 
-The default checked backend remains q3:
+The checked paper measurement profile for this row remains q3:
 
 ```text
 src/stwo_backend/mod.rs:
 FriConfig::new(0, 1, 3, 1)
 ```
+
+This is the fixed experimental Stwo PCS measurement profile for the
+bounded-attention paper, not a production-security profile and not the older
+Vanilla STARK `publication_v1_stark_options()` path in `src/proof.rs`.
 
 For q6, patch only the FRI query count:
 

--- a/docs/paper/PAPER_RELEASE_AUDIT_PACKET_2026_06_04.md
+++ b/docs/paper/PAPER_RELEASE_AUDIT_PACKET_2026_06_04.md
@@ -97,7 +97,9 @@ configuration:
 | backend | unmodified Stwo backend surface |
 
 These are experimental measurement settings, not production-security parameter
-recommendations.
+recommendations. The legacy code helper `publication_v1_pcs_config()` names this
+fixed Stwo measurement profile; it is separate from the older Vanilla STARK
+`publication_v1_stark_options()` helper in `src/proof.rs`.
 
 ## Mechanism Accounting
 

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -36,6 +36,11 @@ The d64 high-query sensitivity slice lives in
 `../engineering/zkai-attention-kv-d64-high-query-sensitivity-2026-06.md` and
 is engineering evidence only, not a production-security result.
 
+The fixed `q=3` Stwo PCS setting used by the bounded-attention paper is a
+measurement profile. It is separate from the older Vanilla STARK
+`publication_v1_stark_options()` helper in `src/proof.rs` and should not be read
+as a production-security profile.
+
 Tablero presentation files:
 
 - `tablero-typed-verifier-boundaries-2026.md`

--- a/docs/paper/REPRODUCE.md
+++ b/docs/paper/REPRODUCE.md
@@ -63,6 +63,12 @@ release manifest:
 These are measurement settings for boundary-placement experiments, not
 production-security parameter recommendations.
 
+Profile naming note: the repository still contains a legacy helper named
+`publication_v1_pcs_config()` for this `q=3` Stwo PCS measurement profile. That
+helper is not the `publication_v1_stark_options()` Vanilla STARK profile in
+`src/proof.rs` and should not be read as a production-security or `96`-bit
+security setting for the bounded-attention paper.
+
 ## Canonical Release Gate
 
 Run the paper release gate from the repository root:

--- a/docs/paper/evidence/stark-native-transformer-paper-release-manifest-2026-06.json
+++ b/docs/paper/evidence/stark-native-transformer-paper-release-manifest-2026-06.json
@@ -2,13 +2,13 @@
   "artifact_digests": [
     {
       "path": "docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md",
-      "sha256": "fbe5eac037c9fc4c2c4cfa3cb805a593f6aec3b83909a55844d03dd504d6f790",
-      "size_bytes": 48489
+      "sha256": "20a211f894fdcaf154ce3c3586ed6ed6d203e36536d553991bfc83419d21f265",
+      "size_bytes": 49558
     },
     {
       "path": "docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md",
-      "sha256": "2081152a10be09ed16396d8b3a582a4b11d13b60f84d8aafc9df25dc0ab61fd5",
-      "size_bytes": 14081
+      "sha256": "1a17737b15883751ada825e51795fd8d45ce48778a4bca96400efeb7edc36789",
+      "size_bytes": 14459
     },
     {
       "path": "docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json",
@@ -23,7 +23,7 @@
     "fri_log_blowup": 1,
     "fri_query_count": 3,
     "proof_of_work_bits": 10,
-    "security_status": "fixed experimental configuration, not production-security parameter recommendation"
+    "security_status": "fixed experimental Stwo PCS measurement profile; not the 96-bit Vanilla STARK publication-v1 policy and not a production-security parameter recommendation"
   },
   "generated_by": "python3.10 scripts/zkai_paper_claim_pack_gate.py --write-json docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json",
   "last_merged_paper_sync_pr": {

--- a/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
+++ b/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
@@ -258,6 +258,14 @@ and `stwo-constraint-framework = "2.2.0"` in `Cargo.toml`. Public S-two
 documentation is cited for proof-object structure, not as a substitute for the
 exact crate-version statement.
 
+One implementation naming note matters for audit. Some generated Stwo modules
+call the `q=3` PCS setting `publication_v1_pcs_config()`. That is a legacy
+internal name for the fixed Stwo measurement profile above. It is not the same
+object as `publication_v1_stark_options()` in `src/proof.rs`, which belongs to
+an older Vanilla STARK path with a `96`-bit conjectured-security floor. In this
+paper, `q=3` means the fixed experimental Stwo PCS measurement profile in the
+table above, not a production-security profile.
+
 The large `d128_h4_seq64` row is represented by checked gate and route-matrix
 evidence with proof commitments, exact byte counts, mutation rejection, and
 regeneration commands. Its source input plus source, sidecar, and fused
@@ -455,6 +463,13 @@ caveat: when dense relation-specific payload grows, fusion can still save bytes
 against split proofs, but the fused-to-split ratio weakens because less of the
 new work is duplicated opening material.
 
+The model makes the query-count check useful. If the fused boundary is really
+saving shared opening and decommitment plumbing, then increasing only the FRI
+query count should raise absolute savings on the same semantic workload. That is
+what the d64 higher-query slice tests. It is still an engineering sensitivity
+slice, not a production-security sweep, because proof-of-work, blowup, fold
+step, and verifier resource caps are held fixed.
+
 This model is descriptive for the checked artifacts, not a general STARK lower
 bound. A higher-query sensitivity slice supports the mechanism without turning
 it into a production-security claim. On the `d64_four_head_seq64` surface,
@@ -467,12 +482,12 @@ win:
 | `6` | `453,733` | `390,437` | `63,296` | `0.860499x` |
 | `12` | `727,747` | `612,237` | `115,510` | `0.841277x` |
 
-Figure 4 plots the same row. The publication profile remains the default `q=3`
-configuration. The q6 and q12 rows are engineering reruns under an explicit
-FRI-query-count patch with proof-of-work, blowup, and fold step held fixed.
-They show that the fused advantage survives a larger query count on a real d64
-headline surface; they do not recommend production parameters or claim that the
-same pattern has been measured on d128.
+Figure 4 plots the same row. The main checked measurement profile remains the
+fixed `q=3` Stwo PCS configuration. The q6 and q12 rows are engineering reruns
+under an explicit FRI-query-count patch with proof-of-work, blowup, and fold
+step held fixed. They show that the fused advantage survives a larger query
+count on a real d64 headline surface; they do not recommend production
+parameters or claim that the same pattern has been measured on d128.
 
 ![Figure 4: D64 four-head seq64 higher-query sensitivity. FRI query count is changed under an explicit patch while proof-of-work, blowup, and fold step stay fixed. This is proof-byte engineering evidence only, not a production-security or timing claim.](figures/proof-pressure-d64-high-query-sensitivity-2026-06.svg)
 
@@ -625,7 +640,8 @@ The scope of the result is limited in several ways.
    proof bytes and fused-to-split ratios. A d64 four-head seq64 sensitivity
    slice at FRI query counts `6` and `12` is included as engineering evidence,
    but it is not a production-security profile, not a timing claim, and not a
-   d128 high-query result.
+   d128 high-query result. Width-axis high-query sensitivity remains future work
+   for a separate artifact package.
 10. **Backend optimization scope.** The paper does not claim a Stwo-AI fork,
     upstream Stwo patch, SIMD change, verifier rewrite, or new PCS. The checked
     savings come from proof-boundary construction over the existing backend

--- a/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
+++ b/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
@@ -88,6 +88,12 @@ experimental Stwo configuration: proof-of-work `10` bits, FRI log blowup `1`
 measurements are proof-byte measurements under that fixed configuration, not
 production-security constants and not timing claims.
 
+The `q=3` Stwo PCS setting is a measurement profile. The legacy code helper
+named `publication_v1_pcs_config()` should not be confused with the separate
+`publication_v1_stark_options()` Vanilla STARK path in `src/proof.rs`, which
+records a `96`-bit conjectured-security floor. The bounded-attention paper does
+not use the `q=3` Stwo PCS setting as a production-security claim.
+
 The route matrix records thirty checked matched `route_rows` entries. Across
 those entries,
 the fused proof bytes total `6,397,632` versus `7,164,515` bytes for the

--- a/scripts/zkai_paper_claim_pack_gate.py
+++ b/scripts/zkai_paper_claim_pack_gate.py
@@ -226,7 +226,11 @@ EXPECTED_RELEASE_FIXED_CONFIG = {
     "fri_log_blowup": 1,
     "fri_query_count": 3,
     "proof_of_work_bits": 10,
-    "security_status": "fixed experimental configuration, not production-security parameter recommendation",
+    "security_status": (
+        "fixed experimental Stwo PCS measurement profile; not the 96-bit "
+        "Vanilla STARK publication-v1 policy and not a production-security "
+        "parameter recommendation"
+    ),
 }
 EXPECTED_RELEASE_NO_DRIFT_PATHS = (
     "docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json",

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -265,6 +265,11 @@ use stwo::core::fri::FriConfig;
 use stwo::core::pcs::PcsConfig;
 
 #[cfg(feature = "stwo-backend")]
+/// Fixed Stwo PCS measurement profile used by the bounded-attention artifacts.
+///
+/// The name is legacy internal shorthand. It does not refer to the
+/// `publication_v1_stark_options()` Vanilla STARK policy in `src/proof.rs`, and
+/// it is not a production-security parameter recommendation.
 pub(crate) fn publication_v1_pcs_config() -> PcsConfig {
     PcsConfig {
         pow_bits: 10,


### PR DESCRIPTION
## Summary

This PR hardens the proof-pressure paper package for the next reviewer pass by clarifying the measurement/security profile boundary.

What changed:
- clarifies that the bounded-attention `q=3` Stwo PCS setting is a fixed experimental measurement profile, not a production-security profile;
- distinguishes the legacy `publication_v1_pcs_config()` helper from the older Vanilla STARK `publication_v1_stark_options()` path and its 96-bit conjectured floor;
- strengthens the paper's cost-model wording for why q6/q12 sensitivity is relevant without making it a production-security claim;
- syncs the claim pack, reproduction guide, release packets, README, source comment, and release manifest guard.

## Claim Boundary

This is paper/package hardening only. It does not add a new proof artifact, production-security claim, timing claim, Stwo optimization, Stwo-AI fork, full transformer inference claim, or external zkML benchmark comparison.

## Validation

Local validation on commit `902812e8023f336c2d946c5966d65125b7b30966`:

```bash
PYTHONDONTWRITEBYTECODE=1 .venv/bin/python scripts/zkai_paper_claim_pack_gate.py \
  --write-json docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json
PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m py_compile \
  scripts/zkai_paper_claim_pack_gate.py \
  scripts/tests/test_zkai_paper_claim_pack_gate.py
cargo +nightly-2025-07-14 fmt --check
PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m unittest scripts.tests.test_zkai_paper_claim_pack_gate
PYTHONDONTWRITEBYTECODE=1 .venv/bin/python scripts/paper/paper_preflight.py --repo-root .
PYTHONDONTWRITEBYTECODE=1 scripts/run_paper_preflight_suite.sh
PYTHON_BIN=.venv/bin/python scripts/run_proof_pressure_release_gate.sh
```

Release gate result: PASS. Regeneration produced no diff against the committed paper artifacts.

Closes no issue; updates #765.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified multiple paper and reproduction docs to distinguish the fixed `q=3` measurement profile from production-security settings.
  * Improved guidance around reproduction commands and configuration notes for high-query experiments.
  * Added clearer wording in the paper draft about query-count sensitivity checks, reruns, and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->