### PR TITLE
Clarify fixed Stwo measurement PCS profile

### DIFF
--- a/docs/engineering/zkai-attention-kv-d8-high-query-sensitivity-2026-06-26.md
+++ b/docs/engineering/zkai-attention-kv-d8-high-query-sensitivity-2026-06-26.md
@@ -23,7 +23,7 @@ The q12 run is useful but should stay engineering-scoped: it is a small d8 sensi
 
 ## Reproduction
 
-Use a throwaway worktree. Do not change the publication branch's default `publication_v1_pcs_config`.
+Use a throwaway worktree. Do not change the publication branch's default `fixed_stwo_measurement_pcs_config` settings.
 
 For q6, patch:
 

--- a/docs/paper/PAPER_NEXT_REVIEW_PACKET_2026_06_27.md
+++ b/docs/paper/PAPER_NEXT_REVIEW_PACKET_2026_06_27.md
@@ -46,9 +46,11 @@ around lookup-heavy work.
    row.
 3. The paper explicitly says the `q=3` Stwo PCS setting is a fixed experimental
    measurement profile, not production security.
-4. The legacy helper `publication_v1_pcs_config()` is distinguished from the
-   older Vanilla STARK `publication_v1_stark_options()` path with its `96`-bit
-   conjectured floor.
+4. The fixed Stwo measurement PCS profile is named
+   `fixed_stwo_measurement_pcs_config()` in new code. The older
+   `publication_v1_pcs_config()` helper remains only as a compatibility alias
+   and is distinguished from the Vanilla STARK `publication_v1_stark_options()`
+   path with its `96`-bit conjectured floor.
 5. The claim pack, reproduction note, release packets, README, and release
    manifest all carry the same profile boundary.
 
@@ -145,9 +147,11 @@ Please answer these before launch:
 
 ## Known Follow-Ups
 
-- Issue #773 tracks a later rename or deprecation of the legacy
-  `publication_v1_pcs_config()` helper. Do not block the paper on this unless a
-  reviewer thinks the current documentation is still too confusing.
+- Issue #773 tracks the helper-name cleanup for the fixed Stwo measurement PCS
+  profile. After that cleanup, reviewers should see
+  `fixed_stwo_measurement_pcs_config()` as the canonical helper name and
+  `publication_v1_pcs_config()` only as a compatibility alias for older
+  generated modules.
 - d128 high-query sensitivity is future work. A cheap probe crossed the current
   bounded verifier cap, so it should not be folded into this launch package.
 - Full transformer-block proving and external apples-to-apples baselines remain

--- a/docs/paper/PAPER_RELEASE_AUDIT_PACKET_2026_06_04.md
+++ b/docs/paper/PAPER_RELEASE_AUDIT_PACKET_2026_06_04.md
@@ -97,9 +97,11 @@ configuration:
 | backend | unmodified Stwo backend surface |
 
 These are experimental measurement settings, not production-security parameter
-recommendations. The legacy code helper `publication_v1_pcs_config()` names this
-fixed Stwo measurement profile; it is separate from the older Vanilla STARK
-`publication_v1_stark_options()` helper in `src/proof.rs`.
+recommendations. The canonical helper
+`fixed_stwo_measurement_pcs_config()` names this fixed Stwo measurement profile.
+The older `publication_v1_pcs_config()` helper remains only as a compatibility
+alias for older generated modules; both are separate from the older Vanilla
+STARK `publication_v1_stark_options()` helper in `src/proof.rs`.
 
 ## Mechanism Accounting
 

--- a/docs/paper/REPRODUCE.md
+++ b/docs/paper/REPRODUCE.md
@@ -63,11 +63,12 @@ release manifest:
 These are measurement settings for boundary-placement experiments, not
 production-security parameter recommendations.
 
-Profile naming note: the repository still contains a legacy helper named
-`publication_v1_pcs_config()` for this `q=3` Stwo PCS measurement profile. That
-helper is not the `publication_v1_stark_options()` Vanilla STARK profile in
-`src/proof.rs` and should not be read as a production-security or `96`-bit
-security setting for the bounded-attention paper.
+Profile naming note: the canonical helper for this `q=3` Stwo PCS measurement
+profile is `fixed_stwo_measurement_pcs_config()`. The repository still contains
+`publication_v1_pcs_config()` as a compatibility alias for older generated
+modules. Neither name is the `publication_v1_stark_options()` Vanilla STARK
+profile in `src/proof.rs`, and neither should be read as a production-security
+or `96`-bit security setting for the bounded-attention paper.
 
 ## Canonical Release Gate
 

--- a/docs/paper/evidence/stark-native-transformer-paper-release-manifest-2026-06.json
+++ b/docs/paper/evidence/stark-native-transformer-paper-release-manifest-2026-06.json
@@ -2,13 +2,13 @@
   "artifact_digests": [
     {
       "path": "docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md",
-      "sha256": "20a211f894fdcaf154ce3c3586ed6ed6d203e36536d553991bfc83419d21f265",
-      "size_bytes": 49558
+      "sha256": "44bc0ee184be8cbf95535be240bd34609a491e03dc0bda048c82585f0a54f4c5",
+      "size_bytes": 49630
     },
     {
       "path": "docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md",
-      "sha256": "1a17737b15883751ada825e51795fd8d45ce48778a4bca96400efeb7edc36789",
-      "size_bytes": 14459
+      "sha256": "89ed6c8328193f0282386d8e6099060b9b45e7d0fffabb96a134d1ab06774005",
+      "size_bytes": 14576
     },
     {
       "path": "docs/paper/evidence/stark-native-transformer-claim-pack-2026-05.json",

--- a/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
+++ b/docs/paper/proof-pressure-boundaries-for-stark-native-transformers-2026.md
@@ -258,11 +258,12 @@ and `stwo-constraint-framework = "2.2.0"` in `Cargo.toml`. Public S-two
 documentation is cited for proof-object structure, not as a substitute for the
 exact crate-version statement.
 
-One implementation naming note matters for audit. Some generated Stwo modules
-call the `q=3` PCS setting `publication_v1_pcs_config()`. That is a legacy
-internal name for the fixed Stwo measurement profile above. It is not the same
-object as `publication_v1_stark_options()` in `src/proof.rs`, which belongs to
-an older Vanilla STARK path with a `96`-bit conjectured-security floor. In this
+One implementation naming note matters for audit. New code names the `q=3` PCS
+setting `fixed_stwo_measurement_pcs_config()`. Older generated modules may
+still call the compatibility alias `publication_v1_pcs_config()`. Both names
+refer to the fixed Stwo measurement profile above. They are not the same object
+as `publication_v1_stark_options()` in `src/proof.rs`, which belongs to an
+older Vanilla STARK path with a `96`-bit conjectured-security floor. In this
 paper, `q=3` means the fixed experimental Stwo PCS measurement profile in the
 table above, not a production-security profile.
 

--- a/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
+++ b/docs/paper/stark-native-transformer-proof-claim-pack-2026-05.md
@@ -88,8 +88,10 @@ experimental Stwo configuration: proof-of-work `10` bits, FRI log blowup `1`
 measurements are proof-byte measurements under that fixed configuration, not
 production-security constants and not timing claims.
 
-The `q=3` Stwo PCS setting is a measurement profile. The legacy code helper
-named `publication_v1_pcs_config()` should not be confused with the separate
+The `q=3` Stwo PCS setting is a measurement profile. New code names this helper
+`fixed_stwo_measurement_pcs_config()`. The older
+`publication_v1_pcs_config()` name remains as a compatibility alias for older
+generated modules and should not be confused with the separate
 `publication_v1_stark_options()` Vanilla STARK path in `src/proof.rs`, which
 records a `96`-bit conjectured-security floor. The bounded-attention paper does
 not use the `q=3` Stwo PCS setting as a production-security claim.

--- a/scripts/zkai_attention_kv_high_query_sensitivity_gate.py
+++ b/scripts/zkai_attention_kv_high_query_sensitivity_gate.py
@@ -538,7 +538,7 @@ def write_md(path: pathlib.Path, payload: dict[str, Any]) -> None:
             "",
             "## Reproduction",
             "",
-            "Use a throwaway worktree. Do not change the publication branch's default `publication_v1_pcs_config`.",
+            "Use a throwaway worktree. Do not change the publication branch's default `fixed_stwo_measurement_pcs_config` settings.",
             "",
             "For q6, patch:",
             "",

--- a/src/stwo_backend/attention_kv_native_bounded_weighted_proof.rs
+++ b/src/stwo_backend/attention_kv_native_bounded_weighted_proof.rs
@@ -100,7 +100,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, bounded weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_bounded_weighted_proof.rs
+++ b/src/stwo_backend/attention_kv_native_bounded_weighted_proof.rs
@@ -100,7 +100,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, bounded weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -950,7 +950,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_four_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_four_head_seq32_bounded_softmax_table_proof.rs
@@ -133,7 +133,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d128_four_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_four_head_seq32_bounded_softmax_table_proof.rs
@@ -133,7 +133,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1157,7 +1157,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_four_head_seq32_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_four_head_seq32_fused_softmax_table_proof.rs
@@ -1030,7 +1030,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_four_head_seq32_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_four_head_seq32_softmax_table_lookup_proof.rs
@@ -668,7 +668,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_four_head_seq64_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_four_head_seq64_bounded_softmax_table_proof.rs
@@ -133,7 +133,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d128_four_head_seq64_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_four_head_seq64_bounded_softmax_table_proof.rs
@@ -133,7 +133,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1157,7 +1157,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_four_head_seq64_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_four_head_seq64_fused_softmax_table_proof.rs
@@ -1030,7 +1030,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_four_head_seq64_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_four_head_seq64_softmax_table_lookup_proof.rs
@@ -668,7 +668,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_single_head_seq16_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_single_head_seq16_bounded_softmax_table_proof.rs
@@ -128,7 +128,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1021,7 +1021,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_single_head_seq16_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_single_head_seq16_bounded_softmax_table_proof.rs
@@ -128,7 +128,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d128_single_head_seq16_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_single_head_seq16_fused_softmax_table_proof.rs
@@ -1025,7 +1025,7 @@ fn bytes_to_channel_words(bytes: &[u8]) -> Vec<u32> {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_single_head_seq16_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_single_head_seq16_softmax_table_lookup_proof.rs
@@ -701,7 +701,7 @@ fn bytes_to_channel_words(bytes: &[u8]) -> Vec<u32> {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_two_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1146,7 +1146,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_two_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d128_two_head_seq32_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_two_head_seq32_fused_softmax_table_proof.rs
@@ -1037,7 +1037,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_two_head_seq32_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_two_head_seq32_softmax_table_lookup_proof.rs
@@ -666,7 +666,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_two_head_seq64_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_two_head_seq64_bounded_softmax_table_proof.rs
@@ -133,7 +133,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d128_two_head_seq64_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_two_head_seq64_bounded_softmax_table_proof.rs
@@ -133,7 +133,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1157,7 +1157,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_two_head_seq64_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_two_head_seq64_fused_softmax_table_proof.rs
@@ -1027,7 +1027,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d128_two_head_seq64_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d128_two_head_seq64_softmax_table_lookup_proof.rs
@@ -666,7 +666,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_bounded_softmax_table_proof.rs
@@ -125,7 +125,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d16_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_bounded_softmax_table_proof.rs
@@ -125,7 +125,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1004,7 +1004,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_fused_softmax_table_proof.rs
@@ -996,7 +996,7 @@ fn bytes_to_channel_words(bytes: &[u8]) -> Vec<u32> {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_softmax_table_lookup_proof.rs
@@ -669,7 +669,7 @@ fn bytes_to_channel_words(bytes: &[u8]) -> Vec<u32> {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_two_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_bounded_softmax_table_proof.rs
@@ -129,7 +129,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1098,7 +1098,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_two_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_bounded_softmax_table_proof.rs
@@ -129,7 +129,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d16_two_head_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_fused_softmax_table_proof.rs
@@ -957,7 +957,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_two_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_longseq_bounded_softmax_table_proof.rs
@@ -129,7 +129,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d16_two_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_longseq_bounded_softmax_table_proof.rs
@@ -129,7 +129,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1101,7 +1101,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_two_head_longseq_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_longseq_fused_softmax_table_proof.rs
@@ -975,7 +975,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_two_head_longseq_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_longseq_softmax_table_lookup_proof.rs
@@ -668,7 +668,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1146,7 +1146,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d16_two_head_seq32_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_seq32_fused_softmax_table_proof.rs
@@ -1027,7 +1027,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_two_head_seq32_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_seq32_softmax_table_lookup_proof.rs
@@ -663,7 +663,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d16_two_head_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d16_two_head_softmax_table_lookup_proof.rs
@@ -654,7 +654,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d256_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d256_two_head_seq32_bounded_softmax_table_proof.rs
@@ -132,7 +132,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d256_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d256_two_head_seq32_bounded_softmax_table_proof.rs
@@ -132,7 +132,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1148,7 +1148,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d256_two_head_seq32_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d256_two_head_seq32_fused_softmax_table_proof.rs
@@ -1031,7 +1031,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d256_two_head_seq32_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d256_two_head_seq32_softmax_table_lookup_proof.rs
@@ -679,7 +679,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_bounded_softmax_table_proof.rs
@@ -125,7 +125,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_bounded_softmax_table_proof.rs
@@ -125,7 +125,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1004,7 +1004,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_four_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_four_head_longseq_bounded_softmax_table_proof.rs
@@ -131,7 +131,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d32_four_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_four_head_longseq_bounded_softmax_table_proof.rs
@@ -131,7 +131,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1153,7 +1153,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_four_head_longseq_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_four_head_longseq_fused_softmax_table_proof.rs
@@ -1036,7 +1036,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_four_head_longseq_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_four_head_longseq_softmax_table_lookup_proof.rs
@@ -683,7 +683,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_four_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_four_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1152,7 +1152,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_four_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_four_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d32_four_head_seq32_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_four_head_seq32_fused_softmax_table_proof.rs
@@ -1031,7 +1031,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_four_head_seq32_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_four_head_seq32_softmax_table_lookup_proof.rs
@@ -680,7 +680,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_fused_softmax_table_proof.rs
@@ -996,7 +996,7 @@ fn bytes_to_channel_words(bytes: &[u8]) -> Vec<u32> {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_softmax_table_lookup_proof.rs
@@ -676,7 +676,7 @@ fn bytes_to_channel_words(bytes: &[u8]) -> Vec<u32> {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_two_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1142,7 +1142,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_two_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d32_two_head_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_fused_softmax_table_proof.rs
@@ -1012,7 +1012,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_two_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_longseq_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1146,7 +1146,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_two_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_longseq_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d32_two_head_longseq_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_longseq_fused_softmax_table_proof.rs
@@ -1030,7 +1030,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_two_head_longseq_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_longseq_softmax_table_lookup_proof.rs
@@ -668,7 +668,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1146,7 +1146,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d32_two_head_seq32_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_seq32_fused_softmax_table_proof.rs
@@ -1027,7 +1027,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_two_head_seq32_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_seq32_softmax_table_lookup_proof.rs
@@ -663,7 +663,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d32_two_head_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d32_two_head_softmax_table_lookup_proof.rs
@@ -654,7 +654,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_four_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_longseq_bounded_softmax_table_proof.rs
@@ -131,7 +131,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d64_four_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_longseq_bounded_softmax_table_proof.rs
@@ -131,7 +131,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1153,7 +1153,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_four_head_longseq_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_longseq_fused_softmax_table_proof.rs
@@ -1052,7 +1052,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_four_head_longseq_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_longseq_softmax_table_lookup_proof.rs
@@ -683,7 +683,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_four_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1152,7 +1152,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_four_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d64_four_head_seq32_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_seq32_fused_softmax_table_proof.rs
@@ -1033,7 +1033,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_four_head_seq32_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_seq32_softmax_table_lookup_proof.rs
@@ -680,7 +680,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_four_head_seq64_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_seq64_bounded_softmax_table_proof.rs
@@ -131,7 +131,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d64_four_head_seq64_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_seq64_bounded_softmax_table_proof.rs
@@ -131,7 +131,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1200,7 +1200,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_four_head_seq64_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_seq64_fused_softmax_table_proof.rs
@@ -1036,7 +1036,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_four_head_seq64_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_four_head_seq64_softmax_table_lookup_proof.rs
@@ -680,7 +680,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_single_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_single_head_longseq_bounded_softmax_table_proof.rs
@@ -128,7 +128,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1022,7 +1022,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_single_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_single_head_longseq_bounded_softmax_table_proof.rs
@@ -128,7 +128,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d64_single_head_longseq_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_single_head_longseq_fused_softmax_table_proof.rs
@@ -1023,7 +1023,7 @@ fn bytes_to_channel_words(bytes: &[u8]) -> Vec<u32> {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_single_head_longseq_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_single_head_longseq_softmax_table_lookup_proof.rs
@@ -701,7 +701,7 @@ fn bytes_to_channel_words(bytes: &[u8]) -> Vec<u32> {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_two_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_longseq_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1146,7 +1146,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_two_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_longseq_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d64_two_head_longseq_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_longseq_fused_softmax_table_proof.rs
@@ -1030,7 +1030,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_two_head_longseq_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_longseq_softmax_table_lookup_proof.rs
@@ -668,7 +668,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1146,7 +1146,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d64_two_head_seq32_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_seq32_fused_softmax_table_proof.rs
@@ -1027,7 +1027,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_two_head_seq32_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_seq32_softmax_table_lookup_proof.rs
@@ -663,7 +663,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_two_head_seq64_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_seq64_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1152,7 +1152,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_two_head_seq64_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_seq64_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d64_two_head_seq64_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_seq64_fused_softmax_table_proof.rs
@@ -1033,7 +1033,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d64_two_head_seq64_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d64_two_head_seq64_softmax_table_lookup_proof.rs
@@ -677,7 +677,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs
@@ -125,7 +125,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d8_bounded_softmax_table_proof.rs
@@ -125,7 +125,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1004,7 +1004,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d8_bounded_weighted_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d8_bounded_weighted_proof.rs
@@ -101,7 +101,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, bounded weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -951,7 +951,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d8_bounded_weighted_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d8_bounded_weighted_proof.rs
@@ -101,7 +101,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes append-only KV carry, max score, bounded weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_d8_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d8_fused_softmax_table_proof.rs
@@ -977,7 +977,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_d8_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_d8_softmax_table_lookup_proof.rs
@@ -635,7 +635,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_eight_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_eight_head_bounded_softmax_table_proof.rs
@@ -129,7 +129,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1099,7 +1099,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_eight_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_eight_head_bounded_softmax_table_proof.rs
@@ -129,7 +129,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_eight_head_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_eight_head_fused_softmax_table_proof.rs
@@ -1028,7 +1028,7 @@ fn mix_transcript_bytes(channel: &mut Blake2sM31Channel, bytes: &[u8]) {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_eight_head_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_eight_head_softmax_table_lookup_proof.rs
@@ -650,7 +650,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_four_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_four_head_bounded_softmax_table_proof.rs
@@ -128,7 +128,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1100,7 +1100,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_four_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_four_head_bounded_softmax_table_proof.rs
@@ -128,7 +128,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_four_head_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_four_head_fused_softmax_table_proof.rs
@@ -1027,7 +1027,7 @@ fn mix_transcript_bytes(channel: &mut Blake2sM31Channel, bytes: &[u8]) {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_four_head_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_four_head_softmax_table_lookup_proof.rs
@@ -650,7 +650,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_masked_sequence_proof.rs
+++ b/src/stwo_backend/attention_kv_native_masked_sequence_proof.rs
@@ -150,7 +150,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR binds selected candidate values to the emitted attention output row",
     "verifier recomputes append-only KV carry and lowest-position tie-break before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_masked_sequence_proof.rs
+++ b/src/stwo_backend/attention_kv_native_masked_sequence_proof.rs
@@ -150,7 +150,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR binds selected candidate values to the emitted attention output row",
     "verifier recomputes append-only KV carry and lowest-position tie-break before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1253,7 +1253,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(attention_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_sixteen_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_sixteen_head_bounded_softmax_table_proof.rs
@@ -129,7 +129,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_sixteen_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_sixteen_head_bounded_softmax_table_proof.rs
@@ -129,7 +129,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1109,7 +1109,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_sixteen_head_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_sixteen_head_fused_softmax_table_proof.rs
@@ -1042,7 +1042,7 @@ fn mix_transcript_bytes(channel: &mut Blake2sM31Channel, bytes: &[u8]) {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_sixteen_head_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_sixteen_head_softmax_table_lookup_proof.rs
@@ -660,7 +660,7 @@ fn mix_lookup_summary_string(channel: &mut Blake2sM31Channel, value: &str) {
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_two_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_bounded_softmax_table_proof.rs
@@ -128,7 +128,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1093,7 +1093,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_two_head_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_bounded_softmax_table_proof.rs
@@ -128,7 +128,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_two_head_bounded_weighted_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_bounded_weighted_proof.rs
@@ -109,7 +109,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, bounded weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_two_head_bounded_weighted_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_bounded_weighted_proof.rs
@@ -109,7 +109,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, bounded weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1036,7 +1036,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_two_head_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_fused_softmax_table_proof.rs
@@ -954,7 +954,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_two_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_longseq_bounded_softmax_table_proof.rs
@@ -129,7 +129,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1099,7 +1099,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_two_head_longseq_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_longseq_bounded_softmax_table_proof.rs
@@ -129,7 +129,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_two_head_longseq_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_longseq_fused_softmax_table_proof.rs
@@ -970,7 +970,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_two_head_longseq_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_longseq_softmax_table_lookup_proof.rs
@@ -662,7 +662,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];
@@ -1142,7 +1142,7 @@ fn verify_rows(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(weighted_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(attention_pcs_config())

--- a/src/stwo_backend/attention_kv_native_two_head_seq32_bounded_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_seq32_bounded_softmax_table_proof.rs
@@ -130,7 +130,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "native Stwo AIR proves output quotient/remainder rows against the verifier-recomputed weighted numerator and denominator",
     "verifier recomputes per-head append-only KV carry, max score, clipped score gaps, table-derived weights, weighted numerators, denominators, and outputs before proof verification",
     "score-row, initial-KV, input-step, final-KV, output, public-instance, and statement commitments are recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "bounded envelope JSON before deserialization and bounded proof bytes before proof parsing",
     "commitment-vector length check before commitment indexing",
 ];

--- a/src/stwo_backend/attention_kv_native_two_head_seq32_fused_softmax_table_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_seq32_fused_softmax_table_proof.rs
@@ -1043,7 +1043,7 @@ fn mix_fused_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(fused_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(fused_pcs_config())

--- a/src/stwo_backend/attention_kv_native_two_head_seq32_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_seq32_softmax_table_lookup_proof.rs
@@ -657,7 +657,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/attention_kv_native_two_head_softmax_table_lookup_proof.rs
+++ b/src/stwo_backend/attention_kv_native_two_head_softmax_table_lookup_proof.rs
@@ -650,7 +650,7 @@ fn mix_lookup_summary(
 fn validate_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(lookup_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(lookup_pcs_config())

--- a/src/stwo_backend/d128_native_activation_swiglu_proof.rs
+++ b/src/stwo_backend/d128_native_activation_swiglu_proof.rs
@@ -958,7 +958,7 @@ fn verify_activation_swiglu_rows(
 fn validate_activation_swiglu_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(activation_swiglu_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(activation_swiglu_pcs_config())

--- a/src/stwo_backend/d128_native_component_two_slice_reprove.rs
+++ b/src/stwo_backend/d128_native_component_two_slice_reprove.rs
@@ -978,7 +978,7 @@ fn compact_preprocessed_reprove_commitment_roots(
 fn validate_reprove_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(reprove_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(reprove_pcs_config())

--- a/src/stwo_backend/d128_native_down_projection_proof.rs
+++ b/src/stwo_backend/d128_native_down_projection_proof.rs
@@ -925,7 +925,7 @@ fn verify_down_projection_rows(
 fn validate_down_projection_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(down_projection_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(down_projection_pcs_config())

--- a/src/stwo_backend/d128_native_gate_value_projection_proof.rs
+++ b/src/stwo_backend/d128_native_gate_value_projection_proof.rs
@@ -1115,7 +1115,7 @@ fn verify_compact_preprocessed_gate_value_rows(
 fn validate_gate_value_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(gate_value_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(gate_value_pcs_config())

--- a/src/stwo_backend/d128_native_residual_add_proof.rs
+++ b/src/stwo_backend/d128_native_residual_add_proof.rs
@@ -893,7 +893,7 @@ fn verify_residual_add_rows(input: &ZkAiD128ResidualAddProofInput, proof: &[u8])
 fn validate_residual_add_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(residual_add_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(residual_add_pcs_config())

--- a/src/stwo_backend/d128_native_rmsnorm_public_row_proof.rs
+++ b/src/stwo_backend/d128_native_rmsnorm_public_row_proof.rs
@@ -873,7 +873,7 @@ fn verify_public_rows(input: &ZkAiD128RmsnormPublicRowProofInput, proof: &[u8]) 
 fn validate_public_row_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(public_row_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(public_row_pcs_config())

--- a/src/stwo_backend/d128_native_rmsnorm_to_projection_bridge_proof.rs
+++ b/src/stwo_backend/d128_native_rmsnorm_to_projection_bridge_proof.rs
@@ -560,7 +560,7 @@ fn verify_bridge_rows(
 fn validate_bridge_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(bridge_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(bridge_pcs_config())

--- a/src/stwo_backend/d128_native_two_slice_outer_statement_proof.rs
+++ b/src/stwo_backend/d128_native_two_slice_outer_statement_proof.rs
@@ -660,7 +660,7 @@ fn verify_outer_statement_rows(
 fn validate_outer_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(outer_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(outer_pcs_config())

--- a/src/stwo_backend/d64_native_activation_swiglu_proof.rs
+++ b/src/stwo_backend/d64_native_activation_swiglu_proof.rs
@@ -698,7 +698,7 @@ fn verify_activation_swiglu_rows(
 fn validate_activation_swiglu_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(activation_swiglu_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(activation_swiglu_pcs_config())

--- a/src/stwo_backend/d64_native_down_projection_proof.rs
+++ b/src/stwo_backend/d64_native_down_projection_proof.rs
@@ -660,7 +660,7 @@ fn verify_down_projection_rows(
 fn validate_down_projection_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(down_projection_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(down_projection_pcs_config())

--- a/src/stwo_backend/d64_native_gate_value_projection_proof.rs
+++ b/src/stwo_backend/d64_native_gate_value_projection_proof.rs
@@ -793,7 +793,7 @@ fn verify_gate_value_rows(
 fn validate_gate_value_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(gate_value_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(gate_value_pcs_config())

--- a/src/stwo_backend/d64_native_residual_add_proof.rs
+++ b/src/stwo_backend/d64_native_residual_add_proof.rs
@@ -524,7 +524,7 @@ fn verify_residual_add_rows(input: &ZkAiD64ResidualAddProofInput, proof: &[u8]) 
 fn validate_residual_add_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(residual_add_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(residual_add_pcs_config())

--- a/src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs
+++ b/src/stwo_backend/d64_native_rmsnorm_public_row_proof.rs
@@ -659,7 +659,7 @@ fn verify_public_rows(input: &ZkAiD64RmsnormPublicRowProofInput, proof: &[u8]) -
 fn validate_public_row_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(public_row_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(public_row_pcs_config())

--- a/src/stwo_backend/d64_native_rmsnorm_to_projection_bridge_proof.rs
+++ b/src/stwo_backend/d64_native_rmsnorm_to_projection_bridge_proof.rs
@@ -434,7 +434,7 @@ fn verify_bridge_rows(input: &ZkAiD64RmsnormToProjectionBridgeInput, proof: &[u8
 fn validate_bridge_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(bridge_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(bridge_pcs_config())

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -339,6 +339,20 @@ mod fixed_stwo_measurement_pcs_config_tests {
         assert!(fixed_stwo_measurement_pcs_config_matches(&legacy));
         assert!(publication_v1_pcs_config_matches(&canonical));
     }
+
+    #[test]
+    fn fixed_measurement_profile_matchers_reject_mismatched_config() {
+        let mut mutated = fixed_stwo_measurement_pcs_config();
+
+        mutated.pow_bits += 1;
+        assert!(!fixed_stwo_measurement_pcs_config_matches(&mutated));
+        assert!(!publication_v1_pcs_config_matches(&mutated));
+
+        let mut mutated = fixed_stwo_measurement_pcs_config();
+        mutated.fri_config.n_queries += 1;
+        assert!(!fixed_stwo_measurement_pcs_config_matches(&mutated));
+        assert!(!publication_v1_pcs_config_matches(&mutated));
+    }
 }
 
 pub use adapter::{

--- a/src/stwo_backend/mod.rs
+++ b/src/stwo_backend/mod.rs
@@ -267,10 +267,11 @@ use stwo::core::pcs::PcsConfig;
 #[cfg(feature = "stwo-backend")]
 /// Fixed Stwo PCS measurement profile used by the bounded-attention artifacts.
 ///
-/// The name is legacy internal shorthand. It does not refer to the
-/// `publication_v1_stark_options()` Vanilla STARK policy in `src/proof.rs`, and
-/// it is not a production-security parameter recommendation.
-pub(crate) fn publication_v1_pcs_config() -> PcsConfig {
+/// This is the q=3 engineering measurement profile used to isolate
+/// boundary-placement effects. It is not the `publication_v1_stark_options()`
+/// Vanilla STARK policy in `src/proof.rs`, and it is not a
+/// production-security parameter recommendation.
+pub(crate) fn fixed_stwo_measurement_pcs_config() -> PcsConfig {
     PcsConfig {
         pow_bits: 10,
         fri_config: FriConfig::new(0, 1, 3, 1),
@@ -279,8 +280,18 @@ pub(crate) fn publication_v1_pcs_config() -> PcsConfig {
 }
 
 #[cfg(feature = "stwo-backend")]
-pub(crate) fn publication_v1_pcs_config_matches(actual: &PcsConfig) -> bool {
-    let expected = publication_v1_pcs_config();
+/// Compatibility alias for older generated modules and artifact notes.
+///
+/// New code should call `fixed_stwo_measurement_pcs_config()` so the helper name
+/// reads as an experimental measurement profile, not a publication-security
+/// claim.
+pub(crate) fn publication_v1_pcs_config() -> PcsConfig {
+    fixed_stwo_measurement_pcs_config()
+}
+
+#[cfg(feature = "stwo-backend")]
+pub(crate) fn fixed_stwo_measurement_pcs_config_matches(actual: &PcsConfig) -> bool {
+    let expected = fixed_stwo_measurement_pcs_config();
     actual.pow_bits == expected.pow_bits
         && actual.fri_config.log_blowup_factor == expected.fri_config.log_blowup_factor
         && actual.fri_config.n_queries == expected.fri_config.n_queries
@@ -288,6 +299,46 @@ pub(crate) fn publication_v1_pcs_config_matches(actual: &PcsConfig) -> bool {
             == expected.fri_config.log_last_layer_degree_bound
         && actual.fri_config.fold_step == expected.fri_config.fold_step
         && actual.lifting_log_size == expected.lifting_log_size
+}
+
+#[cfg(feature = "stwo-backend")]
+pub(crate) fn publication_v1_pcs_config_matches(actual: &PcsConfig) -> bool {
+    fixed_stwo_measurement_pcs_config_matches(actual)
+}
+
+#[cfg(all(feature = "stwo-backend", test))]
+mod fixed_stwo_measurement_pcs_config_tests {
+    use super::{
+        fixed_stwo_measurement_pcs_config, fixed_stwo_measurement_pcs_config_matches,
+        publication_v1_pcs_config, publication_v1_pcs_config_matches,
+    };
+
+    #[test]
+    fn legacy_publication_v1_alias_matches_fixed_measurement_profile() {
+        let canonical = fixed_stwo_measurement_pcs_config();
+        let legacy = publication_v1_pcs_config();
+
+        assert_eq!(canonical.pow_bits, 10);
+        assert_eq!(canonical.fri_config.log_blowup_factor, 1);
+        assert_eq!(canonical.fri_config.n_queries, 3);
+        assert_eq!(canonical.fri_config.fold_step, 1);
+        assert_eq!(canonical.lifting_log_size, None);
+
+        assert_eq!(legacy.pow_bits, canonical.pow_bits);
+        assert_eq!(
+            legacy.fri_config.log_blowup_factor,
+            canonical.fri_config.log_blowup_factor
+        );
+        assert_eq!(legacy.fri_config.n_queries, canonical.fri_config.n_queries);
+        assert_eq!(
+            legacy.fri_config.log_last_layer_degree_bound,
+            canonical.fri_config.log_last_layer_degree_bound
+        );
+        assert_eq!(legacy.fri_config.fold_step, canonical.fri_config.fold_step);
+        assert_eq!(legacy.lifting_log_size, canonical.lifting_log_size);
+        assert!(fixed_stwo_measurement_pcs_config_matches(&legacy));
+        assert!(publication_v1_pcs_config_matches(&canonical));
+    }
 }
 
 pub use adapter::{

--- a/src/stwo_backend/native_attention_mlp_single_proof.rs
+++ b/src/stwo_backend/native_attention_mlp_single_proof.rs
@@ -199,7 +199,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "combined preprocessed trace column count checked before committing",
     "combined base trace binds attention rows and six MLP component traces",
     "statement/public-instance/native-parameter commitments recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "commitment-vector length check before commitment indexing",
     "bounded proof bytes before JSON deserialization",
 ];

--- a/src/stwo_backend/native_attention_mlp_single_proof.rs
+++ b/src/stwo_backend/native_attention_mlp_single_proof.rs
@@ -199,7 +199,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "combined preprocessed trace column count checked before committing",
     "combined base trace binds attention rows and six MLP component traces",
     "statement/public-instance/native-parameter commitments recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "commitment-vector length check before commitment indexing",
     "bounded proof bytes before JSON deserialization",
 ];
@@ -2008,7 +2008,7 @@ fn validate_pcs_config(
         || actual.lifting_log_size != expected.lifting_log_size
     {
         return Err(single_error(
-            "PCS config does not match publication-v1 profile with route-specific explicit lifting log size",
+            "PCS config does not match fixed Stwo measurement PCS profile with route-specific explicit lifting log size",
         ));
     }
     Ok(expected)
@@ -2029,7 +2029,7 @@ fn single_pcs_config(adapter_mode: ZkAiNativeAttentionMlpAdapterMode) -> Result<
     config.lifting_log_size = Some(SINGLE_PCS_LIFTING_LOG_SIZE);
     if publication_v1_pcs_config_matches(&config) {
         return Err(single_error(
-            "single proof PCS config unexpectedly matches publication-v1 default",
+            "single proof PCS config unexpectedly matches fixed Stwo measurement default",
         ));
     }
     Ok(config)

--- a/src/stwo_backend/native_d128_seq32_attention_mlp_single_proof.rs
+++ b/src/stwo_backend/native_d128_seq32_attention_mlp_single_proof.rs
@@ -262,7 +262,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "combined preprocessed trace column count checked before committing",
     "combined base trace binds attention rows and six MLP component traces",
     "statement/public-instance/native-parameter commitments recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "commitment-vector length check before commitment indexing",
     "bounded proof bytes before JSON deserialization",
 ];
@@ -280,7 +280,7 @@ const EXPECTED_D128_ATTENTION_DERIVED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "combined preprocessed trace column count checked before committing",
     "combined base trace binds attention rows and six MLP component traces",
     "statement/public-instance/native-parameter commitments recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "commitment-vector length check before commitment indexing",
     "bounded proof bytes before JSON deserialization",
 ];

--- a/src/stwo_backend/native_d128_seq32_attention_mlp_single_proof.rs
+++ b/src/stwo_backend/native_d128_seq32_attention_mlp_single_proof.rs
@@ -262,7 +262,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "combined preprocessed trace column count checked before committing",
     "combined base trace binds attention rows and six MLP component traces",
     "statement/public-instance/native-parameter commitments recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "commitment-vector length check before commitment indexing",
     "bounded proof bytes before JSON deserialization",
 ];
@@ -280,7 +280,7 @@ const EXPECTED_D128_ATTENTION_DERIVED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "combined preprocessed trace column count checked before committing",
     "combined base trace binds attention rows and six MLP component traces",
     "statement/public-instance/native-parameter commitments recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "commitment-vector length check before commitment indexing",
     "bounded proof bytes before JSON deserialization",
 ];
@@ -2537,7 +2537,7 @@ fn validate_pcs_config(
         || actual.lifting_log_size != expected.lifting_log_size
     {
         return Err(single_error(
-            "PCS config does not match publication-v1 profile with route-specific explicit lifting log size",
+            "PCS config does not match fixed Stwo measurement PCS profile with route-specific explicit lifting log size",
         ));
     }
     Ok(expected)
@@ -2560,7 +2560,7 @@ fn single_pcs_config(
     config.lifting_log_size = Some(SINGLE_PCS_LIFTING_LOG_SIZE);
     if publication_v1_pcs_config_matches(&config) {
         return Err(single_error(
-            "single proof PCS config unexpectedly matches publication-v1 default",
+            "single proof PCS config unexpectedly matches fixed Stwo measurement default",
         ));
     }
     Ok(config)

--- a/src/stwo_backend/native_seq32_attention_mlp_single_proof.rs
+++ b/src/stwo_backend/native_seq32_attention_mlp_single_proof.rs
@@ -233,7 +233,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "combined preprocessed trace column count checked before committing",
     "combined base trace binds attention rows and six MLP component traces",
     "statement/public-instance/native-parameter commitments recomputed before proof verification",
-    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
+    "fixed Stwo measurement PCS profile before commitment-root recomputation",
     "commitment-vector length check before commitment indexing",
     "bounded proof bytes before JSON deserialization",
 ];
@@ -2361,7 +2361,7 @@ fn validate_pcs_config(
         || actual.lifting_log_size != expected.lifting_log_size
     {
         return Err(single_error(
-            "PCS config does not match publication-v1 profile with route-specific explicit lifting log size",
+            "PCS config does not match fixed Stwo measurement PCS profile with route-specific explicit lifting log size",
         ));
     }
     Ok(expected)
@@ -2382,7 +2382,7 @@ fn single_pcs_config(adapter_mode: ZkAiNativeSeq32AttentionMlpAdapterMode) -> Re
     config.lifting_log_size = Some(SINGLE_PCS_LIFTING_LOG_SIZE);
     if publication_v1_pcs_config_matches(&config) {
         return Err(single_error(
-            "single proof PCS config unexpectedly matches publication-v1 default",
+            "single proof PCS config unexpectedly matches fixed Stwo measurement default",
         ));
     }
     Ok(config)

--- a/src/stwo_backend/native_seq32_attention_mlp_single_proof.rs
+++ b/src/stwo_backend/native_seq32_attention_mlp_single_proof.rs
@@ -233,7 +233,7 @@ const EXPECTED_PROOF_VERIFIER_HARDENING: &[&str] = &[
     "combined preprocessed trace column count checked before committing",
     "combined base trace binds attention rows and six MLP component traces",
     "statement/public-instance/native-parameter commitments recomputed before proof verification",
-    "fixed Stwo measurement PCS profile before commitment-root recomputation",
+    "fixed publication-v1 PCS verifier profile before commitment-root recomputation",
     "commitment-vector length check before commitment indexing",
     "bounded proof bytes before JSON deserialization",
 ];

--- a/src/stwo_backend/zkai_vector_block_residual_add_proof.rs
+++ b/src/stwo_backend/zkai_vector_block_residual_add_proof.rs
@@ -591,7 +591,7 @@ fn verify_vector_block_rows(input: &ZkAiVectorBlockProofInput, proof: &[u8]) -> 
 fn validate_vector_block_pcs_config(actual: PcsConfig) -> Result<PcsConfig> {
     if !super::publication_v1_pcs_config_matches(&actual) {
         return Err(vector_block_error(
-            "PCS config does not match publication-v1 verifier profile",
+            "PCS config does not match fixed Stwo measurement PCS profile",
         ));
     }
     Ok(vector_block_pcs_config())


### PR DESCRIPTION
## Summary

- Add `fixed_stwo_measurement_pcs_config()` as the canonical helper name for the fixed q=3 Stwo PCS measurement profile.
- Keep `publication_v1_pcs_config()` and its matcher as compatibility aliases for older generated modules.
- Update the paper, claim pack, reproduction note, release/audit packets, and high-query generator wording so reviewers see the fixed measurement profile as an experimental setting, not a publication-security profile.
- Refresh the paper release manifest hashes for the two touched markdown artifacts only.

## Why

Issue #773 tracks a reviewer-hygiene concern: the old helper name sounded like a publication-security profile even though it is only the fixed Stwo measurement configuration used for the bounded-attention proof-byte experiments. This PR clarifies the name without changing the measured configuration, evidence rows, proof bytes, or paper claims.

## Hardening

- Trusted-core path touched: `src/stwo_backend/mod.rs`.
- Compatibility preserved: legacy `publication_v1_pcs_config()` and `publication_v1_pcs_config_matches()` remain wrappers, so older generated modules keep working.
- Regression coverage: added a feature-gated unit test proving the legacy alias and canonical helper produce the same fixed q=3 profile.
- Tamper-path impact: none; no verifier, proof parsing, mutation gate, or evidence-binding logic changes.
- Artifact impact: no new proof artifacts and no proof-byte changes. Only markdown artifact digests in the paper release manifest changed because paper text changed.

## Validation

- `cargo +nightly-2025-07-14 fmt --check`
- `cargo +nightly-2025-07-14 check --lib --features stwo-backend`
- `PYTHON_BIN=.venv/bin/python scripts/run_proof_pressure_release_gate.sh`

Note: a direct `cargo test ... --features stwo-backend` attempt reached Rust compilation but failed at the final linker step with macOS `errno=28` because the local disk was full. I cleared only this repo's `target/` cache and used `cargo check` plus the full paper release gate instead.

## Non-claims

- No Stwo optimization.
- No new security profile.
- No production-security parameter change.
- No new proof artifact.
- No proof-byte, evidence, or paper-claim change.

Closes #773.
